### PR TITLE
use RISCV_PREFIX instead of RISCV_TOOLCHAIN

### DIFF
--- a/docs/datasheet/software.adoc
+++ b/docs/datasheet/software.adoc
@@ -152,7 +152,7 @@ ASM_INC ?= -I .
 # Optimization
 EFFORT ?= -Os
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
 MABI  ?= -mabi=ilp32
@@ -170,7 +170,7 @@ NEORV32_HOME ?= ../../..
 | _APP_INC_         | Include file folders; separated by white spaces; must be defined with `-I` prefix
 | _ASM_INC_         | Include file folders that are used only for the assembly source files (`*.S`/`*.s`).
 | _EFFORT_          | Optimization level, optimize for size (`-Os`) is default; legal values: `-O0`, `-O1`, `-O2`, `-O3`, `-Os`
-| _RISCV_TOOLCHAIN_ | The toolchain prefix to be used; follows the naming convention "architecture-vendor-output"
+| _RISCV_PREFIX_    | The toolchain prefix to be used; follows the naming convention "architecture-vendor-output-"
 | _MARCH_           | The targetd RISC-V architecture/ISA. Only `rv32` is supported by the NEORV32. Enable compiler support of optional CPU extension by adding the according extension letter (e.g. `rv32im` for _M_ CPU extension). See https://stnolting.github.io/neorv32/ug/#_enabling_risc_v_cpu_extensions[User Guide: Enabling RISC-V CPU Extensions] for more information.
 | _MABI_            | The default 32-bit integer ABI.
 | _USER_FLAGS_      | Additional flags that will be forwarded to the compiler tools
@@ -282,7 +282,7 @@ These four regions contain everything required for the application to run:
 [cols="<1,<9"]
 [options="header",grid="rows"]
 |=======================
-| Region    | Description 
+| Region    | Description
 | `.text`   | Executable instructions generated from the start-up code and all application sources.
 | `.rodata` | Constants (like strings) from the application; also the initial data for initialized variables.
 | `.data`   | This section is required for the address generation of fixed (= global) variables only.
@@ -415,7 +415,7 @@ _OPTIONAL_: The MTIME machine timer (<<_io_mtime_en>> generic is _true_) and the
 To interact with the bootloader, connect the primary UART (UART0) signals (`uart0_txd_o` and
 `uart0_rxd_o`) of the processor's top entity via a serial port (-adapter) to your computer (hardware flow control is
 not used so the according interface signals can be ignored.), configure your
-terminal program using the following settings and perform a reset of the processor. 
+terminal program using the following settings and perform a reset of the processor.
 
 Terminal console settings (`19200-8-N-1`):
 

--- a/docs/userguide/content.adoc
+++ b/docs/userguide/content.adoc
@@ -13,8 +13,8 @@ There are two possibilities to get this:
 2. Download and install a prebuilt version of the toolchain; this might also done via the package manager / app store of your OS
 
 [TIP]
-The default toolchain prefix for this project is **`riscv32-unknown-elf`**. Of course you can use any other RISC-V
-toolchain (like `riscv64-unknown-elf`) that is capable to emit code for a `rv32` architecture. Just change the _RISCV_TOOLCHAIN_ variable in the application
+The default toolchain prefix for this project is **`riscv32-unknown-elf-`**. Of course you can use any other RISC-V
+toolchain (like `riscv64-unknown-elf-`) that is capable to emit code for a `rv32` architecture. Just change the _RISCV_PREFIX_ variable in the application
 makefile(s) according to your needs or define this variable when invoking the makefile.
 
 [IMPORTANT]
@@ -264,7 +264,7 @@ More information can be found in the datasheet section https://stnolting.github.
 :sectnums:
 == Application Program Compilation
 
-This guide shows how to compile an example C-code application into a NEORV32 executable that 
+This guide shows how to compile an example C-code application into a NEORV32 executable that
 can be uploaded via the bootloader or the on-chip debugger.
 
 [IMPORTANT]
@@ -298,7 +298,7 @@ Memory utilization:
    3176       0     120    3296     ce0 main.elf
 Compiling ../../../sw/image_gen/image_gen
 Executable (neorv32_exe.bin) size in bytes:
-3188  
+3188
 ----
 
 [start=5]
