### PR TITLE
Rework TRNG module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 22.11.2021 | 1.6.3.10 | reworked **TRNG** (less hardware requirements, improved quality), see [PR #212](https://github.com/stnolting/neorv32/pull/212) and [stnolting/neoTRNG](https://github.com/stnolting/neoTRNG) |
 | 21.11.2021 | 1.6.3.9 | minor rtl edits: configuring an IMEM or DMEM size (`MEM_INT_IMEM_SIZE` / `MEM_INT_DMEM_SIZE` generic) of 0 will now exclude the according memory from synthesis (and also clears the according `NEORV32_SYSINFO.SOC` flags) |
 | 18.11.2021 | 1.6.3.8 | TWI: removed TWI_CTRL_CKSTEN flag (enable clock stretching) from control registers, clock-stretching is now _always_ enabled |
 | 14.11.2021 | 1.6.3.7 | major control unit and ALU logic optimizations, reduced hardware footprint; :lock: closed further illegal instruction encoding holes (system environment instructions, ALU and ALU-immediate instructions, FENCE instructions); [PR #204](https://github.com/stnolting/neorv32/pull/204) |

--- a/docs/datasheet/soc_trng.adoc
+++ b/docs/datasheet/soc_trng.adoc
@@ -13,72 +13,43 @@
 | CPU interrupts:          | none | 
 |=======================
 
+
 **Theory of Operation**
 
-The NEORV32 true random number generator provides _physical true random numbers_ for your application.
-Instead of using a pseudo RNG like a LFSR, the TRNG of the processor uses a simple, straight-forward ring
-oscillator as physical entropy source. Hence, voltage and thermal fluctuations are used to provide true
-physical random data.
+The NEORV32 true random number generator provides _physical_ true random numbers.
+Instead of using a pseudo RNG like a LFSR, the TRNG uses a simple, straight-forward ring
+oscillator concept as physical entropy source. Hence, voltage, thermal and also semiconductor manufacturing
+fluctuations are used to provide a true physical entropy source.
+
+The TRNG is based on the neoTRNG[https://github.com/stnolting/neoTRNG], which is a "spin-off project" of the
+NEORV32 processor. The TRNG uses the default neoTRNG configuration, which showed very good results in the
+`dieharder` battery of random number tests. More detailed information about the neoTRNG, it's architecture and a
+detailed evaluation of the random number quality can be found it it's repository: https://github.com/stnolting/neoTRNG
 
 [NOTE]
 The TRNG features a platform independent architecture without FPGA-specific primitives, macros or
-attributes.
+attributes so it can be synthesized for _any_ FPGA.
 
-**Architecture**
-
-The NEORV32 TRNG is based on simple ring oscillators, which are implemented as an inverter chain with
-an odd number of inverters. A **latch** is used to decouple each individual inverter. Basically, this architecture
-is some king of asynchronous LFSR.
-
-The output of several ring oscillators are synchronized using two registers and are XORed together. The
-resulting output is de-biased using a von-Neumann randomness extractor. This de-biased output is further
-processed by a simple 8-bit Fibonacci LFSR to improve whitening. After at least 8 clock cycles the state of
-the LFSR is sampled and provided as final data output.
-
-To prevent the synthesis tool from doing logic optimization and thus, removing all but one inverter, the
-TRNG uses simple latches to decouple an inverter and its actual output. The latches are reset when the
-TRNG is disabled and are enabled one by one by a "real" shift register when the TRNG is activated. This
-construct can be synthesized for any FPGA platform. Thus, the NEORV32 TRNG provides a platform
-independent architecture.
-
-**TRNG Configuration**
-
-The TRNG uses several ring-oscillators, where the next oscillator provides a slightly longer chain (more
-inverters) than the one before. This increment is constant for all implemented oscillators. This setup can be
-customized by modifying the "Advanced Configuration" constants in the TRNG's VHDL file:
-
-* The `num_roscs_c` constant defines the total number of ring oscillators in the system. num_inv_start_c
-defines the number of inverters used by the first ring oscillators (has to be an odd number). Each additional
-ring oscillator provides `num_inv_inc_c` more inverters that the one before (has to be an even number).
-* The LFSR-based post-processing can be deactivated using the `lfsr_en_c` constant. The polynomial tap
-mask of the LFSR can be customized using `lfsr_taps_c`.
 
 **Using the TRNG**
 
 The TRNG features a single register for status and data access. When the _TRNG_CTRL_EN_ control register (`CTRL`)
 bit is set, the TRNG is enabled and starts operation. As soon as the _TRNG_CTRL_VALID_ bit is set, the currently
 sampled 8-bit random data byte can be obtained from the lowest 8 bits of the `CTRL` register
-(_TRNG_CTRL_DATA_MSB_ : _TRNG_CTRL_DATA_LSB_). The _TRNG_CTRL_VALID_ bit is automatically cleared
-when reading the control register.
+(_TRNG_CTRL_DATA_MSB_ : _TRNG_CTRL_DATA_LSB_). These bits always keep the latest valid data obtained from the TRNG
+entropy source. The _TRNG_CTRL_VALID_ bit is automatically cleared when reading the control register.
 
-[IMPORTANT]
-The TRNG needs at least 8 clock cycles to generate a new random byte. During this sampling time
-the current output random data is kept stable in the output register until a valid sampling of the new byte has
-completed.
+[NOTE]
+The TRNG core does not provide a dedicated reset. In order to ensure correct operations, the TRNG should be
+disabled (=reset) by clearing the _TRNG_CTRL_EN_ and waiting some milliseconds before re-enabling it.
 
-Randomness "Quality"
-I have not verified the quality of the generated random numbers (for example using NIST test suites). The
-quality is highly effected by the actual configuration of the TRNG and the resulting FPGA mapping/routing.
-However, generating larger histograms of the generated random number shows an equal distribution (binary
-average of the random numbers = 127). A simple evaluation test/demo program can be found in
-`sw/example/demo_trng`.
 
 .TRNG register map (`struct NEORV32_TRNG`)
 [cols="<2,<2,<4,^1,<7"]
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.3+<| `0xffffffb8` .3+<| `NEORV32_TRNG.CTRL` <|`7:0` _TRNG_CTRL_DATA_MSB_ : _TRNG_CTRL_DATA_MSB_ ^| r/- <| 8-bit random data output
-                                             <|`30` _TRNG_CTRL_EN_                             ^| r/w <| TRNG enable
-                                             <|`31` _TRNG_CTRL_VALID_                          ^| r/- <| random data output is valid when set
+.3+<| `0xffffffb8` .3+<| `NEORV32_TRNG.CTRL` <|`7:0` _TRNG_CTRL_DATA_MSB_ : _TRNG_CTRL_DATA_MSB_ ^| r/- <| 8-bit random data
+                                             <|`30` _TRNG_CTRL_EN_                               ^| r/w <| TRNG enable
+                                             <|`31` _TRNG_CTRL_VALID_                            ^| r/- <| random data is valid when set
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060309"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060310"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- External Interface Types ---------------------------------------------------------------

--- a/rtl/core/neorv32_trng.vhd
+++ b/rtl/core/neorv32_trng.vhd
@@ -1,10 +1,8 @@
 -- #################################################################################################
 -- # << NEORV32 - True Random Number Generator (TRNG) >>                                           #
 -- # ********************************************************************************************* #
--- # This unit implements a *true* random number generator which uses several ring oscillators as  #
--- # entropy source. The outputs of all chains are XORed and de-biased using a John von Neumann    #
--- # randomness extractor. The de-biased signal is further processed by a simple LFSR for improved #
--- # whitening.                                                                                    #
+-- # This processor module instantiates the "neoTRNG" true random number generator.                #
+-- # See the neoTRNG's documentation for more information: https://github.com/stnolting/neoTRNG    #
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
@@ -59,18 +57,16 @@ end neorv32_trng;
 
 architecture neorv32_trng_rtl of neorv32_trng is
 
-  -- Advanced Configuration --------------------------------------------------------------------------------
-  constant num_roscs_c     : natural := 4; -- total number of ring oscillators
-  constant num_inv_start_c : natural := 5; -- number of inverters in FIRST ring oscillator (has to be odd)
-  constant num_inv_inc_c   : natural := 2; -- number of inverters increment for each next ring oscillator (has to be even)
-  constant lfsr_en_c       : boolean := true; -- use LFSR-based post-processing
-  constant lfsr_taps_c     : std_ulogic_vector(7 downto 0) := "10111000"; -- Fibonacci post-processing LFSR feedback taps
-  -- -------------------------------------------------------------------------------------------------------
+  -- neoTRNG Configuration -------------------------------------------------------------------------------------------
+  constant num_cells_c     : natural := 3; -- total number of ring-oscillator cells
+  constant num_inv_start_c : natural := 3; -- number of inverters in first cell (short path), has to be odd
+  constant num_inv_inc_c   : natural := 2; -- number of additional inverters in next cell (short path), has to be even
+  constant num_inv_delay_c : natural := 2; -- additional inverters to form cell's long path, has to be even
+  -- -----------------------------------------------------------------------------------------------------------------
 
   -- control register bits --
   constant ctrl_data_lsb_c : natural :=  0; -- r/-: Random data byte LSB
   constant ctrl_data_msb_c : natural :=  7; -- r/-: Random data byte MSB
-  --
   constant ctrl_en_c       : natural := 30; -- r/w: TRNG enable
   constant ctrl_valid_c    : natural := 31; -- r/-: Output data valid
 
@@ -78,56 +74,37 @@ architecture neorv32_trng_rtl of neorv32_trng is
   constant hi_abb_c : natural := index_size_f(io_size_c)-1; -- high address boundary bit
   constant lo_abb_c : natural := index_size_f(trng_size_c); -- low address boundary bit
 
-  -- Component: Ring-Oscillator --
-  component neorv32_trng_ring_osc
-    generic (
-      NUM_INV : natural := 16 -- number of inverters in chain
-    );
-    port (
-      clk_i    : in  std_ulogic;
-      enable_i : in  std_ulogic; -- enable chain input
-      enable_o : out std_ulogic; -- enable chain output
-      data_o   : out std_ulogic  -- sync random bit
-    );
-  end component;
-
   -- access control --
   signal acc_en : std_ulogic; -- module access enable
   signal wren   : std_ulogic; -- full word write enable
   signal rden   : std_ulogic; -- read enable
 
-  -- ring-oscillator array --
-  signal osc_array_en_in  : std_ulogic_vector(num_roscs_c-1 downto 0);
-  signal osc_array_en_out : std_ulogic_vector(num_roscs_c-1 downto 0);
-  signal osc_array_data   : std_ulogic_vector(num_roscs_c-1 downto 0);
+  -- Component: neoTRNG true random number generator --
+  component neoTRNG
+    generic (
+      NUM_CELLS     : natural; -- total number of ring-oscillator cells
+      NUM_INV_START : natural; -- number of inverters in first cell (short path), has to be odd
+      NUM_INV_INC   : natural; -- number of additional inverters in next cell (short path), has to be even
+      NUM_INV_DELAY : natural  -- additional inverters to form cell's long path, has to be even
+    );
+    port (
+      clk_i    : in  std_ulogic; -- global clock line
+      enable_i : in  std_ulogic; -- unit enable (high-active), reset unit when low
+      data_o   : out std_ulogic_vector(7 downto 0); -- random data byte output
+      valid_o  : out std_ulogic  -- data_o is valid when set
+    );
+  end component;
 
-  -- von-Neumann de-biasing --
-  type debiasing_t is record
-    sreg  : std_ulogic_vector(1 downto 0);
-    state : std_ulogic; -- process de-biasing every second cycle
-    valid : std_ulogic; -- de-biased data
-    data  : std_ulogic; -- de-biased data valid
-  end record;
-  signal debiasing : debiasing_t;
+  -- TRNG interface --
+  signal trng_data  : std_ulogic_vector(7 downto 0);
+  signal trng_valid : std_ulogic;
 
-  -- (post-)processing core --
-  type processing_t is record
-    enable : std_ulogic; -- TRNG enable flag
-    cnt    : std_ulogic_vector(3 downto 0); -- bit counter
-    sreg   : std_ulogic_vector(7 downto 0); -- data shift register
-    output : std_ulogic_vector(7 downto 0); -- output register
-    valid  : std_ulogic; -- data output valid flag
-  end record;
-  signal processing : processing_t;
+  -- arbiter --
+  signal enable  : std_ulogic;
+  signal valid   : std_ulogic;
+  signal rnd_reg : std_ulogic_vector(7 downto 0);
 
 begin
-
-  -- Sanity Checks --------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  assert not (num_roscs_c = 0) report "NEORV32 PROCESSOR CONFIG ERROR: TRNG - Total number of ring-oscillators has to be >0." severity error;
-  assert not ((num_inv_start_c mod 2)  = 0) report "NEORV32 PROCESSOR CONFIG ERROR: TRNG - Number of inverters in first ring has to be odd." severity error;
-  assert not ((num_inv_inc_c   mod 2) /= 0) report "NEORV32 PROCESSOR CONFIG ERROR: TRNG - Number of inverters increment for each next ring has to be even." severity error;
-
 
   -- Access Control -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -141,110 +118,56 @@ begin
   rw_access: process(clk_i)
   begin
     if rising_edge(clk_i) then
+      -- host bus acknowledge --
       ack_o <= wren or rden;
+
       -- write access --
       if (wren = '1') then
-        processing.enable <= data_i(ctrl_en_c);
+        enable <= data_i(ctrl_en_c);
       end if;
+
       -- read access --
       data_o <= (others => '0');
       if (rden = '1') then
-        data_o(ctrl_data_msb_c downto ctrl_data_lsb_c) <= processing.output;
-        data_o(ctrl_en_c)                              <= processing.enable;
-        data_o(ctrl_valid_c)                           <= processing.valid;
+        data_o(ctrl_data_msb_c downto ctrl_data_lsb_c) <= rnd_reg;
+        data_o(ctrl_en_c)    <= enable;
+        data_o(ctrl_valid_c) <= valid;
+      end if;
+
+      -- sample --
+      if (trng_valid = '1') then
+        rnd_reg <= trng_data;
+      end if;
+
+      -- data valid? --
+      if (enable = '0') then -- disabled
+        valid <= '0';
+      else
+        if (trng_valid = '1') then
+          valid <= '1';
+        elsif (rden = '1') then
+          valid <= '0';
+        end if;
       end if;
     end if;
   end process rw_access;
 
 
-  -- Entropy Source -------------------------------------------------------------------------
+  -- neoTRNG --------------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  neorv32_trng_ring_osc_inst:
-  for i in 0 to num_roscs_c-1 generate
-    neorv32_trng_ring_osc_inst_i: neorv32_trng_ring_osc
+  neoTRNG_inst: neoTRNG
     generic map (
-      NUM_INV => num_inv_start_c + (i*num_inv_inc_c) -- number of inverters in chain
+      NUM_CELLS     => num_cells_c,
+      NUM_INV_START => num_inv_start_c,
+      NUM_INV_INC   => num_inv_inc_c,
+      NUM_INV_DELAY => num_inv_delay_c
     )
     port map (
       clk_i    => clk_i,
-      enable_i => osc_array_en_in(i),
-      enable_o => osc_array_en_out(i),
-      data_o   => osc_array_data(i)
+      enable_i => enable,
+      data_o   => trng_data,
+      valid_o  => trng_valid
     );
-  end generate;
-
-  -- RO enable chain --
-  array_intercon: process(processing.enable, osc_array_en_out)
-  begin
-    for i in 0 to num_roscs_c-1 loop
-      if (i = 0) then -- start of enable chain
-        osc_array_en_in(i) <= processing.enable;
-      else
-        osc_array_en_in(i) <= osc_array_en_out(i-1);
-      end if;
-    end loop; -- i
-  end process array_intercon;
-
-
-  -- John von Neumann De-Biasing ------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  neumann_debiasing_sync: process(clk_i)
-  begin
-    if rising_edge(clk_i) then
-      debiasing.sreg  <= debiasing.sreg(debiasing.sreg'left-1 downto 0) & xor_reduce_f(osc_array_data);
-      debiasing.state <= (not debiasing.state) and osc_array_en_out(num_roscs_c-1); -- start toggling when last RO is enabled -> process in every second cycle
-    end if;
-  end process neumann_debiasing_sync;
-
-  -- Edge detector --
-  neumann_debiasing_comb: process(debiasing)
-    variable tmp_v : std_ulogic_vector(2 downto 0);
-  begin
-    -- check groups of two non-overlapping bits from the input stream
-    tmp_v := debiasing.state & debiasing.sreg;
-    case tmp_v is
-      when "101"  => debiasing.valid <= '1'; debiasing.data <= '1'; -- rising edge  -> '1'
-      when "110"  => debiasing.valid <= '1'; debiasing.data <= '0'; -- falling edge -> '0'
-      when others => debiasing.valid <= '0'; debiasing.data <= '0'; -- no valid data
-    end case;
-  end process neumann_debiasing_comb;
-
-
-  -- Processing Core ------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  processing_core: process(clk_i)
-  begin
-    if rising_edge(clk_i) then
-      -- sample random data bit and apply post-processing --
-      if (processing.enable = '0') then
-        processing.cnt  <= (others => '0');
-        processing.sreg <= (others => '0');
-      elsif (debiasing.valid = '1') then -- valid random sample?
-        if (processing.cnt = "1000") then
-          processing.cnt <= (others => '0');
-        else
-          processing.cnt <= std_ulogic_vector(unsigned(processing.cnt) + 1);
-        end if;
-        if (lfsr_en_c = true) then -- LFSR post-processing
-          processing.sreg <= processing.sreg(processing.sreg'left-1 downto 0) & ((not xor_reduce_f(processing.sreg and lfsr_taps_c)) xnor debiasing.data);
-        else -- NO post-processing
-          processing.sreg <= processing.sreg(processing.sreg'left-1 downto 0) & debiasing.data;
-        end if;
-      end if;
-
-      -- data output register --
-      if (processing.cnt = "1000") then
-        processing.output <= processing.sreg;
-      end if;
-
-      -- data ready/valid flag --
-      if (processing.cnt = "1000") then -- new sample ready?
-        processing.valid <= '1';
-      elsif (processing.enable = '0') or (rden = '1') then -- clear when deactivated or on data read
-        processing.valid <= '0';
-      end if;
-    end if;
-  end process processing_core;
 
 
 end neorv32_trng_rtl;
@@ -255,13 +178,23 @@ end neorv32_trng_rtl;
 
 
 -- #################################################################################################
--- # << NEORV32 - True Random Number Generator (TRNG) - Ring-Oscillator-Based Entropy Source >>    #
+-- # << neoTRNG - A Tiny and Platform-Independent True Random Number Generator for any FPGA >>     #
 -- # ********************************************************************************************* #
--- # An inverter chain (ring oscillator) is used as entropy source.                                #
--- # The inverter chain is constructed as an "asynchronous" LFSR. The single inverters are         #
--- # connected via latches that are used to enable/disable the TRNG. Also, these latches are used  #
--- # as additional delay element. By using unique enable signals for each latch, the synthesis     #
--- # tool cannot "optimize" (=remove) any of the inverters out of the design.                      #
+-- # This generator is based on entropy cells, which implement simple ring-oscillators. Each ring- #
+-- # oscillator features a short and a long delay path that is dynamically selected defining the   #
+-- # primary oscillation frequency. The cells are cascaded so that the random data output of a     #
+-- # cell controls the delay path of the next cell (which has the next-larger inverter chain).     #
+-- #                                                                                               #
+-- # The random data outputs of all cells are XOR-ed and de-biased using a von Neumann randomness  #
+-- # extractor (converting edges into bits). The resulting bit is sampled in chunks of 8 bits to   #
+-- # provide the final random data output. No further internal post-processing is applied. Hence,  #
+-- # the TRNG produces simple de-biased *RAW* data.                                                #
+-- #                                                                                               #
+-- # The entropy cell architecture uses individually-controlled latches and inverters to create    #
+-- # the inverter chain in a platform-agnostic style that can be implemented for any FPGA without  #
+-- # requiring primitive instantiation or technology-specific attributes.                          #
+-- #                                                                                               #
+-- # See the neoTRNG's documentation for more information: https://github.com/stnolting/neoTRNG    #
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
@@ -291,73 +224,327 @@ end neorv32_trng_rtl;
 -- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
 -- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
 -- # ********************************************************************************************* #
--- # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+-- # neoTRNG - https://github.com/stnolting/neoTRNG                            (c) Stephan Nolting #
 -- #################################################################################################
 
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library neorv32;
-use neorv32.neorv32_package.all;
-
-entity neorv32_trng_ring_osc is
+entity neoTRNG is
   generic (
-    NUM_INV : natural := 15 -- number of inverters in chain
+    NUM_CELLS     : natural; -- total number of ring-oscillator cells
+    NUM_INV_START : natural; -- number of inverters in first cell (short path), has to be odd
+    NUM_INV_INC   : natural; -- number of additional inverters in next cell (short path), has to be even
+    NUM_INV_DELAY : natural  -- additional inverters to form cell's long path, has to be even
   );
   port (
-    clk_i    : in  std_ulogic;
+    clk_i    : in  std_ulogic; -- global clock line
+    enable_i : in  std_ulogic; -- unit enable (high-active), reset unit when low
+    data_o   : out std_ulogic_vector(7 downto 0); -- random data byte output
+    valid_o  : out std_ulogic  -- data_o is valid when set
+  );
+end neoTRNG;
+
+architecture neoTRNG_rtl of neoTRNG is
+
+  -- Component: neoTRNG entropy cell --
+  component neoTRNG_cell
+    generic (
+      NUM_INV_S : natural; -- number of inverters in short path
+      NUM_INV_L : natural  -- number of inverters in long path
+    );
+    port (
+      clk_i    : in  std_ulogic; -- system clock
+      select_i : in  std_ulogic; -- delay select
+      enable_i : in  std_ulogic; -- enable chain input
+      enable_o : out std_ulogic; -- enable chain output
+      data_o   : out std_ulogic  -- sync random bit
+    );
+  end component;
+
+  -- ring-oscillator array interconnect --
+  type cell_array_t is record
+    en_in  : std_ulogic_vector(NUM_CELLS-1 downto 0);
+    en_out : std_ulogic_vector(NUM_CELLS-1 downto 0);
+    rnd    : std_ulogic_vector(NUM_CELLS-1 downto 0);
+    sel    : std_ulogic_vector(NUM_CELLS-1 downto 0);
+  end record;
+  signal cell_array : cell_array_t;
+
+  -- global cell-XOR --
+  signal rnd_bit : std_ulogic;
+
+  -- von-Neumann de-biasing --
+  type debiasing_t is record
+    sreg  : std_ulogic_vector(1 downto 0);
+    state : std_ulogic; -- process de-biasing every second cycle
+    valid : std_ulogic; -- de-biased data
+    data  : std_ulogic; -- de-biased data valid
+  end record;
+  signal deb : debiasing_t;
+
+  -- control unit --
+  type ctrl_t is record
+    enable : std_ulogic;
+    run    : std_ulogic;
+    cnt    : std_ulogic_vector(2 downto 0); -- bit counter
+    sreg   : std_ulogic_vector(7 downto 0); -- data shift register
+  end record;
+  signal ctrl : ctrl_t;
+
+begin
+
+  -- Sanity Checks --------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  assert not (NUM_CELLS < 2) report "neoTRNG config ERROR: Total number of ring-oscillator cells <NUM_CELLS> has to be >= 2." severity error;
+  assert not ((NUM_INV_START mod 2)  = 0) report "neoTRNG config ERROR: Number of inverters in first cell <NUM_INV_START> has to be odd." severity error;
+  assert not ((NUM_INV_INC   mod 2) /= 0) report "neoTRNG config ERROR: Inverter increment for each next cell <NUM_INV_INC> has to be even." severity error;
+  assert not ((NUM_INV_DELAY mod 2) /= 0) report "neoTRNG config ERROR: Inverter increment to form long path <NUM_INV_DELAY> has to be even." severity error;
+
+
+  -- Entropy Source -------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  neoTRNG_cell_inst:
+  for i in 0 to NUM_CELLS-1 generate
+    neoTRNG_cell_inst_i: neoTRNG_cell
+    generic map (
+      NUM_INV_S => NUM_INV_START + (i*NUM_INV_INC), -- number of inverters in short chain
+      NUM_INV_L => NUM_INV_START + (i*NUM_INV_INC) + NUM_INV_DELAY -- number of inverters in long chain
+    )
+    port map (
+      clk_i    => clk_i,
+      select_i => cell_array.sel(i),
+      enable_i => cell_array.en_in(i),
+      enable_o => cell_array.en_out(i),
+      data_o   => cell_array.rnd(i) -- SYNC data output
+    );
+  end generate;
+
+  -- path select chain --
+  cell_array.sel(0) <= cell_array.rnd(NUM_CELLS-1); -- use output of last cell to select path of first cell
+  cell_array.sel(NUM_CELLS-1 downto 1) <= cell_array.rnd(NUM_CELLS-2 downto 0); -- i+1 <= i
+
+  -- enable chain --
+  cell_array.en_in(0) <= ctrl.enable; -- start of chain
+  cell_array.en_in(NUM_CELLS-1 downto 1) <=cell_array.en_out(NUM_CELLS-2 downto 0); -- i+1 <= i
+
+
+  -- XOR All Cell's Outputs -----------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  cell_xor: process(cell_array.rnd)
+    variable tmp_v : std_ulogic;
+  begin
+    tmp_v := '0';
+    for i in 0 to NUM_CELLS-1 loop
+      tmp_v := tmp_v xor cell_array.rnd(i);
+    end loop; -- i
+    rnd_bit <= tmp_v;
+  end process cell_xor;
+
+
+  -- John von Neumann Randomness Extractor --------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  debiasing_sync: process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      deb.sreg <= deb.sreg(0) & rnd_bit;
+      -- start operation when last cell is enabled and process in every second cycle --
+      deb.state <= (not deb.state) and cell_array.en_out(NUM_CELLS-1);
+    end if;
+  end process debiasing_sync;
+
+  -- edge detector --
+  debiasing_comb: process(deb)
+    variable tmp_v : std_ulogic_vector(2 downto 0);
+  begin
+    tmp_v := deb.state & deb.sreg(1 downto 0); -- check groups of two non-overlapping bits from the input stream
+    case tmp_v is
+      when "101"  => deb.valid <= '1'; deb.data <= '0'; -- rising edge = '0'
+      when "110"  => deb.valid <= '1'; deb.data <= '1'; -- falling edge = '1'
+      when others => deb.valid <= '0'; deb.data <= '-'; -- no valid data
+    end case;
+  end process debiasing_comb;
+
+
+  -- Control Unit ---------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  control_unit: process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      -- make sure enable is sync --
+      ctrl.enable <= enable_i;
+
+      -- sample chunks of 8 bit --
+      if (ctrl.enable = '0') then
+        ctrl.cnt <= (others => '0');
+        ctrl.run <= '0';
+      elsif (deb.valid = '1') then -- valid random sample?
+        ctrl.cnt <= std_ulogic_vector(unsigned(ctrl.cnt) + 1);
+        ctrl.run <= '1';
+      end if;
+
+      -- sample shift register --
+      if (deb.valid = '1') then
+        ctrl.sreg <= ctrl.sreg(ctrl.sreg'left-1 downto 0) & deb.data;
+      end if;
+
+    end if;
+  end process control_unit;
+
+  -- random byte output --
+  data_o <= ctrl.sreg;
+
+  -- data valid? --
+  valid_o <= '1' when (ctrl.cnt = "000") and (ctrl.run = '1') else '0';
+
+
+end neoTRNG_rtl;
+
+
+-- ############################################################################################################################
+-- ############################################################################################################################
+
+
+-- #################################################################################################
+-- # << neoTRNG - A Tiny and Platform-Independent True Random Number Generator for any FPGA >>     #
+-- # ********************************************************************************************* #
+-- # neoTRNG Entropy Cell                                                                          #
+-- #                                                                                               #
+-- # The cell consists of two ring-oscillators build from inverter chains. The short chain uses    #
+-- # NUM_INV_S inverters and oscillates at a "high" frequency and the long chain uses NUM_INV_L    #
+-- # inverters and oscillates at a "low" frequency. The select_i input selects which chain is      #
+-- # actually used.                                                                                #
+-- #                                                                                               #
+-- # Each inverter chain is constructed as an "asynchronous" shift register. The single inverters  #
+-- # are connected via latches that are used to enable/disable the TRNG. Also, these latches are   #
+-- # used as additional delay element. By using unique enable signals for each latch, the          #
+-- # synthesis tool cannot "optimize" (=remove) any of the inverters out of the design making the  #
+-- # design platform-agnostic.                                                                     #
+-- # ********************************************************************************************* #
+-- # BSD 3-Clause License                                                                          #
+-- #                                                                                               #
+-- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- #                                                                                               #
+-- # Redistribution and use in source and binary forms, with or without modification, are          #
+-- # permitted provided that the following conditions are met:                                     #
+-- #                                                                                               #
+-- # 1. Redistributions of source code must retain the above copyright notice, this list of        #
+-- #    conditions and the following disclaimer.                                                   #
+-- #                                                                                               #
+-- # 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
+-- #    conditions and the following disclaimer in the documentation and/or other materials        #
+-- #    provided with the distribution.                                                            #
+-- #                                                                                               #
+-- # 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
+-- #    endorse or promote products derived from this software without specific prior written      #
+-- #    permission.                                                                                #
+-- #                                                                                               #
+-- # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
+-- # OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
+-- # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
+-- # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
+-- # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
+-- # GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
+-- # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
+-- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
+-- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
+-- # ********************************************************************************************* #
+-- # neoTRNG - https://github.com/stnolting/neoTRNG                            (c) Stephan Nolting #
+-- #################################################################################################
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity neoTRNG_cell is
+  generic (
+    NUM_INV_S : natural; -- number of inverters in short path
+    NUM_INV_L : natural  -- number of inverters in long path
+  );
+  port (
+    clk_i    : in  std_ulogic; -- system clock
+    select_i : in  std_ulogic; -- delay select
     enable_i : in  std_ulogic; -- enable chain input
     enable_o : out std_ulogic; -- enable chain output
     data_o   : out std_ulogic  -- sync random bit
   );
-end neorv32_trng_ring_osc;
+end neoTRNG_cell;
 
-architecture neorv32_trng_ring_osc_rtl of neorv32_trng_ring_osc is
+architecture neoTRNG_cell_rtl of neoTRNG_cell is
 
-  signal inv_chain   : std_ulogic_vector(NUM_INV-1 downto 0); -- oscillator chain
-  signal enable_sreg : std_ulogic_vector(NUM_INV-1 downto 0); -- enable shift register
-  signal sync_ff     : std_ulogic_vector(1 downto 0); -- output signal synchronizer
+  signal inv_chain_s   : std_ulogic_vector(NUM_INV_S-1 downto 0); -- short oscillator chain
+  signal inv_chain_l   : std_ulogic_vector(NUM_INV_L-1 downto 0); -- long oscillator chain
+  signal feedback      : std_ulogic; -- cell feedback/output
+  signal enable_sreg_s : std_ulogic_vector(NUM_INV_S-1 downto 0); -- enable shift register for short chain
+  signal enable_sreg_l : std_ulogic_vector(NUM_INV_L-1 downto 0); -- enable shift register for long chain
+  signal sync_ff       : std_ulogic_vector(1 downto 0); -- output signal synchronizer
 
 begin
 
-  -- Ring Oscillator ------------------------------------------------------------------------
+  -- Ring Oscillators -----------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  ring_osc: process(enable_i, enable_sreg, inv_chain)
+  -- Each cell provides a short inverter chain (high frequency) and a long oscillator chain (low frequency).
+  -- The select_i signals defines which chain is enabled.
+  -- NOTE: All signals that control a inverter-latch element have to be registered to ensure a single element
+  -- is mapped to a single LUT (or LUT + FF(latch-mode)).
+
+  -- short oscillator chain --
+  ring_osc_short: process(enable_i, enable_sreg_s, feedback, inv_chain_s)
   begin
-    -- Using individual enable signals for each inverter - derived from a shift register - to prevent the synthesis tool
-    -- from removing all but one inverter (since they implement "logical identical functions").
-    -- This also allows to make the TRNG platform independent.
-    for i in 0 to NUM_INV-1 loop -- inverters in chain
+    for i in 0 to NUM_INV_S-1 loop -- inverters in short chain
       if (enable_i = '0') then -- start with a defined state (latch reset)
-        inv_chain(i) <= '0';
-      elsif (enable_sreg(i) = '1') then
-        -- here we have the inverter chain --
-        if (i = NUM_INV-1) then -- left-most inverter?
-          inv_chain(i) <= not inv_chain(0);
+        inv_chain_s(i) <= '0';
+      elsif (enable_sreg_s(i) = '1') then
+        if (i = NUM_INV_S-1) then -- left-most inverter?
+          inv_chain_s(i) <= not feedback;
         else
-          inv_chain(i) <= not inv_chain(i+1);
+          inv_chain_s(i) <= not inv_chain_s(i+1);
         end if;
       end if;
     end loop; -- i
-  end process ring_osc;
+  end process ring_osc_short;
+
+  -- long oscillator chain --
+  ring_osc_long: process(enable_i, enable_sreg_l, feedback, inv_chain_l)
+  begin
+    for i in 0 to NUM_INV_L-1 loop -- inverters in long chain
+      if (enable_i = '0') then -- start with a defined state (latch reset)
+        inv_chain_l(i) <= '0';
+      elsif (enable_sreg_l(i) = '1') then
+        if (i = NUM_INV_L-1) then -- left-most inverter?
+          inv_chain_l(i) <= not feedback;
+        else
+          inv_chain_l(i) <= not inv_chain_l(i+1);
+        end if;
+      end if;
+    end loop; -- i
+  end process ring_osc_long;
+
+  -- length select --
+  feedback <= inv_chain_l(0) when (select_i = '0') else inv_chain_s(0);
 
 
   -- Control --------------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
+  -- Using individual enable signals for each inverter from a shift register to prevent the synthesis tool
+  -- from removing all but one inverter (since they implement "logical identical functions" (='toggle')).
+  -- This makes the TRNG platform independent (since we do not need to use primitives to ensure a correct architecture).
   ctrl_unit: process(clk_i)
   begin
     if rising_edge(clk_i) then
-      enable_sreg <= enable_sreg(enable_sreg'left-1 downto 0) & enable_i; -- activate right-most inverter first
-      sync_ff     <= sync_ff(0) & inv_chain(0); -- synchronize to prevent metastability 
+      -- enable sreg --
+      enable_sreg_s <= enable_sreg_s(enable_sreg_s'left-1 downto 0) & enable_i;
+      enable_sreg_l <= enable_sreg_l(enable_sreg_l'left-1 downto 0) & enable_sreg_s(enable_sreg_s'left);
+      -- data output sync - no metastability beyond this point --
+      sync_ff <= sync_ff(0) & feedback;
     end if;
   end process ctrl_unit;
 
   -- output for "enable chain" --
-  enable_o <= enable_sreg(enable_sreg'left);
+  enable_o <= enable_sreg_l(enable_sreg_l'left);
 
-  -- rnd output --
+  -- random data output --
   data_o <= sync_ff(1);
 
 
-end neorv32_trng_ring_osc_rtl;
+end neoTRNG_cell_rtl;

--- a/sw/example/demo_trng/main.c
+++ b/sw/example/demo_trng/main.c
@@ -82,7 +82,7 @@ int main(void) {
   neorv32_rte_check_isa(0); // silent = 0 -> show message if isa mismatch
 
   // intro
-  neorv32_uart0_printf("\n--- TRNG Demo ---\n\n");
+  neorv32_uart0_printf("\n<<< NEORV32 TRNG Demo >>>\n");
 
   // check if TRNG unit is implemented at all
   if (neorv32_trng_available() == 0) {
@@ -92,13 +92,14 @@ int main(void) {
 
   // enable TRNG
   neorv32_trng_enable();
+  neorv32_cpu_delay_ms(100); // TRNG "warm up"
 
   while(1) {
 
     // main menu
     neorv32_uart0_printf("\nCommands:\n"
-                        " n: Print 8-bit random numbers (abort by pressing any key)\n"
-                        " h: Generate and print histogram\n");
+                         " n: Print 8-bit random numbers (abort by pressing any key)\n"
+                         " h: Generate and print histogram\n");
 
     neorv32_uart0_printf("CMD:> ");
     char cmd = neorv32_uart0_getc();

--- a/sw/lib/source/neorv32_trng.c
+++ b/sw/lib/source/neorv32_trng.c
@@ -99,20 +99,15 @@ void neorv32_trng_disable(void) {
  **************************************************************************/
 int neorv32_trng_get(uint8_t *data) {
 
-  const int retries = 3;
-  int i;
   uint32_t ct_reg;
 
-  for (i=0; i<retries; i++) {
-    ct_reg = NEORV32_TRNG.CTRL;
+  ct_reg = NEORV32_TRNG.CTRL;
 
-    if ((ct_reg & (1<<TRNG_CTRL_VALID)) == 0) { // output data valid?
-      continue;
-    }
-
+  if (ct_reg & (1<<TRNG_CTRL_VALID)) { // output data valid?
     *data = (uint8_t)(ct_reg >> TRNG_CTRL_DATA_LSB);
     return 0; // valid data
   }
-
-  return -1; // no valid data available
+  else {
+    return -1;
+  }
 }


### PR DESCRIPTION
This PR is a rework of the processor-internal TRNG module. There is a completely new architecture of the entropy source that requires less hardware while improving random number quality. A detailed description and evaluation of the reworked TRNG will be made available in the "spin-off" repository [stnolting/neoTRNG](https://github.com/stnolting/neoTRNG).

✔️ The changes in this PR are fully backwards-compatible (no change of the software interface).