### PR TITLE
[docs] move Makefile from project root to subdir 'docs'

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -47,7 +47,7 @@ jobs:
         fetch-depth: 0
 
     - name: '📚 Build Datasheet and User Guide (PDF and HTML)'
-      run: make container
+      run: make -C docs container
 
     - name: '📤 Upload Artifact: HTML'
       uses: actions/upload-artifact@v2

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,12 +1,11 @@
 .DEFAULT_GOAL := help
 
 all: pdf html ug-pdf ug-html
-	mkdir -p docs/public/img/
-	cp -vr docs/figures/* docs/public/img/
+	mkdir -p public/img/
+	cp -vr figures/* public/img/
 
 # Generate PDF datasheet
 pdf:
-	cd docs; \
 	[ -f revnumber.txt ] && REVNUMBER='-a revnumber='"$$(cat revnumber.txt)" || unset REVNUMBER; \
 	asciidoctor-pdf $$REVNUMBER \
 	  -a pdf-theme=neorv32-theme.yml \
@@ -16,7 +15,6 @@ pdf:
 
 # Generate HTML datasheet
 html:
-	cd docs; \
 	[ -f revnumber.txt ] && REVNUMBER='-a revnumber='"$$(cat revnumber.txt)" || unset REVNUMBER; \
 	asciidoctor $$REVNUMBER \
 	  -r asciidoctor-diagram \
@@ -25,7 +23,6 @@ html:
 
 # Generate PDF user guide
 ug-pdf:
-	cd docs; \
 	[ -f revnumber.txt ] && REVNUMBER='-a revnumber='"$$(cat revnumber.txt)" || unset REVNUMBER; \
 	asciidoctor-pdf $$REVNUMBER \
 	  -a pdf-theme=neorv32-theme.yml \
@@ -35,7 +32,6 @@ ug-pdf:
 
 # Generate HTML user guide
 ug-html:
-	cd docs; \
 	[ -f revnumber.txt ] && REVNUMBER='-a revnumber='"$$(cat revnumber.txt)" || unset REVNUMBER; \
 	asciidoctor $$REVNUMBER \
 	  -r asciidoctor-diagram \
@@ -44,25 +40,24 @@ ug-html:
 
 # Generate DOXYGEN software documentation
 doxygen:
-	cd docs; \
 	doxygen Doxyfile
 
 # Generate revnumber.txt for overriding the revnumber attribute in 'pdf' and/or 'html'
 revnumber:
 	if [ `git tag -l | grep nightly` ]; then git tag -d nightly; fi
-	git describe --long --tags | sed 's#\([^-]*-g\)#r\1#;' > docs/revnumber.txt
-	cat docs/revnumber.txt
+	git describe --long --tags | sed 's#\([^-]*-g\)#r\1#;' > revnumber.txt
+	cat revnumber.txt
 
 # Build 'pdf' and 'html' in an 'asciidoctor-wavedrom' container
 container: revnumber
-	docker run --rm -v /$(PWD)://documents/ btdi/asciidoctor make all
+	docker run --rm -v /$(shell pwd)://documents/ btdi/asciidoctor make all
 
 # Help
 help:
 	@echo "Targets:"
 	@echo " help    - show this text"
-	@echo " pdf     - build datasheet as pdf file (docs/public/pdf/NEORV32.pdf)"
-	@echo " html    - build datasheet as HTML page (docs/public/index.html)"
-	@echo " ug-pdf  - build user guide as pdf file (docs/public/pdf/NEORV32_UserGuide.pdf)"
-	@echo " ug-html - build user guide as HTML page (docs/public/ug/index.html)"
-	@echo " doxygen - build software documentation as HTML page (docs/doxygen_build/html/index.html)"
+	@echo " pdf     - build datasheet as pdf file (public/pdf/NEORV32.pdf)"
+	@echo " html    - build datasheet as HTML page (public/index.html)"
+	@echo " ug-pdf  - build user guide as pdf file (public/pdf/NEORV32_UserGuide.pdf)"
+	@echo " ug-html - build user guide as HTML page (public/ug/index.html)"
+	@echo " doxygen - build software documentation as HTML page (doxygen_build/html/index.html)"

--- a/docs/userguide/content.adoc
+++ b/docs/userguide/content.adoc
@@ -917,7 +917,7 @@ neorv32/sim$ sh ghdl_sim.sh --stop-time=20ms
 The documentation (datasheet + user guide) is written using `asciidoc`. The according source files
 can be found in `docs/...`. The documentation of the software framework is written _in-code_ using `doxygen`.
 
-A makefiles in the project's root directory is provided to build all of the documentation as HTML pages
+A makefiles in the project's `docs` directory is provided to build all of the documentation as HTML pages
 or as PDF documents.
 
 [TIP]
@@ -928,13 +928,13 @@ The makefile provides a help target to show all available build options and thei
 
 [source,bash]
 ----
-neorv32$ make help
+neorv32/docs$ make help
 ----
 
 .Example: Generate HTML documentation (data sheet) using `asciidoctor`
 [source,bash]
 ----
-neorv32$ make html
+neorv32/docs$ make html
 ----
 
 [TIP]


### PR DESCRIPTION
Initially, we put the Makefile for building the docs in the root of the repo, because we expected to add entrypoints for other tasks in the same file. However, given how the rest of the repo evolved, that is probably not going to happen. We will probably have some orchestration/entrypoint in the root which wraps the different makefiles. Therefore, this PR moves the Makefile for building the documentation into subdir `docs`.