### PR TITLE
add pydoit to custom dockerfiles

### DIFF
--- a/.github/impl.dockerfile
+++ b/.github/impl.dockerfile
@@ -1,3 +1,11 @@
 FROM gcr.io/hdl-containers/debian/buster/impl
 
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+  python3-pip \
+ && pip3 install wheel setuptools \
+ && pip3 install doit \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && rm -rf /var/lib/apt/lists/*
+
 ENV GHDL_PLUGIN_MODULE=ghdl

--- a/.github/sim.dockerfile
+++ b/.github/sim.dockerfile
@@ -5,9 +5,12 @@ RUN apt-get update -qq \
   g++ \
   git \
   make \
+  python3-pip \
   time \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists/* \
+ && pip3 install wheel setuptools \
+ && pip3 install doit \
  && mkdir -p /opt/riscv \
  && curl -fsSL https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-2.0.0/riscv32-unknown-elf.gcc-10.2.0.rv32i.ilp32.newlib.tar.gz | \
  tar -xzf - -C /opt/riscv \


### PR DESCRIPTION
This is in preparation for #110.

In this PR, [pydoit](https://pydoit.org/) is added to the dockerfiles used in CI. No further modification is done yet, so doit is actually unused. However, it allows users providing their own `dodo.py` file to use containers `ghcr.io/umarcor/neorv32/sim` and/or `ghcr.io/umarcor/neorv32/impl`.