### PR TITLE
sim: update readme

### DIFF
--- a/sim/README.md
+++ b/sim/README.md
@@ -8,10 +8,10 @@ This folder contains a script for simulating the processor using GHDL.
 
 This folder provides additional/alternative simulation components (mainly optimized memory components yet). See the comments in the according files for more information.
 
-### [`vivado`](https://github.com/stnolting/neorv32/tree/master/sim/vivado)
-
-This folder provides an example waveform configuration (for Xilinx ISIM simulator) for the default testbench.
-
 ### [`neorv32_tb.vhd`](https://github.com/stnolting/neorv32/tree/master/sim/neorv32_tb.vhd)
 
-Default testbench for the NEORV32 Processor.
+VUnit testbench for the NEORV32 Processor.
+
+### [`neorv32_tb.simple.vhd`](https://github.com/stnolting/neorv32/tree/master/sim/neorv32_tb.simple.vhd)
+
+Simple testbench for the NEORV32 Processor.


### PR DESCRIPTION
Subdir `sim/vivado` was removed in https://github.com/stnolting/neorv32/commit/6eff0dfea90e72d9ea5d60a61ba66060b182ae2d#diff-507a9a8be3d145a86daa9644b28bf42a8dc0720d8baeabdf0406c393692bf082, but the `sim/README.md` was not updated accordingly.