### PR TITLE
[docs] add attrs.adoc and attrs.main.adoc

### DIFF
--- a/docs/attrs.adoc
+++ b/docs/attrs.adoc
@@ -1,0 +1,12 @@
+:author: Dipl.-Ing. Stephan Nolting
+:email: stnolting@gmail.com
+:description: A size-optimized, customizable and open-source full-scale 32-bit RISC-V soft-core CPU and SoC written in platform-independent VHDL.
+:revnumber: v1.5.6.0
+:doctype: book
+:sectnums:
+:stem:
+:reproducible:
+:listing-caption: Listing
+:toclevels: 4
+:title-logo-image: neorv32_logo_dark.png[pdfwidth=6.25in,align=center]
+:favicon: img/icon.png

--- a/docs/attrs.main.adoc
+++ b/docs/attrs.main.adoc
@@ -1,0 +1,7 @@
+:icons: image
+:iconsdir: ../icons
+:imagesdir: ../figures
+:toc: macro
+:title-logo-image: image:neorv32_logo_dark.png[pdfwidth=6.25in,align=center]
+// Uncomment next line to set page size (default is A4)
+//:pdf-page-size: Letter

--- a/docs/datasheet/index.adoc
+++ b/docs/datasheet/index.adoc
@@ -1,18 +1,9 @@
 = The NEORV32 RISC-V Processor: Datasheet
+include::../attrs.adoc[]
 :title: [Datasheet] The NEORV32 RISC-V Processor
-:author: Dipl.-Ing. Stephan Nolting
-:email: stnolting@gmail.com
-:description: A size-optimized, customizable and open-source full-scale 32-bit RISC-V soft-core CPU and SoC written in platform-independent VHDL.
-:revnumber: v1.5.6.0
-:doctype: book
-:sectnums:
 :icons: font
 :imagesdir: img
-:stem:
-:reproducible:
-:listing-caption: Listing
 :toc: left
-:toclevels: 4
 :title-logo-image: neorv32_logo_dark.png[pdfwidth=6.25in,align=center]
 :favicon: img/icon.png
 

--- a/docs/datasheet/main.adoc
+++ b/docs/datasheet/main.adoc
@@ -1,21 +1,6 @@
 = The NEORV32 RISC-V Processor: Datasheet
-:author: Dipl.-Ing. Stephan Nolting
-:email: stnolting@gmail.com
-:description: A size-optimized, customizable and open-source full-scale 32-bit RISC-V soft-core CPU and SoC written in platform-independent VHDL.
-:revnumber: v1.5.6.0
-:doctype: book
-:sectnums:
-:icons: image
-:iconsdir: ../icons
-:imagesdir: ../figures
-:stem:
-:reproducible:
-:listing-caption: Listing
-:toc: macro
-:toclevels: 4
-:title-logo-image: image:neorv32_logo_dark.png[pdfwidth=6.25in,align=center]
-// Uncomment next line to set page size (default is A4)
-//:pdf-page-size: Letter
+include::../attrs.adoc[]
+include::../attrs.main.adoc[]
 
 
 <<<

--- a/docs/userguide/index.adoc
+++ b/docs/userguide/index.adoc
@@ -1,18 +1,9 @@
 = The NEORV32 RISC-V Processor: User Guide
+include::../attrs.adoc[]
 :title: [User Guide] The NEORV32 RISC-V Processor
-:author: Dipl.-Ing. Stephan Nolting
-:email: stnolting@gmail.com
-:description: A size-optimized, customizable and open-source full-scale 32-bit RISC-V soft-core CPU and SoC written in platform-independent VHDL.
-:revnumber: v1.5.6.0
-:doctype: book
-:sectnums:
 :icons: font
 :imagesdir: ../img
-:stem:
-:reproducible:
-:listing-caption: Listing
 :toc: left
-:toclevels: 4
 :title-logo-image: neorv32_logo_dark.png[pdfwidth=6.25in,align=center]
 :favicon: ../img/icon.png
 

--- a/docs/userguide/main.adoc
+++ b/docs/userguide/main.adoc
@@ -1,21 +1,6 @@
 = The NEORV32 RISC-V Processor: User Guide
-:author: Dipl.-Ing. Stephan Nolting
-:email: stnolting@gmail.com
-:description: A size-optimized, customizable and open-source full-scale 32-bit RISC-V soft-core CPU and SoC written in platform-independent VHDL.
-:revnumber: v1.5.6.0
-:doctype: book
-:sectnums:
-:icons: image
-:iconsdir: ../icons
-:imagesdir: ../figures
-:stem:
-:reproducible:
-:listing-caption: Listing
-:toc: macro
-:toclevels: 4
-:title-logo-image: image:neorv32_logo_dark.png[pdfwidth=6.25in,align=center]
-// Uncomment next line to set page size (default is A4)
-//:pdf-page-size: Letter
+include::../attrs.adoc[]
+include::../attrs.main.adoc[]
 
 
 <<<


### PR DESCRIPTION
This PR reduces the duplication of the frontmatter in the docs. `attrs.adoc` is included in all docs (either `index.adoc` or `main.adoc`). `attrs.main.adoc` is included in PDF docs only (`main.adoc`).