### PR TITLE
[riscv-arch-test] measure execution time of each test

### DIFF
--- a/sw/isa-test/port-neorv32/device/rv32i_m/C/Makefile.include
+++ b/sw/isa-test/port-neorv32/device/rv32i_m/C/Makefile.include
@@ -32,7 +32,7 @@ RUN_TARGET=\
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.bin; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led install; \
 	touch $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out; \
-	sh $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
+	$(shell which time) -v $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
 	cp $(NEORV32_LOCAL_COPY)/sim/neorv32.uart0.sim_mode.data.out $(*).signature.output;
 
 

--- a/sw/isa-test/port-neorv32/device/rv32i_m/I/Makefile.include
+++ b/sw/isa-test/port-neorv32/device/rv32i_m/I/Makefile.include
@@ -32,7 +32,7 @@ RUN_TARGET=\
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.bin; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led install; \
 	touch $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out; \
-	sh $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
+	$(shell which time) -v $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
 	cp $(NEORV32_LOCAL_COPY)/sim/neorv32.uart0.sim_mode.data.out $(*).signature.output;
 
 

--- a/sw/isa-test/port-neorv32/device/rv32i_m/M/Makefile.include
+++ b/sw/isa-test/port-neorv32/device/rv32i_m/M/Makefile.include
@@ -32,7 +32,7 @@ RUN_TARGET=\
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.bin; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led install; \
 	touch $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out; \
-	sh $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
+	$(shell which time) -v $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
 	cp $(NEORV32_LOCAL_COPY)/sim/neorv32.uart0.sim_mode.data.out $(*).signature.output;
 
 

--- a/sw/isa-test/port-neorv32/device/rv32i_m/Zifencei/Makefile.include
+++ b/sw/isa-test/port-neorv32/device/rv32i_m/Zifencei/Makefile.include
@@ -32,7 +32,7 @@ RUN_TARGET=\
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.bin; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led install; \
 	touch $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out; \
-	sh $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
+	$(shell which time) -v $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
 	cp $(NEORV32_LOCAL_COPY)/sim/neorv32.uart0.sim_mode.data.out $(*).signature.output;
 
 

--- a/sw/isa-test/port-neorv32/device/rv32i_m/privilege/Makefile.include
+++ b/sw/isa-test/port-neorv32/device/rv32i_m/privilege/Makefile.include
@@ -32,7 +32,7 @@ RUN_TARGET=\
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led main.bin; \
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led install; \
 	touch $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out; \
-	sh $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
+	$(shell which time) -v $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
 	cp $(NEORV32_LOCAL_COPY)/sim/neorv32.uart0.sim_mode.data.out $(*).signature.output;
 
 


### PR DESCRIPTION
This PR adds `time -v` to the architecture test simulation calls, in order to measure the execution time and resource usage.

Most of the tests need 20-60s, which is reasonable. However, `I/jal-01` needs 17 minutes!  @stnolting, is that expected? Might that be caused by some bug?