### PR TITLE
[doit] add task RunRISCVArchitectureTests

### DIFF
--- a/.github/workflows/riscv-arch-test.yml
+++ b/.github/workflows/riscv-arch-test.yml
@@ -30,17 +30,19 @@ jobs:
           echo "$GITHUB_WORKSPACE/riscv/bin" >> $GITHUB_PATH
           echo $GITHUB_WORKSPACE
 
-      - name: '🔧 Setup RISC-V GCC'
+      - name: '🔧 Setup RISC-V GCC and doit'
         run: |
           mkdir riscv
           curl -fsSL https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-2.0.0/riscv32-unknown-elf.gcc-10.2.0.rv32i.ilp32.newlib.tar.gz | \
           tar -xzf - -C riscv
           ls -al riscv
 
+          pip3 install doit
+
       - name: '🔧 Setup GHDL Simulator'
         uses: ghdl/setup-ghdl-ci@nightly
         with:
           backend: gcc
 
-      - name: '⚙️ Run RISC-V Architecture Tests'
-        run: ./sim/run_riscv_arch_test.sh ${{ matrix.suite }}
+      - name: '🚧 Run RISC-V Architecture Tests'
+        run: ./do.py RunRISCVArchitectureTests -s ${{ matrix.suite }}

--- a/do.py
+++ b/do.py
@@ -15,6 +15,35 @@ DOIT_CONFIG = {"verbosity": 2, "action_string_formatting": "both"}
 ROOT = Path(__file__).parent
 
 
+def task_RunRISCVArchitectureTests():
+    return {
+        "actions": [CmdAction(
+            "./run_riscv_arch_test.sh {suite}",
+            cwd=ROOT / "sim"
+        )],
+        "doc": "Run RISC-V Architecture Tests",
+        "params": [
+            {
+                "name": "suite",
+                "short": "s",
+                "long": "suite",
+                "default": "M",
+                "choices": ((item, "") for item in [
+                    "I",
+                    "C",
+                    "M",
+                    "privilege",
+                    "Zifencei",
+                    "rv32e_C",
+                    "rv32e_E",
+                    "rv32e_M"
+                ]),
+                "help": "Test suite to be executed",
+            }
+        ],
+    }
+
+
 def task_Documentation():
     return {
         "actions": ["make -C docs {posargs}"],


### PR DESCRIPTION
Similarly to #162 and #163, this is a subset of #110.

Instead of calling `sim/run_riscv_arch_test.sh` directly, it is wrapped in a doit task named RunRISCVArchitectureTests. An option (`-s`|`--suite`) of type "choice" allows selecting which tests to run.

In upcoming PRs, we might remove `sim/run_riscv_arch_test.sh` and replace it with more specific doit/python code. Particularly, https://github.com/stnolting/neorv32/blob/master/sim/run_riscv_arch_test.sh#L49-L61 might be enhanced by using enums/dictionaries.