### PR TITLE
setups/osflow/Makefile: support overriding variables

### DIFF
--- a/setups/osflow/Makefile
+++ b/setups/osflow/Makefile
@@ -29,71 +29,92 @@ run:
 # Boards
 
 Fomu:
+	$(eval BITSTREAM ?= neorv32_$(BOARD)_$(FOMU_REV)_$(DESIGN).bit)
 ifeq ($(DESIGN),Minimal)
 	$(eval IMEM_SRC := ../../rtl/core/mem/neorv32_imem.default.vhd)
 else
 	$(eval IMEM_SRC := devices/ice40/neorv32_imem.ice40up_spram.vhd)
 endif
+	$(eval NEORV32_MEM_SRC ?= ${IMEM_SRC} devices/ice40/neorv32_dmem.ice40up_spram.vhd)
 	$(MAKE) \
-	  BITSTREAM=neorv32_$(BOARD)_$(FOMU_REV)_$(DESIGN).bit \
-	  NEORV32_MEM_SRC="${IMEM_SRC} devices/ice40/neorv32_dmem.ice40up_spram.vhd" \
+	  BITSTREAM="$(BITSTREAM)" \
+	  NEORV32_MEM_SRC="$(NEORV32_MEM_SRC)" \
 	  run
 
 iCESugar:
+	$(eval BITSTREAM ?= neorv32_$(BOARD)_$(DESIGN).bit)
+	$(eval NEORV32_MEM_SRC ?= devices/ice40/neorv32_imem.ice40up_spram.vhd devices/ice40/neorv32_dmem.ice40up_spram.vhd)
 	$(MAKE) \
-	  BITSTREAM=neorv32_$(BOARD)_$(DESIGN).bit \
-	  NEORV32_MEM_SRC="devices/ice40/neorv32_imem.ice40up_spram.vhd devices/ice40/neorv32_dmem.ice40up_spram.vhd" \
+	  BITSTREAM="$(BITSTREAM)" \
+	  NEORV32_MEM_SRC="$(NEORV32_MEM_SRC)" \
 	  run
 
 UPduino:
+	$(eval BITSTREAM ?= neorv32_$(BOARD)_$(UPduino_REV)_$(DESIGN).bit)
+	$(eval NEORV32_MEM_SRC ?= devices/ice40/neorv32_imem.ice40up_spram.vhd devices/ice40/neorv32_dmem.ice40up_spram.vhd)
 	$(MAKE) \
-	  BITSTREAM=neorv32_$(BOARD)_$(UPduino_REV)_$(DESIGN).bit \
-	  NEORV32_MEM_SRC="devices/ice40/neorv32_imem.ice40up_spram.vhd devices/ice40/neorv32_dmem.ice40up_spram.vhd" \
+	  BITSTREAM="$(BITSTREAM)" \
+	  NEORV32_MEM_SRC="$(NEORV32_MEM_SRC)" \
 	  run
 
 OrangeCrab:
+	$(eval BITSTREAM ?= neorv32_$(BOARD)_$(OrangeCrab_REV)_$(DESIGN).bit)
+	$(eval NEORV32_MEM_SRC ?= ../../rtl/core/mem/neorv32_imem.default.vhd ../../rtl/core/mem/neorv32_dmem.default.vhd)
 	$(MAKE) \
-	  BITSTREAM=neorv32_$(BOARD)_$(OrangeCrab_REV)_$(DESIGN).bit \
-	  NEORV32_MEM_SRC="../../rtl/core/mem/neorv32_imem.default.vhd ../../rtl/core/mem/neorv32_dmem.default.vhd" \
+	  BITSTREAM="$(BITSTREAM)" \
+	  NEORV32_MEM_SRC="$(NEORV32_MEM_SRC)" \
 	  run
 
 AlhambraII:
+	$(eval BITSTREAM ?= neorv32_$(BOARD)_$(DESIGN).bit)
+	$(eval NEORV32_MEM_SRC ?= ../../rtl/core/mem/neorv32_imem.default.vhd ../../rtl/core/mem/neorv32_dmem.default.vhd)
 	$(MAKE) \
