### PR TITLE
Use asciidoctor-diagram with wavedrom support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ docs/doxygen_build
 
 # HTML datasheet
 /docs/index.html
+
+# asciidoctor cache
+/docs/.asciidoctor

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,28 @@
+# Generate PDF datasheet
 pdf:
 	cd docs; \
 	[ -f revnumber.txt ] && REVNUMBER='-a revnumber='"$$(cat revnumber.txt)" || unset REVNUMBER; \
 	asciidoctor-pdf $$REVNUMBER \
 	  -a pdf-theme=src_adoc/neorv32-theme.yml \
+	  -r asciidoctor-diagram \
 	  src_adoc/neorv32.adoc \
 	  --out-file NEORV32.pdf
 
+# Generate HTML datasheet
 html:
 	cd docs; \
 	[ -f revnumber.txt ] && REVNUMBER='-a revnumber='"$$(cat revnumber.txt)" || unset REVNUMBER; \
 	asciidoctor $$REVNUMBER \
+	  -r asciidoctor-diagram \
 	  src_adoc/index.adoc \
 	  --out-file index.html
 
+# Generate revnumber.txt for overriding the revnumber attribute in 'pdf' and/or 'html'
 revnumber:
 	if [ `git tag -l | grep nightly` ]; then git tag -d nightly; fi
-	git describe --long --tags  | sed 's#\([^-]*-g\)#r\1#;' > docs/revnumber.txt
+	git describe --long --tags | sed 's#\([^-]*-g\)#r\1#;' > docs/revnumber.txt
 	cat docs/revnumber.txt
 
+# Build 'pdf' and 'html' in an 'asciidoctor-wavedrom' container
 container: revnumber
-	docker run --rm -v /$(PWD)://documents/ asciidoctor/docker-asciidoctor make pdf html
+	docker run --rm -v /$(PWD)://documents/ btdi/asciidoctor make pdf html


### PR DESCRIPTION
For some time, I wanted to learn how to use asciidoctor-diagram with wavedrom support, so I gave it a try.

For illustration purposes, in the last commit of this PR `wavedrom.adoc` is added and it is included in `content.adoc`. It shows a timing diagram, a bit-field diagram and a logic circuit, all generated through wavedrom. It also shows how to include a wavedrom figure from a JSON5 file, instead of writing the wave/diagram in the adoc source.

It works both for the HTML and the PDF outputs. See page 7 of [NEORV32.pdf](https://github.com/stnolting/neorv32/files/6529157/NEORV32.pdf).

Nevertheless, this PR is not ready to be merged because the `wavedrom.adoc` file is just a demo. @stnolting, let me know if you find this feature interesting. You can make a copy of the `wavedrom.adoc` file, and I'll remove it from this PR.
