### PR TITLE
[containers] update from Debian Buster to Debian Bullseye

### DIFF
--- a/.github/impl.dockerfile
+++ b/.github/impl.dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/hdl-containers/debian/buster/impl
+FROM gcr.io/hdl-containers/debian/bullseye/impl
 
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \

--- a/.github/sim.dockerfile
+++ b/.github/sim.dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/hdl-containers/debian/buster/sim/osvb
+FROM gcr.io/hdl-containers/debian/bullseye/sim/osvb
 
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \


### PR DESCRIPTION
Debian Bullseye was released in August. This PR updates the containers for them to be based on that instead of Debian Buster.