### PR TITLE
[TWI] remove clock-stretching enable flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 18.11.2021 | 1.6.3.8 | TWI: removed TWI_CTRL_CKSTEN flag (enable clock stretching) from control registers, clock-stretching is now _always_ enabled |
 | 14.11.2021 | 1.6.3.7 | major control unit and ALU logic optimizations, reduced hardware footprint; :lock: closed further illegal instruction encoding holes (system environment instructions, ALU and ALU-immediate instructions, FENCE instructions); [PR #204](https://github.com/stnolting/neorv32/pull/204) |
 | 10.11.2021 | 1.6.3.6 | optimized BUSKEEPER: removed redundant logic - bus keeper now also shows an external interface access timeout (if implemented) as "timeout error"; removed _BUSKEEPER_ERR_SRC_ status flag; :warning: added `err_o` (fault access operation) to the custom functions subsystem (CFS) |
 | 09.11.2021 | 1.6.3.5 | :warning: reworked IRQ trigger logic of SPI, TWI, UART0, UART1, NELOED and SLINK; FIRQs now only trigger **once** when the programmed interrupt condition is met instead of triggering **all the time** (see [PR #202](https://github.com/stnolting/neorv32/pull/202)) |

--- a/docs/datasheet/soc_twi.adoc
+++ b/docs/datasheet/soc_twi.adoc
@@ -21,8 +21,8 @@ components. Since this interface only needs two signals (the serial data line `t
 clock line `twi_scl_io`) - despite of the number of connected devices - it allows easy interconnections of
 several peripheral nodes.
 
-The NEORV32 TWI implements a **TWI controller**. It features "clock stretching" (if enabled via the control
-register), so a slow peripheral can halt the transmission by pulling the SCL line low. Currently, **no multi-controller
+The NEORV32 TWI implements a **TWI controller**. It supports "clock so a slow peripheral can halt
+the transmission by pulling the SCL line low. Currently, **no multi-controller
 support** is available. Also, the NEORV32 TWI unit cannot operate in peripheral mode.
 
 The TWI is enabled via the _TWI_CTRL_EN_ bit in the `CTRL` control register. The user program can start / stop a
@@ -90,15 +90,14 @@ or the state of the TWI module.
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.10+<| `0xffffffb0` .10+<| `NEORV32_TWI.CTRL` <|`0` _TWI_CTRL_EN_     ^| r/w <| TWI enable
-                                              <|`1` _TWI_CTRL_START_  ^| r/w <| generate START condition
-                                              <|`2` _TWI_CTRL_STOP_   ^| r/w <| generate STOP condition
-                                              <|`3` _TWI_CTRL_PRSC0_  ^| r/w .3+<| 3-bit clock prescaler select
-                                              <|`4` _TWI_CTRL_PRSC1_  ^| r/w
-                                              <|`5` _TWI_CTRL_PRSC2_  ^| r/w
-                                              <|`6` _TWI_CTRL_MACK_   ^| r/w <| generate controller ACK for each transmission ("MACK")
-                                              <|`7` _TWI_CTRL_CKSTEN_ ^| r/w <| allow clock-stretching by peripherals when set
-                                              <|`30` _TWI_CTRL_ACK_   ^| r/- <| ACK received when set
-                                              <|`31` _TWI_CTRL_BUSY_  ^| r/- <| transfer/START/STOP in progress when set
+.9+<| `0xffffffb0` .9+<| `NEORV32_TWI.CTRL` <|`0` _TWI_CTRL_EN_     ^| r/w <| TWI enable
+                                            <|`1` _TWI_CTRL_START_  ^| r/w <| generate START condition
+                                            <|`2` _TWI_CTRL_STOP_   ^| r/w <| generate STOP condition
+                                            <|`3` _TWI_CTRL_PRSC0_  ^| r/w .3+<| 3-bit clock prescaler select
+                                            <|`4` _TWI_CTRL_PRSC1_  ^| r/w
+                                            <|`5` _TWI_CTRL_PRSC2_  ^| r/w
+                                            <|`6` _TWI_CTRL_MACK_   ^| r/w <| generate controller ACK for each transmission ("MACK")
+                                            <|`30` _TWI_CTRL_ACK_   ^| r/- <| ACK received when set
+                                            <|`31` _TWI_CTRL_BUSY_  ^| r/- <| transfer/START/STOP in progress when set
 | `0xffffffb4` | `NEORV32_TWI.DATA` |`7:0` _TWI_DATA_MSB_ : TWI_DATA_LSB_ | r/w | receive/transmit data
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060307"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060308"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- External Interface Types ---------------------------------------------------------------

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1156,8 +1156,8 @@ int main() {
 
     cnt_test++;
 
-    // configure TWI, fastest clock, no peripheral clock stretching
-    neorv32_twi_setup(CLK_PRSC_2, 0);
+    // configure TWI, fastest clock
+    neorv32_twi_setup(CLK_PRSC_2);
 
     // enable TWI FIRQ
     neorv32_cpu_irq_enable(CSR_MIE_FIRQ7E);

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -1027,17 +1027,16 @@ typedef struct __attribute__((packed,aligned(4))) {
 
 /** TWI control register bits */
 enum NEORV32_TWI_CTRL_enum {
-  TWI_CTRL_EN     =  0, /**< TWI control register(0) (r/w): TWI enable */
-  TWI_CTRL_START  =  1, /**< TWI control register(1) (-/w): Generate START condition, auto-clears */
-  TWI_CTRL_STOP   =  2, /**< TWI control register(2) (-/w): Generate STOP condition, auto-clears */
-  TWI_CTRL_PRSC0  =  3, /**< TWI control register(3) (r/w): Clock prescaler select bit 0 */
-  TWI_CTRL_PRSC1  =  4, /**< TWI control register(4) (r/w): Clock prescaler select bit 1 */
-  TWI_CTRL_PRSC2  =  5, /**< TWI control register(5) (r/w): Clock prescaler select bit 2 */
-  TWI_CTRL_MACK   =  6, /**< TWI control register(6) (r/w): Generate controller ACK for each transmission */
-  TWI_CTRL_CKSTEN =  7, /**< TWI control register(7) (r/w): Enable clock stretching (by peripheral) */
+  TWI_CTRL_EN    =  0, /**< TWI control register(0) (r/w): TWI enable */
+  TWI_CTRL_START =  1, /**< TWI control register(1) (-/w): Generate START condition, auto-clears */
+  TWI_CTRL_STOP  =  2, /**< TWI control register(2) (-/w): Generate STOP condition, auto-clears */
+  TWI_CTRL_PRSC0 =  3, /**< TWI control register(3) (r/w): Clock prescaler select bit 0 */
+  TWI_CTRL_PRSC1 =  4, /**< TWI control register(4) (r/w): Clock prescaler select bit 1 */
+  TWI_CTRL_PRSC2 =  5, /**< TWI control register(5) (r/w): Clock prescaler select bit 2 */
+  TWI_CTRL_MACK  =  6, /**< TWI control register(6) (r/w): Generate ACK by controller for each transmission */
 
-  TWI_CTRL_ACK    = 30, /**< TWI control register(30) (r/-): ACK received when set */
-  TWI_CTRL_BUSY   = 31  /**< TWI control register(31) (r/-): Transfer in progress, busy flag */
+  TWI_CTRL_ACK   = 30, /**< TWI control register(30) (r/-): ACK received when set */
+  TWI_CTRL_BUSY  = 31  /**< TWI control register(31) (r/-): Transfer in progress, busy flag */
 };
 
 /** WTD receive/transmit data register bits */

--- a/sw/lib/include/neorv32_twi.h
+++ b/sw/lib/include/neorv32_twi.h
@@ -46,7 +46,7 @@
 
 // prototypes
 int neorv32_twi_available(void);
-void neorv32_twi_setup(uint8_t prsc, uint8_t ckst_en);
+void neorv32_twi_setup(uint8_t prsc);
 void neorv32_twi_disable(void);
 void neorv32_twi_enable(void);
 void neorv32_twi_mack_enable(void);

--- a/sw/lib/source/neorv32_twi.c
+++ b/sw/lib/source/neorv32_twi.c
@@ -65,9 +65,8 @@ int neorv32_twi_available(void) {
  * Enable and configure TWI controller. The TWI control register bits are listed in #NEORV32_TWI_CTRL_enum.
  *
  * @param[in] prsc Clock prescaler select (0..7). See #NEORV32_CLOCK_PRSC_enum.
- * @param[in] ckst_en Enable clock-stretching by peripherals when 1.
  **************************************************************************/
-void neorv32_twi_setup(uint8_t prsc, uint8_t ckst_en) {
+void neorv32_twi_setup(uint8_t prsc) {
 
   NEORV32_TWI.CTRL = 0; // reset
 
@@ -77,10 +76,7 @@ void neorv32_twi_setup(uint8_t prsc, uint8_t ckst_en) {
   uint32_t ct_prsc = (uint32_t)(prsc & 0x07);
   ct_prsc = ct_prsc << TWI_CTRL_PRSC0;
 
-  uint32_t ct_cksten = (uint32_t)(ckst_en & 0x01);
-  ct_cksten = ct_cksten << TWI_CTRL_CKSTEN;
-
-  NEORV32_TWI.CTRL = ct_enable | ct_prsc | ct_cksten;
+  NEORV32_TWI.CTRL = ct_enable | ct_prsc;
 }
 
 


### PR DESCRIPTION
This PR removes the `TWI_CTRL_CKSTEN` flag (bit 7) from the TWI control register. Clock stretching is now always enabled and bit 7 of the control register is hardwired to zero.