### PR TITLE
[docs] set revnumber through git describe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,20 @@
 pdf:
-	asciidoctor-pdf -a pdf-theme=docs/src_adoc/neorv32-theme.yml docs/src_adoc/neorv32.adoc --out-file docs/NEORV32.pdf
+	cd docs; \
+	[ -f revnumber.txt ] && REVNUMBER='-a revnumber='"$$(cat revnumber.txt)" || unset REVNUMBER; \
+	asciidoctor-pdf $$REVNUMBER \
+	  -a pdf-theme=src_adoc/neorv32-theme.yml \
+	  src_adoc/neorv32.adoc \
+	  --out-file NEORV32.pdf
 
 html:
-	asciidoctor docs/src_adoc/index.adoc --out-file docs/index.html
+	cd docs; \
+	[ -f revnumber.txt ] && REVNUMBER='-a revnumber='"$$(cat revnumber.txt)" || unset REVNUMBER; \
+	asciidoctor $$REVNUMBER \
+	  src_adoc/index.adoc \
+	  --out-file index.html
 
-container:
+revnumber:
+	git describe --long --tags  | sed 's#\([^-]*-g\)#r\1#;' > docs/revnumber.txt
+
+container: revnumber
 	docker run --rm -v /$(PWD)://documents/ asciidoctor/docker-asciidoctor make pdf html


### PR DESCRIPTION
Close #33

In this PR, `git describe` is used for setting a unique revnumber for each commit. Since the container does not include git, a `docs/revnumber.txt` file is created outside. If it exists, it's used for overriding the revnumber attribute through the CLI. Otherwise, the revnumber set in the adoc sources is used.