### PR TITLE
[sim/ghdl] use --workdir=build

### DIFF
--- a/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/C/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/C/Makefile.include
@@ -33,7 +33,7 @@ RUN_TARGET=\
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led install; \
 	touch $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out; \
 	sh $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
-	cp $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out $(*).signature.output;
+	cp $(NEORV32_LOCAL_COPY)/sim/neorv32.uart0.sim_mode.data.out $(*).signature.output;
 
 
 RISCV_PREFIX   ?= riscv32-unknown-elf-

--- a/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/I/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/I/Makefile.include
@@ -33,7 +33,7 @@ RUN_TARGET=\
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led install; \
 	touch $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out; \
 	sh $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
-	cp $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out $(*).signature.output;
+	cp $(NEORV32_LOCAL_COPY)/sim/neorv32.uart0.sim_mode.data.out $(*).signature.output;
 
 
 RISCV_PREFIX   ?= riscv32-unknown-elf-

--- a/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/M/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/M/Makefile.include
@@ -33,7 +33,7 @@ RUN_TARGET=\
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led install; \
 	touch $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out; \
 	sh $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
-	cp $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out $(*).signature.output;
+	cp $(NEORV32_LOCAL_COPY)/sim/neorv32.uart0.sim_mode.data.out $(*).signature.output;
 
 
 RISCV_PREFIX   ?= riscv32-unknown-elf-

--- a/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/Zifencei/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/Zifencei/Makefile.include
@@ -33,7 +33,7 @@ RUN_TARGET=\
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led install; \
 	touch $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out; \
 	sh $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
-	cp $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out $(*).signature.output;
+	cp $(NEORV32_LOCAL_COPY)/sim/neorv32.uart0.sim_mode.data.out $(*).signature.output;
 
 
 RISCV_PREFIX   ?= riscv32-unknown-elf-

--- a/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/privilege/Makefile.include
+++ b/riscv-arch-test/port-neorv32/framework_v2.0/riscv-target/neorv32/device/rv32i_m/privilege/Makefile.include
@@ -33,7 +33,7 @@ RUN_TARGET=\
 	make -C $(NEORV32_LOCAL_COPY)/sw/example/blink_led install; \
 	touch $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out; \
 	sh $(NEORV32_LOCAL_COPY)/sim/ghdl_sim.sh --stop-time=$(SIM_TIME) >> /dev/null; \
-	cp $(NEORV32_LOCAL_COPY)/neorv32.uart0.sim_mode.data.out $(*).signature.output;
+	cp $(NEORV32_LOCAL_COPY)/sim/neorv32.uart0.sim_mode.data.out $(*).signature.output;
 
 
 RISCV_PREFIX   ?= riscv32-unknown-elf-

--- a/sim/ghdl_sim.sh
+++ b/sim/ghdl_sim.sh
@@ -8,7 +8,7 @@
 # Abort if any command returns != 0
 set -e
 
-cd $(dirname "$0")/..
+cd $(dirname "$0")
 
 # Simulation configuration
 SIM_CONFIG=--stop-time=10ms
@@ -19,13 +19,15 @@ echo "Using simulation config: $SIM_CONFIG";
 
 echo "Tip: Compile application with USER_FLAGS+=-DUART[0/1]_SIM_MODE to auto-enable UART[0/1]'s simulation mode (redirect UART output to simulator console)."
 
+mkdir -p build
+
 # Analyse sources; libs and images at first!
-ghdl -i --work=neorv32 \
-  rtl/core/*.vhd \
-  rtl/templates/processor/*.vhd \
-  rtl/templates/system/*.vhd \
-  sim/neorv32_tb.simple.vhd \
-  sim/uart_rx.simple.vhd
+ghdl -i --work=neorv32 --workdir=build \
+  ../rtl/core/*.vhd \
+  ../rtl/templates/processor/*.vhd \
+  ../rtl/templates/system/*.vhd \
+  neorv32_tb.simple.vhd \
+  uart_rx.simple.vhd
 
 # Prepare simulation output files for UART0 and UART 1
 # - Testbench receiver log file (neorv32.testbench_uart?.out)
@@ -42,7 +44,9 @@ for item in \
 done
 
 # Run simulation
-ghdl -m --work=neorv32 neorv32_tb_simple
-ghdl -r --work=neorv32 neorv32_tb_simple --max-stack-alloc=0 --ieee-asserts=disable --assert-level=error $SIM_CONFIG
+ghdl -m --work=neorv32 --workdir=build neorv32_tb_simple
+ghdl -r --work=neorv32 --workdir=build neorv32_tb_simple --max-stack-alloc=0 --ieee-asserts=disable --assert-level=error $SIM_CONFIG
 
 cat neorv32.uart0.sim_mode.text.out | grep "CPU TEST COMPLETED SUCCESSFULLY!"
+
+rm -rf *.{o,cf,lst,out} build


### PR DESCRIPTION
Instead of executing the simulation in the root of the repo, this PR modifies `sim/ghdl_sim.sh` for running it in subdir `sim` and generating intermediate files in `sim/build`.