### PR TITLE
Make uart_rx a VUnit verification component. Step 4.

### DIFF
--- a/sim/uart_rx.vhd
+++ b/sim/uart_rx.vhd
@@ -13,11 +13,7 @@ context vunit_lib.vc_context;
 use work.uart_rx_pkg.all;
 
 entity uart_rx is
-  generic (
-    actor : actor_t;
-    logger : logger_t;
-    uart_baud_val_c : real);
-
+  generic (handle : uart_rx_t);
   port (
     clk : in std_ulogic;
     uart_txd : in std_ulogic
@@ -31,8 +27,8 @@ architecture a of uart_rx is
   signal uart_rx_baud_cnt : real;
   signal uart_rx_bitcnt : natural;
 
-  file file_uart_tx_out : text open write_mode is "neorv32.testbench_" & get_name(logger) & ".out";
-  constant checker : checker_t := new_checker(logger);
+  file file_uart_tx_out : text open write_mode is "neorv32.testbench_" & get_name(handle.p_logger) & ".out";
+  constant checker : checker_t := new_checker(handle.p_logger);
   constant character_queue : queue_t := new_queue;
 
 begin
@@ -47,7 +43,7 @@ begin
       end loop;
     end procedure put_characters_in_queue;
   begin
-    receive(net, actor, request_msg);
+    receive(net, handle.p_actor, request_msg);
     msg_type := message_type(request_msg);
 
     -- Standard handling of standard wait_for_time messages = wait for the given time
@@ -82,7 +78,7 @@ begin
       -- arbiter --
       if (uart_rx_busy = '0') then  -- idle
         uart_rx_busy <= '0';
-        uart_rx_baud_cnt <= round(0.5 * uart_baud_val_c);
+        uart_rx_baud_cnt <= round(0.5 * handle.p_baud_val);
         uart_rx_bitcnt <= 9;
         if (uart_rx_sync(4 downto 1) = "1100") then  -- start bit? (falling edge)
           uart_rx_busy <= '1';
@@ -90,9 +86,9 @@ begin
       else
         if (uart_rx_baud_cnt <= 0.0) then
           if (uart_rx_bitcnt = 1) then
-            uart_rx_baud_cnt <= round(0.5 * uart_baud_val_c);
+            uart_rx_baud_cnt <= round(0.5 * handle.p_baud_val);
           else
-            uart_rx_baud_cnt <= round(uart_baud_val_c);
+            uart_rx_baud_cnt <= round(handle.p_baud_val);
           end if;
           if (uart_rx_bitcnt = 0) then
             uart_rx_busy <= '0';  -- done

--- a/sim/uart_rx_pkg.vhd
+++ b/sim/uart_rx_pkg.vhd
@@ -1,25 +1,59 @@
 library vunit_lib;
+context vunit_lib.vunit_context;
 context vunit_lib.com_context;
 
 package uart_rx_pkg is
   constant check_uart_msg : msg_type_t := new_msg_type("check_uart");
 
+  type uart_rx_t is record
+    p_baud_val : real;
+    p_logger : logger_t;
+    p_actor : actor_t;
+  end record;
+
+  impure function new_uart_rx(
+    baud_val : real;
+    logger : logger_t := null_logger;
+    actor : actor_t := null_actor) return uart_rx_t;
+
+  function get_actor(handle : uart_rx_t) return actor_t;
+
   procedure check_uart(
     signal net : inout network_t;
-    constant actor : in actor_t;
+    constant handle : in uart_rx_t;
     constant data : in string);
 end package uart_rx_pkg;
 
 package body uart_rx_pkg is
+  constant uart_rx_logger  : logger_t  := get_logger("neorv32_lib:uart_rx_pkg");
+
+  impure function new_uart_rx(
+    baud_val : real;
+    logger : logger_t := null_logger;
+    actor : actor_t := null_actor) return uart_rx_t is
+    variable result : uart_rx_t;
+  begin
+    result.p_baud_val := baud_val;
+    result.p_logger := logger when logger /= null_logger else uart_rx_logger;
+    result.p_actor := actor when actor /= null_actor else new_actor;
+
+    return result;
+  end;
+
+  function get_actor(handle : uart_rx_t) return actor_t is
+  begin
+    return handle.p_actor;
+  end;
+
   procedure check_uart(
     signal net : inout network_t;
-    constant actor : in actor_t;
+    constant handle : in uart_rx_t;
     constant data : in string) is
     variable msg : msg_t;
   begin
     msg := new_msg(check_uart_msg);
     push(msg, data);
-    send(net, actor, msg);
+    send(net, handle.p_actor, msg);
   end;
 
 end package body uart_rx_pkg;


### PR DESCRIPTION
Collect all generics into a single handle generic. A single generic is easier to pass
around and makes it easier to update the VC without changing the user code.
Also using a `check_uart` procedure to raise the abstraction of the API.