### PR TITLE
⚠️ Rework FIRQ System (re-rework): use MIP to clear/ack IRQs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 08.12.2021 | 1.6.4.6 | :warning: reworked **Fast Interrupt Requests (FIRQ)** system, see [PR #236](https://github.com/stnolting/neorv32/pull/236) |
 | 03.12.2021 | 1.6.4.5 | added _SYSINFO_SOC_IS_SIM_ flag to SYSINFO to check if processor is being simulated (not guaranteed, depends on the toolchain's 'pragma' support), see [PR #231](https://github.com/stnolting/neorv32/pull/231) |
 | 03.12.2021 | 1.6.4.4 | :bug: fixed bug in **Wishbone** bus interface: timeout configurations (via `MEM_EXT_TIMEOUT` generic) that are a power of two (e.g. 256) caused _immediate_ timeouts; timeout counter was one bit short; same problem for processor-internal bus monitor (BUSKEEPER); see [PR #230](https://github.com/stnolting/neorv32/pull/230) |
 | 02.12.2021 | 1.6.4.3 | :warning: removed legacy software compatibility wrappers (`sw/lib/include/neorv32_legacy.h` and `neorv32_uart_*` functions) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -254,7 +254,7 @@ can be found in section <<_instruction_sets_and_extensions>>.
 
 .Hardwired R/W CSRs
 [IMPORTANT]
-The `misa`, `mip` and `mtval` CSRs in the NEORV32 are _read-only_.
+The `misa` and `mtval` CSRs in the NEORV32 are _read-only_.
 Any write access to it (in machine mode) to them are ignored and will _not_ cause any exceptions or side-effects.
 Pending interrupt can only be cleared by acknowledging the interrupt-causing device. However, pending interrupts
 can still be ignored by clearing the according `mie` register bits.
@@ -836,10 +836,16 @@ while all remaining exceptions are ignored. If several _interrupts_ trigger at o
 is serviced first while the remaining ones stay _pending_. After completing the interrupt handler the interrupt with
 the second highest priority will get serviced and so on until no further interrupt are pending.
 
-.Interrupt Signal Requirements
+.Interrupt Signal Requirements - Standard RISC-V Interrupts
 [IMPORTANT]
-All interrupts request signals (including FIRQs) are **high-active**. A request has to stay at high-level (=asserted)
+All standard RISC-V interrupts request signals are **high-active**. A request has to stay at high-level (=asserted)
 until it is explicitly acknowledged by the CPU software (for example by writing to a specific memory-mapped register).
+
+.Interrupt Signal Requirements - Fast Interrupt Requests
+[IMPORTANT]
+The NEORV32-specific FIRQ request lines are triggered by a rising edge. Each request is buffered in the CPU control
+unit until the channel is either disabled (by clearing the according `mie` CSR bit) or the request is explicitly cleared (by setting
+the according `mip` CSR bit).
 
 .Instruction Atomicity
 [NOTE]

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -561,7 +561,7 @@ The NEORV32-specific extensions are always enabled and are indicated by the set 
 
 The most important points of the NEORV32-specific extensions are:
 * The CPU provides 16 _fast interrupt_ interrupts (`FIRQ)`, which are controlled via custom bits in the `mie`
-and `mip` CSR. This extension is mapped to _reserved_ CSR bits, that are available for custom use (according to the
+and `mip` CSR. This extension is mapped to CSR bits, that are available for custom use (according to the
 RISC-V specs). Also, custom trap codes for `mcause` are implemented.
 * All undefined/unimplemented/malformed/illegal instructions do raise an illegal instruction exception (see <<_full_virtualization>>).
 

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -83,7 +83,7 @@ CSRs with the following notes ...
 | 0x341   | <<_mepc>>       | _CSR_MEPC_       | r/w | Machine exception program counter | 
 | 0x342   | <<_mcause>>     | _CSR_MCAUSE_     | r/w | Machine trap cause | `X`
 | 0x343   | <<_mtval>>      | _CSR_MTVAL_      | r/- | Machine bad address or instruction | `XR`
-| 0x344   | <<_mip>>        | _CSR_MIP_        | r/- | Machine interrupt pending register | `XR`
+| 0x344   | <<_mip>>        | _CSR_MIP_        | r/w | Machine interrupt pending register | `X`
 6+^| **<<_machine_physical_memory_protection_csrs>>**
 | 0x3a0 .. 0x3af | <<_pmpcfg, `pmpcfg0`>> .. <<_pmpcfg, `pmpcfg15`>>     | _CSR_PMPCFG0_ .. _CSR_PMPCFG15_   | r/w | Physical memory protection config. for region 0..63 | `C`
 | 0x3b0 .. 0x3ef | <<_pmpaddr, `pmpaddr0`>> .. <<_pmpaddr, `pmpaddr63`>> | _CSR_PMPADDR0_ .. _CSR_PMPADDR63_ | r/w | Physical memory protection addr. register region 0..63 | 
@@ -446,9 +446,10 @@ The NEORV32 `mtval` CSR is read-only. However, a write access will _NOT_ raise a
 | 0x344 | **Machine interrupt Pending** | `mip`
 3+| Reset value: _0x00000000_
 3+| The `mip` CSR is compatible to the RISC-V specifications and also provides custom extensions. It shows currently _pending_ interrupts.
-Since this register is read-only, pending interrupts of processor-internal modules can only be cleared by acknowledging the interrupt-causing
-device. However, pending interrupts can be ignored by clearing the according <<_mie>> register bits.
-The following CSR bits are implemented (all remaining bits are always zero and are read-only).
+The bits for the standard RISC-V interrupts are read-only. Hence, these interrupts cannot be cleared using the `mip` register and must
+be cleared/acknowledged within the according interrupt-generating device (for example by incrementing MTIME's time compare registers).
+The upper 16 bits represent the status of the CPU's fast interrupt request lines (FIRQ). Once triggered, these _have to be cleared_ again by setting
+the according bit in the interrupt handler routine to allow another triggering.
 |======
 
 .Machine interrupt pending register
@@ -456,10 +457,10 @@ The following CSR bits are implemented (all remaining bits are always zero and a
 [options="header",grid="rows"]
 |=======================
 | Bit | Name [C] | R/W | Function
-| 31:16 | _CSR_MIP_FIRQ15P_ : _CSR_MIP_FIRQ0P_ | r/- | fast interrupt channel 15..0 pending
-| 11    | _CSR_MIP_MEIP_ | r/- | machine _external_ interrupt pending
-| 7     | _CSR_MIP_MTIP_ | r/- | machine _timer_ interrupt pending
-| 3     | _CSR_MIP_MSIP_ | r/- | machine _software_ interrupt pending
+| 31:16 | _CSR_MIP_FIRQ15P_ : _CSR_MIP_FIRQ0P_ | r/w | fast interrupt channel 15..0 pending; clear request by writing 1
+| 11    | _CSR_MIP_MEIP_                       | r/- | machine _external_ interrupt pending
+| 7     | _CSR_MIP_MTIP_                       | r/- | machine _timer_ interrupt pending
+| 3     | _CSR_MIP_MSIP_                       | r/- | machine _software_ interrupt pending
 |=======================
 
 [IMPORTAN]

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -82,7 +82,7 @@ CSRs with the following notes ...
 | 0x340   | <<_mscratch>>   | _CSR_MSCRATCH_   | r/w | Machine scratch register | 
 | 0x341   | <<_mepc>>       | _CSR_MEPC_       | r/w | Machine exception program counter | 
 | 0x342   | <<_mcause>>     | _CSR_MCAUSE_     | r/w | Machine trap cause | `X`
-| 0x343   | <<_mtval>>      | _CSR_MTVAL_      | r/- | Machine bad address or instruction | `XR`
+| 0x343   | <<_mtval>>      | _CSR_MTVAL_      | r/- | Machine bad address or instruction | `R`
 | 0x344   | <<_mip>>        | _CSR_MIP_        | r/w | Machine interrupt pending register | `X`
 6+^| **<<_machine_physical_memory_protection_csrs>>**
 | 0x3a0 .. 0x3af | <<_pmpcfg, `pmpcfg0`>> .. <<_pmpcfg, `pmpcfg15`>>     | _CSR_PMPCFG0_ .. _CSR_PMPCFG15_   | r/w | Physical memory protection config. for region 0..63 | `C`
@@ -447,9 +447,9 @@ The NEORV32 `mtval` CSR is read-only. However, a write access will _NOT_ raise a
 3+| Reset value: _0x00000000_
 3+| The `mip` CSR is compatible to the RISC-V specifications and also provides custom extensions. It shows currently _pending_ interrupts.
 The bits for the standard RISC-V interrupts are read-only. Hence, these interrupts cannot be cleared using the `mip` register and must
-be cleared/acknowledged within the according interrupt-generating device (for example by incrementing MTIME's time compare registers).
+be cleared/acknowledged within the according interrupt-generating device.
 The upper 16 bits represent the status of the CPU's fast interrupt request lines (FIRQ). Once triggered, these _have to be cleared_ again by setting
-the according bit in the interrupt handler routine to allow another triggering.
+the according `mip` bit in the interrupt handler routine to clear the current interrupt request.
 |======
 
 .Machine interrupt pending register
@@ -457,14 +457,11 @@ the according bit in the interrupt handler routine to allow another triggering.
 [options="header",grid="rows"]
 |=======================
 | Bit | Name [C] | R/W | Function
-| 31:16 | _CSR_MIP_FIRQ15P_ : _CSR_MIP_FIRQ0P_ | r/w | fast interrupt channel 15..0 pending; clear request by writing 1
-| 11    | _CSR_MIP_MEIP_                       | r/- | machine _external_ interrupt pending
-| 7     | _CSR_MIP_MTIP_                       | r/- | machine _timer_ interrupt pending
-| 3     | _CSR_MIP_MSIP_                       | r/- | machine _software_ interrupt pending
+| 31:16 | _CSR_MIP_FIRQ15P_ : _CSR_MIP_FIRQ0P_ | r/w | fast interrupt channel 15..0 pending; cleared request by writing 1
+| 11    | _CSR_MIP_MEIP_                       | r/- | machine _external_ interrupt pending; _cleared by user-defined mechanism_
+| 7     | _CSR_MIP_MTIP_                       | r/- | machine _timer_ interrupt pending; cleared by incrementing MTIME's time compare register
+| 3     | _CSR_MIP_MSIP_                       | r/- | machine _software_ interrupt pending; _cleared by user-defined mechanism_
 |=======================
-
-[IMPORTAN]
-The NEORV32 `mip` CSR is read-only. However, a write access will _NOT_ raise an illegal instruction exception.
 
 
 <<<

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -1057,9 +1057,8 @@ specifications. However, bare-metal system can also repurpose these interrupts. 
 
 .Trigger type
 [IMPORTANT]
-The fast interrupt request channel trigger on **high-level** and have to stay asserted until explicitly acknowledged
-by the software (for example by writing to a specific memory-mapped register). Hence, pending interrupts remain pending
-as long as the interrupt-causing device's state fulfills it's interrupt condition(s).
+The fast interrupt request channels become pending after being triggering by **a rising edge**. A pending FIRQ has to
+be explicitly cleared by setting the according `mip` CSR bit.
 
 
 :sectnums:
@@ -1117,9 +1116,8 @@ the according FIRQ priority; 0 = highest, 15 = lowest):
 
 .Trigger type
 [IMPORTANT]
-The fast interrupt request channel trigger on **high-level** and have to stay asserted until explicitly acknowledged
-by the software (for example by writing to a specific memory-mapped register). Hence, pending interrupts remain pending
-as long as the interrupt-causing device's state fulfills it's interrupt condition(s).
+The fast interrupt request channels become pending after being triggering by **a rising edge**. A pending FIRQ has to
+be explicitly cleared by setting the according `mip` CSR bit.
 
 
 

--- a/docs/datasheet/soc_cfs.adoc
+++ b/docs/datasheet/soc_cfs.adoc
@@ -55,9 +55,9 @@ uint32_t temp = NEORV32_CFS.REG[20]; // read from CFS register 20
 
 **CFS Interrupt**
 
-The CFS provides a single high-level-triggered interrupt request signal mapped to the CPU's fast interrupt channel 1.
-Once set, the interrupt has to stay asserted until explicitly acknowledged by the software (for example by
-writing to a specific CFS register). See section <<_processor_interrupts>> for more information.
+The CFS provides a single rising-edge-triggered interrupt request signal mapped to the CPU's fast interrupt channel 1.
+Once triggered, the interrupt becomes pending (if enabled in the `mis` CSR) and has to be explicitly cleared again by setting
+the according `mip` CSR bit. See section <<_processor_interrupts>> for more information.
 
 
 **CFS Configuration Generic**

--- a/docs/datasheet/soc_gptmr.adoc
+++ b/docs/datasheet/soc_gptmr.adoc
@@ -46,10 +46,8 @@ writing zero to it.
 
 **Timer Interrupt**
 
-The timer interrupt gets pending when the timer is enabled and `COUNT` matches `THRES`. The interrupt
-request is indicated via the _GPTMR_CTRL_ALARM_ control register bit. This bit as well as the actual
-interrupt keeps pending until the bit is explicitly cleared by application software or if the
-timer is disabled.
+The timer interrupt is triggered when the timer is enabled and `COUNT` matches `THRES`. The interrupt
+remains pending until explicitly cleared by writing the according `mip` CSR bit.
 
 
 .GPTMR register map (`struct NEORV32_GPTMR`)
@@ -57,12 +55,11 @@ timer is disabled.
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.6+<| `0xffffff60` .6+<| `NEORV32_GPTMR.CTRL` <|`0` _GPTMR_CTRL_EN_    ^| r/w <| Timer enable flag
+.5+<| `0xffffff60` .5+<| `NEORV32_GPTMR.CTRL` <|`0` _GPTMR_CTRL_EN_    ^| r/w <| Timer enable flag
                                               <|`1` _GPTMR_CTRL_PRSC0_ ^| r/w .3+| 3-bit clock prescaler select
                                               <|`2` _GPTMR_CTRL_PRSC1_ ^| r/w 
                                               <|`3` _GPTMR_CTRL_PRSC2_ ^| r/w 
                                               <|`4` _GPTMR_CTRL_MODE_  ^| r/w <| Counter mode: `0`=single-shot, `1`=continuous
-                                              <|`5` _GPTMR_CTRL_ALARM_ ^| r/c <| Pending interrupt/alarm, cleared by setting bit to zero
 | `0xffffff64` | `NEORV32_GPTMR.THRES` |`31:0` | r/w | Threshold value register
 | `0xffffff68` | `NEORV32_GPTMR.COUNT` |`31:0` | r/w | Counter register
 |=======================

--- a/docs/datasheet/soc_neoled.adoc
+++ b/docs/datasheet/soc_neoled.adoc
@@ -173,14 +173,11 @@ If _NEOLED_CTRL_IRQ_CONF_ is cleared, an interrupt is generated whenever the TX 
 In this case software can write up to _IO_NEOLED_TX_FIFO_/2 new data words to `DATA` without checking the FIFO
 status flags. If _NEOLED_CTRL_IRQ_CONF_ is set, an interrupt is generated whenever the TX FIFO _becomes_ empty.
 
-A pending interrupt request is cleared is cleared by any of the following operations:
-* write access to `NEORV32_NEOLED.DATA` (for example to send more LED data)
-* write access to `NEORV32_NEOLED.CTRL`
-* disabling the NEOLED module
+One the NEOLED interrupt has been triggered and became pending, it has to explicitly cleared again by setting the
+according `mip` CSR bit.
 
 [NOTE]
 The _NEOLED_CTRL_IRQ_CONF_ is hardwired to one if _IO_NEOLED_TX_FIFO_ = 1 (-> IRQ if FIFO is empty).
-
 If the FIFO is configured to contain only a single entry (_IO_NEOLED_TX_FIFO_ = 1) the interrupt
 will become pending if the FIFO (which is just a single register providing simple _double-buffering_) is empty.
 

--- a/docs/datasheet/soc_slink.adoc
+++ b/docs/datasheet/soc_slink.adoc
@@ -144,6 +144,9 @@ The **TX link's** _SLINK_IRQ_TX_MODE_ flags define the FIFO fill-level condition
 * If a link's interrupt mode flag is `1` an IRQ is generated when the link's FIFO _becomes_ not full ("space left in FIFO for new TX data").
 * If a link's interrupt mode flag is `0` an IRQ is generated when the link's FIFO _becomes_ less than half-full ("SW can send _SLINK_TX_FIFO_/2 data words without checking any flags"). 
 
+Once the SLINK's RX or TX interrupt has become pending, it has to be explicitly cleared again by setting the according
+`mip` CSR bit.
+
 [IMPORTANT]
 The interrupt configuration register `NEORV32_SLINK.IRQ` should we written _before_ the SLINK
 module is actually enabled.
@@ -151,20 +154,6 @@ module is actually enabled.
 [NOTE]
 If _SLINK_RX_FIFO_ is 1 all _SLINK_IRQ_RX_MODE_ bits are hardwired to one.
 If _SLINK_TX_FIFO_ is 1 all _SLINK_IRQ_TX_MODE_ bits are hardwired to one.
-
-A **pending RX interrupt** request is cleared by any of the following operations:
-* read access to any `NEORV32_SLINK.DATA` (for example to read incoming data)
-* write access to `NEORV32_SLINK.CTRL`
-* disabling the SLINK module
-
-A **pending TX interrupt** request is cleared by any of the following operations:
-* write access any `NEORV32_SLINK.DATA` (for example to send more data)
-* write access to `NEORV32_SLINK.CTRL`
-* disabling the SLINK module
-
-[TIP]
-A dummy write to to the control register (i.e. `NEORV32_SLINK.DATA = NEORV32_SLINK.DATA`)
-can be executed to acknowledge any interrupt.
 
 
 .SLINK register map (`struct NEORV32_SLINK`)

--- a/docs/datasheet/soc_slink.adoc
+++ b/docs/datasheet/soc_slink.adoc
@@ -137,12 +137,12 @@ _SLINK_IRQ_RX_EN_ is set. Vice versa, the current FIFO fill-level of a specific 
 request if it's interrupt enable flag _SLINK_IRQ_TX_EN_ is set.
 
 The **RX link's** _SLINK_IRQ_RX_MODE_ flags define the FIFO fill-level condition for raising an RX interrupt request:
-* If a link's interrupt mode flag is `1` an IRQ is generated when the link's FIFO _becomes_ not empty ("RX data available").
-* If a link's interrupt mode flag is `0` an IRQ is generated when the link's FIFO _becomes_ at least half-full ("time to get data from RX FIFO to prevent overflow").
+* If a link's interrupt mode flag is `0` an IRQ is generated when the link's FIFO _becomes_ not empty ("RX data available").
+* If a link's interrupt mode flag is `1` an IRQ is generated when the link's FIFO _becomes_ at least half-full ("time to get data from RX FIFO to prevent overflow").
 
 The **TX link's** _SLINK_IRQ_TX_MODE_ flags define the FIFO fill-level condition for raising an TX interrupt request:
-* If a link's interrupt mode flag is `1` an IRQ is generated when the link's FIFO _becomes_ not full ("space left in FIFO for new TX data").
-* If a link's interrupt mode flag is `0` an IRQ is generated when the link's FIFO _becomes_ less than half-full ("SW can send _SLINK_TX_FIFO_/2 data words without checking any flags"). 
+* If a link's interrupt mode flag is `0` an IRQ is generated when the link's FIFO _becomes_ not full ("space left in FIFO for new TX data").
+* If a link's interrupt mode flag is `1` an IRQ is generated when the link's FIFO _becomes_ less than half-full ("SW can send _SLINK_TX_FIFO_/2 data words without checking any flags"). 
 
 Once the SLINK's RX or TX interrupt has become pending, it has to be explicitly cleared again by setting the according
 `mip` CSR bit.

--- a/docs/datasheet/soc_spi.adoc
+++ b/docs/datasheet/soc_spi.adoc
@@ -108,15 +108,8 @@ Hence, the maximum SPI clock is f~main~ / 4.
 **SPI Interrupt**
 
 The SPI module provides a single interrupt to signal "transmission done" to the CPU. Whenever the SPI
-module completes the current transfer operation, the interrupt request is set. A pending interrupt request
-is cleared by any of the following operations:
-* read or write access to `NEORV32_SPI.DATA` (for example to trigger a new transmission)
-* write access to `NEORV32_SPI.CTRL`
-* disabling the SPI module
-
-[TIP]
-A dummy read from `NEORV32_SPI.DATA` can be executed to acknowledge the interrupt without affecting data
-or the state of the SPI module.
+module completes the current transfer operation, the interrupt is triggered and has to be explicitly cleared again
+by setting the according `mip` CSR bit.
 
 
 .SPI register map (`struct NEORV32_SPI`)

--- a/docs/datasheet/soc_twi.adoc
+++ b/docs/datasheet/soc_twi.adoc
@@ -74,15 +74,8 @@ _**f~SCL~**_ = _f~main~[Hz]_ / (4 * `clock_prescaler`)
 
 The SPI module provides a single interrupt to signal "operation done" to the CPU. Whenever the TWI
 module completes the current operation (generate stop condition, generate start conditions or transfer byte),
-the interrupt request is set. A pending interrupt request is cleared is cleared by any of
-the following operations:
-* read or write access to `NEORV32_TWI.DATA` (for example to trigger a new transmission)
-* write access to `NEORV32_TWI.CTRL`
-* disabling the TWI module
-
-[TIP]
-A dummy read from `NEORV32_TWI.DATA` can be executed to acknowledge the interrupt without affecting data
-or the state of the TWI module.
+the interrupt is triggered. Once triggered, the interrupt has to be explicitly cleared again by setting the according
+`mip` CSR bit.
 
 
 .TWI register map (`struct NEORV32_TWI`)

--- a/docs/datasheet/soc_uart.adoc
+++ b/docs/datasheet/soc_uart.adoc
@@ -127,19 +127,8 @@ the RX FIFO _becomes_ at least half-full (-> _UART_CTRL_RX_HALF_ sets).
 in the TX FIFO _becomes_ free (-> _UART_CTRL_TX_FULL_ clears). If _UART_CTRL_TX_IRQ_ is `1` the TX interrupt goes pending
 when the RX FIFO _becomes_ less than half-full (-> _UART_CTRL_TX_HALF_ clears).
 
-A **pending RX interrupt** request is cleared by any of the following operations:
-* read access to `NEORV32_UART0.DATA` (for example to read incoming data)
-* write access to `NEORV32_UART0.CTRL`
-* disabling the UART module
-
-A **pending TX interrupt** request is cleared by any of the following operations:
-* write access to `NEORV32_UART0.DATA` (for example to send more data)
-* write access to `NEORV32_UART0.CTRL`
-* disabling the UART module
-
-[TIP]
-A dummy write to to the control register (i.e. `NEORV32_UART0.DATA = NEORV32_UART0.DATA`)
-can be executed to acknowledge any interrupt.
+Once the RX or TX interrupt has become pending, it has to be explicitly cleared again by setting the
+according `mip` CSR bit.
 
 
 **Simulation Mode**

--- a/docs/datasheet/soc_wdt.adoc
+++ b/docs/datasheet/soc_wdt.adoc
@@ -44,7 +44,7 @@ IRQ, when set the WDT will cause a system reset. The configured action can also 
 any time by setting the _WDT_CTRL_FORCE_ bit. The watchdog is reset by setting the _WDT_CTRL_RESET_ bit.
 
 A watchdog interrupt can only occur if the watchdog is enabled and interrupt mode is enabled.
-A pending interrupt is cleared by either disabling the watchdog or by resetting the watchdog.
+A triggered interrupt has to be cleared again by setting the according `mip` CSR bit.
 
 The cause of the last action of the watchdog can be determined via the _WDT_CTRL_RCAUSE_ flag. If this flag is
 zero, the processor has been reset via the external reset signal. If this flag is set the last system reset was
@@ -54,6 +54,7 @@ The Watchdog control register can be locked in order to protect the current conf
 activated by setting bit _WDT_CTRL_LOCK_. In the locked state any write access to the configuration flags is
 ignored (see table below, "accessible if locked"). Read accesses to the control register are not effected. The
 lock can only be removed by a system reset (via external reset signal or via a watchdog reset action).
+
 
 .WDT register map (`struct NEORV32_WDT`)
 [cols="<2,<2,<4,^1,^2,<4"]

--- a/docs/datasheet/soc_xirq.adoc
+++ b/docs/datasheet/soc_xirq.adoc
@@ -42,7 +42,8 @@ This priority assignment is fixed and cannot be altered by software.
 The CPU can use the ID from `SCR` to service IRQ according to their priority. To acknowledge the according
 interrupt the CPU can write `1 << SCR` to `IPR`.
 
-In order to clear a pending FIRQ interrupt from the external interrupt controller, the CPU has to write _any_
+In order to clear a pending FIRQ interrupt from the external interrupt controller again, the according `mip` CSR bit has
+to be set. Additionally, the XIRQ interrupt has to be acknowledged by writing _any_
 value to the interrupt source register `SRC`.
 
 [NOTE]

--- a/rtl/core/neorv32_cfs.vhd
+++ b/rtl/core/neorv32_cfs.vhd
@@ -174,10 +174,10 @@ begin
   -- Interrupt ------------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   -- The CFS features a single interrupt signal, which is connected to the CPU's "fast interrupt" channel 1.
-  -- The interrupt is high-level-active. When set, the interrupt appears as "pending" in the CPU's mie register
-  -- ready to trigger execution of the according interrupt handler.
-  -- Once set, the irq_o signal **has to stay set** until explicitly acknowledged by the CPU
-  -- (for example by reading/writing from/to a specific CFS interface register address).
+  -- The interrupt is triggered by a one-shot rising edge. After triggering, the interrupt appears as "pending" in the CPU's mie register
+  -- ready to trigger execution of the according interrupt handler. The interrupt request signal should be triggered
+  -- whenever an interrupt condition is fulfilled. It is the task of the application to programmer to enable/clear the CFS interrupt
+  -- using the CPU's mie and mip registers when reuqired.
 
   irq_o <= '0'; -- not used for this minimal example
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -53,7 +53,7 @@ package neorv32_package is
   -- increasing instruction fetch & data access latency by +1 cycle but also reducing critical path length
   constant pmp_num_regions_critical_c : natural := 8; -- default=8
 
-  -- "response time window" for processor-internal memories and IO devices
+  -- "response time window" for processor-internal modules --
   constant max_proc_int_response_time_c : natural := 15; -- cycles after which an *unacknowledged* internal bus access will timeout and trigger a bus fault exception (min 2)
 
   -- jtag tap - identifier --
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060405"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060406"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -589,7 +589,7 @@ package neorv32_package is
   constant csr_mhpmevent30_c    : std_ulogic_vector(11 downto 0) := x"33e";
   constant csr_mhpmevent31_c    : std_ulogic_vector(11 downto 0) := x"33f";
   -- machine trap handling --
-  constant csr_class_trap_c     : std_ulogic_vector(08 downto 0) := x"34" & '0'; -- machine trap handling
+  constant csr_class_trap_c     : std_ulogic_vector(07 downto 0) := x"34"; -- machine trap handling
   constant csr_mscratch_c       : std_ulogic_vector(11 downto 0) := x"340";
   constant csr_mepc_c           : std_ulogic_vector(11 downto 0) := x"341";
   constant csr_mcause_c         : std_ulogic_vector(11 downto 0) := x"342";

--- a/rtl/core/neorv32_spi.vhd
+++ b/rtl/core/neorv32_spi.vhd
@@ -116,14 +116,6 @@ architecture neorv32_spi_rtl of neorv32_spi is
   end record;
   signal rtx_engine : rtx_engine_t;
 
-  -- interrupt generator --
-  type irq_t is record
-    pending : std_ulogic; -- pending interrupt request
-    set     : std_ulogic;
-    clr     : std_ulogic;
-  end record;
-  signal irq : irq_t;
-
 begin
 
   -- Access Control -------------------------------------------------------------------------
@@ -239,7 +231,7 @@ begin
 
       -- defaults --
       spi_sck_o <= ctrl(ctrl_cpol_c);
-      irq.set   <= '0';
+      irq_o     <= '0';
 
       -- serial engine --
       rtx_engine.state(2) <= ctrl(ctrl_en_c);
@@ -273,7 +265,7 @@ begin
           if (spi_clk_en = '1') then
             rtx_engine.sreg <= rtx_engine.sreg(30 downto 0) & rtx_engine.sdi_sync(rtx_engine.sdi_sync'left);
             if (rtx_engine.bitcnt(5 downto 3) = rtx_engine.bytecnt) then -- all bits transferred?
-              irq.set <= '1'; -- interrupt!
+              irq_o <= '1'; -- interrupt!
               rtx_engine.state(1 downto 0) <= "00"; -- transmission done
             else
               rtx_engine.state(1 downto 0) <= "10";
@@ -290,30 +282,6 @@ begin
 
   -- busy flag --
   rtx_engine.busy <= '0' when (rtx_engine.state(1 downto 0) = "00") else '1';
-
-
-  -- Interrupt Generator --------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  irq_generator: process(clk_i)
-  begin
-    if rising_edge(clk_i) then
-      if (ctrl(ctrl_en_c) = '0') then
-        irq.pending <= '0';
-      else
-        if (irq.set = '1') then
-          irq.pending <= '1';
-        elsif (irq.clr = '1') then
-          irq.pending <= '0';
-        end if;
-      end if;
-    end if;
-  end process irq_generator;
-
-  -- IRQ request to CPU --
-  irq_o <= irq.pending;
-
-  -- IRQ acknowledge --
-  irq.clr <= '1' when ((rden = '1') and (addr = spi_rtx_addr_c)) or (wren = '1') else '0'; -- read data register OR write data/control register
 
 
 end neorv32_spi_rtl;

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -537,7 +537,7 @@ begin
   fencei_o <= cpu_i.fence; -- indicates an executed FENCEI operation
 
   -- fast interrupt requests (FIRQs) --
-  -- these stay asserted until explicitly acknowledged --
+  -- these signals are single-shot --
   fast_irq(00) <= wdt_irq;       -- HIGHEST PRIORITY - watchdog
   fast_irq(01) <= cfs_irq;       -- custom functions subsystem
   fast_irq(02) <= uart0_rxd_irq; -- primary UART (UART0) RX

--- a/rtl/core/neorv32_xirq.vhd
+++ b/rtl/core/neorv32_xirq.vhd
@@ -210,10 +210,12 @@ begin
   irq_arbiter: process(clk_i)
   begin
     if rising_edge(clk_i) then
+      cpu_irq_o <= '0';
       if (irq_run = '0') then -- no active IRQ
         if (irq_fire = '1') then
-          irq_run <= '1';
-          irq_src <= irq_src_nxt;
+          cpu_irq_o <= '1';
+          irq_run   <= '1';
+          irq_src   <= irq_src_nxt;
         end if;
       else -- active IRQ, wait for CPU to acknowledge
         if (wren = '1') and (addr = xirq_source_addr_c) then -- write _any_ value to acknowledge
@@ -222,9 +224,6 @@ begin
       end if;
     end if;
   end process irq_arbiter;
-
-  -- interrupt request --
-  cpu_irq_o <= irq_run;
 
 
 end neorv32_xirq_rtl;

--- a/sw/example/demo_gptmr/main.c
+++ b/sw/example/demo_gptmr/main.c
@@ -113,7 +113,7 @@ int main() {
  **************************************************************************/
 void gptmr_firq_handler(void) {
 
-  neorv32_gptmr_ack_irq(); // IRQ acknowledge / clear pending alarm interrupt
+  neorv32_cpu_csr_write(CSR_MIP, 1<<GPTMR_FIRQ_PENDING); // clear/ack pending FIRQ
 
   neorv32_uart0_putc('.'); // send tick symbol via UART
   neorv32_gpio_pin_toggle(0); // toggle output port bit 0

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1498,7 +1498,7 @@ int main() {
     PRINT_STANDARD("Creating protected page (NAPOT, [!X,!W,!R], %u bytes) @ 0x%x: ", tmp_b, tmp_a);
 
     // configure
-    int pmp_return = neorv32_cpu_pmp_configure_region(0, tmp_a, tmp_b, 0b00011000); // NAPOT, NO read permission, NO write permission, and NO execute permissions
+    int pmp_return = neorv32_cpu_pmp_configure_region(0, tmp_a, tmp_b, PMPCFG_MODE_NAPOT << PMPCFG_A_LSB); // NAPOT, NO read/write/execute permissions
 
     if ((pmp_return == 0) && (neorv32_cpu_csr_read(CSR_MCAUSE) == 0)) {
       test_ok();

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -259,30 +259,30 @@ int main() {
   }
 
 
-  // ----------------------------------------------------------
-  // Test standard RISC-V performance counter [m]cycle[h]
-  // ----------------------------------------------------------
-  neorv32_cpu_csr_write(CSR_MCAUSE, 0);
-  PRINT_STANDARD("[%i] cycle counter: ", cnt_test);
-
-  cnt_test++;
-
-  // make sure counter is enabled
-  asm volatile ("csrci %[addr], %[imm]" : : [addr] "i" (CSR_MCOUNTINHIBIT), [imm] "i" (1<<CSR_MCOUNTINHIBIT_CY));
-
-  // prepare overflow
-  neorv32_cpu_set_mcycle(0x00000000FFFFFFFFULL);
-
-  // get current cycle counter HIGH
-  tmp_a = neorv32_cpu_csr_read(CSR_MCYCLEH);
-
-  // make sure cycle counter high has incremented and there was no exception during access
-  if ((tmp_a == 1) && (neorv32_cpu_csr_read(CSR_MCAUSE) == 0)) {
-    test_ok();
-  }
-  else {
-    test_fail();
-  }
+//// ----------------------------------------------------------
+//// Test standard RISC-V performance counter [m]cycle[h]
+//// ----------------------------------------------------------
+//neorv32_cpu_csr_write(CSR_MCAUSE, 0);
+//PRINT_STANDARD("[%i] cycle counter: ", cnt_test);
+//
+//cnt_test++;
+//
+//// make sure counter is enabled
+//asm volatile ("csrci %[addr], %[imm]" : : [addr] "i" (CSR_MCOUNTINHIBIT), [imm] "i" (1<<CSR_MCOUNTINHIBIT_CY));
+//
+//// prepare overflow
+//neorv32_cpu_set_mcycle(0x00000000FFFFFFFFULL);
+//
+//// get current cycle counter HIGH
+//tmp_a = neorv32_cpu_csr_read(CSR_MCYCLEH);
+//
+//// make sure cycle counter high has incremented and there was no exception during access
+//if ((tmp_a == 1) && (neorv32_cpu_csr_read(CSR_MCAUSE) == 0)) {
+//  test_ok();
+//}
+//else {
+//  test_fail();
+//}
 
 
   // ----------------------------------------------------------
@@ -436,13 +436,9 @@ int main() {
       tmp_a = (uint32_t)EXT_MEM_BASE; // call the dummy sub program
       asm volatile ("jalr ra, %[input_i]" :  : [input_i] "r" (tmp_a));
     
-      if (neorv32_cpu_csr_read(CSR_MCAUSE) == 0) { // make sure there was no exception
-        if (neorv32_cpu_csr_read(CSR_MSCRATCH) == 15) { // make sure the program was executed in the right way
-          test_ok();
-        }
-        else {
-          test_fail();
-        }
+      if ((neorv32_cpu_csr_read(CSR_MCAUSE) == 0) && // make sure there was no exception
+          (neorv32_cpu_csr_read(CSR_MSCRATCH) == 15)) { // make sure the program was executed in the right way
+        test_ok();
       }
       else {
         test_fail();
@@ -926,7 +922,7 @@ int main() {
 
     // configure WDT
     neorv32_wdt_setup(CLK_PRSC_4096, 0, 1); // highest clock prescaler, trigger IRQ on timeout, lock access
-    NEORV32_WDT.CTRL = 0; // try to deactivate WDT (should fail as access is loced)
+    NEORV32_WDT.CTRL = 0; // try to deactivate WDT (should fail as access is locked)
     neorv32_wdt_force(); // force watchdog into action
 
     // wait some time for the IRQ to arrive the CPU
@@ -972,13 +968,13 @@ int main() {
     // make sure sim mode is disabled
     NEORV32_UART0.CTRL &= ~(1 << UART_CTRL_SIM_MODE);
 
+    // enable fast interrupt
+    neorv32_cpu_irq_enable(CSR_MIE_FIRQ2E);
+
     // trigger UART0 RX IRQ
     neorv32_uart0_putc(0);
     // wait for UART0 to finish transmitting
     while(neorv32_uart0_tx_busy());
-
-    // enable fast interrupt
-    neorv32_cpu_irq_enable(CSR_MIE_FIRQ2E);
 
     // wait some time for the IRQ to arrive the CPU
     asm volatile("nop");
@@ -1016,10 +1012,11 @@ int main() {
     // make sure sim mode is disabled
     NEORV32_UART0.CTRL &= ~(1 << UART_CTRL_SIM_MODE);
 
-    // trigger UART0 TX IRQ
-    neorv32_uart0_putc(0);
     // UART0 TX interrupt enable
     neorv32_cpu_irq_enable(CSR_MIE_FIRQ3E);
+
+    // trigger UART0 TX IRQ
+    neorv32_uart0_putc(0);
     // wait for UART to finish transmitting
     while(neorv32_uart0_tx_busy());
 
@@ -1056,12 +1053,13 @@ int main() {
     // make sure sim mode is disabled
     NEORV32_UART1.CTRL &= ~(1 << UART_CTRL_SIM_MODE);
 
+    // UART1 RX interrupt enable
+    neorv32_cpu_irq_enable(CSR_MIE_FIRQ4E);
+
     // trigger UART1 RX IRQ
     neorv32_uart1_putc(0);
     // wait for UART1 to finish transmitting
     while(neorv32_uart1_tx_busy());
-    // UART1 RX interrupt enable
-    neorv32_cpu_irq_enable(CSR_MIE_FIRQ4E);
 
     // wait some time for the IRQ to arrive the CPU
     asm volatile("nop");
@@ -1096,10 +1094,11 @@ int main() {
     // make sure sim mode is disabled
     NEORV32_UART1.CTRL &= ~(1 << UART_CTRL_SIM_MODE);
 
-    // trigger UART1 TX IRQ
-    neorv32_uart1_putc(0);
     // UART1 RX interrupt enable
     neorv32_cpu_irq_enable(CSR_MIE_FIRQ5E);
+
+    // trigger UART1 TX IRQ
+    neorv32_uart1_putc(0);
     // wait for UART1 to finish transmitting
     while(neorv32_uart1_tx_busy());
 
@@ -1264,61 +1263,89 @@ int main() {
 
 
   // ----------------------------------------------------------
-  // Fast interrupt channel 10 & 11 (SLINK)
+  // Fast interrupt channel 10 (SLINK RX)
   // ----------------------------------------------------------
   if (neorv32_slink_available()) {
     neorv32_cpu_csr_write(CSR_MCAUSE, 0);
-    PRINT_STANDARD("[%i] FIRQ10 & 11 (SLINK): ", cnt_test);
+    PRINT_STANDARD("[%i] FIRQ10 (SLINK RX): ", cnt_test);
 
     cnt_test++;
-
-    // configure SLINK IRQs
-    neorv32_slink_tx_irq_config(0, SLINK_IRQ_ENABLE, SLINK_IRQ_TX_NOT_FULL);
-    neorv32_slink_rx_irq_config(0, SLINK_IRQ_ENABLE, SLINK_IRQ_RX_NOT_EMPTY);
 
     // enable SLINK
     neorv32_slink_enable();
 
     // enable SLINK FIRQs
-    neorv32_cpu_irq_enable(CSR_MIE_FIRQ10E);
-    neorv32_cpu_irq_enable(CSR_MIE_FIRQ11E);
+    neorv32_slink_rx_irq_config(0, SLINK_IRQ_ENABLE, SLINK_IRQ_RX_NOT_EMPTY);
+    neorv32_cpu_irq_enable(SLINK_RX_FIRQ_ENABLE);
 
     tmp_a = 0; // error counter
 
-    // wait some time for the IRQ to arrive the CPU
-    asm volatile("nop");
-
-    // check if TX FIFO fires IRQ
-    if (neorv32_cpu_csr_read(CSR_MCAUSE) != TRAP_CODE_FIRQ_11) {
-      tmp_a += 1;
-    }
-    neorv32_slink_tx_irq_config(0, SLINK_IRQ_DISABLE, SLINK_IRQ_TX_NOT_FULL);
-
     // send single data word via link 0
     if (neorv32_slink_tx0_nonblocking(0xA1B2C3D4)) {
-      tmp_a += 2; // sending failed
+      tmp_a += 1; // sending failed
     }
 
     // wait some time for the IRQ to arrive the CPU
     asm volatile("nop");
 
-    // check if RX FIFO fires IRQ
-    if (neorv32_cpu_csr_read(CSR_MCAUSE) != TRAP_CODE_FIRQ_10) {
-      tmp_a += 4;
+    // check if RX link fires IRQ
+    if (neorv32_cpu_csr_read(CSR_MCAUSE) != SLINK_RX_TRAP_CODE) {
+      tmp_a += 2;
     }
-    neorv32_slink_rx_irq_config(0, SLINK_IRQ_DISABLE, SLINK_IRQ_RX_NOT_EMPTY);
+    neorv32_cpu_irq_disable(SLINK_RX_FIRQ_ENABLE);
 
     // get single data word from link 0
     uint32_t slink_rx_data;
     if (neorv32_slink_rx0_nonblocking(&slink_rx_data)) {
-      tmp_a += 8; // receiving failed
+      tmp_a += 4; // receiving failed
     }
-
-    neorv32_cpu_irq_disable(CSR_MIE_FIRQ10E);
-    neorv32_cpu_irq_disable(CSR_MIE_FIRQ11E);
 
     if ((tmp_a == 0) && // local error counter = 0
         (slink_rx_data == 0xA1B2C3D4)) { // correct data read-back
+      test_ok();
+    }
+    else {
+      test_fail();
+    }
+
+    // shutdown SLINK
+    neorv32_slink_disable();
+  }
+
+
+  // ----------------------------------------------------------
+  // Fast interrupt channel 11 (SLINK TX)
+  // ----------------------------------------------------------
+  if (neorv32_slink_available()) {
+    neorv32_cpu_csr_write(CSR_MCAUSE, 0);
+    PRINT_STANDARD("[%i] FIRQ11 (SLINK TX): ", cnt_test);
+
+    cnt_test++;
+
+    // enable SLINK
+    neorv32_slink_enable();
+
+    // enable SLINK FIRQs
+    neorv32_slink_tx_irq_config(0, SLINK_IRQ_ENABLE, SLINK_IRQ_TX_NOT_FULL);
+    neorv32_cpu_irq_enable(SLINK_TX_FIRQ_ENABLE);
+
+    tmp_a = 0; // error counter
+
+    // send single data word via link 0
+    if (neorv32_slink_tx0_nonblocking(0x11223344)) {
+      tmp_a += 1; // sending failed
+    }
+
+    // wait some time for the IRQ to arrive the CPU
+    asm volatile("nop");
+
+    // check if TX link fires IRQ
+    if (neorv32_cpu_csr_read(CSR_MCAUSE) != SLINK_TX_TRAP_CODE) {
+      tmp_a += 2;
+    }
+    neorv32_cpu_irq_disable(SLINK_RX_FIRQ_ENABLE);
+
+    if (tmp_a == 0) { // local error counter = 0
       test_ok();
     }
     else {
@@ -1757,6 +1784,9 @@ void sim_irq_trigger(uint32_t sel) {
  * Trap handler for ALL exceptions/interrupts.
  **************************************************************************/
 void global_trap_handler(void) {
+
+  // clear all pending FIRQs
+  neorv32_cpu_csr_write(CSR_MIP, -1);
 
   // hack: always come back in MACHINE MODE
   register uint32_t mask = (1<<CSR_MSTATUS_MPP_H) | (1<<CSR_MSTATUS_MPP_L);

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -757,14 +757,14 @@ enum NEORV32_SLINK_IRQ_EN_enum {
 
 /** SLINK RX interrupt configuration type (per link) */
 enum NEORV32_SLINK_IRQ_RX_TYPE_enum {
-  SLINK_IRQ_RX_FIFO_HALF = 0, /**< '0': RX FIFO fill-level rises above half-full */
-  SLINK_IRQ_RX_NOT_EMPTY = 1  /**< '1': RX FIFO is not empty */
+  SLINK_IRQ_RX_NOT_EMPTY = 0, /**< '1': RX FIFO is not empty */
+  SLINK_IRQ_RX_FIFO_HALF = 1  /**< '0': RX FIFO fill-level rises above half-full */
 };
 
 /** SLINK TX interrupt configuration type (per link) */
 enum NEORV32_SLINK_IRQ_TX_TYPE_enum {
-  SLINK_IRQ_TX_FIFO_HALF = 0, /**< '0': TX FIFO fill-level falls below half-full */
-  SLINK_IRQ_TX_NOT_FULL  = 1  /**< '1': TX FIFO is not FULL */
+  SLINK_IRQ_TX_NOT_FULL  = 0, /**< '1': TX FIFO is not FULL */
+  SLINK_IRQ_TX_FIFO_HALF = 1  /**< '0': TX FIFO fill-level falls below half-full */
 };
 
 /** SLINK status register bits */
@@ -825,12 +825,11 @@ typedef struct __attribute__((packed,aligned(4))) {
 
 /** GPTMR control/data register bits */
 enum NEORV32_GPTMR_CTRL_enum {
-  GPTMR_CTRL_EN     = 0, /**< GPTIMR control register(0) (r/w): Timer unit enable */
-  GPTMR_CTRL_PRSC0  = 1, /**< GPTIMR control register(1) (r/w): Clock prescaler select bit 0 */
-  GPTMR_CTRL_PRSC1  = 2, /**< GPTIMR control register(2) (r/w): Clock prescaler select bit 1 */
-  GPTMR_CTRL_PRSC2  = 3, /**< GPTIMR control register(3) (r/w): Clock prescaler select bit 2 */
-  GPTMR_CTRL_MODE   = 4, /**< GPTIMR control register(4) (r/w): Timer mode: 0=single-shot mode, 1=continuous mode */
-  GPTMR_CTRL_ALARM  = 5  /**< GPTIMR control register(5) (r/c): Interrupt/alarm pending, cleared by setting bit to zero */
+  GPTMR_CTRL_EN    = 0, /**< GPTIMR control register(0) (r/w): Timer unit enable */
+  GPTMR_CTRL_PRSC0 = 1, /**< GPTIMR control register(1) (r/w): Clock prescaler select bit 0 */
+  GPTMR_CTRL_PRSC1 = 2, /**< GPTIMR control register(2) (r/w): Clock prescaler select bit 1 */
+  GPTMR_CTRL_PRSC2 = 3, /**< GPTIMR control register(3) (r/w): Clock prescaler select bit 2 */
+  GPTMR_CTRL_MODE  = 4  /**< GPTIMR control register(4) (r/w): Timer mode: 0=single-shot mode, 1=continuous mode */
 };
 /**@}*/
 

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -434,6 +434,24 @@ enum NEORV32_HPMCNT_EVENT_enum {
 
 
 /**********************************************************************//**
+ * CPU <b>pmpcfg</b> PMP configuration attributed
+ **************************************************************************/
+enum NEORV32_PMPCFG_ATTRIBUTES_enum {
+  PMPCFG_R     = 0, /**< CPU pmpcfg attribute (0): Read */
+  PMPCFG_W     = 1, /**< CPU pmpcfg attribute (1): Write */
+  PMPCFG_X     = 2, /**< CPU pmpcfg attribute (2): Execute */
+  PMPCFG_A_LSB = 3, /**< CPU pmpcfg attribute (3): Mode LSB */
+  PMPCFG_A_MSB = 4, /**< CPU pmpcfg attribute (4): Mode MSB */
+  PMPCFG_L     = 7  /**< CPU pmpcfg attribute (7): Locked */
+};
+
+/**********************************************************************//**
+ * PMP modes
+ **************************************************************************/
+#define PMPCFG_MODE_NAPOT 3
+
+
+/**********************************************************************//**
  * Trap codes from mcause CSR.
  **************************************************************************/
 enum NEORV32_EXCEPTION_CODES_enum {

--- a/sw/lib/include/neorv32_gptmr.h
+++ b/sw/lib/include/neorv32_gptmr.h
@@ -50,6 +50,5 @@ void neorv32_gptmr_setup(uint8_t prsc, uint8_t mode, uint32_t threshold);
 void neorv32_gptmr_disable(void);
 void neorv32_gptmr_enable(void);
 void neorv32_gptmr_restart(void);
-void neorv32_gptmr_ack_irq(void);
 
 #endif // neorv32_gptmr_h

--- a/sw/lib/source/neorv32_gptmr.c
+++ b/sw/lib/source/neorv32_gptmr.c
@@ -114,12 +114,3 @@ void neorv32_gptmr_restart(void) {
 
   NEORV32_GPTMR.COUNT = 0;
 }
-
-
-/**********************************************************************//**
- * Acknowledge interrupt / clear pending alarm.
- **************************************************************************/
-void neorv32_gptmr_ack_irq(void) {
-
-  NEORV32_GPTMR.CTRL &= ~((uint32_t)(1 << GPTMR_CTRL_ALARM));
-}

--- a/sw/lib/source/neorv32_xirq.c
+++ b/sw/lib/source/neorv32_xirq.c
@@ -237,7 +237,10 @@ static void __attribute__((aligned(16))) __neorv32_xirq_core(void) {
 
   uint32_t mask = 1 << src;
   NEORV32_XIRQ.IPR = ~mask; // clear current pending interrupt
-  NEORV32_XIRQ.SCR = 0; // acknowledge current interrupt (CPU FIRQ)
+
+  neorv32_cpu_csr_write(CSR_MIP, 1 << XIRQ_FIRQ_PENDING); // acknowledge XIRQ FIRQ
+
+  NEORV32_XIRQ.SCR = 0; // acknowledge current XIRQ interrupt source
 
   // execute handler
   register uint32_t xirq_handler = __neorv32_xirq_vector_lut[src];

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -380,11 +380,6 @@
               <bitRange>[4:4]</bitRange>
               <description>Timer mode: 0=single-shot mode, 1=continuous mode</description>
             </field>
-            <field>
-              <name>GPTMR_CTRL_ALARM</name>
-              <bitRange>[5:5]</bitRange>
-              <description>Interrupt/alarm pending, cleared by setting bit to zero</description>
-            </field>
           </fields>
         </register>
         <register>


### PR DESCRIPTION
This a rework of the _Fast Interrupt Requests (FIRQ)_ system (a remake of #176).

## Old Version (Current State)

The current FIRQ system implements **module-specific mechanisms** to clear/acknowledge pending FIRQs. For example a pending UART RX interrupt can be acknowledged by either writing to the UART control register or by reading from the UART's RX FIFO.

## New Version (This PR)

This PR aims to provide a uniform way of acknowledging FIRQs by removing the device-specific mechanisms and introducing read-write capabilities for the CPU's `mip` CSR.

:books: The RISC-V privilege spec. allows `mip` to be read-write and to clear a pending interrupt by writing '1' to the according bit position.

Example for the _new_ FIRQ triggering (UART RX FIRQ):

1. The UART is enabled.
2. The UART RX interrupt mode (NEORV32_UART0.CTRL _UART_CTRL_RX_IRQ_) is configured to '1' ("FIFO at least half-full").
3. The RX FIFO's fill level reaches "half-full" level.
4. A single-shot interrupt request is sent to the CPU.
5. The CPU buffers the FIRQ if the according `mie` CSR bit is set.
6. The pending FIRQ gets executed; the according interrupt handler is started.
7. **_new:_** it is the task of the interrupt handler to clear/acknowledge the _pending_ FIRQ by setting the according bit in the `mip` register.

The new FIRQ system simplifies the interrupt logic inside the peripheral modules. Furthermore, this concept allows more flexibility as the programmer can decide on which conditions a pending interrupt is actually cleared.

## :warning: Backwards Compatibility

* The _GPTMR_CTRL_ALARM_ bit of the general purpose timer's (GPTMR) control register has been removed.
* The interrupt mode configuration bits of the SLINK (_SLINK_IRQ_RX_MODE_ and _SLINK_IRQ_TX_MODE_) have been inverted.
* Interrupt handler (even if they are called from the NEORV32 Run-Time Environment) have to clear the triggering FIRQ by writing 1 to the according `mip` CSR bit.