### PR TITLE
:bug: [rtl/system_integration] fix uart1 rx/tx signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 03.10.2021 | 1.6.1.3 | :bug: fixed UART signal connection in `rtl/system_integration` wrappers |
 | 01.10.2021 | 1.6.1.2 | :warning: removed `mstatus.TW` (timeout wait) bit, `wfi` instruction is now always allowed to be executed in less-privileged modes; minor CPU control unit logic optimizations |
 | 01.10.2021 | 1.6.1.1 | on-chip-debugger: `wfi` instruction acts as a simple `nop` when _in_ debug mode or during single-stepping |
 | 28.09.2021 |[**:rocket:1.6.1**](https://github.com/stnolting/neorv32/releases/tag/v1.6.1) | **New release** |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060102"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060103"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- External Interface Types ---------------------------------------------------------------

--- a/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
+++ b/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
@@ -441,8 +441,12 @@ begin
 
   uart0_txd_o     <= std_logic(uart0_txd_o_int);
   uart0_rxd_i_int <= std_ulogic(uart0_rxd_i);
+  uart0_rts_o     <= std_logic(uart0_rts_o_int);
+  uart0_cts_i_int <= std_ulogic(uart0_cts_i);
   uart1_txd_o     <= std_logic(uart1_txd_o_int);
   uart1_rxd_i_int <= std_ulogic(uart1_rxd_i);
+  uart1_rts_o     <= std_logic(uart1_rts_o_int);
+  uart1_cts_i_int <= std_ulogic(uart1_cts_i);
 
   spi_sck_o       <= std_logic(spi_sck_o_int);
   spi_sdo_o       <= std_logic(spi_sdo_o_int);

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -405,8 +405,12 @@ begin
 
   uart0_txd_o     <= std_logic(uart0_txd_o_int);
   uart0_rxd_i_int <= std_ulogic(uart0_rxd_i);
+  uart0_rts_o     <= std_logic(uart0_rts_o_int);
+  uart0_cts_i_int <= std_ulogic(uart0_cts_i);
   uart1_txd_o     <= std_logic(uart1_txd_o_int);
   uart1_rxd_i_int <= std_ulogic(uart1_rxd_i);
+  uart1_rts_o     <= std_logic(uart1_rts_o_int);
+  uart1_cts_i_int <= std_ulogic(uart1_cts_i);
 
   spi_sck_o       <= std_logic(spi_sck_o_int);
   spi_sdo_o       <= std_logic(spi_sdo_o_int);

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -405,8 +405,8 @@ begin
 
   uart0_txd_o     <= std_logic(uart0_txd_o_int);
   uart0_rxd_i_int <= std_ulogic(uart0_rxd_i);
-  uart1_txd_o     <= std_logic(uart0_txd_o_int);
-  uart1_rxd_i_int <= std_ulogic(uart0_rxd_i);
+  uart1_txd_o     <= std_logic(uart1_txd_o_int);
+  uart1_rxd_i_int <= std_ulogic(uart1_rxd_i);
 
   spi_sck_o       <= std_logic(spi_sck_o_int);
   spi_sdo_o       <= std_logic(spi_sdo_o_int);


### PR DESCRIPTION
Fix routing of the UART1 rx/tx signals in the AXI4Lite system integration top.