### PR TITLE
[ci] add workflow 'Containers'

### DIFF
--- a/.github/impl.dockerfile
+++ b/.github/impl.dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/hdl-containers/debian/buster/impl
+
+ENV GHDL_PLUGIN_MODULE=ghdl

--- a/.github/sim.dockerfile
+++ b/.github/sim.dockerfile
@@ -1,0 +1,16 @@
+FROM gcr.io/hdl-containers/debian/buster/sim/osvb
+
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+  g++ \
+  git \
+  make \
+  time \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir -p /opt/riscv \
+ && curl -fsSL https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-2.0.0/riscv32-unknown-elf.gcc-10.2.0.rv32i.ilp32.newlib.tar.gz | \
+ tar -xzf - -C /opt/riscv \
+ && ls -al /opt/riscv
+
+ENV PATH $PATH:/opt/riscv/bin

--- a/.github/workflows/Containers.yml
+++ b/.github/workflows/Containers.yml
@@ -1,0 +1,40 @@
+name: Containers
+
+on:
+  push:
+    paths:
+    - '.github/*.dockerfile'
+  schedule:
+    - cron: '0 0 * * 5'
+  workflow_dispatch:
+
+jobs:
+
+  Container:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+        - impl
+        - sim
+    name: '🛳️ ${{ matrix.image }}'
+
+    steps:
+
+    - name: '🧰 Repository Checkout'
+      uses: actions/checkout@v2
+
+    - name: '⛴️ Build neorv32/${{ matrix.image }}'
+      run: docker build -t ghcr.io/stnolting/neorv32/${{ matrix.image }} - < .github/${{ matrix.image }}.dockerfile
+
+    - name: '🔑 Login to ghcr.io'
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: gha
+        password: ${{ github.token }}
+
+    - name: '🛰️ Push image to ghcr.io'
+      run: docker push ghcr.io/stnolting/neorv32/${{ matrix.image }}

--- a/.github/workflows/Implementation.yml
+++ b/.github/workflows/Implementation.yml
@@ -39,16 +39,14 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.Matrix.outputs.matrix) }}
     name: '🛳️ All-in-one | ${{ matrix.board }} · ${{ matrix.design }}'
-    env:
-      GHDL_PLUGIN_MODULE: ghdl
 
     steps:
 
     - name: '🧰 Repository Checkout'
       uses: actions/checkout@v2
 
-    - name: '⚙️ Generate ${{ matrix.board }} ${{ matrix.design }} bitstream'
-      uses: docker://ghcr.io/hdl/debian-buster/impl
+    - name: '🚧 Generate ${{ matrix.board }} ${{ matrix.design }} bitstream'
+      uses: docker://ghcr.io/stnolting/neorv32/impl
       with:
         args: make -C setups/examples BOARD=${{ matrix.board }} ${{ matrix.design }}
 

--- a/.github/workflows/Processor.yml
+++ b/.github/workflows/Processor.yml
@@ -31,28 +31,15 @@ jobs:
     - name: '🧰 Repository Checkout'
       uses: actions/checkout@v2
 
-    - name: '🔧 Setup Environment Variables'
-      run: |
-        echo "$GITHUB_WORKSPACE/riscv/bin" >> $GITHUB_PATH
-        echo $GITHUB_WORKSPACE
-
-    - name: '⚙️ Setup RISC-V GCC'
-      run: |
-        mkdir riscv
-        curl -fsSL https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-2.0.0/riscv32-unknown-elf.gcc-10.2.0.rv32i.ilp32.newlib.tar.gz | \
-        tar -xzf - -C riscv
-        ls -al riscv
-
-    - name: '⚙️ Setup GHDL Simulator'
-      uses: ghdl/setup-ghdl-ci@nightly
-      with:
-        backend: llvm
-
     - name: '🚧 Run Software Framework Tests'
-      run: ./sw/example/processor_check/check.sh
+      uses: docker://ghcr.io/stnolting/neorv32/sim
+      with:
+        args: ./sw/example/processor_check/check.sh
 
     - name: '🚧 Run Processor Hardware Tests with shell script'
-      run: ./sim/ghdl.sh
+      uses: docker://ghcr.io/stnolting/neorv32/sim
+      with:
+        args: ./sim/ghdl.sh
 
 
   VUnit-Container:
@@ -64,27 +51,17 @@ jobs:
     - name: '🧰 Repository Checkout'
       uses: actions/checkout@v2
 
-    - name: '🔧 Setup Environment Variables'
-      run: |
-        echo "$GITHUB_WORKSPACE/riscv/bin" >> $GITHUB_PATH
-        echo $GITHUB_WORKSPACE
-
-    - name: '⚙️ Setup RISC-V GCC'
-      run: |
-        mkdir riscv
-        curl -fsSL https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-2.0.0/riscv32-unknown-elf.gcc-10.2.0.rv32i.ilp32.newlib.tar.gz | \
-        tar -xzf - -C riscv
-        ls -al riscv
-
     - name: '⚙️ Build and install Processor Check software'
-      run: |
-        make -C sw/example/processor_check \
-          clean_all \
-          USER_FLAGS+=-DRUN_CHECK \
-          USER_FLAGS+=-DUART0_SIM_MODE \
-          USER_FLAGS+=-DSUPPRESS_OPTIONAL_UART_PRINT \
-          MARCH=-march=rv32imac \
-          info \
+      uses: docker://ghcr.io/stnolting/neorv32/sim
+      with:
+        args: >-
+          make -C sw/example/processor_check
+          clean_all
+          USER_FLAGS+=-DRUN_CHECK
+          USER_FLAGS+=-DUART0_SIM_MODE
+          USER_FLAGS+=-DSUPPRESS_OPTIONAL_UART_PRINT
+          MARCH=-march=rv32imac
+          info
           all
 
     - name: '📤 Archive Processor Check application image'
@@ -96,4 +73,5 @@ jobs:
     - name: '🚧 Run Processor Hardware Tests with VUnit'
       uses: VUnit/vunit_action@master
       with:
+        image: ghcr.io/stnolting/neorv32/sim
         cmd: ./sim/run.py --ci-mode -v


### PR DESCRIPTION
Instead of installing the dependencies in each CI workflow and job, in this PR a 'Containers' workflow is added for building custom images to be used in this repo. Precisely, images `ghcr.io/stnolting/neorv32/sim` and `ghcr.io/stnolting/neorv32/impl` are built and pushed. Then, in other workflows, those images are used.

Workflow 'Containers' is not triggered by pushes or PRs. It is executed weekly, and it can be triggered manually.

Note that we are currently using container images already. Therefore, the only advantage of this PR for now is avoiding the installation of the RISCV toolchain. However, it sets the foundation for future enhancements, such as the ones in #110.
