### PR TITLE
[sim] use custom VUnit loggers for better verbosity control 

### DIFF
--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -148,14 +148,17 @@ architecture neorv32_tb_rtl of neorv32_tb is
   end record;
   signal ext_mem_a, ext_mem_b, ext_mem_c : ext_mem_t;
 
+  constant uart0_rx_logger : logger_t := get_logger("UART0.RX");
+
 begin
   test_runner : process
   begin
     test_runner_setup(runner, runner_cfg);
+    -- Show passing checks for UART0 on the display (stdout)
+    show(uart0_rx_logger, display_handler, pass);
     wait for 35 ms; -- Just wait for all UART output to be produced
     test_runner_cleanup(runner);
   end process;
-
 
   -- Clock/Reset Generator ------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -318,7 +321,7 @@ begin
   begin
     uart0_checker: entity work.uart_rx
       generic map (
-        name => "uart0",
+        logger => uart0_rx_logger,
         expected => uart0_expectation,
         uart_baud_val_c => uart0_baud_val_c)
       port map (
@@ -328,7 +331,7 @@ begin
 
     uart1_checker: entity work.uart_rx
       generic map (
-        name => "uart1",
+        logger => get_logger("uart1.rx"),
         expected => uart1_expectation,
         uart_baud_val_c => uart1_baud_val_c)
       port map (

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -149,6 +149,7 @@ architecture neorv32_tb_rtl of neorv32_tb is
   signal ext_mem_a, ext_mem_b, ext_mem_c : ext_mem_t;
 
   constant uart0_rx_logger : logger_t := get_logger("UART0.RX");
+  constant uart1_rx_logger : logger_t := get_logger("UART1.RX");
 
 begin
   test_runner : process
@@ -156,6 +157,7 @@ begin
     test_runner_setup(runner, runner_cfg);
     -- Show passing checks for UART0 on the display (stdout)
     show(uart0_rx_logger, display_handler, pass);
+    show(uart1_rx_logger, display_handler, pass);
     wait for 35 ms; -- Just wait for all UART output to be produced
     test_runner_cleanup(runner);
   end process;
@@ -331,7 +333,7 @@ begin
 
     uart1_checker: entity work.uart_rx
       generic map (
-        logger => get_logger("uart1.rx"),
+        logger => uart1_rx_logger,
         expected => uart1_expectation,
         uart_baud_val_c => uart1_baud_val_c)
       port map (


### PR DESCRIPTION
Close #48

This PR superseeds #48, but it needs to be merged after #80.

That is, @LarsAsplund's PR2 branch can be analysed/understood in three parts:

1. PR1 was already split and merged in previours PRs.
2. The software modifications for controlling UART verbosity are being handled in #80.
3. This PR adds VUnit loggers to the hardware testbench plumbing.