### PR TITLE
[setups/osflow/filesets] do not provide default NEORV32_MEM_SRC, require it to be explicitly set

### DIFF
--- a/setups/osflow/Makefile
+++ b/setups/osflow/Makefile
@@ -42,11 +42,13 @@ endif
 iCESugar:
 	$(MAKE) \
 	  BITSTREAM=neorv32_$(BOARD)_$(DESIGN).bit \
+	  NEORV32_MEM_SRC="devices/ice40/neorv32_imem.ice40up_spram.vhd devices/ice40/neorv32_dmem.ice40up_spram.vhd" \
 	  run
 
 UPduino:
 	$(MAKE) \
 	  BITSTREAM=neorv32_$(BOARD)_$(UPduino_REV)_$(DESIGN).bit \
+	  NEORV32_MEM_SRC="devices/ice40/neorv32_imem.ice40up_spram.vhd devices/ice40/neorv32_dmem.ice40up_spram.vhd" \
 	  run
 
 OrangeCrab:

--- a/setups/osflow/filesets.mk
+++ b/setups/osflow/filesets.mk
@@ -9,10 +9,6 @@ NEORV32_MEM_ENTITIES := \
   $(RTL_CORE_SRC)/neorv32_dmem.entity.vhd \
   $(RTL_CORE_SRC)/neorv32_imem.entity.vhd
 
-NEORV32_MEM_SRC := \
-  devices/ice40/neorv32_imem.ice40up_spram.vhd \
-  devices/ice40/neorv32_dmem.ice40up_spram.vhd
-
 NEORV32_CORE_SRC := \
   $(RTL_CORE_SRC)/neorv32_bootloader_image.vhd \
   $(RTL_CORE_SRC)/neorv32_boot_rom.vhd \
@@ -47,6 +43,9 @@ NEORV32_CORE_SRC := \
   $(RTL_CORE_SRC)/neorv32_wdt.vhd \
   $(RTL_CORE_SRC)/neorv32_wishbone.vhd \
   $(RTL_CORE_SRC)/neorv32_xirq.vhd
+
+# Before including this partial makefile, NEORV32_MEM_SRC needs to be set
+# (containing two VHDL sources: one for IMEM and one for DMEM)
 
 NEORV32_SRC := ${NEORV32_PKG} ${NEORV32_APP_SRC} ${NEORV32_MEM_ENTITIES} ${NEORV32_MEM_SRC} ${NEORV32_CORE_SRC}
 


### PR DESCRIPTION
As the title explains, currently there is a default NEORV32_MEM_SRC variable in `filesets.mk`, which is overriden for some boards/examples. In this PR, that is changed so that no default NEORV32_MEM_SRC is defined. Therefore, for each board/design, the user needs to explicitly select whether to use the default description or some custom sources (such as SPRAM on UP5K).