### PR TITLE
[ci/processor] test all GHDL backends, test VUnit master too

### DIFF
--- a/.github/workflows/Processor.yml
+++ b/.github/workflows/Processor.yml
@@ -11,12 +11,12 @@ on:
     - 'sw/**'
     - 'sim/**'
   pull_request:
-    branches:
-    - master
-    paths:
-    - 'rtl/**'
-    - 'sw/**'
-    - 'sim/**'
+    #branches:
+    #- master
+    #paths:
+    #- 'rtl/**'
+    #- 'sw/**'
+    #- 'sim/**'
   workflow_dispatch:
 
 jobs:
@@ -44,6 +44,16 @@ jobs:
 
   VUnit-Container:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        backend:
+        - mcode
+        - llvm
+        - gcc
+        - mcode-master
+        - llvm-master
+        - gcc-master
     name: '🛳️ Container | VUnit'
 
     steps:
@@ -73,5 +83,6 @@ jobs:
     - name: '🚧 Run Processor Hardware Tests with VUnit'
       uses: VUnit/vunit_action@master
       with:
-        image: ghcr.io/stnolting/neorv32/sim
+        #image: ghcr.io/stnolting/neorv32/sim
+        image: ghdl/vunit:${{ matrix.backend }}
         cmd: ./sim/run.py --ci-mode -v


### PR DESCRIPTION
This PR is NOT to be merged. It's for illustrating an issue.

As commented in #116, when changing the container image used for running VUnit, it would fail. In this PR, the VUnit test is executed six times:

- GHDL mcode with VUnit stable
- GHDL LLVM with VUnit stable
- GHDL GCC with VUnit stable
- GHDL mcode with VUnit master
- GHDL LLVM with VUnit master
- GHDL GCC with VUnit master

All three jobs using VUnit stable do work, but the ones using VUnit master fail.

The problem seems to be in the NEORV32 codebase, so it's surprising to me why changing the version of VUnit triggers it. @LarsAsplund, any guess?