### PR TITLE
Rework peripheral's FIRQ triggering

### DIFF
--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -531,19 +531,20 @@ begin
   fence_o  <= cpu_d.fence; -- indicates an executed FENCE operation
   fencei_o <= cpu_i.fence; -- indicates an executed FENCEI operation
 
-  -- fast interrupts --
-  fast_irq(00) <= wdt_irq;       -- HIGHEST PRIORITY - watchdog timeout
+  -- fast interrupt requests (FIRQs) --
+  -- these stay asserted until explicitly acknowledged --
+  fast_irq(00) <= wdt_irq;       -- HIGHEST PRIORITY - watchdog
   fast_irq(01) <= cfs_irq;       -- custom functions subsystem
-  fast_irq(02) <= uart0_rxd_irq; -- primary UART (UART0) RX interrupt
-  fast_irq(03) <= uart0_txd_irq; -- primary UART (UART0) TX interrupt
-  fast_irq(04) <= uart1_rxd_irq; -- secondary UART (UART1) RX interrupt
-  fast_irq(05) <= uart1_txd_irq; -- secondary UART (UART1) TX interrupt
-  fast_irq(06) <= spi_irq;       -- SPI idle
-  fast_irq(07) <= twi_irq;       -- TWI idle
+  fast_irq(02) <= uart0_rxd_irq; -- primary UART (UART0) RX
+  fast_irq(03) <= uart0_txd_irq; -- primary UART (UART0) TX
+  fast_irq(04) <= uart1_rxd_irq; -- secondary UART (UART1) RX
+  fast_irq(05) <= uart1_txd_irq; -- secondary UART (UART1) TX
+  fast_irq(06) <= spi_irq;       -- SPI
+  fast_irq(07) <= twi_irq;       -- TWI
   fast_irq(08) <= xirq_irq;      -- external interrupt controller
   fast_irq(09) <= neoled_irq;    -- NEOLED buffer free
-  fast_irq(10) <= slink_rx_irq;  -- SLINK RX interrupt
-  fast_irq(11) <= slink_tx_irq;  -- SLINK TX interrupt
+  fast_irq(10) <= slink_rx_irq;  -- SLINK RX
+  fast_irq(11) <= slink_tx_irq;  -- SLINK TX
   fast_irq(12) <= gptmr_irq;     -- general purpose timer
   --
   fast_irq(13) <= '0'; -- reserved


### PR DESCRIPTION
This PR changes the behavior of the IO module's fast interrupt request signals.

Affected peripheral devices: `SPI`, `TWI`, `UART0`, `UART1`, `NEOLED`, `SLINK`

## Pre-PR

In the current pre-PR design the interrupts are triggered whenever the according module is **_in_** the interrupt triggering state. For example, the SPI unit's interrupt gets pending whenever the SPI module is idle. This is disruptive because once the interrupt is configured and enabled it keeps firing all the time even if there is no data to be send via SPI right now.

In the current version an interrupt is acknowledged (= no longer pending) by resolving the interrupt-causing conditions. In term of the SPI module this mean triggering a new transmission.

## Post-PR

This PR changes the triggering of the module's FIRQ interrupts so that they are triggered when the according module **_enters_** the interrupt-triggering state. For example, the SPI unit's interrupt only gets pending once when the module finishes it's current transmission and enters idle mode. Once the interrupt is processed there will be no new interrupt request until the SPI module finishes another transmission.

This PR also reworks (⚠️) the mechanism for acknowledging interrupts. In the updated design interrupt are acknowledged by either writing to a unit' control register (this can also be a dummy write like reading the control register and writing it back) or by reading/writing the module's data register(s) - the last point is device specific.

Example 1: the SPI interrupt is acknowledged by writing the SPI control register or by reading or writing the SPI data register.

Example 2: the UART0 RX interrupt is acknowledged by writing the UART0 control register or by reading the UART0 data register.

Example 3: the UART TX interrupt is acknowledged by writing the UART0 control register or by writing the UART0 data register.

## Misc

This PR also reworks the SLINK interrupt system (also the trigger logic) and fixes some bugs in the interrupt logic (also fixing #199).