### PR TITLE
Fix neorv32_gpio_port_get()

### DIFF
--- a/sw/lib/source/neorv32_gpio.c
+++ b/sw/lib/source/neorv32_gpio.c
@@ -164,8 +164,8 @@ uint64_t neorv32_gpio_port_get(void) {
     uint32_t uint32[sizeof(uint64_t)/2];
   } data;
 
-  data.uint32[0] = NEORV32_GPIO.OUTPUT_LO;
-  data.uint32[1] = NEORV32_GPIO.OUTPUT_HI;
+  data.uint32[0] = NEORV32_GPIO.INPUT_LO;
+  data.uint32[1] = NEORV32_GPIO.INPUT_HI;
 
   return data.uint64;
 }


### PR DESCRIPTION
This function should read from:
 - NEORV32_GPIO.INPUT_LO and NEORV32_GPIO.INPUT_HI

But previously it was reading from:
 - NEORV32_GPIO.OUTPUT_LO and NEORV32_GPIO.OUTPUT_HI

So it wasn't working correctly. The function neorv32_pin_get() was
reading the correct values (from INPUT instead of OUTPUT) and thus it
was working correctly.