### PR TITLE
[doit] add initial doit file; add task DeployToGitHubPages

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -93,14 +93,8 @@ jobs:
           NEORV32-SITE-nightly.tar.gz
           pdf/NEORV32*nightly.pdf
 
+    - name: '🐍 Install doit'
+      run: pip install doit
+
     - name: '🚀 Deploy to GitHub-Pages'
-      run: |
-        cd public
-        git init
-        cp ../.git/config ./.git/config
-        touch .nojekyll
-        git add .
-        git config --local user.email "push@gha"
-        git config --local user.name "GHA"
-        git commit -am "update ${{ github.sha }}"
-        git push -u origin +HEAD:gh-pages
+      run: doit DeployToGitHubPages "update ${{ github.sha }}"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -97,4 +97,4 @@ jobs:
       run: pip install doit
 
     - name: '🚀 Deploy to GitHub-Pages'
-      run: doit DeployToGitHubPages "update ${{ github.sha }}"
+      run: ./do.py DeployToGitHubPages "update ${{ github.sha }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# doit databases
+/.doit.db.*
+
+# python
+__pycache__
+
 # generated application files
 *.bin
 *.o

--- a/do.py
+++ b/do.py
@@ -1,10 +1,14 @@
+#!/usr/bin/env python3
+
 # doit
 
-from sys import executable
+from sys import executable, argv as sys_argv, exit as sys_exit
 from os import environ
 from pathlib import Path
 
 from doit.action import CmdAction
+from doit.cmd_base import ModuleTaskLoader
+from doit.doit_cmd import DoitMain
 
 DOIT_CONFIG = {"verbosity": 2, "action_string_formatting": "both"}
 
@@ -30,3 +34,7 @@ def task_DeployToGitHubPages():
         "doc": "Create a clean branch in subdir 'public' and push to branch 'gh-pages'",
         "pos_arg": "posargs",
     }
+
+
+if __name__ == '__main__':
+    sys_exit(DoitMain(ModuleTaskLoader(globals())).run(sys_argv[1:]))

--- a/dodo.py
+++ b/dodo.py
@@ -1,0 +1,32 @@
+# doit
+
+from sys import executable
+from os import environ
+from pathlib import Path
+
+from doit.action import CmdAction
+
+DOIT_CONFIG = {"verbosity": 2, "action_string_formatting": "both"}
+
+ROOT = Path(__file__).parent
+
+
+def task_DeployToGitHubPages():
+    cwd = str(ROOT / "public")
+    return {
+        "actions": [
+            CmdAction(cmd, cwd=cwd)
+            for cmd in [
+                "git init",
+                "cp ../.git/config ./.git/config",
+                "touch .nojekyll",
+                "git add .",
+                'git config --local user.email "push@gha"',
+                'git config --local user.name "GHA"',
+                "git commit -am '{posargs}'",
+                "git push -u origin +HEAD:gh-pages",
+            ]
+        ],
+        "doc": "Create a clean branch in subdir 'public' and push to branch 'gh-pages'",
+        "pos_arg": "posargs",
+    }


### PR DESCRIPTION
This is a subset of #110.

As an initial approach to using [pydoit](https://pydoit.org/), in this PR a `do.py` file is added. It includes a single task for uploading the documentation to GitHub Pages. So, instead of having those commands hardcoded in the workflow file, the workflow executes the task through doit.

doit can be executed as a CLI tool (which will search for a `dodo.py`) or it can be used through an executable script. In this case, I made the script executable and I named it `do.py`. As a result, `./do.py` is equivalent to `doit -f do.py`.