### PR TITLE
VUnit checking

### DIFF
--- a/.github/workflows/Processor.yml
+++ b/.github/workflows/Processor.yml
@@ -23,6 +23,7 @@ jobs:
 
   Processor:
     runs-on: ubuntu-latest
+    name: '🐧 Ubuntu'
 
     steps:
 
@@ -34,34 +35,63 @@ jobs:
           echo "$GITHUB_WORKSPACE/riscv/bin" >> $GITHUB_PATH
           echo $GITHUB_WORKSPACE
 
-      - name: '🔧 Setup RISC-V GCC'
+      - name: '⚙️ Setup RISC-V GCC'
         run: |
           mkdir riscv
           curl -fsSL https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-2.0.0/riscv32-unknown-elf.gcc-10.2.0.rv32i.ilp32.newlib.tar.gz | \
           tar -xzf - -C riscv
           ls -al riscv
 
-      - name: '🔧 Setup GHDL Simulator'
+      - name: '⚙️ Setup GHDL Simulator'
         uses: ghdl/setup-ghdl-ci@nightly
         with:
           backend: llvm
 
-      - name: '⚙️ Run Software Framework Tests'
+      - name: '🚧 Run Software Framework Tests'
         run: ./sw/example/processor_check/check.sh
 
-      - name: Archive application
+      - name: '🚧 Run Processor Hardware Tests with shell script'
+        run: ./sim/ghdl/ghdl_sim.sh
+
+
+  VUnit:
+    runs-on: ubuntu-latest
+    name: '🛳️ VUnit'
+
+    steps:
+
+      - name: '🧰 Repository Checkout'
+        uses: actions/checkout@v2
+
+      - name: '🔧 Setup Environment Variables'
+        run: |
+          echo "$GITHUB_WORKSPACE/riscv/bin" >> $GITHUB_PATH
+          echo $GITHUB_WORKSPACE
+
+      - name: '⚙️ Setup RISC-V GCC'
+        run: |
+          mkdir riscv
+          curl -fsSL https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-2.0.0/riscv32-unknown-elf.gcc-10.2.0.rv32i.ilp32.newlib.tar.gz | \
+          tar -xzf - -C riscv
+          ls -al riscv
+
+      - name: '⚙️ Build and install Processor Check software'
+        run: |
+          make -C sw/example/processor_check \
+            clean_all \
+            USER_FLAGS+=-DRUN_CHECK \
+            USER_FLAGS+=-DUART0_SIM_MODE \
+            MARCH=-march=rv32imac \
+            info \
+            all
+
+      - name: '📤 Archive Processor Check application image'
         uses: actions/upload-artifact@v2
         with:
           name: application
           path: rtl/core/neorv32_application_image.vhd
 
-      - name: '⚙️ Run Processor Hardware Tests with VUnit'
+      - name: '🚧 Run Processor Hardware Tests with VUnit'
         uses: VUnit/vunit_action@master
         with:
           cmd: ./sim/run.py --ci-mode -v
-
-      - name: '🔧 Clean simulation artifacts'
-        run: sudo rm *.testbench_uart?.out *.data.out *.text.out
-
-      - name: '⚙️ Run Processor Hardware Tests with shell script'
-        run: ./sim/ghdl/ghdl_sim.sh

--- a/riscv-arch-test/port-neorv32/framework_v1.0/riscv-target/neorv32/README.md
+++ b/riscv-arch-test/port-neorv32/framework_v1.0/riscv-target/neorv32/README.md
@@ -3,7 +3,7 @@
 The NEORV32 Processor is simulated using the its default testbench.
 
 Each architecture-specific makefile in the `device` folder uses an _uncool hack_: `sed` is used to
-enable/disable the required `CPU_EXTENSION_RISCV_xxx` VHDL configuration generics in the testbench (`neorv32/sim/neorv32_tb.vhd`).
+enable/disable the required `CPU_EXTENSION_RISCV_xxx` VHDL configuration generics in the testbench (`neorv32/sim/neorv32_tb.simple.vhd`).
 
 For instance, the `rv32i` tests requires the `C`-extensions to be disabled - which is enabled by default in the testbench.
 

