### PR TITLE
riscv-arch-test script cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ sw/image_gen/image_gen.exe
 
 # example bitstreams
 /setups/examples/*.bit
+/setups/examples/*.svf

--- a/setups/osflow/.gitignore
+++ b/setups/osflow/.gitignore
@@ -1,6 +1,8 @@
 *.asc
 *.bit
+*.cfg
 *.dfu
 *.history
 *.json
+*.svf
 *-report.txt


### PR DESCRIPTION
This is some cleanup of the `riscv-arch-test/run_riscv_arch_test.sh` script. It should be functionally equivalent, but easier to read/maintain.

Moreover, it seems that subdir `riscv-arch-test` is used just for simulation with GHDL. @stnolting, what do you think about moving it into `sim/riscv-arch-test`? That would keep the root of the project cleaner, while making it explicit that the riscv-arch-test are used for testing/verification. In the future, we might enhance `run_riscv_arch_test.sh` for using some VUnit features, or have it removed and handle these tests in the existing `sim/run.py` script.