### PR TITLE
[setups/examples] add iCESugar Minimal

### DIFF
--- a/.github/generate-job-matrix.py
+++ b/.github/generate-job-matrix.py
@@ -23,6 +23,10 @@ print('::set-output name=matrix::' + str([
   'bitstream': 'neorv32_Fomu_pvt_UP5KDemo.bit'
 }, {
   'board': 'iCESugar',
+  'design': 'Minimal',
+  'bitstream': 'neorv32_iCESugar_Minimal.bit'
+}, {
+  'board': 'iCESugar',
   'design': 'MinimalBoot',
   'bitstream': 'neorv32_iCESugar_MinimalBoot.bit'
 }]))

--- a/setups/examples/Makefile
+++ b/setups/examples/Makefile
@@ -44,7 +44,7 @@ UPduino_v3:
 Minimal:
 	$(MAKE) \
 	  DESIGN=$@ \
-	  DESIGN_SRC=$(TEMPLATES)/processor/neorv32_ProcessorTop_Minimal.vhd \
+	  DESIGN_SRC=$(TEMPLATES)/processor/neorv32_ProcessorTop_Minimal*.vhd \
 	  $(BOARD)
 
 MinimalBoot:

--- a/setups/examples/neorv32_iCESugar_BoardTop_Minimal.vhd
+++ b/setups/examples/neorv32_iCESugar_BoardTop_Minimal.vhd
@@ -1,0 +1,172 @@
+-- #################################################################################################
+-- # << NEORV32 - Example setup with an external clock, for the iCESugar (c) Board >>              #
+-- # ********************************************************************************************* #
+-- # BSD 3-Clause License                                                                          #
+-- #                                                                                               #
+-- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- #                                                                                               #
+-- # Redistribution and use in source and binary forms, with or without modification, are          #
+-- # permitted provided that the following conditions are met:                                     #
+-- #                                                                                               #
+-- # 1. Redistributions of source code must retain the above copyright notice, this list of        #
+-- #    conditions and the following disclaimer.                                                   #
+-- #                                                                                               #
+-- # 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
+-- #    conditions and the following disclaimer in the documentation and/or other materials        #
+-- #    provided with the distribution.                                                            #
+-- #                                                                                               #
+-- # 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
+-- #    endorse or promote products derived from this software without specific prior written      #
+-- #    permission.                                                                                #
+-- #                                                                                               #
+-- # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
+-- # OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
+-- # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
+-- # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
+-- # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
+-- # GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
+-- # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
+-- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
+-- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
+-- # ********************************************************************************************* #
+-- # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+-- #################################################################################################
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library iCE40;
+use iCE40.components.all; -- for device primitives and macros
+
+entity neorv32_iCESugar_BoardTop_Minimal is
+  port (
+    -- 48MHz Clock input
+    iCESugarv15_CLK : in std_logic;
+    -- UART0
+    iCESugarv15_RX : in  std_logic;
+    iCESugarv15_TX : out std_logic;
+    -- LED outputs
+    iCESugarv15_LED_R : out std_logic;
+    iCESugarv15_LED_G : out std_logic;
+    iCESugarv15_LED_B : out std_logic;
+    -- USB Pins (which should be statically driven if not being used)
+    iCESugarv15_USB_DP    : out std_logic;
+    iCESugarv15_USB_DN    : out std_logic;
+    iCESugarv15_USB_DP_PU : out std_logic
+  );
+end entity;
+
+architecture neorv32_iCESugar_BoardTop_Minimal_rtl of neorv32_iCESugar_BoardTop_Minimal is
+
+  -- configuration --
+  constant f_clock_c : natural := 22000000; -- PLL output clock frequency in Hz
+
+  -- Globals
+  signal pll_rstn : std_logic;
+  signal pll_clk  : std_logic;
+
+  -- internal IO connection --
+  signal con_gpio_o : std_ulogic_vector(3 downto 0);
+  signal con_pwm  : std_logic_vector(2 downto 0);
+
+begin
+
+  -- Assign USB pins to "0" so as to disconnect iCESugar from
+  -- the host system.  Otherwise it would try to talk to
+  -- us over USB, which wouldn't work since we have no stack.
+  iCESugarv15_USB_DP    <= '0';
+  iCESugarv15_USB_DN    <= '0';
+  iCESugarv15_USB_DP_PU <= '0';
+
+  -- System PLL -----------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  -- Settings generated by icepll -i 12 -o 22:
+  -- F_PLLIN:      12.000 MHz (given)
+  -- F_PLLOUT:     22.000 MHz (requested)
+  -- F_PLLOUT:     22.000 MHz (achieved)
+  -- FEEDBACK:     SIMPLE
+  -- F_PFD:        12.000 MHz
+  -- F_VCO:        708.000 MHz
+  -- DIVR:         0 (4'b0000)
+  -- DIVF:        58 (7'b0111010)
+  -- DIVQ:         5 (3'b101)
+  -- FILTER_RANGE: 1 (3'b001)
+  Pll_inst : SB_PLL40_PAD
+  generic map (
+    FEEDBACK_PATH => "SIMPLE",
+    DIVR          =>  x"0",
+    DIVF          => 7x"3A",
+    DIVQ          => 3x"5",
+    FILTER_RANGE  => 3x"1"
+  )
+  port map (
+    PACKAGEPIN      => iCESugarv15_CLK,
+    PLLOUTCORE      => open,
+    PLLOUTGLOBAL    => pll_clk,
+    EXTFEEDBACK     => '0',
+    DYNAMICDELAY    => x"00",
+    LOCK            => pll_rstn,
+    BYPASS          => '0',
+    RESETB          => '1',
+    LATCHINPUTVALUE => '0',
+    SDO             => open,
+    SDI             => '0',
+    SCLK            => '0'
+  );
+
+  -- The core of the problem ----------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+
+  neorv32_inst: entity work.neorv32_ProcessorTop_MinimalBoot
+  generic map (
+    CLOCK_FREQUENCY              => f_clock_c,  -- clock frequency of clk_i in Hz
+    CPU_EXTENSION_RISCV_A        => false,
+    CPU_EXTENSION_RISCV_C        => false,
+    CPU_EXTENSION_RISCV_E        => false,
+    CPU_EXTENSION_RISCV_M        => false,
+    CPU_EXTENSION_RISCV_U        => false,
+    CPU_EXTENSION_RISCV_Zfinx    => false,
+    CPU_EXTENSION_RISCV_Zicsr    => true,
+    CPU_EXTENSION_RISCV_Zifencei => false
+  )
+  port map (
+    -- Global control --
+    clk_i      => std_ulogic(pll_clk),
+    rstn_i     => std_ulogic(pll_rstn),
+
+    -- GPIO --
+    gpio_o     => con_gpio_o,
+
+    -- primary UART --
+    uart_txd_o => iCESugarv15_TX, -- UART0 send data
+    uart_rxd_i => iCESugarv15_RX, -- UART0 receive data
+    uart_rts_o => open, -- hw flow control: UART0.RX ready to receive ("RTR"), low-active, optional
+    uart_cts_i => '0',  -- hw flow control: UART0.TX allowed to transmit, low-active, optional
+
+    -- PWM (to on-board RGB LED) --
+    pwm_o      => con_pwm
+  );
+
+  -- IO Connection --------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+
+  RGB_inst: SB_RGBA_DRV
+  generic map (
+    CURRENT_MODE => "0b1",
+    RGB0_CURRENT => "0b000011",
+    RGB1_CURRENT => "0b000011",
+    RGB2_CURRENT => "0b000011"
+  )
+  port map (
+    CURREN   => '1',  -- I
+    RGBLEDEN => '1',  -- I
+    RGB2PWM  => con_pwm(2),                   -- I - blue  - pwm channel 2
+    RGB1PWM  => con_pwm(1) or con_gpio_o(0),  -- I - red   - pwm channel 1 || BOOT blink
+    RGB0PWM  => con_pwm(0),                   -- I - green - pwm channel 0
+    RGB2     => iCESugarv15_LED_B,  -- O - blue
+    RGB1     => iCESugarv15_LED_R,  -- O - red
+    RGB0     => iCESugarv15_LED_G   -- O - green
+  );
+
+end architecture;

--- a/setups/osflow/devices/ice40/sb_ice40_components.vhd
+++ b/setups/osflow/devices/ice40/sb_ice40_components.vhd
@@ -36,8 +36,8 @@ package components is
     DIVF                           : std_logic_vector(6 downto 0) := "0000000";
     DIVQ                           : std_logic_vector(2 downto 0) := "000";
     FILTER_RANGE                   : std_logic_vector(2 downto 0) := "000";
-    ENABLE_ICEGATE                 : std_logic := '0';
-    TEST_MODE                      : std_logic := '0';
+    ENABLE_ICEGATE                 : bit := '0';
+    TEST_MODE                      : bit := '0';
     EXTERNAL_DIVIDE_FACTOR         : integer := 1
   );
   port (
@@ -56,7 +56,40 @@ package components is
   );
   end component;
 
-  component  SB_RGBA_DRV
+  component SB_PLL40_PAD
+  generic (
+    FEEDBACK_PATH                   : string := "SIMPLE";
+    DELAY_ADJUSTMENT_MODE_FEEDBACK  : string := "FIXED";
+    DELAY_ADJUSTMENT_MODE_RELATIVE  : string := "FIXED";
+    SHIFTREG_DIV_MODE               : bit_vector(1 downto 0) := "00";
+    FDA_FEEDBACK                    : bit_vector(3 downto 0) := "0000";
+    FDA_RELATIVE                    : bit_vector(3 downto 0) := "0000";
+    PLLOUT_SELECT                   : string := "GENCLK";
+    DIVR                            : bit_vector(3 downto 0) := x"0";
+    DIVF                            : bit_vector(6 downto 0) := "0000000";
+    DIVQ                            : bit_vector(2 downto 0) := "000";
+    FILTER_RANGE                    : bit_vector(2 downto 0) := "000";
+    ENABLE_ICEGATE                  : bit := '0';
+    TEST_MODE                       : bit := '0';
+    EXTERNAL_DIVIDE_FACTOR          : integer := 1
+  );
+  port (
+    PACKAGEPIN      : in  std_logic;
+    PLLOUTCORE      : out std_logic;
+    PLLOUTGLOBAL    : out std_logic;
+    EXTFEEDBACK     : in  std_logic;
+    DYNAMICDELAY    : in  std_logic_vector(7 downto 0);
+    LOCK            : out std_logic;
+    BYPASS          : in  std_logic;
+    RESETB          : in  std_logic;
+    LATCHINPUTVALUE : in  std_logic;
+    SDO             : out std_logic;
+    SDI             : in  std_logic;
+    SCLK            : in  std_logic
+  );
+  end component;
+
+  component SB_RGBA_DRV
   generic (
     CURRENT_MODE : string := "0b0";
     RGB0_CURRENT : string := "0b000000";


### PR DESCRIPTION
Name Minimal may not be the most descriptive. The purpose of this PR is to modify the MinimalBoot example of the iCESugar for using the "external" clock from pin 35, instead of the internal oscillator.

On the Fomu, we could use SB_PLL40_CORE for instantiating the PLL, regardless of the clk input being internal or external. That is because of the bank where the clk input is located (`IOB_11b_G5	DPIO/GBIN	1	COMP_of_IOB_10a	F4`). On the iCESugar, that is `IOT_46b_G0	DPIO/GBIN	0		B3	35`. As explained in https://github.com/wuxx/icesugar/blob/master/doc/LatticeSemi/SBTICETechnologyLibrary201708.pdf, SB_PLL40_PAD needs to be used.

Therefore, SB_PLL40_PAD was added to `setups/osflow/devices/ice40/sb_ice40_components.vhd`. Compared to iCESugar MinimalBoot, this one (iCESugar Minimal) instantiates SB_PLL40_PAD instead of SB_PLL40_CORE, and removes the internal oscillator instantiation. All extensions are disabled except Zicsr. However, the UART is preserved. That is, the ProcessorTop_MinimalBoot template is used.

Moreover, pin 35 of the UP5K is connected to a pin of the ARM on the board, through jumper J1. See https://raw.githubusercontent.com/wuxx/icesugar/master/schematic/iCESugar-v1.5.pdf. We are not sure whether the purpose is for the ARM to send a clock to the FPGA, or for the FPGA to send a clock to the ARM. The source of the firmware on the ARM seems not to be available: https://github.com/wuxx/icesugar/tree/master/firmware. Hence, @juanmard asked about the purpose of this connection in wuxx/icesugar#29. However, there is a comment in the readme: https://github.com/wuxx/icesugar/blob/master/README_en.md#icelink

> *4. the MCO can provide 12Mhz clock for FPGA as extern clock.*

Therefore, we adjusted the PLL for `icepll -i 12 -o 22`, and it works!

![](https://files.gitter.im/5f81b0dbd73408ce4ff12e8b/CJqI/imagen.png)

/cc @juanmard
