### PR TITLE
[setups/vivado] Fix fileset paths

### DIFF
--- a/setups/vivado/arty-a7-test-setup/create_project.tcl
+++ b/setups/vivado/arty-a7-test-setup/create_project.tcl
@@ -39,13 +39,9 @@ set fileset_design ./../../../rtl/test_setups/neorv32_test_setup_bootloader.vhd
 set fileset_constraints [glob ./*.xdc]
 
 ## Simulation-only sources
-set fileset_sim [list ./../../../sim/neorv32_tb.simple.vhd ./../../../sim/uart_rx.simple.vhd]
+set fileset_sim [list ./../../../sim/simple/neorv32_tb.simple.vhd ./../../../sim/simple/uart_rx.simple.vhd]
 
 # Add source files
-
-## Core
-add_files $fileset_neorv32
-set_property library neorv32 [get_files $fileset_neorv32]
 
 ## Design
 add_files $fileset_design

--- a/setups/vivado/nexys-a7-test-setup/create_project.tcl
+++ b/setups/vivado/nexys-a7-test-setup/create_project.tcl
@@ -35,7 +35,7 @@ set_property library neorv32 [get_files [glob ./../../../rtl/core/mem/neorv32_*m
 add_files [glob ./../../../rtl/test_setups/neorv32_test_setup_bootloader.vhd]
 
 # add source files: simulation-only
-add_files -fileset sim_1 [list ./../../../sim/neorv32_tb.simple.vhd ./../../../sim/uart_rx.simple.vhd]
+add_files -fileset sim_1 [list ./../../../sim/simple/neorv32_tb.simple.vhd ./../../../sim/simple/uart_rx.simple.vhd]
 
 # add source files: constraints
 add_files -fileset constrs_1 [glob ./*.xdc]


### PR DESCRIPTION
Fix the fileset paths in the Vivado project setups. Some were using the wrong path and one was being setup using an undefined variable.