### PR TITLE
[BUSKEEPER] add memory-mapped status register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 30.10.2021 | 1.6.2.12 | :sparkles: :lock: added memory-mapped register to BUSKEEPER module - software can now retrieve the actual cause of an instruction / data-load / data-store bus access fault exception (access timeout or device error); see [PR #192](https://github.com/stnolting/neorv32/pull/191) |
 | 28.10.2021 | 1.6.2.11 | :sparkles: added `Zba` bit-manipulation sub-extension; :warning: removed configuration option for `B` sub-extensions: removed `CPU_EXTENSION_RISCV_Zbb` generic and according SYSINFO flag, added new `CPU_EXTENSION_RISCV_B` generic (to implement bit-manipulation `B` ISA extension with _all_ currently supported subsets), see [PR #190](https://github.com/stnolting/neorv32/pull/190) |
 | 27.10.2021 | 1.6.2.10 | :bug: CPU control unit: fixed _imprecise_ illegal instruction exceptions - `MEPC` and `MTAVL` did not reflect the correct exception-causing data for illegal ALU-class (non-multi-cycle like `SUB`) operations; optimized critical path of exception logic (illegal compressed instruction detection) |
 | 27.10.2021 | 1.6.2.9 | CPU control unit: minor logic optimization - `fence.i` instruction needs 1 cycle less to execute, reduced HW footprint of control engine, shortened CPU's critical path (PC update logic) |

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ for tightly-coupled custom co-processor extensions
 * on-chip debugger ([OCD](https://stnolting.github.io/neorv32/#_on_chip_debugger_ocd)) via JTGA - implementing
 the [*Minimal RISC-V Debug Specification Version 0.13.2*](https://github.com/riscv/riscv-debug-spec)
 and compatible with *OpenOCD* and *gdb*
+* bus keeper to monitor processor-internal bus transactions ([BUSKEEPER](https://stnolting.github.io/neorv32/#_internal_bus_monitor_buskeeper))
 
 :information_source: It is recommended to use the processor setup even if you want to **use the CPU in stand-alone mode**.
 Just disable all optional processor-internal modules via the according generics and you will get a "CPU wrapper" that

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -978,7 +978,7 @@ Processor-internal peripherals or memories do not have to respond within one cyc
 However, the bus transaction has to be completed (= acknowledged) within a certain **response time window**. This time window is defined
 by the global `max_proc_int_response_time_c` constant (default = 15 cycles) from the processor's VHDL package file (`rtl/neorv32_package.vhd`).
 It defines the maximum number of cycles after which an _unacknowledged_ processor-internal bus transfer will timeout and raise a **bus fault exception**.
-The _BUSKEEPER_ hardware module (`rtl/core/neorv32_bus_keeper.vhd`) keeps track of all _internal_ bus transactions. If any bus operations times out
+The _BUSKEEPER_ hardware module (see section <<_internal_bus_monitor_buskeeper>>) keeps track of all _internal_ bus transactions. If any bus operations times out
 (for example when accessing "address space holes") this unit will issue a bus error to the CPU that will raise the according instruction fetch or data access bus exception.
 Note that **the bus keeper does not track external accesses via the external memory bus interface**. However, the external memory bus interface also provides
 an _optional_ bus timeout (see section <<_processor_external_memory_interface_wishbone_axi4_lite>>).

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -26,6 +26,7 @@ image::neorv32_processor.png[align=center]
 * _optional_ NeoPixel(TM)/WS2812-compatible smart LED interface (<<_smart_led_interface_neoled,**NEOLED**>>)
 * _optional_ external interrupt controller with up to 32 channels (<<_external_interrupt_controller_xirq,**XIRQ**>>)
 * _optional_ on-chip debugger with JTAG TAP (<<_on_chip_debugger_ocd,**OCD**>>)
+* bus keeper to monitor processor-internal bus transactions (<<_internal_bus_monitor_buskeeper,**BUSKEEPER**>>)
 * system configuration information memory to check HW configuration via software (<<_system_configuration_information_memory_sysinfo,**SYSINFO**>>)
 
 
@@ -1433,6 +1434,8 @@ include::soc_bootrom.adoc[]
 include::soc_icache.adoc[]
 
 include::soc_wishbone.adoc[]
+
+include::soc_buskeeper.adoc[]
 
 include::soc_slink.adoc[]
 

--- a/docs/datasheet/soc_buskeeper.adoc
+++ b/docs/datasheet/soc_buskeeper.adoc
@@ -30,8 +30,8 @@ constant from the processor's VHDL package file (`rtl/neorv32_package.vhd`). The
 
 In case of a bus access fault exception application software can evaluate the Bus Keeper's control register
 `NEORV32_BUSKEEPER.CTRL` to retrieve further details of the bus exception. The _BUSKEEPER_ERR_FLAG_ bit indicates
-that an actual bus access fault has occurred. The bit is sticky once set and has to be explicitly cleared by writing
-zero to it. The _BUSKEEPER_ERR_TYPE_ indicated the tape or bus fault:
+that an actual bus access fault has occurred. The bit is sticky once set is automatically cleared when reading the
+`NEORV32_BUSKEEPER.CTRL` register. The _BUSKEEPER_ERR_TYPE_ indicated the tape or bus fault:
 
 * _BUSKEEPER_ERR_TYPE_ = `0` - "Device Error": The bus access exception was cause by the memory-mapped device that
 has been accessed (the device asserted it's `err_o`).
@@ -60,5 +60,5 @@ However, the external memory bus interface also provides an _optional_ and indep
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
 .3+<| `0xffffff7C` .3+<| `NEORV32_BUSKEEPER.CTRL` <|`0`  _BUSKEEPER_ERR_TYPE_ ^| r/- <| Bus error type, valid if _BUSKEEPER_ERR_FLAG_ is set: `0`=device error, `1`=access timeout
                                                   <|`1`  _BUSKEEPER_ERR_SRC_  ^| r/- <| Error source: `0`=processor-internal, `1`=processor-external (via Wishbone bus interface)
-                                                  <|`31` _BUSKEEPER_ERR_FLAG_ ^| r/c <| Sticky error flag, cleared by writing zero
+                                                  <|`31` _BUSKEEPER_ERR_FLAG_ ^| r/- <| Sticky error flag, clears after read
 |=======================

--- a/docs/datasheet/soc_buskeeper.adoc
+++ b/docs/datasheet/soc_buskeeper.adoc
@@ -1,0 +1,64 @@
+<<<
+:sectnums:
+==== Internal Bus Monitor (BUSKEEPER)
+
+[cols="<3,<3,<4"]
+[frame="topbot",grid="none"]
+|=======================
+| Hardware source file(s): | neorv32_buskeeper.vhd | 
+| Software driver file(s): | none | explicitly used
+| Top entity port:         | none | 
+| Configuration generics:  | none | 
+| Package constants:       | `max_proc_int_response_time_c` | Access time window (#cycles)
+| CPU interrupts:          | none | 
+|=======================
+
+**Theory of Operation**
+
+The Bus Keeper is a fundamental component of the processor's internal bus system that ensures correct bus operations
+to maintain execution safety. The Bus Keeper monitors every single bus transactions that is intimated by the CPU.
+If an accessed device responds with an error condition or do not respond within a specific _access time window_,
+the according bus access fault exception is raised. The following exceptions can be raised by the Bus Keeper
+(see section <<_neorv32_trap_listing>> for all CPU exceptions):
+
+* `TRAP_CODE_I_ACCESS`: error during instruction fetch bus access
+* `TRAP_CODE_S_ACCESS`: error during data store bus access
+* `TRAP_CODE_L_ACCESS`: error during data load bus access
+
+The **access time window**, in which an accessed device has to respond, is defined by the `max_proc_int_response_time_c`
+constant from the processor's VHDL package file (`rtl/neorv32_package.vhd`). The default value is **15 clock cycles**.
+
+In case of a bus access fault exception application software can evaluate the Bus Keeper's control register
+`NEORV32_BUSKEEPER.CTRL` to retrieve further details of the bus exception. The _BUSKEEPER_ERR_FLAG_ bit indicates
+that an actual bus access fault has occurred. The bit is sticky once set and has to be explicitly cleared by writing
+zero to it. The _BUSKEEPER_ERR_TYPE_ indicated the tape or bus fault:
+
+* _BUSKEEPER_ERR_TYPE_ = `0` - "Device Error": The bus access exception was cause by the memory-mapped device that
+has been accessed (the device asserted it's `err_o`).
+* _BUSKEEPER_ERR_TYPE_ = `1` - "Timeout Error": The bus access exception was caused by the Bus Keeper because the
+accessed memory-mapped device did not respond within the access time window.
+
+[NOTE]
+Bus access fault exceptions are also raised if a physical memory protection rule is violated. In this case
+the _BUSKEEPER_ERR_FLAG_ bit remains zero.
+
+Furthermore, application software can determine the source of the bus access fault via the _BUSKEEPER_ERR_SRC_ bit:
+
+* _BUSKEEPER_ERR_SRC_ = `0`: The error was cause during access via the <<_processor_external_memory_interface_wishbone_axi4_lite>>).
+* _BUSKEEPER_ERR_SRC_ = `1`: The error was cause during access to an processor-internal module.
+
+[NOTE]
+The Bus Keeper does not track **timeout errors** of processor-external accesses via the external memory bus interface.
+However, the external memory bus interface also provides an _optional_ and independent bus timeout feature
+(see section <<_processor_external_memory_interface_wishbone_axi4_lite>>).
+
+
+.BUSKEEPER register map (`struct NEORV32_BUSKEEPER`)
+[cols="<2,<2,<4,^1,<4"]
+[options="header",grid="all"]
+|=======================
+| Address | Name [C] | Bit(s), Name [C] | R/W | Function
+.3+<| `0xffffff7C` .3+<| `NEORV32_BUSKEEPER.CTRL` <|`0`  _BUSKEEPER_ERR_TYPE_ ^| r/- <| Bus error type, valid if _BUSKEEPER_ERR_FLAG_ is set: `0`=device error, `1`=access timeout
+                                                  <|`1`  _BUSKEEPER_ERR_SRC_  ^| r/- <| Error source: `0`=processor-internal, `1`=processor-external (via Wishbone bus interface)
+                                                  <|`31` _BUSKEEPER_ERR_FLAG_ ^| r/c <| Sticky error flag, cleared by writing zero
+|=======================

--- a/rtl/core/neorv32_bus_keeper.vhd
+++ b/rtl/core/neorv32_bus_keeper.vhd
@@ -210,8 +210,8 @@ begin
     end if;
   end process keeper_control;
 
-  -- inform CPU --
-  err_o <= control.bus_err;
+  -- only output timeout errors here - device errors are already propagated by the bus system --
+  err_o <= control.bus_err and control.err_type;
 
 
 end neorv32_bus_keeper_rtl;

--- a/rtl/core/neorv32_bus_keeper.vhd
+++ b/rtl/core/neorv32_bus_keeper.vhd
@@ -62,20 +62,44 @@ entity neorv32_bus_keeper is
   );
   port (
     -- host access --
-    clk_i  : in  std_ulogic; -- global clock line
-    rstn_i : in  std_ulogic; -- global reset line, low-active
-    addr_i : in  std_ulogic_vector(31 downto 0); -- address
-    rden_i : in  std_ulogic; -- read enable
-    wren_i : in  std_ulogic; -- write enable
-    ack_i  : in  std_ulogic; -- transfer acknowledge from bus system
-    err_i  : in  std_ulogic; -- transfer error from bus system
-    err_o  : out std_ulogic  -- bus error
+    clk_i      : in  std_ulogic; -- global clock line
+    rstn_i     : in  std_ulogic; -- global reset, low-active, async
+    addr_i     : in  std_ulogic_vector(31 downto 0); -- address
+    rden_i     : in  std_ulogic; -- read enable
+    wren_i     : in  std_ulogic; -- write enable
+    data_i     : in  std_ulogic_vector(31 downto 0); -- data in
+    data_o     : out std_ulogic_vector(31 downto 0); -- data out
+    ack_o      : out std_ulogic; -- transfer acknowledge
+    err_o      : out std_ulogic; -- transfer error
+    -- bus monitoring --
+    bus_addr_i : in  std_ulogic_vector(31 downto 0); -- address
+    bus_rden_i : in  std_ulogic; -- read enable
+    bus_wren_i : in  std_ulogic; -- write enable
+    bus_ack_i  : in  std_ulogic; -- transfer acknowledge from bus system
+    bus_err_i  : in  std_ulogic  -- transfer error from bus system
   );
 end neorv32_bus_keeper;
 
 architecture neorv32_bus_keeper_rtl of neorv32_bus_keeper is
 
-  -- access check --
+  -- IO space: module base address --
+  constant hi_abb_c : natural := index_size_f(io_size_c)-1; -- high address boundary bit
+  constant lo_abb_c : natural := index_size_f(buskeeper_size_c); -- low address boundary bit
+
+  -- Control register --
+  constant ctrl_err_type_c : natural :=  0; -- r/-: error type: 0=device error, 1=access timeout
+  constant ctrl_err_src_c  : natural :=  1; -- r/-: error source: 0=processor-external, 1=processor-internal
+  constant ctrl_err_flag_c : natural := 31; -- r/c: bus error encountered, sticky; cleared by writing zero
+
+  -- sticky error flag --
+  signal err_flag : std_ulogic;
+
+  -- access control --
+  signal acc_en : std_ulogic; -- module access enable
+  signal wren   : std_ulogic; -- word write enable
+  signal rden   : std_ulogic; -- read enable
+
+  -- bus access check --
   type access_check_t is record
     int_imem       : std_ulogic;
     int_dmem       : std_ulogic;
@@ -86,9 +110,11 @@ architecture neorv32_bus_keeper_rtl of neorv32_bus_keeper is
 
   -- controller --
   type control_t is record
-    pending : std_ulogic;
-    timeout : std_ulogic_vector(index_size_f(max_proc_int_response_time_c)-1 downto 0);
-    bus_err : std_ulogic;
+    pending  : std_ulogic;
+    timeout  : std_ulogic_vector(index_size_f(max_proc_int_response_time_c)-1 downto 0);
+    err_type : std_ulogic;
+    int_ext  : std_ulogic;
+    bus_err  : std_ulogic;
   end record;
   signal control : control_t;
 
@@ -101,13 +127,46 @@ begin
 
   -- Access Control -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
+  acc_en <= '1' when (addr_i(hi_abb_c downto lo_abb_c) = buskeeper_base_c(hi_abb_c downto lo_abb_c)) else '0';
+  wren   <= acc_en and wren_i;
+  rden   <= acc_en and rden_i;
+
+
+  -- Bus Access Check -----------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
   -- access to processor-internal IMEM or DMEM? --
-  access_check.int_imem <= '1' when (addr_i(31 downto index_size_f(MEM_INT_IMEM_SIZE)) = imem_base_c(31 downto index_size_f(MEM_INT_IMEM_SIZE))) and (MEM_INT_IMEM_EN = true) else '0';
-  access_check.int_dmem <= '1' when (addr_i(31 downto index_size_f(MEM_INT_DMEM_SIZE)) = dmem_base_c(31 downto index_size_f(MEM_INT_DMEM_SIZE))) and (MEM_INT_DMEM_EN = true) else '0';
+  access_check.int_imem <= '1' when (bus_addr_i(31 downto index_size_f(MEM_INT_IMEM_SIZE)) = imem_base_c(31 downto index_size_f(MEM_INT_IMEM_SIZE))) and (MEM_INT_IMEM_EN = true) else '0';
+  access_check.int_dmem <= '1' when (bus_addr_i(31 downto index_size_f(MEM_INT_DMEM_SIZE)) = dmem_base_c(31 downto index_size_f(MEM_INT_DMEM_SIZE))) and (MEM_INT_DMEM_EN = true) else '0';
   -- access to processor-internal BOOTROM or IO devices? --
-  access_check.int_bootrom_io <= '1' when (addr_i(31 downto 16) = boot_rom_base_c(31 downto 16)) else '0'; -- hacky!
+  access_check.int_bootrom_io <= '1' when (bus_addr_i(31 downto 16) = boot_rom_base_c(31 downto 16)) else '0'; -- hacky!
   -- actual internal bus access? --
   access_check.valid <= access_check.int_imem or access_check.int_dmem or access_check.int_bootrom_io;
+
+
+  -- Read/Write Access ----------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  rw_access: process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      -- bus handshake --
+      ack_o <= wren or rden;
+
+      -- write access --
+      if (control.bus_err = '1') then
+        err_flag <= '1'; -- sticky error flag
+      elsif (wren = '1') and (data_i(ctrl_err_flag_c) = '0') then -- clear when writing zero
+        err_flag <= '0';
+      end if;
+
+      -- read access --
+      data_o <= (others => '0');
+      if (rden = '1') then
+        data_o(ctrl_err_type_c) <= control.err_type;
+        data_o(ctrl_err_src_c)  <= control.int_ext;
+        data_o(ctrl_err_flag_c) <= err_flag;
+      end if;
+    end if;
+  end process rw_access;
 
 
   -- Keeper ---------------------------------------------------------------------------------
@@ -115,35 +174,43 @@ begin
   keeper_control: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      control.pending <= '0';
-      control.bus_err <= '0';
-      control.timeout <= (others => def_rst_val_c);
+      control.pending  <= '0';
+      control.bus_err  <= '0';
+      control.err_type <= def_rst_val_c;
+      control.int_ext  <= def_rst_val_c;
+      control.timeout  <= (others => def_rst_val_c);
     elsif rising_edge(clk_i) then
-
-      -- pending access? --
       control.bus_err <= '0';
       if (control.pending = '0') then -- idle
-        if ((rden_i or wren_i) = '1') and ((access_check.valid = '1') or (MEM_EXT_EN = false)) then -- valid INTERNAL access
+        control.timeout <= std_ulogic_vector(to_unsigned(max_proc_int_response_time_c, index_size_f(max_proc_int_response_time_c)));
+        if (bus_rden_i = '1') or (bus_wren_i = '1') then
+          if (access_check.valid = '1') or (MEM_EXT_EN = false) then
+            control.int_ext <= '1'; -- processor-internal access
+          else
+            control.int_ext <= '0'; -- processor-external access
+          end if;
           control.pending <= '1';
         end if;
-      else -- pending
-        if (ack_i = '1') or (err_i = '1') then -- termination by bus system
-          control.pending <= '0';
-        elsif (or_reduce_f(control.timeout) = '0') then -- timeout! terminate bus transfer
-          control.pending <= '0';
-          control.bus_err <= '1';
-        end if;
-      end if;
-
-      -- timeout counter --
-      if (control.pending = '0') then
-        control.timeout <= std_ulogic_vector(to_unsigned(max_proc_int_response_time_c, index_size_f(max_proc_int_response_time_c)));
-      else
+      else -- pending access
         control.timeout <= std_ulogic_vector(unsigned(control.timeout) - 1); -- countdown timer
+        if (bus_ack_i = '1') then -- normal termination by bus system
+          control.err_type <= '0'; -- don't care
+          control.bus_err  <= '0';
+          control.pending  <= '0';
+        elsif (bus_err_i = '1') then -- error termination by bus system
+          control.err_type <= '0';
+          control.bus_err  <= '1';
+          control.pending  <= '0';
+        elsif (or_reduce_f(control.timeout) = '0') and (control.int_ext = '1') then -- timeout! terminate bus transfer (internal accesses only!)
+          control.err_type <= '1';
+          control.bus_err  <= '1';
+          control.pending  <= '0';
+        end if;
       end if;
     end if;
   end process keeper_control;
 
+  -- inform CPU --
   err_o <= control.bus_err;
 
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060211"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060212"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- External Interface Types ---------------------------------------------------------------
@@ -217,7 +217,11 @@ package neorv32_package is
 
   -- reserved --
 --constant reserved_base_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff78"; -- base address
---constant reserved_size_c      : natural := 2*4; -- module's address space size in bytes
+--constant reserved_size_c      : natural := 1*4; -- module's address space size in bytes
+
+  -- Bus Access Keeper (BUSKEEPER) --
+  constant buskeeper_base_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff7c"; -- base address
+  constant buskeeper_size_c     : natural := 1*4; -- module's address space size in bytes
 
   -- External Interrupt Controller (XIRQ) --
   constant xirq_base_c          : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff80"; -- base address
@@ -1405,14 +1409,21 @@ package neorv32_package is
     );
     port (
       -- host access --
-      clk_i  : in  std_ulogic; -- global clock line
-      rstn_i : in  std_ulogic; -- global reset line, low-active
-      addr_i : in  std_ulogic_vector(31 downto 0); -- address
-      rden_i : in  std_ulogic; -- read enable
-      wren_i : in  std_ulogic; -- write enable
-      ack_i  : in  std_ulogic; -- transfer acknowledge from bus system
-      err_i  : in  std_ulogic; -- transfer error from bus system
-      err_o  : out std_ulogic  -- bus error
+      clk_i      : in  std_ulogic; -- global clock line
+      rstn_i     : in  std_ulogic; -- global reset, low-active, async
+      addr_i     : in  std_ulogic_vector(31 downto 0); -- address
+      rden_i     : in  std_ulogic; -- read enable
+      wren_i     : in  std_ulogic; -- write enable
+      data_i     : in  std_ulogic_vector(31 downto 0); -- data in
+      data_o     : out std_ulogic_vector(31 downto 0); -- data out
+      ack_o      : out std_ulogic; -- transfer acknowledge
+      err_o      : out std_ulogic; -- transfer error
+      -- bus monitoring --
+      bus_addr_i : in  std_ulogic_vector(31 downto 0); -- address
+      bus_rden_i : in  std_ulogic; -- read enable
+      bus_wren_i : in  std_ulogic; -- write enable
+      bus_ack_i  : in  std_ulogic; -- transfer acknowledge from bus system
+      bus_err_i  : in  std_ulogic  -- transfer error from bus system
     );
   end component;
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -1414,7 +1414,6 @@ package neorv32_package is
       addr_i     : in  std_ulogic_vector(31 downto 0); -- address
       rden_i     : in  std_ulogic; -- read enable
       wren_i     : in  std_ulogic; -- write enable
-      data_i     : in  std_ulogic_vector(31 downto 0); -- data in
       data_o     : out std_ulogic_vector(31 downto 0); -- data out
       ack_o      : out std_ulogic; -- transfer acknowledge
       err_o      : out std_ulogic; -- transfer error

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -684,7 +684,6 @@ begin
     addr_i     => p_bus.addr,                     -- address
     rden_i     => io_rden,                        -- read enable
     wren_i     => io_wren,                        -- byte write enable
-    data_i     => p_bus.wdata,                    -- data in
     data_o     => resp_bus(RESP_BUSKEEPER).rdata, -- data out
     ack_o      => resp_bus(RESP_BUSKEEPER).ack,   -- transfer acknowledge
     err_o      => resp_bus(RESP_BUSKEEPER).err,   -- transfer error

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -305,7 +305,7 @@ architecture neorv32_top_rtl of neorv32_top is
   constant resp_bus_entry_terminate_c : resp_bus_entry_t := (rdata => (others => '0'), ack => '0', err => '0');
 
   -- module response bus - device ID --
-  type resp_bus_id_t is (RESP_IMEM, RESP_DMEM, RESP_BOOTROM, RESP_WISHBONE, RESP_GPIO, RESP_MTIME, RESP_UART0, RESP_UART1, RESP_SPI,
+  type resp_bus_id_t is (RESP_BUSKEEPER, RESP_IMEM, RESP_DMEM, RESP_BOOTROM, RESP_WISHBONE, RESP_GPIO, RESP_MTIME, RESP_UART0, RESP_UART1, RESP_SPI,
                          RESP_TWI, RESP_PWM, RESP_WDT, RESP_TRNG, RESP_CFS, RESP_NEOLED, RESP_SYSINFO, RESP_OCD, RESP_SLINK, RESP_XIRQ);
 
   -- module response bus --
@@ -329,8 +329,7 @@ architecture neorv32_top_rtl of neorv32_top is
   signal xirq_irq      : std_ulogic;
 
   -- misc --
-  signal mtime_time     : std_ulogic_vector(63 downto 0); -- current system time from MTIME
-  signal bus_keeper_err : std_ulogic; -- bus keeper: bus access timeout
+  signal mtime_time : std_ulogic_vector(63 downto 0); -- current system time from MTIME
 
 begin
 
@@ -646,7 +645,7 @@ begin
   p_bus.fence <= cpu_d.fence or cpu_i.fence;
 
   -- bus response --
-  bus_response: process(resp_bus, bus_keeper_err)
+  bus_response: process(resp_bus)
     variable rdata_v : std_ulogic_vector(data_width_c-1 downto 0);
     variable ack_v   : std_ulogic;
     variable err_v   : std_ulogic;
@@ -661,11 +660,11 @@ begin
     end loop; -- i
     p_bus.rdata <= rdata_v; -- processor bus: CPU transfer data input
     p_bus.ack   <= ack_v;   -- processor bus: CPU transfer ACK input
-    p_bus.err   <= err_v or bus_keeper_err; -- processor bus: CPU transfer data bus error input
+    p_bus.err   <= err_v;   -- processor bus: CPU transfer data bus error input
   end process;
 
 
-  -- Processor-Internal Bus Keeper (BUS_KEEPER) ---------------------------------------------
+  -- Bus Keeper (BUSKEEPER) -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   neorv32_bus_keeper_inst: neorv32_bus_keeper
   generic map (
@@ -680,14 +679,21 @@ begin
   )
   port map (
     -- host access --
-    clk_i  => clk_i,         -- global clock line
-    rstn_i => sys_rstn,      -- global reset line, low-active
-    addr_i => p_bus.addr,    -- address
-    rden_i => p_bus.re,      -- read enable
-    wren_i => p_bus.we,      -- write enable
-    ack_i  => p_bus.ack,     -- transfer acknowledge from bus system
-    err_i  => p_bus.err,     -- transfer error from bus system
-    err_o  => bus_keeper_err -- bus error
+    clk_i      => clk_i,                          -- global clock line
+    rstn_i     => sys_rstn,                       -- global reset line, low-active, use as async
+    addr_i     => p_bus.addr,                     -- address
+    rden_i     => io_rden,                        -- read enable
+    wren_i     => io_wren,                        -- byte write enable
+    data_i     => p_bus.wdata,                    -- data in
+    data_o     => resp_bus(RESP_BUSKEEPER).rdata, -- data out
+    ack_o      => resp_bus(RESP_BUSKEEPER).ack,   -- transfer acknowledge
+    err_o      => resp_bus(RESP_BUSKEEPER).err,   -- transfer error
+    -- bus monitoring --
+    bus_addr_i => p_bus.addr,                     -- address
+    bus_rden_i => p_bus.re,                       -- read enable
+    bus_wren_i => p_bus.we,                       -- write enable
+    bus_ack_i  => p_bus.ack,                      -- transfer acknowledge from bus system
+    bus_err_i  => p_bus.err                       -- transfer error from bus system
   );
 
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -154,10 +154,10 @@ int main() {
 
 
   // reset performance counter
-  neorv32_cpu_csr_write(CSR_MCYCLEH, 0);
-  neorv32_cpu_csr_write(CSR_MCYCLE, 0);
-  neorv32_cpu_csr_write(CSR_MINSTRETH, 0);
-  neorv32_cpu_csr_write(CSR_MINSTRET, 0);
+  // neorv32_cpu_csr_write(CSR_MCYCLEH, 0);   -> done in crt0.S
+  // neorv32_cpu_csr_write(CSR_MCYCLE, 0);    -> done in crt0.S
+  // neorv32_cpu_csr_write(CSR_MINSTRETH, 0); -> done in crt0.S
+  // neorv32_cpu_csr_write(CSR_MINSTRET, 0);  -> done in crt0.S
   neorv32_cpu_csr_write(CSR_MCOUNTINHIBIT, 0); // enable performance counter auto increment (ALL counters)
   neorv32_cpu_csr_write(CSR_MCOUNTEREN, 7); // allow access from user-mode code to standard counters only
 
@@ -180,16 +180,15 @@ int main() {
 
   // configure RTE
   // -----------------------------------------------
-  PRINT_STANDARD("\n\nConfiguring NEORV32 RTE... ");
+  PRINT_STANDARD("\n\nRTE setup... ");
 
   int install_err = 0;
   // initialize ALL provided trap handler (overriding the default debug handlers)
   for (id=0; id<NEORV32_RTE_NUM_TRAPS; id++) {
     install_err += neorv32_rte_exception_install(id, global_trap_handler);
   }
-
   if (install_err) {
-    PRINT_CRITICAL("RTE install error (%i)!\n", install_err);
+    PRINT_CRITICAL("ERROR!\n");
     return 1;
   }
 
@@ -200,7 +199,7 @@ int main() {
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
   // test intro
-  PRINT_STANDARD("\nStarting tests...\n\n");
+  PRINT_STANDARD("\nStarting tests.\n\n");
 
   // enable global interrupts
   neorv32_cpu_eint();
@@ -215,7 +214,7 @@ int main() {
   // Test performance counter: setup as many events and counter as feasible
   // ----------------------------------------------------------
   neorv32_cpu_csr_write(CSR_MCAUSE, 0);
-  PRINT_STANDARD("[%i] Configuring HPM events: ", cnt_test);
+  PRINT_STANDARD("[%i] Setup HPM events: ", cnt_test);
 
   num_hpm_cnts_global = neorv32_cpu_hpm_get_counters();
 
@@ -254,7 +253,7 @@ int main() {
   // Test standard RISC-V performance counter [m]cycle[h]
   // ----------------------------------------------------------
   neorv32_cpu_csr_write(CSR_MCAUSE, 0);
-  PRINT_STANDARD("[%i] [m]cycle[h] counter: ", cnt_test);
+  PRINT_STANDARD("[%i] cycle counter: ", cnt_test);
 
   cnt_test++;
 
@@ -280,7 +279,7 @@ int main() {
   // Test standard RISC-V performance counter [m]instret[h]
   // ----------------------------------------------------------
   neorv32_cpu_csr_write(CSR_MCAUSE, 0);
-  PRINT_STANDARD("[%i] [m]instret[h] counter: ", cnt_test);
+  PRINT_STANDARD("[%i] instret counter: ", cnt_test);
 
   cnt_test++;
 

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -817,7 +817,7 @@ typedef struct __attribute__((packed,aligned(4))) {
 enum NEORV32_BUSKEEPER_CTRL_enum {
   BUSKEEPER_ERR_TYPE =  0, /**< BUSKEEPER control register(0)  (r/-): Bus error type: 0=device error, 1=access timeout */
   BUSKEEPER_ERR_SRC  =  1, /**< BUSKEEPER control register(1)  (r/-): Bus error source: 0=processor-external, 1=processor-internal */
-  BUSKEEPER_ERR_FLAG = 31  /**< BUSKEEPER control register(31) (r/c): Sticky error flag, cleared by writing zero */
+  BUSKEEPER_ERR_FLAG = 31  /**< BUSKEEPER control register(31) (r/c): Sticky error flag, clears after read */
 };
 /**@}*/
 

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -802,6 +802,27 @@ enum NEORV32_SLINK_STATUS_enum {
 
 
 /**********************************************************************//**
+ * @name IO Device: Bus Monitor (BUSKEEPER)
+ **************************************************************************/
+/**@{*/
+/** BUSKEEPER module prototype */
+typedef struct __attribute__((packed,aligned(4))) {
+	uint32_t CTRL; /**< offset 0: control register (#NEORV32_BUSKEEPER_CTRL_enum) */
+} neorv32_buskeeper_t;
+
+/** BUSKEEPER module hardware access (#neorv32_buskeeper_t) */
+#define NEORV32_BUSKEEPER (*((volatile neorv32_buskeeper_t*) (0xFFFFFF7CUL)))
+
+/** BUSKEEPER control/data register bits */
+enum NEORV32_BUSKEEPER_CTRL_enum {
+  BUSKEEPER_ERR_TYPE =  0, /**< BUSKEEPER control register(0)  (r/-): Bus error type: 0=device error, 1=access timeout */
+  BUSKEEPER_ERR_SRC  =  1, /**< BUSKEEPER control register(1)  (r/-): Bus error source: 0=processor-external, 1=processor-internal */
+  BUSKEEPER_ERR_FLAG = 31  /**< BUSKEEPER control register(31) (r/c): Sticky error flag, cleared by writing zero */
+};
+/**@}*/
+
+
+/**********************************************************************//**
  * @name IO Device: External Interrupt Controller (XIRQ)
  **************************************************************************/
 /**@{*/

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -202,14 +202,12 @@ static void __neorv32_rte_debug_exc_handler(void) {
     return; // handler cannot output anything if UART0 is not implemented
   }
 
-  char tmp;
-
   // intro
   neorv32_uart0_print("<RTE> ");
 
   // cause
   register uint32_t trap_cause = neorv32_cpu_csr_read(CSR_MCAUSE);
-  tmp = (char)(trap_cause & 0xf);
+  register char tmp = (char)(trap_cause & 0xf);
   if (tmp >= 10) {
     tmp = 'a' + (tmp - 10);
   }
@@ -249,9 +247,26 @@ static void __neorv32_rte_debug_exc_handler(void) {
     default:                     neorv32_uart0_print("Unknown trap cause: "); __neorv32_rte_print_hex_word(trap_cause); break;
   }
 
+  // check cause if bus access fault exception
+  if ((trap_cause == TRAP_CODE_I_ACCESS) || (trap_cause == TRAP_CODE_L_ACCESS) || (trap_cause == TRAP_CODE_S_ACCESS)) {
+    register uint32_t bus_err = NEORV32_BUSKEEPER.CTRL;
+    if (bus_err & (1<<BUSKEEPER_ERR_FLAG)) { // exception caused by bus system?
+      if (bus_err & (1<<BUSKEEPER_ERR_TYPE)) {
+        neorv32_uart0_print(" [TIMEOUT_ERR]");
+      }
+      else {
+        neorv32_uart0_print(" [DEVICE_ERR]");
+      }
+    }
+    else { // exception was not caused by bus system -> has to be caused by PMP rule violation
+      neorv32_uart0_print(" [PMP_ERR]");
+    }
+    NEORV32_BUSKEEPER.CTRL = 0; // clear bus error flag
+  }
+
   // instruction address
   neorv32_uart0_print(" @ PC=");
-  __neorv32_rte_print_hex_word(neorv32_cpu_csr_read(CSR_MSCRATCH)); // rte core stores actual mepc to mscratch
+  __neorv32_rte_print_hex_word(neorv32_cpu_csr_read(CSR_MSCRATCH)); // rte core stores original mepc to mscratch
 
   // additional info
   neorv32_uart0_print(", MTVAL=");

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -261,7 +261,6 @@ static void __neorv32_rte_debug_exc_handler(void) {
     else { // exception was not caused by bus system -> has to be caused by PMP rule violation
       neorv32_uart0_print(" [PMP_ERR]");
     }
-    NEORV32_BUSKEEPER.CTRL = 0; // clear bus error flag
   }
 
   // instruction address


### PR DESCRIPTION
This PR add a read-only memory-mapped status register to the `BUSKEEPER` module. The status register gives additional information regarding the actual cause of an instruction / data-load / data-store bus access fault exception:
* `BUSKEEPER_ERR_TYPE` = `0`: error caused by device itself (by asserting the `err_o` signal)
* `BUSKEEPER_ERR_TYPE` = `1`: error caused by bus timeout (accessed device is not responding at all)
* `BUSKEEPER_ERR_SRC` = `0`: error caused during access to processor-internal module
* `BUSKEEPER_ERR_SRC` = `1`: error caused during access via processor-external bus interface

✔️ This PR is fully backwards compatible - the memory-mapped BUSKEEPER register uses a previously unused IO space address (`0xffffff7C`).