### PR TITLE
rename logical library 'iCE40UP' to 'iCE40'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ sw/image_gen/image_gen.exe
 *.o
 
 # example bitstreams
-/examples/*.bit
+/setups/examples/*.bit

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ sw/image_gen/image_gen.exe
 /docs/doxygen_build/
 /docs/.asciidoctor/
 /docs/public/
+/docs/figures/diag-*.svg
 
 # compiled ghdl stuff
 *.cf

--- a/setups/examples/neorv32_Fomu_BoardTop_Minimal.vhd
+++ b/setups/examples/neorv32_Fomu_BoardTop_Minimal.vhd
@@ -36,8 +36,8 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library iCE40UP;
-use iCE40UP.components.all; -- for device primitives and macros
+library iCE40;
+use iCE40.components.all; -- for device primitives and macros
 
 entity neorv32_Fomu_BoardTop_Minimal is
   port (

--- a/setups/examples/neorv32_Fomu_BoardTop_MinimalBoot.vhd
+++ b/setups/examples/neorv32_Fomu_BoardTop_MinimalBoot.vhd
@@ -36,8 +36,8 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library iCE40UP;
-use iCE40UP.components.all; -- for device primitives and macros
+library iCE40;
+use iCE40.components.all; -- for device primitives and macros
 
 entity neorv32_Fomu_BoardTop_MinimalBoot is
   port (

--- a/setups/examples/neorv32_Fomu_BoardTop_UP5KDemo.vhd
+++ b/setups/examples/neorv32_Fomu_BoardTop_UP5KDemo.vhd
@@ -36,8 +36,8 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library iCE40UP;
-use iCE40UP.components.all; -- for device primitives and macros
+library iCE40;
+use iCE40.components.all; -- for device primitives and macros
 
 entity neorv32_Fomu_BoardTop_UP5KDemo is
   port (

--- a/setups/examples/neorv32_UPduino_v3_BoardTop_MinimalBoot.vhd
+++ b/setups/examples/neorv32_UPduino_v3_BoardTop_MinimalBoot.vhd
@@ -36,8 +36,8 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library iCE40UP;
-use iCE40UP.components.all; -- for device primitives and macros
+library iCE40;
+use iCE40.components.all; -- for device primitives and macros
 
 entity neorv32_UPduino_v3_BoardTop_MinimalBoot is
   port (

--- a/setups/examples/neorv32_UPduino_v3_BoardTop_UP5KDemo.vhd
+++ b/setups/examples/neorv32_UPduino_v3_BoardTop_UP5KDemo.vhd
@@ -36,8 +36,8 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library iCE40UP;
-use iCE40UP.components.all; -- for device primitives and macros
+library iCE40;
+use iCE40.components.all; -- for device primitives and macros
 
 entity neorv32_UPduino_v3_BoardTop_UP5KDemo is
   port (

--- a/setups/osflow/devices/ice40/neorv32_dmem.ice40up_spram.vhd
+++ b/setups/osflow/devices/ice40/neorv32_dmem.ice40up_spram.vhd
@@ -42,8 +42,8 @@ use ieee.numeric_std.all;
 library neorv32;
 use neorv32.neorv32_package.all;
 
-library iCE40UP;
-use iCE40UP.components.all;
+library iCE40;
+use iCE40.components.all;
 
 entity neorv32_dmem is
   generic (
@@ -96,7 +96,7 @@ begin
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   assert not (DMEM_SIZE > 64*1024) report "DMEM has a fixed physical size of 64kB. Logical size must be less or equal." severity error;
-  
+
 
   -- Access Control -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/setups/osflow/devices/ice40/neorv32_imem.ice40up_spram.vhd
+++ b/setups/osflow/devices/ice40/neorv32_imem.ice40up_spram.vhd
@@ -42,8 +42,8 @@ use ieee.numeric_std.all;
 library neorv32;
 use neorv32.neorv32_package.all;
 
-library iCE40UP;
-use iCE40UP.components.all;
+library iCE40;
+use iCE40.components.all;
 
 entity neorv32_imem is
   generic (

--- a/setups/osflow/synthesis.mk
+++ b/setups/osflow/synthesis.mk
@@ -1,7 +1,7 @@
-ice40up-obj08.cf: ${ICE40_SRC}
-	ghdl -a $(GHDL_FLAGS) --work=iCE40UP ${ICE40_SRC}
+ice40-obj08.cf: ${ICE40_SRC}
+	ghdl -a $(GHDL_FLAGS) --work=iCE40 ${ICE40_SRC}
 
-neorv32-obj08.cf: ice40up-obj08.cf ${NEORV32_SRC}
+neorv32-obj08.cf: ice40-obj08.cf ${NEORV32_SRC}
 	ghdl -a $(GHDL_FLAGS) --work=neorv32 ${NEORV32_SRC}
 
 work-obj08.cf: neorv32-obj08.cf ${DESIGN_SRC} ${BOARD_SRC}

--- a/setups/radiant/UPduino_v2/neorv32_dmem.ice40up_spram.vhd
+++ b/setups/radiant/UPduino_v2/neorv32_dmem.ice40up_spram.vhd
@@ -42,8 +42,8 @@ use ieee.numeric_std.all;
 library neorv32;
 use neorv32.neorv32_package.all;
 
-library iCE40UP;
-use iCE40UP.components.all;
+library iCE40;
+use iCE40.components.all;
 
 entity neorv32_dmem is
   generic (

--- a/setups/radiant/UPduino_v2/neorv32_imem.ice40up_spram.vhd
+++ b/setups/radiant/UPduino_v2/neorv32_imem.ice40up_spram.vhd
@@ -42,8 +42,8 @@ use ieee.numeric_std.all;
 library neorv32;
 use neorv32.neorv32_package.all;
 
-library iCE40UP;
-use iCE40UP.components.all;
+library iCE40;
+use iCE40.components.all;
 
 entity neorv32_imem is
   generic (

--- a/setups/radiant/UPduino_v2/neorv32_upduino_v2_top.vhd
+++ b/setups/radiant/UPduino_v2/neorv32_upduino_v2_top.vhd
@@ -39,8 +39,8 @@ use ieee.numeric_std.all;
 library neorv32;
 use neorv32.neorv32_package.all;
 
-library iCE40UP;
-use iCE40UP.components.all; -- for device primitives
+library iCE40;
+use iCE40.components.all; -- for device primitives
 
 entity neorv32_upduino_v2_top is
   port (

--- a/setups/radiant/UPduino_v3/neorv32_dmem.ice40up_spram.vhd
+++ b/setups/radiant/UPduino_v3/neorv32_dmem.ice40up_spram.vhd
@@ -42,8 +42,8 @@ use ieee.numeric_std.all;
 library neorv32;
 use neorv32.neorv32_package.all;
 
-library iCE40UP;
-use iCE40UP.components.all;
+library iCE40;
+use iCE40.components.all;
 
 entity neorv32_dmem is
   generic (
@@ -96,7 +96,7 @@ begin
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   assert not (DMEM_SIZE > 64*1024) report "DMEM has a fixed physical size of 64kB. Logical size must be less or equal." severity error;
-  
+
 
   -- Access Control -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/setups/radiant/UPduino_v3/neorv32_imem.ice40up_spram.vhd
+++ b/setups/radiant/UPduino_v3/neorv32_imem.ice40up_spram.vhd
@@ -42,8 +42,8 @@ use ieee.numeric_std.all;
 library neorv32;
 use neorv32.neorv32_package.all;
 
-library iCE40UP;
-use iCE40UP.components.all;
+library iCE40;
+use iCE40.components.all;
 
 entity neorv32_imem is
   generic (

--- a/setups/radiant/UPduino_v3/neorv32_upduino_v3_top.vhd
+++ b/setups/radiant/UPduino_v3/neorv32_upduino_v3_top.vhd
@@ -39,8 +39,8 @@ use ieee.numeric_std.all;
 library neorv32;
 use neorv32.neorv32_package.all;
 
-library iCE40UP;
-use iCE40UP.components.all; -- for device primitives and macros
+library iCE40;
+use iCE40.components.all; -- for device primitives and macros
 
 entity neorv32_upduino_v3_top is
   port (


### PR DESCRIPTION
Although we've been using the sb_ice40_components source for UP5K devices only, some of those can be used with other ICE40 devices too. This PR renames the logical library name from `iCE40UP` to `iCE40`.

By the way, `.gitignore` is updated.