### PR TITLE
Add open source implementation flow for Upduino v3 board

### DIFF
--- a/boards/UPduino_v3/.gitignore
+++ b/boards/UPduino_v3/.gitignore
@@ -18,3 +18,5 @@ source/*
 !*.rdf
 !*.pdc
 !*.bin
+!*.pcf
+!Makefile

--- a/boards/UPduino_v3/Makefile
+++ b/boards/UPduino_v3/Makefile
@@ -47,6 +47,7 @@ IMPL_NAME := ${DESIGN_NAME}_impl_2
 .PHONY: syn impl bin clean
 
 # Some phony targets for convenience
+all: bin
 syn: ${IMPL_NAME}.json
 impl: ${IMPL_NAME}.asc
 bin: ${IMPL_NAME}.bin
@@ -61,10 +62,12 @@ work-obj08.cf: neorv32-obj08.cf ${UPDUINO_SRC}
 	ghdl -a --std=08 --work=work ${UPDUINO_SRC}
 
 ${IMPL_NAME}.json: work-obj08.cf
-	yosys -m ghdl -p 'ghdl --std=08 --no-formal neorv32_upduino_v3_top; synth_ice40 -abc2 -dsp -json $@'
+	yosys -m ghdl -p 'ghdl --std=08 -gyosys=true --no-formal neorv32_upduino_v3_top; synth_ice40 -abc2 -dsp -json $@' 2>&1 | tee yosys-report.txt
 
 ${IMPL_NAME}.asc: ${IMPL_NAME}.json ${DESIGN_NAME}.pcf
-	nextpnr-ice40 --ignore-loops --up5k --package sg48 --json $< --pcf ${DESIGN_NAME}.pcf --asc $@
+	nextpnr-ice40 --ignore-loops --timing-allow-fail \
+	  --up5k --package sg48 --json $< --pcf ${DESIGN_NAME}.pcf \
+	  --asc $@ 2>&1 | tee nextpnr-report.txt
 
 ${IMPL_NAME}.bin: ${IMPL_NAME}.asc
 	icepack $< $@

--- a/boards/UPduino_v3/Makefile
+++ b/boards/UPduino_v3/Makefile
@@ -1,0 +1,73 @@
+NEORV32_PKG := ../../rtl/core/neorv32_package.vhd
+
+NEORV32_SRC := \
+  neorv32_dmem.ice40up_spram.vhd \
+  neorv32_imem.ice40up_spram.vhd \
+  ../../rtl/core/neorv32_bootloader_image.vhd   \
+  ../../rtl/core/neorv32_application_image.vhd   \
+  ../../rtl/core/neorv32_boot_rom.vhd   \
+  ../../rtl/core/neorv32_bus_keeper.vhd   \
+  ../../rtl/core/neorv32_busswitch.vhd   \
+  ../../rtl/core/neorv32_cfs.vhd   \
+  ../../rtl/core/neorv32_cpu.vhd   \
+  ../../rtl/core/neorv32_cpu_alu.vhd   \
+  ../../rtl/core/neorv32_cpu_bus.vhd   \
+  ../../rtl/core/neorv32_cpu_control.vhd   \
+  ../../rtl/core/neorv32_cpu_cp_bitmanip.vhd   \
+  ../../rtl/core/neorv32_cpu_cp_fpu.vhd   \
+  ../../rtl/core/neorv32_cpu_cp_muldiv.vhd   \
+  ../../rtl/core/neorv32_cpu_decompressor.vhd   \
+  ../../rtl/core/neorv32_cpu_regfile.vhd   \
+  ../../rtl/core/neorv32_gpio.vhd   \
+  ../../rtl/core/neorv32_icache.vhd   \
+  ../../rtl/core/neorv32_mtime.vhd   \
+  ../../rtl/core/neorv32_nco.vhd   \
+  ../../rtl/core/neorv32_neoled.vhd   \
+  ../../rtl/core/neorv32_pwm.vhd   \
+  ../../rtl/core/neorv32_spi.vhd   \
+  ../../rtl/core/neorv32_sysinfo.vhd   \
+  ../../rtl/core/neorv32_top.vhd   \
+  ../../rtl/core/neorv32_trng.vhd   \
+  ../../rtl/core/neorv32_twi.vhd   \
+  ../../rtl/core/neorv32_uart.vhd   \
+  ../../rtl/core/neorv32_wdt.vhd   \
+  ../../rtl/core/neorv32_wishbone.vhd
+
+UPDUINO_SRC := \
+  system_pll.vhd \
+  neorv32_upduino_v3_top.vhd
+
+ICE40_SRC := \
+  sb_ice40_components.vhd \
+  yosys_ice40_components.vhd
+
+DESIGN_NAME := neorv32_upduino_v3
+IMPL_NAME := ${DESIGN_NAME}_impl_2
+
+.PHONY: syn impl bin clean
+
+# Some phony targets for convenience
+syn: ${IMPL_NAME}.json
+impl: ${IMPL_NAME}.asc
+bin: ${IMPL_NAME}.bin
+
+ice40up-obj08.cf: ${ICE40_SRC}
+	ghdl -a --std=08 --work=iCE40UP ${ICE40_SRC}
+
+neorv32-obj08.cf: ice40up-obj08.cf ${NEORV32_PKG} ${NEORV32_SRC}
+	ghdl -a --std=08 --work=neorv32 ${NEORV32_PKG} ${NEORV32_SRC}
+
+work-obj08.cf: neorv32-obj08.cf ${UPDUINO_SRC}
+	ghdl -a --std=08 --work=work ${UPDUINO_SRC}
+
+${IMPL_NAME}.json: work-obj08.cf
+	yosys -m ghdl -p 'ghdl --std=08 --no-formal neorv32_upduino_v3_top; synth_ice40 -abc2 -dsp -json $@'
+
+${IMPL_NAME}.asc: ${IMPL_NAME}.json ${DESIGN_NAME}.pcf
+	nextpnr-ice40 --ignore-loops --up5k --package sg48 --json $< --pcf ${DESIGN_NAME}.pcf --asc $@
+
+${IMPL_NAME}.bin: ${IMPL_NAME}.asc
+	icepack $< $@
+
+clean:
+	rm -f *.cf ${IMPL_NAME}.*

--- a/boards/UPduino_v3/neorv32_upduino_v3.pcf
+++ b/boards/UPduino_v3/neorv32_upduino_v3.pcf
@@ -1,0 +1,36 @@
+## UART (uart0)
+set_io uart_txd_o 38
+set_io uart_rxd_i 28
+
+## SPI - on-board flash
+set_io flash_sdo_o 14
+set_io flash_sck_o 15
+set_io flash_csn_o 16
+set_io flash_sdi_i 17
+
+## SPI - user port
+set_io spi_sdo_o 34
+set_io spi_sck_o 43
+set_io spi_csn_o 36
+set_io spi_sdi_i 42
+
+## TWI
+set_io twi_sda_io 31
+set_io twi_scl_io 37
+
+## GPIO - input
+set_io gpio_i[0] 44
+set_io gpio_i[1] 4
+set_io gpio_i[2] 3
+set_io gpio_i[3] 48
+
+## GPIO - output
+set_io gpio_o[0] 45
+set_io gpio_o[1] 47
+set_io gpio_o[2] 46
+set_io gpio_o[3] 2
+
+## RGB power LED
+set_io pwm_o[0] 39
+set_io pwm_o[1] 40
+set_io pwm_o[2] 41

--- a/boards/UPduino_v3/neorv32_upduino_v3_top.vhd
+++ b/boards/UPduino_v3/neorv32_upduino_v3_top.vhd
@@ -310,7 +310,7 @@ begin
 
   RGB_inst: RGB
   generic map (
-    CURRENT_MODE => "1",
+    CURRENT_MODE => "0b1",
     RGB0_CURRENT => "0b000001",
     RGB1_CURRENT => "0b000001",
     RGB2_CURRENT => "0b000001"

--- a/boards/UPduino_v3/neorv32_upduino_v3_top.vhd
+++ b/boards/UPduino_v3/neorv32_upduino_v3_top.vhd
@@ -43,6 +43,9 @@ library iCE40UP;
 use iCE40UP.components.all; -- for device primitives and macros
 
 entity neorv32_upduino_v3_top is
+  generic (
+    yosys : boolean := false
+  );
   port (
     -- UART (uart0) --
     uart_txd_o  : out std_ulogic;
@@ -200,7 +203,7 @@ begin
     IO_TWI_EN                    => true,        -- implement two-wire interface (TWI)?
     IO_PWM_EN                    => true,        -- implement pulse-width modulation unit (PWM)?
     IO_WDT_EN                    => true,        -- implement watch dog timer (WDT)?
-    IO_TRNG_EN                   => true,       -- implement true random number generator (TRNG)?
+    IO_TRNG_EN                   => not yosys,   -- implement true random number generator (TRNG)?
     IO_CFS_EN                    => false,       -- implement custom functions subsystem (CFS)?
     IO_CFS_CONFIG                => x"00000000", -- custom CFS configuration generic
     IO_CFS_IN_SIZE               => 32,          -- size of CFS input conduit in bits

--- a/boards/UPduino_v3/sb_ice40_components.vhd
+++ b/boards/UPduino_v3/sb_ice40_components.vhd
@@ -1,0 +1,137 @@
+library ieee ;
+use ieee.std_logic_1164.all;
+
+package components is
+
+
+  -- Radiant components
+
+  component HSOSC
+  generic (
+    CLKHF_DIV : string
+  );
+  port (
+    CLKHFPU  : in  std_logic;
+    CLKHFEN  : in  std_logic;
+    CLKHF    : out std_logic
+  );
+  end component;
+
+  component SB_PLL40_CORE is
+  generic (
+    FEEDBACK_PATH                  : string := "SIMPLE";
+    DELAY_ADJUSTMENT_MODE_FEEDBACK : string := "FIXED";
+    DELAY_ADJUSTMENT_MODE_RELATIVE : string := "FIXED";
+    SHIFTREG_DIV_MODE              : std_logic := '0';
+    FDA_FEEDBACK                   : std_logic_vector(3 downto 0) := x"0";
+    FDA_RELATIVE                   : std_logic_vector(3 downto 0) := x"0";
+    PLLOUT_SELECT                  : string := "GENCLK";
+    DIVR                           : std_logic_vector(3 downto 0) := x"0";
+    DIVF                           : std_logic_vector(6 downto 0) := "0000000";
+    DIVQ                           : std_logic_vector(2 downto 0) := "000";
+    FILTER_RANGE                   : std_logic_vector(2 downto 0) := "000";
+    ENABLE_ICEGATE                 : std_logic := '0';
+    TEST_MODE                      : std_logic := '0';
+    EXTERNAL_DIVIDE_FACTOR         : integer := 1
+  );
+  port (
+    REFERENCECLK    : in  std_logic;
+    PLLOUTCORE      : out std_logic;
+    PLLOUTGLOBAL    : out std_logic;
+    EXTFEEDBACK     : in  std_logic;
+    DYNAMICDELAY    : in  std_logic_vector(7 downto 0);
+    LOCK            : out std_logic;
+    BYPASS          : in  std_logic;
+    RESETB          : in  std_logic;
+    LATCHINPUTVALUE : in  std_logic;
+    SDO             : out std_logic;
+    SDI             : in  std_logic;
+    SCLK            : in  std_logic
+  );
+  end component;
+
+
+  component  RGB
+  generic (
+    CURRENT_MODE : string := "0b0";
+    RGB0_CURRENT : string := "0b000000";
+    RGB1_CURRENT : string := "0b000000";
+    RGB2_CURRENT : string := "0b000000"
+  );
+  port (
+    RGB0PWM  : in  std_logic;
+    RGB1PWM  : in  std_logic;
+    RGB2PWM  : in  std_logic;
+    CURREN   : in  std_logic;
+    RGBLEDEN : in  std_logic;
+    RGB0     : out std_logic;
+    RGB1     : out std_logic;
+    RGB2     : out std_logic
+  );
+  end component;
+
+  component SP256K is
+  port (
+    AD        : in std_logic_vector(13 downto 0);
+    DI        : in std_logic_vector(15 downto 0);
+    MASKWE    : in std_logic_vector(3 downto 0);
+    WE        : in std_logic;
+    CS        : in std_logic;
+    CK        : in std_logic;
+    STDBY     : in std_logic;
+    SLEEP     : in std_logic;
+    PWROFF_N  : in std_logic;
+    DO        : out std_logic_vector(15 downto 0)
+  );
+  end component;
+
+
+  -- Yosys / IceCube wrapper components
+
+  component SB_HFOSC
+  generic (
+    CLKHF_DIV : string
+  );
+  port (
+    CLKHFPU  : in  std_logic;
+    CLKHFEN  : in  std_logic;
+    CLKHF    : out std_logic
+  );
+  end component;
+
+  component  SB_RGBA_DRV
+  generic (
+    CURRENT_MODE : string := "0b0";
+    RGB0_CURRENT : string := "0b000000";
+    RGB1_CURRENT : string := "0b000000";
+    RGB2_CURRENT : string := "0b000000"
+  );
+  port (
+    RGB0PWM  : in  std_logic;
+    RGB1PWM  : in  std_logic;
+    RGB2PWM  : in  std_logic;
+    CURREN   : in  std_logic;
+    RGBLEDEN : in  std_logic;
+    RGB0     : out std_logic;
+    RGB1     : out std_logic;
+    RGB2     : out std_logic
+  );
+  end component;
+
+
+  component SB_SPRAM256KA
+  port (
+    ADDRESS    : in std_logic_vector(13 downto 0);
+    DATAIN     : in std_logic_vector(15 downto 0);
+    MASKWREN   : in std_logic_vector(3 downto 0);
+    WREN       : in std_logic;
+    CHIPSELECT : in std_logic;
+    CLOCK      : in std_logic;
+    STANDBY    : in std_logic;
+    SLEEP      : in std_logic;
+    POWEROFF   : in std_logic;
+    DATAOUT    : out std_logic_vector(15 downto 0)
+  );
+  end component;
+
+end components;

--- a/boards/UPduino_v3/system_pll.vhd
+++ b/boards/UPduino_v3/system_pll.vhd
@@ -1,0 +1,39 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library iCE40UP;
+use iCE40UP.components.all; -- for device primitives and macros
+
+entity system_pll is
+  port (
+    ref_clk_i   : in  std_logic;
+    rst_n_i     : in  std_logic;
+    lock_o      : out std_logic;
+    outcore_o   : out std_logic;
+    outglobal_o : out std_logic
+  );
+end entity;
+
+
+architecture rtl of system_pll is
+
+begin
+
+  Pll_inst : SB_PLL40_CORE
+  port map (
+    REFERENCECLK    => ref_clk_i,
+    PLLOUTCORE      => outcore_o,
+    PLLOUTGLOBAL    => outglobal_o,
+    EXTFEEDBACK     => '0',
+    DYNAMICDELAY    => x"00",
+    LOCK            => lock_o,
+    BYPASS          => '0',
+    RESETB          => rst_n_i,
+    LATCHINPUTVALUE => '0',
+    SDO             => open,
+    SDI             => '0',
+    SCLK            => '0'
+  );
+
+end architecture;

--- a/boards/UPduino_v3/yosys_ice40_components.vhd
+++ b/boards/UPduino_v3/yosys_ice40_components.vhd
@@ -1,0 +1,127 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library iCE40UP;
+use iCE40UP.components.all;
+
+entity SP256K is
+  port (
+    AD       : in std_logic_vector(13 downto 0);
+    DI       : in std_logic_vector(15 downto 0);
+    MASKWE   : in std_logic_vector(3 downto 0);
+    WE       : in std_logic;
+    CS       : in std_logic;
+    CK       : in std_logic;
+    STDBY    : in std_logic;
+    SLEEP    : in std_logic;
+    PWROFF_N : in std_logic;
+    DO       : out std_logic_vector(15 downto 0)
+  );
+end entity SP256K;
+
+
+architecture rtl of SP256K is
+
+begin
+
+  ram_inst : SB_SPRAM256KA
+  port map (
+    ADDRESS    => AD,
+    DATAIN     => DI,
+    MASKWREN   => MASKWE,
+    WREN       => WE,
+    CHIPSELECT => CS,
+    CLOCK      => CK,
+    STANDBY    => STDBY,
+    SLEEP      => SLEEP,
+    POWEROFF   => PWROFF_N,
+    DATAOUT    => DO
+  );
+
+end architecture rtl;
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library iCE40UP;
+use iCE40UP.components.all;
+
+entity HSOSC is
+  generic (
+    CLKHF_DIV : string
+  );
+  port (
+    CLKHFPU : in  std_logic;
+    CLKHFEN : in  std_logic;
+    CLKHF   : out std_logic
+  );
+end entity HSOSC;
+
+architecture rtl of HSOSC is
+
+begin
+
+  osc_inst : SB_HFOSC
+  generic map (
+    CLKHF_DIV => CLKHF_DIV
+  )
+  port map (
+    CLKHFPU => CLKHFPU,
+    CLKHFEN => CLKHFEN,
+    CLKHF   => CLKHF
+  );
+
+end architecture rtl;
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library iCE40UP;
+use iCE40UP.components.all;
+
+entity RGB is
+  generic (
+    CURRENT_MODE : string := "0b0";
+    RGB0_CURRENT : string := "0b000000";
+    RGB1_CURRENT : string := "0b000000";
+    RGB2_CURRENT : string := "0b000000"
+  );
+  port (
+    CURREN   : in  std_logic;
+    RGBLEDEN : in  std_logic;
+    RGB0PWM  : in  std_logic;
+    RGB1PWM  : in  std_logic;
+    RGB2PWM  : in  std_logic;
+    RGB0     : out std_logic;
+    RGB1     : out std_logic;
+    RGB2     : out std_logic
+  );
+end entity RGB;
+
+architecture rtl of RGB is
+
+begin
+
+  RGB_inst: SB_RGBA_DRV
+  generic map (
+    CURRENT_MODE => CURRENT_MODE,
+    RGB0_CURRENT => RGB0_CURRENT,
+    RGB1_CURRENT => RGB1_CURRENT,
+    RGB2_CURRENT => RGB2_CURRENT
+  )
+  port map (
+    CURREN   => CURREN,
+    RGBLEDEN => RGBLEDEN,
+    RGB0PWM  => RGB0PWM,
+    RGB1PWM  => RGB1PWM,
+    RGB2PWM  => RGB2PWM,
+    RGB2     => RGB0,
+    RGB1     => RGB1,
+    RGB0     => RGB2
+  );
+
+end architecture rtl;


### PR DESCRIPTION
This is an attempt to add an implementation flow for the Upduino v.3 board which uses free & open source tools (GHDL, Yosys, nextpnr, Icestorm) only.

Some files were added:

* Makefile (obvious)
* sb_ice40_components.vhd (VHDL component definitions for FPGA hard macros, for Yosys/iceCube style & Radiant)
* yosys_ice40_components.vhd (Components which wrap the Radiant style macros to the Yosys (iceCube) ones) 
* system_pll.vhd (Hopefully functional similar to the verilog version)
* neorv32_upduino_v3.pcf (Constraint file for the nextpnr P&R tool)

Yosys uses the component definitions which the former Lattice tool (iceCube) used. That's the reason for the wrapper components in the yosys_ice40_components.vhd file. I tried to not change the original files, only the `CURRENT_MODE` generic was changed to a equivalent value `"1"` -> `"0b1"`.

I get the design fitted on the FPGA when I disable the TRNG (or maybe another) peripheral. If no feature is disabled, fitting fails with 101% resource allocation.

The resulting bin file is named like the existing one, but with number 2: `neorv32_upduino_v3_impl_2.bin`.

I used the `hdlc/impl` Docker image of the [hdlc](https://github.com/hdl/containers) project. It contains all necessary tools.

The PR is in draft mode and open for hints & discussion 🙂 