### PR TITLE
add mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+Andreas Wenzel <Andreas.Wenzel@hs-wismar.de>
+Lars Asplund <lars.anders.asplund@gmail.com>
+Pascal Cotret <pascal.cotret@gmail.com>
+Stephan Nolting <stnolting@gmail.com> <stnolting@gmail.com>
+Torsten Meissner <programming@goodcleanfun.de>
+Unai Martinez-Corral <unai.martinezcorral@ehu.eus> <unai.martinezcorral@ehu.eus>
+Unai Martinez-Corral <unai.martinezcorral@ehu.eus> <38422348+umarcor@users.noreply.github.com>


### PR DESCRIPTION
This PR adds a `.mailmap` file for cleaning the output of git's author list, which is used in tools such as [gource](https://gource.io/) or [gitinspector](https://github.com/ejwa/gitinspector). 

Without this PR:

```sh
# git shortlog --summary --numbered --email
  1735  stnolting <stnolting@gmail.com>
   180  Stephan <stnolting@gmail.com>
    86  umarcor <unai.martinezcorral@ehu.eus>
     7  Lars Asplund <lars.anders.asplund@gmail.com>
     4  tmeissner <programming@goodcleanfun.de>
     3  AWenzel83 <Andreas.Wenzel@hs-wismar.de>
     2  Andreas Wenzel <Andreas.Wenzel@hs-wismar.de>
     1  Pascal Cotret <pascal.cotret@gmail.com>
     1  Unai Martinez-Corral <38422348+umarcor@users.noreply.github.com>
```

With this PR:

```
# git shortlog --summary --numbered --email
  1915  Stephan Nolting <stnolting@gmail.com>
    88  Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
     7  Lars Asplund <lars.anders.asplund@gmail.com>
     5  Andreas Wenzel <Andreas.Wenzel@hs-wismar.de>
     4  Torsten Meissner <programming@goodcleanfun.de>
     1  Pascal Cotret <pascal.cotret@gmail.com>
```