--- a/riscv-arch-test/port-neorv32/framework_v1.0/riscv-target/neorv32/device/rv32Zicsr/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v1.0/riscv-target/neorv32/device/rv32Zicsr/Makefile.include
@@ -14,7 +14,7 @@ endif
 RUN_TARGET=\
 	cd $(work_dir_isa); \
 	rm -f $(work_dir_isa)/*.out; \
-	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\  CPU_EXTENSION_RISCV_Zicsr => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\  CPU_EXTENSION_RISCV_Zicsr => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.simple.vhd; \
 	make -C $(NEORV32_HOME)/sw/example/blink_led main.elf; \
 	cp -f $< $(NEORV32_HOME)/sw/example/blink_led/main.elf; \
 	make -C $(NEORV32_HOME)/sw/example/blink_led main.bin; \

--- a/riscv-arch-test/port-neorv32/framework_v1.0/riscv-target/neorv32/device/rv32Zifencei/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v1.0/riscv-target/neorv32/device/rv32Zifencei/Makefile.include
@@ -14,8 +14,8 @@ endif
 RUN_TARGET=\
 	cd $(work_dir_isa); \
 	rm -f $(work_dir_isa)/*.out; \
-	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\  CPU_EXTENSION_RISCV_Zicsr => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zifencei/c\  CPU_EXTENSION_RISCV_Zifencei => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\  CPU_EXTENSION_RISCV_Zicsr => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zifencei/c\  CPU_EXTENSION_RISCV_Zifencei => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.simple.vhd; \
 	make -C $(NEORV32_HOME)/sw/example/blink_led main.elf; \
 	cp -f $< $(NEORV32_HOME)/sw/example/blink_led/main.elf; \
 	make -C $(NEORV32_HOME)/sw/example/blink_led main.bin; \

--- a/riscv-arch-test/port-neorv32/framework_v1.0/riscv-target/neorv32/device/rv32i/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v1.0/riscv-target/neorv32/device/rv32i/Makefile.include
@@ -14,8 +14,8 @@ endif
 RUN_TARGET=\
 	cd $(work_dir_isa); \
 	rm -f $(work_dir_isa)/*.out; \
-	sed -i '/CPU_EXTENSION_RISCV_C/c\  CPU_EXTENSION_RISCV_C => false, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\  CPU_EXTENSION_RISCV_Zicsr => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_C/c\  CPU_EXTENSION_RISCV_C => false, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\  CPU_EXTENSION_RISCV_Zicsr => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.simple.vhd; \
 	make -C $(NEORV32_HOME)/sw/example/blink_led main.elf; \
 	cp -f $< $(NEORV32_HOME)/sw/example/blink_led/main.elf; \
 	make -C $(NEORV32_HOME)/sw/example/blink_led main.bin; \

--- a/riscv-arch-test/port-neorv32/framework_v1.0/riscv-target/neorv32/device/rv32im/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v1.0/riscv-target/neorv32/device/rv32im/Makefile.include
@@ -14,8 +14,8 @@ endif
 RUN_TARGET=\
 	cd $(work_dir_isa); \
 	rm -f $(work_dir_isa)/*.out; \
-	sed -i '/CPU_EXTENSION_RISCV_M/c\  CPU_EXTENSION_RISCV_M => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\  CPU_EXTENSION_RISCV_Zicsr => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_M/c\  CPU_EXTENSION_RISCV_M => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\  CPU_EXTENSION_RISCV_Zicsr => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.simple.vhd; \
 	make -C $(NEORV32_HOME)/sw/example/blink_led main.elf; \
 	cp -f $< $(NEORV32_HOME)/sw/example/blink_led/main.elf; \
 	make -C $(NEORV32_HOME)/sw/example/blink_led main.bin; \

--- a/riscv-arch-test/port-neorv32/framework_v1.0/riscv-target/neorv32/device/rv32imc/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v1.0/riscv-target/neorv32/device/rv32imc/Makefile.include
@@ -14,9 +14,9 @@ endif
 RUN_TARGET=\
 	cd $(work_dir_isa); \
 	rm -f $(work_dir_isa)/*.out; \
-	sed -i '/CPU_EXTENSION_RISCV_C/c\  CPU_EXTENSION_RISCV_C => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_M/c\  CPU_EXTENSION_RISCV_M => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\  CPU_EXTENSION_RISCV_Zicsr => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_C/c\  CPU_EXTENSION_RISCV_C => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_M/c\  CPU_EXTENSION_RISCV_M => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\  CPU_EXTENSION_RISCV_Zicsr => true, -- MOD. BY RISCV-COMPL. TEST SCRIPT' $(NEORV32_HOME)/sim/neorv32_tb.simple.vhd; \
 	make -C $(NEORV32_HOME)/sw/example/blink_led main.elf; \
 	cp -f $< $(NEORV32_HOME)/sw/example/blink_led/main.elf; \
 	make -C $(NEORV32_HOME)/sw/example/blink_led main.bin; \

--- a/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/README.md
+++ b/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/README.md
@@ -4,8 +4,8 @@
 The following tasks are executed by the device makefiles:
 
 * replace the original processor's IMEM rtl file by a simulation-optimized IMEM (ROM!)
-* `sed` command is used to modify the default testbench (`neorv32/sim/neorv32_tb.vhd`):
-  * enable/disable the required `CPU_EXTENSION_RISCV_xxx` VHDL configuration generics in the testbench (`neorv32/sim/neorv32_tb.vhd`)
+* `sed` command is used to modify the default testbench (`neorv32/sim/neorv32_tb.simple.vhd`):
+  * enable/disable the required `CPU_EXTENSION_RISCV_xxx` VHDL configuration generics in the testbench (`neorv32/sim/neorv32_tb.simple.vhd`)
   * configure the processor memory configuration (use internal IMEM, IMEM as ROM, IMEM size of 2MB)
 * compile test code and install application image to processor's `rtl/core` folder
   * compilation uses the `link.imem_rom.ld` linker script as default; code (the test code) is executed from IMEM (which is read-only); data including signature is stored to DMEM (RAM)

--- a/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/C/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/C/Makefile.include
@@ -15,18 +15,18 @@ RUN_TARGET=\
 	echo "copying/using SIM-only IMEM (ROM!)"; \
 	rm -f $(NEORV32_LOCAL_COPY)/rtl/core/neorv32_imem.vhd; \
 	cp -f $(NEORV32_LOCAL_COPY)/sim/rtl_modules/neorv32_imem.vhd $(NEORV32_LOCAL_COPY)/rtl/core/neorv32_imem.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_A/c\CPU_EXTENSION_RISCV_A  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_C/c\CPU_EXTENSION_RISCV_C  => true,  -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_E/c\CPU_EXTENSION_RISCV_E  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_M/c\CPU_EXTENSION_RISCV_M  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_U/c\CPU_EXTENSION_RISCV_U  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\CPU_EXTENSION_RISCV_Zicsr  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zifencei/c\CPU_EXTENSION_RISCV_Zifencei  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/constant ext_imem_c/c\constant ext_imem_c : boolean := false; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/signal ext_ram_a : ext_mem_a_ram_t/c\signal ext_ram_a : ext_mem_a_ram_t; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_USE/c\MEM_INT_IMEM_USE  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_SIZE/c\MEM_INT_IMEM_SIZE  => 2*1024*1024, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_ROM/c\MEM_INT_IMEM_ROM  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_A/c\CPU_EXTENSION_RISCV_A  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_C/c\CPU_EXTENSION_RISCV_C  => true,  -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_E/c\CPU_EXTENSION_RISCV_E  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_M/c\CPU_EXTENSION_RISCV_M  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_U/c\CPU_EXTENSION_RISCV_U  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\CPU_EXTENSION_RISCV_Zicsr  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zifencei/c\CPU_EXTENSION_RISCV_Zifencei  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/constant ext_imem_c/c\constant ext_imem_c : boolean := false; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/signal ext_ram_a : ext_mem_a_ram_t/c\signal ext_ram_a : ext_mem_a_ram_t; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_USE/c\MEM_INT_IMEM_USE  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_SIZE/c\MEM_INT_IMEM_SIZE  => 2*1024*1024, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_ROM/c\MEM_INT_IMEM_ROM  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.elf; \
 	cp -f $< $(NEORV32_LOCAL_COPY)/sw/example/blink_led/main.elf; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.bin; \

--- a/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/I/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/I/Makefile.include
@@ -15,18 +15,18 @@ RUN_TARGET=\
 	echo "copying/using SIM-only IMEM (ROM!)"; \
 	rm -f $(NEORV32_LOCAL_COPY)/rtl/core/neorv32_imem.vhd; \
 	cp -f $(NEORV32_LOCAL_COPY)/sim/rtl_modules/neorv32_imem.vhd $(NEORV32_LOCAL_COPY)/rtl/core/neorv32_imem.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_A/c\CPU_EXTENSION_RISCV_A  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_C/c\CPU_EXTENSION_RISCV_C  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_E/c\CPU_EXTENSION_RISCV_E  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_M/c\CPU_EXTENSION_RISCV_M  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_U/c\CPU_EXTENSION_RISCV_U  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\CPU_EXTENSION_RISCV_Zicsr  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zifencei/c\CPU_EXTENSION_RISCV_Zifencei  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/constant ext_imem_c/c\constant ext_imem_c : boolean := false; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/signal ext_ram_a : ext_mem_a_ram_t/c\signal ext_ram_a : ext_mem_a_ram_t; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_USE/c\MEM_INT_IMEM_USE  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_SIZE/c\MEM_INT_IMEM_SIZE  => 2*1024*1024, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_ROM/c\MEM_INT_IMEM_ROM  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_A/c\CPU_EXTENSION_RISCV_A  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_C/c\CPU_EXTENSION_RISCV_C  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_E/c\CPU_EXTENSION_RISCV_E  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_M/c\CPU_EXTENSION_RISCV_M  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_U/c\CPU_EXTENSION_RISCV_U  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\CPU_EXTENSION_RISCV_Zicsr  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zifencei/c\CPU_EXTENSION_RISCV_Zifencei  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/constant ext_imem_c/c\constant ext_imem_c : boolean := false; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/signal ext_ram_a : ext_mem_a_ram_t/c\signal ext_ram_a : ext_mem_a_ram_t; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_USE/c\MEM_INT_IMEM_USE  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_SIZE/c\MEM_INT_IMEM_SIZE  => 2*1024*1024, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_ROM/c\MEM_INT_IMEM_ROM  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.elf; \
 	cp -f $< $(NEORV32_LOCAL_COPY)/sw/example/blink_led/main.elf; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.bin; \

--- a/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/M/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/M/Makefile.include
@@ -15,18 +15,18 @@ RUN_TARGET=\
 	echo "copying/using SIM-only IMEM (ROM!)"; \
 	rm -f $(NEORV32_LOCAL_COPY)/rtl/core/neorv32_imem.vhd; \
 	cp -f $(NEORV32_LOCAL_COPY)/sim/rtl_modules/neorv32_imem.vhd $(NEORV32_LOCAL_COPY)/rtl/core/neorv32_imem.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_A/c\CPU_EXTENSION_RISCV_A  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_C/c\CPU_EXTENSION_RISCV_C  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_E/c\CPU_EXTENSION_RISCV_E  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_M/c\CPU_EXTENSION_RISCV_M  => true,  -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_U/c\CPU_EXTENSION_RISCV_U  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\CPU_EXTENSION_RISCV_Zicsr  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zifencei/c\CPU_EXTENSION_RISCV_Zifencei  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/constant ext_imem_c/c\constant ext_imem_c : boolean := false; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/signal ext_ram_a : ext_mem_a_ram_t/c\signal ext_ram_a : ext_mem_a_ram_t; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_USE/c\MEM_INT_IMEM_USE  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_SIZE/c\MEM_INT_IMEM_SIZE  => 2*1024*1024, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_ROM/c\MEM_INT_IMEM_ROM  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_A/c\CPU_EXTENSION_RISCV_A  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_C/c\CPU_EXTENSION_RISCV_C  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_E/c\CPU_EXTENSION_RISCV_E  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_M/c\CPU_EXTENSION_RISCV_M  => true,  -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_U/c\CPU_EXTENSION_RISCV_U  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\CPU_EXTENSION_RISCV_Zicsr  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zifencei/c\CPU_EXTENSION_RISCV_Zifencei  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/constant ext_imem_c/c\constant ext_imem_c : boolean := false; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/signal ext_ram_a : ext_mem_a_ram_t/c\signal ext_ram_a : ext_mem_a_ram_t; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_USE/c\MEM_INT_IMEM_USE  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_SIZE/c\MEM_INT_IMEM_SIZE  => 2*1024*1024, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_ROM/c\MEM_INT_IMEM_ROM  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.elf; \
 	cp -f $< $(NEORV32_LOCAL_COPY)/sw/example/blink_led/main.elf; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.bin; \

--- a/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/Zifencei/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/Zifencei/Makefile.include
@@ -15,18 +15,18 @@ RUN_TARGET=\
 	echo "restoring/using original IMEM rtl file"; \
 	rm -f $(NEORV32_LOCAL_COPY)/rtl/core/neorv32_imem.vhd; \
 	cp -f $(NEORV32_LOCAL_COPY)/rtl/core/neorv32_imem.ORIGINAL $(NEORV32_LOCAL_COPY)/rtl/core/neorv32_imem.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_A/c\CPU_EXTENSION_RISCV_A  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_C/c\CPU_EXTENSION_RISCV_C  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_E/c\CPU_EXTENSION_RISCV_E  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_M/c\CPU_EXTENSION_RISCV_M  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_U/c\CPU_EXTENSION_RISCV_U  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\CPU_EXTENSION_RISCV_Zicsr  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zifencei/c\CPU_EXTENSION_RISCV_Zifencei  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/constant ext_imem_c/c\constant ext_imem_c : boolean := false; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/signal ext_ram_a : ext_mem_a_ram_t/c\signal ext_ram_a : ext_mem_a_ram_t; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_USE/c\MEM_INT_IMEM_USE  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_SIZE/c\MEM_INT_IMEM_SIZE  => 32*1024, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_ROM/c\MEM_INT_IMEM_ROM  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_A/c\CPU_EXTENSION_RISCV_A  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_C/c\CPU_EXTENSION_RISCV_C  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_E/c\CPU_EXTENSION_RISCV_E  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_M/c\CPU_EXTENSION_RISCV_M  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_U/c\CPU_EXTENSION_RISCV_U  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\CPU_EXTENSION_RISCV_Zicsr  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zifencei/c\CPU_EXTENSION_RISCV_Zifencei  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/constant ext_imem_c/c\constant ext_imem_c : boolean := false; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/signal ext_ram_a : ext_mem_a_ram_t/c\signal ext_ram_a : ext_mem_a_ram_t; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_USE/c\MEM_INT_IMEM_USE  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_SIZE/c\MEM_INT_IMEM_SIZE  => 32*1024, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_ROM/c\MEM_INT_IMEM_ROM  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.elf; \
 	cp -f $< $(NEORV32_LOCAL_COPY)/sw/example/blink_led/main.elf; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.bin; \

--- a/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/privilege/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/privilege/Makefile.include
@@ -15,18 +15,18 @@ RUN_TARGET=\
 	echo "copying/using SIM-only IMEM (ROM!)"; \
 	rm -f $(NEORV32_LOCAL_COPY)/rtl/core/neorv32_imem.vhd; \
 	cp -f $(NEORV32_LOCAL_COPY)/sim/rtl_modules/neorv32_imem.vhd $(NEORV32_LOCAL_COPY)/rtl/core/neorv32_imem.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_A/c\CPU_EXTENSION_RISCV_A  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_C/c\CPU_EXTENSION_RISCV_C  => true,  -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_E/c\CPU_EXTENSION_RISCV_E  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_M/c\CPU_EXTENSION_RISCV_M  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_U/c\CPU_EXTENSION_RISCV_U  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\CPU_EXTENSION_RISCV_Zicsr  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/CPU_EXTENSION_RISCV_Zifencei/c\CPU_EXTENSION_RISCV_Zifencei  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/constant ext_imem_c/c\constant ext_imem_c : boolean := false; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/signal ext_ram_a : ext_mem_a_ram_t/c\signal ext_ram_a : ext_mem_a_ram_t; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_USE/c\MEM_INT_IMEM_USE  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_SIZE/c\MEM_INT_IMEM_SIZE  => 2*1024*1024, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
-	sed -i '/MEM_INT_IMEM_ROM/c\MEM_INT_IMEM_ROM  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_A/c\CPU_EXTENSION_RISCV_A  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_C/c\CPU_EXTENSION_RISCV_C  => true,  -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_E/c\CPU_EXTENSION_RISCV_E  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_M/c\CPU_EXTENSION_RISCV_M  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_U/c\CPU_EXTENSION_RISCV_U  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zicsr/c\CPU_EXTENSION_RISCV_Zicsr  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/CPU_EXTENSION_RISCV_Zifencei/c\CPU_EXTENSION_RISCV_Zifencei  => false, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/constant ext_imem_c/c\constant ext_imem_c : boolean := false; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/signal ext_ram_a : ext_mem_a_ram_t/c\signal ext_ram_a : ext_mem_a_ram_t; -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_USE/c\MEM_INT_IMEM_USE  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_SIZE/c\MEM_INT_IMEM_SIZE  => 2*1024*1024, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
+	sed -i '/MEM_INT_IMEM_ROM/c\MEM_INT_IMEM_ROM  => true, -- MOD. BY RISCV-ARCH-TEST TEST SCRIPT' $(NEORV32_LOCAL_COPY)/sim/neorv32_tb.simple.vhd; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.elf; \
 	cp -f $< $(NEORV32_LOCAL_COPY)/sw/example/blink_led/main.elf; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.bin; \

--- a/setups/vivado/arty-a7-test-setup/create_project.tcl
+++ b/setups/vivado/arty-a7-test-setup/create_project.tcl
@@ -30,7 +30,7 @@ set_property library neorv32 [get_files [glob ./../../../rtl/core/*.vhd]]
 add_files [glob ./../../../rtl/templates/processor/neorv32_ProcessorTop_Test.vhd]
 
 # add source files: simulation-only
-add_files -fileset sim_1 ./../../../sim/neorv32_tb.vhd
+add_files -fileset sim_1 [list ./../../../sim/neorv32_tb.simple.vhd ./../../../sim/uart_rx.simple.vhd]
 
 # add source files: constraints
 add_files -fileset constrs_1 [glob ./*.xdc]

--- a/setups/vivado/nexys-a7-test-setup/create_project.tcl
+++ b/setups/vivado/nexys-a7-test-setup/create_project.tcl
@@ -34,7 +34,7 @@ set_property library neorv32 [get_files [glob ./../../../rtl/core/*.vhd]]
 add_files [glob ./../../../rtl/templates/processor/neorv32_ProcessorTop_Test.vhd]
 
 # add source files: simulation-only
-add_files -fileset sim_1 ./../../../sim/neorv32_tb.vhd
+add_files -fileset sim_1 [list ./../../../sim/neorv32_tb.simple.vhd ./../../../sim/uart_rx.simple.vhd]
 
 # add source files: constraints
 add_files -fileset constrs_1 [glob ./*.xdc]

--- a/sim/ghdl/ghdl_sim.sh
+++ b/sim/ghdl/ghdl_sim.sh
@@ -40,7 +40,7 @@ ghdl -i --work=neorv32 rtl/core/*.vhd
 ghdl -i --work=neorv32 rtl/templates/processor/*.vhd
 ghdl -i --work=neorv32 rtl/templates/system/*.vhd
 ghdl -i --work=neorv32 sim/neorv32_tb.simple.vhd
-ghdl -i --work=neorv32 sim/uart_rx.vhd
+ghdl -i --work=neorv32 sim/uart_rx.simple.vhd
 
 # Prepare simulation output files for UART0 and UART 1
 # - Testbench receiver log file (neorv32.testbench_uart?.out)

--- a/sim/neorv32_tb.simple.vhd
+++ b/sim/neorv32_tb.simple.vhd
@@ -300,10 +300,9 @@ begin
   twi_scl <= 'H';
   twi_sda <= 'H';
 
-  uart0_checker: entity work.uart_rx
+  uart0_checker: entity work.uart_rx_simple
     generic map (
       name => "uart0",
-      expected => nul & nul & cr & lf & "<< PROCESSOR CHECK >>" & cr & lf & "build: ",
       uart_baud_val_c => uart0_baud_val_c)
     port map (
       clk => clk_gen,

--- a/sim/uart_rx.simple.vhd
+++ b/sim/uart_rx.simple.vhd
@@ -1,0 +1,77 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.math_real.all;
+
+use std.textio.all;
+
+entity uart_rx_simple is
+  generic (
+    name : string;
+    uart_baud_val_c : real);
+
+  port (
+    clk : in std_ulogic;
+    uart_txd : in std_ulogic
+    );
+end entity;
+
+architecture a of uart_rx_simple is
+  signal uart_rx_sync : std_ulogic_vector(04 downto 0) := (others => '1');
+  signal uart_rx_busy : std_ulogic := '0';
+  signal uart_rx_sreg : std_ulogic_vector(08 downto 0) := (others => '0');
+  signal uart_rx_baud_cnt : real;
+  signal uart_rx_bitcnt : natural;
+
+  file file_uart_tx_out : text open write_mode is "neorv32.testbench_" & name & ".out";
+
+begin
+  uart_rx_console : process(clk)
+    variable i : integer;
+    variable l : line;
+  begin
+    -- "UART" --
+    if rising_edge(clk) then
+      -- synchronizer --
+      uart_rx_sync <= uart_rx_sync(3 downto 0) & uart_txd;
+      -- arbiter --
+      if (uart_rx_busy = '0') then  -- idle
+        uart_rx_busy <= '0';
+        uart_rx_baud_cnt <= round(0.5 * uart_baud_val_c);
+        uart_rx_bitcnt <= 9;
+        if (uart_rx_sync(4 downto 1) = "1100") then  -- start bit? (falling edge)
+          uart_rx_busy <= '1';
+        end if;
+      else
+        if (uart_rx_baud_cnt <= 0.0) then
+          if (uart_rx_bitcnt = 1) then
+            uart_rx_baud_cnt <= round(0.5 * uart_baud_val_c);
+          else
+            uart_rx_baud_cnt <= round(uart_baud_val_c);
+          end if;
+          if (uart_rx_bitcnt = 0) then
+            uart_rx_busy <= '0';  -- done
+            i := to_integer(unsigned(uart_rx_sreg(8 downto 1)));
+
+            if (i < 32) or (i > 32+95) then  -- printable char?
+              report name & ".tx: (" & integer'image(i) & ")";  -- print code
+            else
+              report name & ".tx: " & character'val(i);  -- print ASCII
+            end if;
+
+            if (i = 10) then  -- Linux line break
+              writeline(file_uart_tx_out, l);
+            elsif (i /= 13) then  -- Remove additional carriage return
+              write(l, character'val(i));
+            end if;
+          else
+            uart_rx_sreg <= uart_rx_sync(4) & uart_rx_sreg(8 downto 1);
+            uart_rx_bitcnt <= uart_rx_bitcnt - 1;
+          end if;
+        else
+          uart_rx_baud_cnt <= uart_rx_baud_cnt - 1.0;
+        end if;
+      end if;
+    end if;
+  end process uart_rx_console;
+end architecture;

--- a/sim/uart_rx.vhd
+++ b/sim/uart_rx.vhd
@@ -5,6 +5,9 @@ use ieee.math_real.all;
 
 use std.textio.all;
 
+library vunit_lib;
+context vunit_lib.vunit_context;
+
 entity uart_rx is
   generic (
     name : string;
@@ -55,20 +58,14 @@ begin
             uart_rx_busy <= '0';  -- done
             i := to_integer(unsigned(uart_rx_sreg(8 downto 1)));
 
-            if (expected_idx < expected'length) or
-              ((expected_idx = expected'length) and (expected(expected'length) /= etx)) then
-              assert character'val(i) = expected(expected_idx)
-                report "Got " & character'val(i) & ", expected " & expected(expected_idx);
-            else
-              assert expected(expected'length) /= etx report "Extra characters received";
-            end if;
-
+            check(expected_idx <= expected'length, "Extra characters received");
+            check_equal(character'val(i), expected(expected_idx), result("for " & name & ".tx"));
             expected_idx := expected_idx + 1;
 
             if (i < 32) or (i > 32+95) then  -- printable char?
-              report name & ".tx: (" & integer'image(i) & ")";  -- print code
+              info(name & ".tx: (" & integer'image(i) & ")");  -- print code
             else
-              report name & ".tx: " & character'val(i);  -- print ASCII
+              info(name & ".tx: " & character'val(i));  -- print ASCII
             end if;
 
             if (i = 10) then  -- Linux line break


### PR DESCRIPTION
In this PR, the Processor workflow is split in two jobs. The main reason is running the VUnit tests and the shell script tests in parallel. Moreover, the installation of the RISC-V toolchain in the VUnit job might be enhanced in the future by using a container.

Other than that, as done with the main testbench, `uart_rx` is copied to `uart_rx.simple.vhd`, and it is reverted to the version before self-checking was in place. Other sources/references are updated accordingly. In upcoming PRs, `uart_rx` will be modified for using VUnit features, while `uart_rx_simple` will be used for the simple testbench.

Last, one of the enhancements from #48 was cherry-picked here. That uses VUnit's features in uart_rx.

/cc @LarsAsplund 