-	  BITSTREAM=neorv32_$(BOARD)_$(DESIGN).bit \
-	  NEORV32_MEM_SRC="../../rtl/core/mem/neorv32_imem.default.vhd ../../rtl/core/mem/neorv32_dmem.default.vhd" \
+	  BITSTREAM="$(BITSTREAM)" \
+	  NEORV32_MEM_SRC="$(NEORV32_MEM_SRC)" \
 	  run
 
 ULX3S:
+	$(eval BITSTREAM ?= neorv32_$(BOARD)_$(DESIGN).bit)
+	$(eval NEORV32_MEM_SRC ?= ../../rtl/core/mem/neorv32_imem.default.vhd ../../rtl/core/mem/neorv32_dmem.default.vhd)
 	$(MAKE) \
-	  BITSTREAM=neorv32_$(BOARD)_$(DESIGN).bit \
-	  NEORV32_MEM_SRC="../../rtl/core/mem/neorv32_imem.default.vhd ../../rtl/core/mem/neorv32_dmem.default.vhd" \
+	  BITSTREAM="$(BITSTREAM)" \
+	  NEORV32_MEM_SRC="$(NEORV32_MEM_SRC)" \
 	  run
 
 # Designs
 
 Minimal:
+	$(eval DESIGN ?= $@)
+	$(eval DESIGN_SRC ?= $(TEMPLATES)/neorv32_ProcessorTop_Minimal*.vhd)
 	$(MAKE) \
-	  DESIGN=$@ \
-	  DESIGN_SRC=$(TEMPLATES)/neorv32_ProcessorTop_Minimal*.vhd \
+	  DESIGN="$(DESIGN)" \
+	  DESIGN_SRC="$(DESIGN_SRC)" \
 	  $(BOARD)
 
 MinimalBoot:
+	$(eval DESIGN ?= $@)
+	$(eval DESIGN_SRC ?= $(TEMPLATES)/neorv32_ProcessorTop_MinimalBoot.vhd)
 	$(MAKE) \
-	  DESIGN=$@ \
-	  DESIGN_SRC=$(TEMPLATES)/neorv32_ProcessorTop_MinimalBoot.vhd \
+	  DESIGN="$(DESIGN)" \
+	  DESIGN_SRC="$(DESIGN_SRC)" \
 	  $(BOARD)
 
 UP5KDemo:
+	$(eval DESIGN ?= $@)
+	$(eval DESIGN_SRC ?= $(TEMPLATES)/neorv32_ProcessorTop_UP5KDemo.vhd)
 	$(MAKE) \
-	  DESIGN=$@ \
-	  DESIGN_SRC=$(TEMPLATES)/neorv32_ProcessorTop_UP5KDemo.vhd \
+	  DESIGN="$(DESIGN)" \
+	  DESIGN_SRC="$(DESIGN_SRC)" \
 	  $(BOARD)
 
 MixedLanguage:
+	$(eval DESIGN ?= $@)
+	$(eval DESIGN_SRC ?= $(TEMPLATES)/neorv32_ProcessorTop_Minimal*.vhd)
+	$(eval NEORV32_VERILOG_SRC ?= devices/ice40/sb_ice40_components.v board_tops/neorv32_Fomu_MixedLanguage_ClkGen.v)
 	$(MAKE) \
-	  DESIGN=$@ \
-	  DESIGN_SRC=$(TEMPLATES)/neorv32_ProcessorTop_Minimal*.vhd \
-	  NEORV32_VERILOG_SRC='devices/ice40/sb_ice40_components.v board_tops/neorv32_Fomu_MixedLanguage_ClkGen.v' \
+	  DESIGN="$(DESIGN)" \
+	  DESIGN_SRC="$(DESIGN_SRC)" \
+	  NEORV32_VERILOG_SRC="$(NEORV32_VERILOG_SRC)" \
 	  $(BOARD)
 
 # Help


### PR DESCRIPTION
As reported by @zipotron in #213, variables passed when calling make are not honored. This PR ensures that overriding them is possible.