### PR TITLE
[doit] add task Documentation

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -46,8 +46,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: '🐍 Install doit'
+      run: pip install doit
+
     - name: '📚 Build Datasheet and User Guide (PDF and HTML)'
-      run: make -C docs container
+      run: ./do.py Documentation container
 
     - name: '📤 Upload Artifact: HTML'
       uses: actions/upload-artifact@v2

--- a/do.py
+++ b/do.py
@@ -15,6 +15,15 @@ DOIT_CONFIG = {"verbosity": 2, "action_string_formatting": "both"}
 ROOT = Path(__file__).parent
 
 
+def task_Documentation():
+    return {
+        "actions": ["make -C docs {posargs}"],
+        "doc": "Run a target in subdir 'doc'",
+        "uptodate": [False],
+        "pos_arg": "posargs",
+    }
+
+
 def task_DeployToGitHubPages():
     cwd = str(ROOT / "public")
     return {


### PR DESCRIPTION
Similarly to #162, this is a subset of #110.

Instead of calling make in the Documentation workflow, a task named Documentation is added to the `do.py` file.
For now, the following are equivalent:

- `./do.py Documentation`
- `doit -f do.py Documentation`
- `make -C docs`

In upcoming PRs, we might remove `docs/Makefile` and replace it with more specific doit tasks.