@@ -455,7 +455,7 @@ Using the IMEM as ROM:
 
 * for this boot concept the bootloader is no longer required
 * this concept only works for the internal IMEM (but can be extended to work with external memories coupled via the processor's bus interface)
-* make sure that the memory components (like block RAM) the IMEM is mapped to support an initialization via the bitstream 
+* make sure that the memory components (like block RAM) the IMEM is mapped to support an initialization via the bitstream
 
 [start=1]
 . At first, make sure your processor setup actually implements the internal IMEM: the `MEM_INT_IMEM_EN` generics has to be set to `true`:
@@ -469,7 +469,7 @@ Using the IMEM as ROM:
 
 [start=2]
 . For this setup we do not want the bootloader to be implemented at all. Disable implementation of the bootloader by setting the
-`INT_BOOTLOADER_EN` generic to `false`. This will also modify the processor-internal IMEM so it is initialized with the executable during synthesis. 
+`INT_BOOTLOADER_EN` generic to `false`. This will also modify the processor-internal IMEM so it is initialized with the executable during synthesis.
 
 .Processor top entity configuration - disable internal bootloader
 [source,vhdl]
@@ -691,7 +691,7 @@ All bootloader boot configuration support uploading new executables via the on-c
 
 [WARNING]
 Note that this boot configuration does not load any executable at all! Hence,
-this boot configuration is intended to be used with the on-chip debugger only. 
+this boot configuration is intended to be used with the on-chip debugger only.
 
 
 

--- a/riscv-arch-test/run_riscv_arch_test.sh
+++ b/riscv-arch-test/run_riscv_arch_test.sh
@@ -5,6 +5,10 @@ set -e
 
 cd $(dirname "$0")
 
+if [ -z "$RISCV_PREFIX" ]; then
+  export RISCV_PREFIX='riscv32-unknown-elf-'
+fi
+
 rm -rf work/neorv32
 mkdir -p work/neorv32
 
@@ -17,7 +21,7 @@ header() {
 }
 
 header "Checking RISC-V GCC toolchain"
-riscv32-unknown-elf-gcc -v
+"$RISCV_PREFIX"gcc -v
 
 header "Checking GHDL simulator"
 ghdl -v

--- a/sim/ghdl_sim.sh
+++ b/sim/ghdl_sim.sh
@@ -10,40 +10,22 @@ set -e
 
 cd $(dirname "$0")/..
 
-# Default simulation configuration
+# Simulation configuration
 SIM_CONFIG=--stop-time=10ms
-
-# Show GHDL version
-ghdl -v
-
-# Simulation time define by user?
-echo ""
-if [ -z $1 ]
-then
-  echo "Using default simulation config: $SIM_CONFIG"
-else
-  SIM_CONFIG=$1;
-  echo "Using user simulation config: $SIM_CONFIG";
+if [ -n "$1" ]; then
+  SIM_CONFIG="$1";
 fi
-echo ""
+echo "Using simulation config: $SIM_CONFIG";
 
-# List files
-#echo "Simulation source files:"
-#ls -l rtl/core
-#ls -l sim
-#ls -l rtl/templates
-#echo ""
-
-# Just a hint
 echo "Tip: Compile application with USER_FLAGS+=-DUART[0/1]_SIM_MODE to auto-enable UART[0/1]'s simulation mode (redirect UART output to simulator console)."
-echo ""
 
 # Analyse sources; libs and images at first!
-ghdl -i --work=neorv32 rtl/core/*.vhd
-ghdl -i --work=neorv32 rtl/templates/processor/*.vhd
-ghdl -i --work=neorv32 rtl/templates/system/*.vhd
-ghdl -i --work=neorv32 sim/neorv32_tb.simple.vhd
-ghdl -i --work=neorv32 sim/uart_rx.simple.vhd
+ghdl -i --work=neorv32 \
+  rtl/core/*.vhd \
+  rtl/templates/processor/*.vhd \
+  rtl/templates/system/*.vhd \
+  sim/neorv32_tb.simple.vhd \
+  sim/uart_rx.simple.vhd
 
 # Prepare simulation output files for UART0 and UART 1
 # - Testbench receiver log file (neorv32.testbench_uart?.out)

--- a/sw/bootloader/makefile
+++ b/sw/bootloader/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/blink_led/makefile
+++ b/sw/example/blink_led/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/coremark/makefile
+++ b/sw/example/coremark/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/demo_freeRTOS/makefile
+++ b/sw/example/demo_freeRTOS/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -185,10 +185,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/demo_neopixel/makefile
+++ b/sw/example/demo_neopixel/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/demo_pwm/makefile
+++ b/sw/example/demo_pwm/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/demo_trng/makefile
+++ b/sw/example/demo_trng/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/demo_twi/makefile
+++ b/sw/example/demo_twi/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/demo_wdt/makefile
+++ b/sw/example/demo_wdt/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/demo_xirq/makefile
+++ b/sw/example/demo_xirq/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/floating_point_test/makefile
+++ b/sw/example/floating_point_test/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/game_of_life/makefile
+++ b/sw/example/game_of_life/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/hello_world/makefile
+++ b/sw/example/hello_world/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/hex_viewer/makefile
+++ b/sw/example/hex_viewer/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/example/processor_check/makefile
+++ b/sw/example/processor_check/makefile
@@ -50,7 +50,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH ?= -march=rv32i
@@ -112,10 +112,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g

--- a/sw/ocd-firmware/makefile
+++ b/sw/ocd-firmware/makefile
@@ -52,7 +52,7 @@ ASM_INC ?= -I .
 EFFORT ?= -Os
 
 # Compiler toolchain
-RISCV_TOOLCHAIN ?= riscv32-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
 MARCH = -march=rv32i
@@ -105,10 +105,10 @@ OBJ = $(SRC:%=%.o)
 # Tools and flags
 # -----------------------------------------------------------------------------
 # Compiler tools
-CC      = $(RISCV_TOOLCHAIN)-gcc
-OBJDUMP = $(RISCV_TOOLCHAIN)-objdump
-OBJCOPY = $(RISCV_TOOLCHAIN)-objcopy
-SIZE    = $(RISCV_TOOLCHAIN)-size
+CC      = $(RISCV_PREFIX)gcc
+OBJDUMP = $(RISCV_PREFIX)objdump
+OBJCOPY = $(RISCV_PREFIX)objcopy
+SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
 CC_X86 = g++ -Wall -O -g


### PR DESCRIPTION
The riscv-arch-test uses variable `RISCV_PREFIX`, but the makefiles in `sw` use `RISCV_TOOLCHAIN` for the same purpose This PR makes them consistent by using `RISCV_PREFIX` only.