### PR TITLE
Add TRNG for UP5KDemo

### DIFF
--- a/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
@@ -222,7 +222,7 @@ begin
     IO_TWI_EN                    => IO_TWI_EN,      -- implement two-wire interface (TWI)?
     IO_PWM_NUM_CH                => IO_PWM_NUM_CH,  -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    => IO_WDT_EN,      -- implement watch dog timer (WDT)?
-    IO_TRNG_EN                   => false,          -- implement true random number generator (TRNG)?
+    IO_TRNG_EN                   => true,           -- implement true random number generator (TRNG)?
     IO_CFS_EN                    => false,          -- implement custom functions subsystem (CFS)?
     IO_CFS_CONFIG                => x"00000000",    -- custom CFS configuration generic
     IO_CFS_IN_SIZE               => 32,             -- size of CFS input conduit in bits

--- a/setups/osflow/boards/index.mk
+++ b/setups/osflow/boards/index.mk
@@ -13,23 +13,23 @@ FOMU_REV ?= pvt
 
 ifeq ($(FOMU_REV),evt1)
 YOSYSFLAGS  ?= -D EVT=1 -D EVT1=1 -D HAVE_PMOD=1
-PNRFLAGS    ?= --up5k --package sg48
+PNRFLAGS    ?= --up5k --package sg48 --ignore-loops
 CONSTRAINTS ?= $(PCF_PATH)/$(BOARD)-evt2.pcf
 else ifeq ($(FOMU_REV),evt2)
 YOSYSFLAGS  ?= -D EVT=1 -D EVT2=1 -D HAVE_PMOD=1
-PNRFLAGS    ?= --up5k --package sg48
+PNRFLAGS    ?= --up5k --package sg48 --ignore-loops
 CONSTRAINTS ?= $(PCF_PATH)/$(BOARD)-$(FOMU_REV).pcf
 else ifeq ($(FOMU_REV),evt3)
 YOSYSFLAGS  ?= -D EVT=1 -D EVT3=1 -D HAVE_PMOD=1
-PNRFLAGS    ?= --up5k --package sg48
+PNRFLAGS    ?= --up5k --package sg48 --ignore-loops
 CONSTRAINTS ?= $(PCF_PATH)/$(BOARD)-$(FOMU_REV).pcf
 else ifeq ($(FOMU_REV),hacker)
 YOSYSFLAGS  ?= -D HACKER=1
-PNRFLAGS    ?= --up5k --package uwg30
+PNRFLAGS    ?= --up5k --package uwg30 --ignore-loops
 CONSTRAINTS ?= $(PCF_PATH)/$(BOARD)-$(FOMU_REV).pcf
 else ifeq ($(FOMU_REV),pvt)
 YOSYSFLAGS  ?= -D PVT=1
-PNRFLAGS    ?= --up5k --package uwg30
+PNRFLAGS    ?= --up5k --package uwg30 --ignore-loops
 CONSTRAINTS ?= $(PCF_PATH)/$(BOARD)-$(FOMU_REV).pcf
 else
 $(error Unrecognized FOMU_REV value. must be "evt1", "evt2", "evt3", "pvt", or "hacker")


### PR DESCRIPTION
This PR is just an "idea"... It enables the [TRNG](https://github.com/stnolting/neorv32/blob/master/rtl/core/neorv32_trng.vhd) module for the [UP5KDemo](https://github.com/stnolting/neorv32/blob/master/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd) processor template.

For the records: The TRNG uses **latches (!)** and **combinatorial loops (!)**.
I know that both constructs are a bit "delicate" when it comes to FPGAs... So maybe it is a good idea to add the TRNG to check GHDL-yosys can handle such constructs.

This is where the latches and comb. loops are described:
https://github.com/stnolting/neorv32/blob/f8d886711cf0d9de93c28764e5d32bbcdc808c16/rtl/core/neorv32_trng.vhd#L492-L505

@umarcor what do you think? Btw, do you know if there's an option to get a "hardware utilization by entity" report from yosys?

The idea comes from a thread in the German [mikrocontroller.net](https://www.mikrocontroller.net/) forum where someone has problems with latches and GHDL/yosys. Here is the google translated thread: https://www-mikrocontroller-net.translate.goog/topic/528149?_x_tr_sl=de&_x_tr_tl=en&_x_tr_hl=de

**edit**
I have tested the bitstream. The TRNG works! ✔️ 