### PR TITLE
:bug: Fix Wishbone timeout bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 03.12.2021 | 1.6.4.4 | :bug: fixed bug in **Wishbone** bus interface: timeout configurations (via `MEM_EXT_TIMEOUT` generic) that are a power of two (e.g. 256) caused _immediate_ timeouts; timeout counter was one bit short; same problem for processor-internal bus monitor (BUSKEEPER); see [PR #230](https://github.com/stnolting/neorv32/pull/230) |
 | 02.12.2021 | 1.6.4.3 | :warning: removed legacy software compatibility wrappers (`sw/lib/include/neorv32_legacy.h` and `neorv32_uart_*` functions) |
 | 28.11.2021 | 1.6.4.2 | :bug: fixed bug in **UART[0/1]** overrun flag (was not set/cleared correctly); fixed bug in UART0 enable function `neorv32_uart0_enable()` |
 | 28.11.2021 | 1.6.4.1 | (:warning:) bootloader now stores executable in _little-endian_ byte-order to SPI flash |

--- a/rtl/core/neorv32_bus_keeper.vhd
+++ b/rtl/core/neorv32_bus_keeper.vhd
@@ -87,7 +87,7 @@ architecture neorv32_bus_keeper_rtl of neorv32_bus_keeper is
   -- controller --
   type control_t is record
     pending  : std_ulogic;
-    timeout  : std_ulogic_vector(index_size_f(max_proc_int_response_time_c)-1 downto 0);
+    timeout  : std_ulogic_vector(index_size_f(max_proc_int_response_time_c) downto 0);
     err_type : std_ulogic;
     bus_err  : std_ulogic;
   end record;
@@ -148,7 +148,7 @@ begin
 
       -- access monitor: IDLE --
       if (control.pending = '0') then
-        control.timeout <= std_ulogic_vector(to_unsigned(max_proc_int_response_time_c, index_size_f(max_proc_int_response_time_c)));
+        control.timeout <= std_ulogic_vector(to_unsigned(max_proc_int_response_time_c, index_size_f(max_proc_int_response_time_c)+1));
         if (bus_rden_i = '1') or (bus_wren_i = '1') then
           control.pending <= '1';
         end if;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060403"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060404"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- External Interface Types ---------------------------------------------------------------
@@ -2090,7 +2090,7 @@ end neorv32_package;
 
 package body neorv32_package is
 
-  -- Function: Minimal required number of bits to represent input number --------------------
+  -- Function: Minimal required number of bits to represent <input> numbers -----------------
   -- -------------------------------------------------------------------------------------------
   function index_size_f(input : natural) return natural is
   begin

--- a/rtl/core/neorv32_wishbone.vhd
+++ b/rtl/core/neorv32_wishbone.vhd
@@ -118,7 +118,7 @@ architecture neorv32_wishbone_rtl of neorv32_wishbone is
     ack      : std_ulogic;
     err      : std_ulogic;
     tmo      : std_ulogic;
-    timeout  : std_ulogic_vector(index_size_f(BUS_TIMEOUT)-1 downto 0);
+    timeout  : std_ulogic_vector(index_size_f(BUS_TIMEOUT) downto 0);
     src      : std_ulogic;
     lock     : std_ulogic;
     priv     : std_ulogic_vector(01 downto 0);
@@ -190,7 +190,7 @@ begin
       ctrl.ack      <= '0';
       ctrl.err      <= '0';
       ctrl.tmo      <= '0';
-      ctrl.timeout  <= std_ulogic_vector(to_unsigned(BUS_TIMEOUT, index_size_f(BUS_TIMEOUT)));
+      ctrl.timeout  <= std_ulogic_vector(to_unsigned(BUS_TIMEOUT, index_size_f(BUS_TIMEOUT)+1));
 
       -- state machine --
       case ctrl.state is

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -317,7 +317,7 @@ begin
     ICACHE_ASSOCIATIVITY         => 2,             -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
     -- External memory interface --
     MEM_EXT_EN                   => true,          -- implement external memory bus interface?
-    MEM_EXT_TIMEOUT              => 255,           -- cycles after a pending bus access auto-terminates (0 = disabled)
+    MEM_EXT_TIMEOUT              => 256,           -- cycles after a pending bus access auto-terminates (0 = disabled)
     -- Stream link interface --
     SLINK_NUM_TX                 => 8,             -- number of TX links (0..8)
     SLINK_NUM_RX                 => 8,             -- number of TX links (0..8)

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -210,7 +210,7 @@ begin
     ICACHE_ASSOCIATIVITY         => 2,             -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
     -- External memory interface --
     MEM_EXT_EN                   => true,          -- implement external memory bus interface?
-    MEM_EXT_TIMEOUT              => 255,           -- cycles after a pending bus access auto-terminates (0 = disabled)
+    MEM_EXT_TIMEOUT              => 256,           -- cycles after a pending bus access auto-terminates (0 = disabled)
     -- Stream link interface --
     SLINK_NUM_TX                 => 8,             -- number of TX links (0..8)
     SLINK_NUM_RX                 => 8,             -- number of TX links (0..8)


### PR DESCRIPTION
This PR fixes a bug in the Wishbone timeout counter.

Wishbone timeout configurations (via the `MEM_EXT_TIMEOUT` generic) that are a power of two (like 256) caused an **immediate** timeout exception since the timeout counter was one bit short.

The same problem occurred in the BUSKEEPER's timeout counter. However, this bug did not actually appeared because the default BUSKEEPER timeout is not a power of two.

Thanks to @emb4fun for identifying this bug. :+1: