### PR TITLE
[ci] prevent tag 'nightly' being used in revnumber

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ html:
 	  --out-file index.html
 
 revnumber:
+	if [ `git tag -l | grep nightly` ]; then git tag -d nightly; fi
 	git describe --long --tags  | sed 's#\([^-]*-g\)#r\1#;' > docs/revnumber.txt
+	cat docs/revnumber.txt
 
 container: revnumber
 	docker run --rm -v /$(PWD)://documents/ asciidoctor/docker-asciidoctor make pdf html


### PR DESCRIPTION
This PR implements one of the two solutions commented in https://github.com/stnolting/neorv32/commit/3ee1ac5df065237d6df22b701901737c052e21ca#commitcomment-51279169.