### PR TITLE
[setups/ULX3S] increase memory sizes to "default"

### DIFF
--- a/setups/osflow/board_tops/neorv32_ULX3S_BoardTop_MinimalBoot.vhd
+++ b/setups/osflow/board_tops/neorv32_ULX3S_BoardTop_MinimalBoot.vhd
@@ -75,8 +75,8 @@ begin
   neorv32_inst: entity work.neorv32_ProcessorTop_MinimalBoot
   generic map (
     CLOCK_FREQUENCY   => f_clock_c, -- clock frequency of clk_i in Hz
-    MEM_INT_IMEM_SIZE => 4*1024,
-    MEM_INT_DMEM_SIZE => 2*1024
+    MEM_INT_IMEM_SIZE => 16*1024,
+    MEM_INT_DMEM_SIZE => 8*1024
   )
   port map (
     -- Global control --


### PR DESCRIPTION
This PR is a spin-off of the discussion in #169.

It increases the processor-internal memory size configuration form _4kB_ IMEM and _2kB_ DMEM to **16kB** IMEM and **8kB** DMEM.

This PR also allows to use the software-framework "as-is" without the need to modify the linker script (see https://github.com/stnolting/neorv32/tree/master/setups#setup-specific-neorv32-software-framework-modification).