### PR TITLE
Add SYSINFO flag to check if processor is being simulated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 03.12.2021 | 1.6.4.5 | added _SYSINFO_SOC_IS_SIM_ flag to SYSINFO to check if processor is being simulated (not guaranteed, depends on the toolchain's 'pragma' support), see [PR #231](https://github.com/stnolting/neorv32/pull/231) |
 | 03.12.2021 | 1.6.4.4 | :bug: fixed bug in **Wishbone** bus interface: timeout configurations (via `MEM_EXT_TIMEOUT` generic) that are a power of two (e.g. 256) caused _immediate_ timeouts; timeout counter was one bit short; same problem for processor-internal bus monitor (BUSKEEPER); see [PR #230](https://github.com/stnolting/neorv32/pull/230) |
 | 02.12.2021 | 1.6.4.3 | :warning: removed legacy software compatibility wrappers (`sw/lib/include/neorv32_legacy.h` and `neorv32_uart_*` functions) |
 | 28.11.2021 | 1.6.4.2 | :bug: fixed bug in **UART[0/1]** overrun flag (was not set/cleared correctly); fixed bug in UART0 enable function `neorv32_uart0_enable()` |

--- a/docs/datasheet/soc_sysinfo.adoc
+++ b/docs/datasheet/soc_sysinfo.adoc
@@ -71,6 +71,7 @@ and default clock speed) for correct operation.
 | `3`  | _SYSINFO_SOC_MEM_INT_DMEM_     | set if the processor-internal IMEM is implemented (via top's <<_mem_int_imem_en>> generic)
 | `4`  | _SYSINFO_SOC_MEM_EXT_ENDIAN_   | set if external bus interface uses BIG-endian byte-order (via top's <<_mem_ext_big_endian>> generic)
 | `5`  | _SYSINFO_SOC_ICACHE_           | set if processor-internal instruction cache is implemented (via top's <<_icache_en>> generic)
+| `13` | _SYSINFO_SOC_IS_SIM_           | set if processor is being **simulated** (⚠️ not guaranteed)
 | `14` | _SYSINFO_SOC_OCD_              | set if on-chip debugger implemented (via top's <<_on_chip_debugger_en>> generic)
 | `15` | _SYSINFO_SOC_HW_RESET_         | set if a dedicated hardware reset of all core registers is implemented (via package's `dedicated_reset_c` constant)
 | `16` | _SYSINFO_SOC_IO_GPIO_          | set if the GPIO is implemented (via top's <<_io_gpio_en>> generic)

--- a/docs/userguide/simulating_the_processor.adoc
+++ b/docs/userguide/simulating_the_processor.adoc
@@ -9,7 +9,13 @@ Therefore, there is a wide range of possible testing and verification strategies
 On the one hand, a simple smoke testbench allows ensuring that functionality is correct from a software point of view.
 That is used for running the RISC-V architecture tests, in order to guarantee compliance with the ISA specification(s).
 
-On the other hand, http://vunit.github.io/[VUnit] and http://vunit.github.io/verification_components/user_guide.html[Verification Components] are used for verifying the functionality of the various peripherals from a hardware point of view.
+On the other hand, http://vunit.github.io/[VUnit] and http://vunit.github.io/verification_components/user_guide.html[Verification Components]
+are used for verifying the functionality of the various peripherals from a hardware point of view.
+
+[TIP]
+The processor can check if it is being simulated by checking the SYSINFO _SYSINFO_SOC_IS_SIM_ flag
+(see https://stnolting.github.io/neorv32/#_system_configuration_information_memory_sysinfo).
+Note that this flag is not guaranteed to be set correctly (depending on the HDL toolchain's pragma support).
 
 :sectnums:
 === Testbench
@@ -134,7 +140,7 @@ Blinking LED demo program
 ==== Hello World!
 
 To do a quick test of the NEORV32 make sure to have https://github.com/ghdl/ghdl[GHDL] and a
-[RISC-V gcc toolchain](https://github.com/stnolting/riscv-gcc-prebuilt) installed.
+https://github.com/stnolting/riscv-gcc-prebuilt[RISC-V gcc toolchain] installed.
 Navigate to the project's `sw/example/hello_world` folder and run `make USER_FLAGS+=-DUART0_SIM_MODE MARCH=rv32imac clean_all sim`:
 
 [TIP]

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,8 +64,22 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060404"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060405"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
+
+  -- Check if we're inside the Matrix -------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  constant is_simulation_c : boolean := false -- seems like we're on real hardware
+-- pragma translate_off
+-- synthesis translate_off
+-- synthesis synthesis_off
+-- RTL_SYNTHESIS OFF
+  or true -- this MIGHT be a simulation
+-- RTL_SYNTHESIS ON
+-- synthesis synthesis_on
+-- synthesis translate_on
+-- pragma translate_on
+  ;
 
   -- External Interface Types ---------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_sysinfo.vhd
+++ b/rtl/core/neorv32_sysinfo.vhd
@@ -163,8 +163,9 @@ begin
   sysinfo_mem(2)(04) <= bool_to_ulogic_f(MEM_EXT_BIG_ENDIAN); -- is external memory bus interface using BIG-endian byte-order?
   sysinfo_mem(2)(05) <= bool_to_ulogic_f(ICACHE_EN);         -- processor-internal instruction cache implemented?
   --
-  sysinfo_mem(2)(13 downto 06) <= (others => '0'); -- reserved
+  sysinfo_mem(2)(12 downto 06) <= (others => '0'); -- reserved
   -- Misc --
+  sysinfo_mem(2)(13) <= bool_to_ulogic_f(is_simulation_c);     -- is this a simulation?
   sysinfo_mem(2)(14) <= bool_to_ulogic_f(ON_CHIP_DEBUGGER_EN); -- on-chip debugger implemented?
   sysinfo_mem(2)(15) <= bool_to_ulogic_f(dedicated_reset_c);   -- dedicated hardware reset of all core registers?
   -- IO --

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -151,6 +151,13 @@ int main() {
   // intro
   PRINT_STANDARD("\n<< PROCESSOR CHECK >>\n");
   PRINT_STANDARD("build: "__DATE__" "__TIME__"\n");
+  PRINT_STANDARD("is simulation: ");
+  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IS_SIM)) {
+    PRINT_STANDARD("yes\n");
+  }
+  else {
+    PRINT_STANDARD("no\n");
+  }
 
 
   // reset performance counter

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -1213,6 +1213,7 @@ enum NEORV32_SYSINFO_SOC_enum {
   SYSINFO_SOC_MEM_EXT_ENDIAN =  4, /**< SYSINFO_FEATURES  (4) (r/-): External bus interface uses BIG-endian byte-order when 1 (via MEM_EXT_BIG_ENDIAN generic) */
   SYSINFO_SOC_ICACHE         =  5, /**< SYSINFO_FEATURES  (5) (r/-): Processor-internal instruction cache implemented when 1 (via ICACHE_EN generic) */
 
+  SYSINFO_SOC_IS_SIM         = 13, /**< SYSINFO_FEATURES (13) (r/-): Set during simulation (not guaranteed) */
   SYSINFO_SOC_OCD            = 14, /**< SYSINFO_FEATURES (14) (r/-): On-chip debugger implemented when 1 (via ON_CHIP_DEBUGGER_EN generic) */
   SYSINFO_SOC_HW_RESET       = 15, /**< SYSINFO_FEATURES (15) (r/-): Dedicated hardware reset of core registers implemented when 1 (via package's dedicated_reset_c constant) */
 


### PR DESCRIPTION
This PR adds a new flag to the SYSINFO module to check if the processor is being simulated:
`NEORV32_SYSINFO.SOC` bit 13: _SYSINFO_SOC_IS_SIM_, set if processor is being simulated

The state of this flag cannot be guaranteed for _all_ platforms as it depends on the toolchains 'pragma' support (works with GHDL, Intel Quartus, Lattice Radiant):

```vhdl
  -- Check if we're inside the Matrix -------------------------------------------------------
  -- -------------------------------------------------------------------------------------------
  constant is_simulation_c : boolean := false -- seems like we're on real hardware
-- pragma translate_off
-- synthesis translate_off
-- synthesis synthesis_off
-- RTL_SYNTHESIS OFF
  or true -- this MIGHT be a simulation
-- RTL_SYNTHESIS ON
-- synthesis synthesis_on
-- synthesis translate_on
-- pragma translate_on
  ;
```