### PR TITLE
[On-Chip Debugger] Fix JTAG timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 22.11.2021 | 1.6.3.11 | on-chip debugger: reworked JTAG signal input/output synchronization logic (see [PR #216](https://github.com/stnolting/neorv32/pull/216)) |
 | 22.11.2021 | 1.6.3.10 | reworked **TRNG** (less hardware requirements, improved quality), see [PR #212](https://github.com/stnolting/neorv32/pull/212) and [stnolting/neoTRNG](https://github.com/stnolting/neoTRNG) |
 | 21.11.2021 | 1.6.3.9 | minor rtl edits: configuring an IMEM or DMEM size (`MEM_INT_IMEM_SIZE` / `MEM_INT_DMEM_SIZE` generic) of 0 will now exclude the according memory from synthesis (and also clears the according `NEORV32_SYSINFO.SOC` flags) |
 | 18.11.2021 | 1.6.3.8 | TWI: removed TWI_CTRL_CKSTEN flag (enable clock stretching) from control registers, clock-stretching is now _always_ enabled |

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -87,13 +87,11 @@ External JTAG access is provided by the following top-level ports.
 | `jtag_tms_i`  | 1     | in        | mode select
 |=======================
 
-.JTAG Clock
+.Maximum JTAG Clock
 [IMPORTANT]
-The actual JTAG clock signal is **not** used as primary clock. Instead it is used to synchronize
-JTGA accesses, while all internal operations trigger on the system clock. Hence, no additional clock domain is required
-for integration of this module.
-However, this constraints the maximal JTAG clock (`jtag_tck_i`) frequency to be less than or equal to
-1/4 of the system clock (`clk_i`) frequency.
+All JTAG signals are synchronized to the processor clock domain by oversampling them in DTM. Hence, no additional
+clock domain is required for the DTM. However, this constraints the maximal JTAG clock frequency (`jtag_tck_i`) to be less
+than or equal to **1/5** of the processor clock frequency (`clk_i`).
 
 [NOTE]
 If the on-chip debugger is disabled (_ON_CHIP_DEBUGGER_EN_ = false) the JTAG serial input `jtag_tdi_i` is directly
@@ -127,10 +125,24 @@ The following table shows the available data registers:
 | others             | `BYPASS` | 1           | default JTAG bypass register
 |=======================
 
+.`DTMCS` - DTM Control and Status Register
+[cols="^2,^3,^1,<8"]
+[options="header",grid="rows"]
+|=======================
+| Bit(s) | Name           | r/w | Description
+| 31:18  | -              | r/- | _reserved_, hardwired to zero
+| 17     | `dmihardreset` | r/w | setting this bit will reset the DM interface; this bit auto-clears
+| 16     | `dmireset`     | r/w | setting this bit will clear ste sticky error state; this bit auto-clears
+| 15     | -              | r/- | _reserved_, hardwired to zero
+| 14:12  | `idle`         | r/- | recommended idle states (= 0, no idle states required)
+| 11:10  | `dmistat`      | r/- | DMI statu: `00` = no error, `01` = reserved, `10` = operation failed, `11` = failed operation during pending DMI operation
+| 9:4    | `abits`        | r/- | number of DMI address bits (= 7)
+| 3:0    | `version`      | r/- | `0001` = spec version 0.13
+|=======================
+
 [INFO]
 See the https://github.com/riscv/riscv-debug-spec[RISC-V debug specification] for more information regarding the data
-registers and operations.
-A local copy can be found in `docs/references`.
+registers and operations. A local copy can be found in `docs/references`.
 
 
 

--- a/rtl/core/neorv32_debug_dtm.vhd
+++ b/rtl/core/neorv32_debug_dtm.vhd
@@ -78,10 +78,10 @@ architecture neorv32_debug_dtm_rtl of neorv32_debug_dtm is
   -- tap JTAG signal synchronizer --
   type tap_sync_t is record
     -- internal --
-    trst_ff     : std_ulogic_vector(4 downto 0);
-    tck_ff      : std_ulogic_vector(4 downto 0);
-    tdi_ff      : std_ulogic_vector(3 downto 0);
-    tms_ff      : std_ulogic_vector(3 downto 0);
+    trst_ff     : std_ulogic_vector(2 downto 0);
+    tck_ff      : std_ulogic_vector(2 downto 0);
+    tdi_ff      : std_ulogic_vector(2 downto 0);
+    tms_ff      : std_ulogic_vector(2 downto 0);
     -- external --
     trst        : std_ulogic;
     tck_rising  : std_ulogic;
@@ -134,10 +134,10 @@ begin
   tap_synchronizer: process(rstn_i, clk_i)
   begin
     if rising_edge(clk_i) then
-      tap_sync.trst_ff <= tap_sync.trst_ff(3 downto 0) & jtag_trst_i;
-      tap_sync.tck_ff  <= tap_sync.tck_ff( 3 downto 0) & jtag_tck_i;
-      tap_sync.tdi_ff  <= tap_sync.tdi_ff( 2 downto 0) & jtag_tdi_i;
-      tap_sync.tms_ff  <= tap_sync.tms_ff( 2 downto 0) & jtag_tms_i;
+      tap_sync.trst_ff <= tap_sync.trst_ff(1 downto 0) & jtag_trst_i;
+      tap_sync.tck_ff  <= tap_sync.tck_ff( 1 downto 0) & jtag_tck_i;
+      tap_sync.tdi_ff  <= tap_sync.tdi_ff( 1 downto 0) & jtag_tdi_i;
+      tap_sync.tms_ff  <= tap_sync.tms_ff( 1 downto 0) & jtag_tms_i;
       if (tap_sync.tck_falling = '1') then -- update output data TDO on falling edge of TCK
         jtag_tdo_o <= tap_sync.tdo;
       end if;
@@ -145,17 +145,17 @@ begin
   end process tap_synchronizer;
 
   -- JTAG reset --
-  tap_sync.trst <= '0' when (tap_sync.trst_ff(4 downto 1) = "0000") else '1';
+  tap_sync.trst <= '0' when (tap_sync.trst_ff(2 downto 1) = "00") else '1';
 
   -- JTAG clock edge --
-  tap_sync.tck_rising  <= '1' when (tap_sync.tck_ff(4 downto 1) = "0011") else '0';
-  tap_sync.tck_falling <= '1' when (tap_sync.tck_ff(4 downto 1) = "1100") else '0';
+  tap_sync.tck_rising  <= '1' when (tap_sync.tck_ff(2 downto 1) = "01") else '0';
+  tap_sync.tck_falling <= '1' when (tap_sync.tck_ff(2 downto 1) = "10") else '0';
 
   -- JTAG test mode select --
-  tap_sync.tms <= tap_sync.tms_ff(3);
+  tap_sync.tms <= tap_sync.tms_ff(2);
 
   -- JTAG serial data input --
-  tap_sync.tdi <= tap_sync.tdi_ff(3);
+  tap_sync.tdi <= tap_sync.tdi_ff(2);
 
 
   -- Tap Control FSM ------------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060310"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060311"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- External Interface Types ---------------------------------------------------------------


### PR DESCRIPTION
This PR reworks the JTAG signal synchronization logic of the DTM (debug transfer module). The pre-PR version of the DTM did not fully comply with the JTAG interface timing requirements (sample TDO and TMS on the _rising_ edge of TCK, update TDO on the _falling_ edge of TCK).

This seems to cause some compatibility troubles with the JLINK EDU as reported by @emb4fun. It would be great if you could test the reworked DTM :wink:

This PR also includes some code clean-ups of the DTM code and also removes the number of recommended debugger wait states to allow faster JTAG operations.