### PR TITLE
Watchdog [WDT]: add option to enable/disable WDT during debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 11.12.2021 | 1.6.4.8 | watchdog: added new _DBEN_ and _HALF_ flags to control register (enable WDT during debugging, check timeout counter level), see [PR #239](https://github.com/stnolting/neorv32/pull/239) |
 | 10.12.2021 | 1.6.4.7 | optimized CPU's multiplication/division co-processor: all mul/div operations are 1 cycle faster + slightly less resource utilization, see [PR #238](https://github.com/stnolting/neorv32/pull/238) |
 | 08.12.2021 | 1.6.4.6 | :warning: reworked **Fast Interrupt Requests (FIRQ)** system, see [PR #236](https://github.com/stnolting/neorv32/pull/236) |
 | 03.12.2021 | 1.6.4.5 | added _SYSINFO_SOC_IS_SIM_ flag to SYSINFO to check if processor is being simulated (not guaranteed, depends on the toolchain's 'pragma' support), see [PR #231](https://github.com/stnolting/neorv32/pull/231) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 10.12.2021 | 1.6.4.7 | optimized CPU's multiplication/division co-processor: all mul/div operations are 1 cycle faster + slightly less resource utilization, see [PR #238](https://github.com/stnolting/neorv32/pull/238) |
 | 08.12.2021 | 1.6.4.6 | :warning: reworked **Fast Interrupt Requests (FIRQ)** system, see [PR #236](https://github.com/stnolting/neorv32/pull/236) |
 | 03.12.2021 | 1.6.4.5 | added _SYSINFO_SOC_IS_SIM_ flag to SYSINFO to check if processor is being simulated (not guaranteed, depends on the toolchain's 'pragma' support), see [PR #231](https://github.com/stnolting/neorv32/pull/231) |
 | 03.12.2021 | 1.6.4.4 | :bug: fixed bug in **Wishbone** bus interface: timeout configurations (via `MEM_EXT_TIMEOUT` generic) that are a power of two (e.g. 256) caused _immediate_ timeouts; timeout counter was one bit short; same problem for processor-internal bus monitor (BUSKEEPER); see [PR #230](https://github.com/stnolting/neorv32/pull/230) |

--- a/README.md
+++ b/README.md
@@ -232,16 +232,12 @@ for more information.
 
 ### Performance
 
-The NEORV32 CPU is based on a two-stages pipelined architecture. Since both stage use a multi-cycle processing scheme,
-each instruction requires several clock cycles to execute (2 cycles for ALU operations, up to 40 cycles for divisions).
+The NEORV32 CPU is based on a two-stages pipelined architecture. 
 The average CPI (cycles per instruction) depends on the instruction mix of a specific applications and also on the
 available CPU extensions.
 
-The following table shows the performance results (relative CoreMark score and average cycles per instruction) for
-_exemplary_ CPU configuration running 2000 iterations of the CoreMark CPU benchmark.
-The source files are available in [`sw/example/coremark`](https://github.com/stnolting/neorv32/blob/master/sw/example/coremark).
-A simple(!) port of the **Dhrystone** benchmark is also available in
-[`sw/example/dhrystone`](https://github.com/stnolting/neorv32/blob/master/sw/example/dhrystone).
+The following table shows the performance results (scores and average CPI) for _exemplary_ CPU configurations executing
+2000 iterations of the [CoreMark](https://github.com/stnolting/neorv32/blob/master/sw/example/coremark) CPU benchmark.
 
 Results generated for hardware version [`1.5.7.10`](https://github.com/stnolting/neorv32/blob/master/CHANGELOG.md).
 

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -300,6 +300,7 @@ direction seen from the CPU.
 | `clk_i`          |     1 | in  | global clock line, all registers triggering on rising edge
 | `rstn_i`         |     1 | in  | global reset, low-active
 | `sleep_o`        |     1 | out | CPU is in sleep mode when set
+| `debug_o`        |     1 | out | CPU is in debug mode when set
 4+^| **Instruction Bus Interface (<<_bus_interface>>)**
 | `i_bus_addr_o`   |    32 | out | destination address
 | `i_bus_rdata_i`  |    32 | in  | read data

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -780,8 +780,8 @@ configurations are presented in <<_cpu_performance>>.
 | Memory access | `I/E` | `lb` `lh` `lw` `lbu` `lhu` `sb` `sh` `sw` | 4 + ML
 | Memory access | `C`   | `c.lw` `c.sw` `c.lwsp` `c.swsp`           | 4 + ML
 | Memory access | `A`   | `lr.w` `sc.w`                             | 4 + ML
-| Multiplication | `M`  | `mul` `mulh` `mulhsu` `mulhu` | 2+31+3; FAST_MULfootnote:[DSP-based multiplication; enabled via `FAST_MUL_EN`.]: 5
-| Division       | `M`  | `div` `divu` `rem` `remu`     | 22+32+4
+| Multiplication | `M`  | `mul` `mulh` `mulhsu` `mulhu` | 3+32+2; FAST_MULfootnote:[DSP-based multiplication; enabled via `FAST_MUL_EN`.]: 6
+| Division       | `M`  | `div` `divu` `rem` `remu`     | 3+32+2
 | CSR access | `Zicsr` | `csrrw` `csrrs` `csrrc` `csrrwi` `csrrsi` `csrrci` | 4
 | System | `I/E`+`Zicsr` | `ecall` `ebreak` | 4
 | System | `I/E` | `fence` | 3

--- a/docs/datasheet/soc_wdt.adoc
+++ b/docs/datasheet/soc_wdt.adoc
@@ -13,15 +13,17 @@
 | CPU interrupts:          | fast IRQ channel 0 | watchdog timer overflow (see <<_processor_interrupts>>)
 |=======================
 
+
 **Theory of Operation**
 
 The watchdog (WDT) provides a last resort for safety-critical applications. The WDT has an internal 20-bit
 wide counter that needs to be reset every now and then by the user program. If the counter overflows, either
 a system reset or an interrupt is generated (depending on the configured operation mode).
+The _WDT_CTRL_HALF_ flag of the control register `CTRL` indicates that at least half of the maximum timeout
+value has been reached.
 
-Configuration of the watchdog is done by a single control register `CTRL`. The watchdog is enabled by
-setting the _WDT_CTRL_EN_ bit. The clock used to increment the internal counter is selected via the 3-bit
-_WDT_CTRL_CLK_SELx_ prescaler:
+The watchdog is enabled by setting the _WDT_CTRL_EN_ bit. The clock used to increment the internal counter
+is selected via the 3-bit _WDT_CTRL_CLK_SELx_ prescaler:
 
 [cols="^3,^3,>4"]
 [options="header",grid="rows"]
@@ -52,22 +54,31 @@ initiated by the watchdog.
 
 The Watchdog control register can be locked in order to protect the current configuration. The lock is
 activated by setting bit _WDT_CTRL_LOCK_. In the locked state any write access to the configuration flags is
-ignored (see table below, "accessible if locked"). Read accesses to the control register are not effected. The
+ignored (see table below, "writable if locked"). Read accesses to the control register are not effected. The
 lock can only be removed by a system reset (via external reset signal or via a watchdog reset action).
+
+.Watchdog Operation during Debugging
+[IMPORTANT]
+By default the watchdog pauses operation when the CPU enters debug mode and will resume normal operation after
+the CPU has left debug mode. This will prevent an unintended watchdog timeout (and a hardware reset if configured)
+during a debug session. However, the watchdog can be configured to keep operating even when the CPU is in debug
+mode by setting the control register's _WDT_CTRL_DBEN_ bit.
 
 
 .WDT register map (`struct NEORV32_WDT`)
 [cols="<2,<2,<4,^1,^2,<4"]
 [options="header",grid="all"]
 |=======================
-| Address | Name [C] | Bit(s), Name [C] | R/W | Writable if locked | Function
-.9+<| `0xffffffbc` .9+<| `NEORV32_WDT.CTRL` <|`0` _WDT_CTRL_EN_       ^| r/w ^| no  <| watchdog enable
-                                            <|`1` _WDT_CTRL_CLK_SEL0_ ^| r/w ^| no  .3+<| 3-bit clock prescaler select
-                                            <|`2` _WDT_CTRL_CLK_SEL1_ ^| r/w ^| no 
-                                            <|`3` _WDT_CTRL_CLK_SEL2_ ^| r/w ^| no 
-                                            <|`4` _WDT_CTRL_MODE_     ^| r/w ^| no  <| overflow action: `1`=reset, `0`=IRQ
-                                            <|`5` _WDT_CTRL_RCAUSE_   ^| r/- ^| -   <| cause of last system reset: `0`=caused by external reset signal, `1`=caused by watchdog
-                                            <|`6` _WDT_CTRL_RESET_    ^| -/w ^| yes <| watchdog reset when set, auto-clears
-                                            <|`7` _WDT_CTRL_FORCE_    ^| -/w ^| yes <| force configured watchdog action when set, auto-clears
-                                            <|`8` _WDT_CTRL_LOCK_     ^| r/w ^| no  <| lock access to configuration when set, clears only on system reset (via external reset signal OR watchdog reset action = reset)
+| Address | Name [C] | Bit(s), Name [C] | R/W | Reset value | Writable if locked | Function
+.11+<| `0xffffffbc` .11+<| `NEORV32_WDT.CTRL` <|`0` _WDT_CTRL_EN_       ^| r/w ^| `0` ^| no  <| watchdog enable
+                                              <|`1` _WDT_CTRL_CLK_SEL0_ ^| r/w ^| `0` ^| no  .3+<| 3-bit clock prescaler select
+                                              <|`2` _WDT_CTRL_CLK_SEL1_ ^| r/w ^| `0` ^| no 
+                                              <|`3` _WDT_CTRL_CLK_SEL2_ ^| r/w ^| `0` ^| no 
+                                              <|`4` _WDT_CTRL_MODE_     ^| r/w ^| `0` ^| no  <| overflow action: `1`=reset, `0`=IRQ
+                                              <|`5` _WDT_CTRL_RCAUSE_   ^| r/- ^| `0` ^| -   <| cause of last system reset: `0`=caused by external reset signal, `1`=caused by watchdog
+                                              <|`6` _WDT_CTRL_RESET_    ^| -/w ^| -   ^| yes <| watchdog reset when set, auto-clears
+                                              <|`7` _WDT_CTRL_FORCE_    ^| -/w ^| -   ^| yes <| force configured watchdog action when set, auto-clears
+                                              <|`8` _WDT_CTRL_LOCK_     ^| r/w ^| `0` ^| no  <| lock access to configuration when set, clears only on system reset (via external reset signal OR watchdog reset action = reset)
+                                              <|`9` _WDT_CTRL_DBEN_     ^| r/w ^| `0` ^| no  <| allow WDT to continue operation even when in debug mode
+                                              <|`10` _WDT_CTRL_HALF_    ^| r/- ^| `0` ^| -   <| set if at least half of the max. timeout counter value has been reached
 |=======================

--- a/docs/datasheet/soc_wdt.adoc
+++ b/docs/datasheet/soc_wdt.adoc
@@ -62,7 +62,8 @@ lock can only be removed by a system reset (via external reset signal or via a w
 By default the watchdog pauses operation when the CPU enters debug mode and will resume normal operation after
 the CPU has left debug mode. This will prevent an unintended watchdog timeout (and a hardware reset if configured)
 during a debug session. However, the watchdog can be configured to keep operating even when the CPU is in debug
-mode by setting the control register's _WDT_CTRL_DBEN_ bit.
+mode by setting the control register's _WDT_CTRL_DBEN_ bit. If the CPU's debug mode is not implemented this flag
+is hardwired to zero.
 
 
 .WDT register map (`struct NEORV32_WDT`)

--- a/docs/datasheet/soc_wdt.adoc
+++ b/docs/datasheet/soc_wdt.adoc
@@ -66,7 +66,7 @@ mode by setting the control register's _WDT_CTRL_DBEN_ bit.
 
 
 .WDT register map (`struct NEORV32_WDT`)
-[cols="<2,<2,<4,^1,^2,<4"]
+[cols="<2,<2,<4,^1,^1,^2,<4"]
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Reset value | Writable if locked | Function

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -94,6 +94,7 @@ entity neorv32_cpu is
     clk_i          : in  std_ulogic; -- global clock, rising edge
     rstn_i         : in  std_ulogic; -- global reset, low-active, async
     sleep_o        : out std_ulogic; -- cpu is in sleep mode when set
+    debug_o        : out std_ulogic; -- cpu is in debug mode when set
     -- instruction bus interface --
     i_bus_addr_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
     i_bus_rdata_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
@@ -315,6 +316,9 @@ begin
 
   -- CPU is sleeping? --
   sleep_o <= ctrl(ctrl_sleep_c); -- set when CPU is sleeping (after WFI)
+
+  -- CPU is in debug mode? --
+  debug_o <= ctrl(ctrl_debug_running_c);
 
 
   -- Register File --------------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060406"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060407"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060407"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060408"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -1103,6 +1103,7 @@ package neorv32_package is
       clk_i          : in  std_ulogic; -- global clock, rising edge
       rstn_i         : in  std_ulogic; -- global reset, low-active, async
       sleep_o        : out std_ulogic; -- cpu is in sleep mode when set
+      debug_o        : out std_ulogic; -- cpu is in debug mode when set
       -- instruction bus interface --
       i_bus_addr_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
       i_bus_rdata_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
@@ -1640,6 +1641,8 @@ package neorv32_package is
       data_i      : in  std_ulogic_vector(31 downto 0); -- data in
       data_o      : out std_ulogic_vector(31 downto 0); -- data out
       ack_o       : out std_ulogic; -- transfer acknowledge
+      -- CPU in debug mode? --
+      cpu_debug_i : in  std_ulogic;
       -- clock generator --
       clkgen_en_o : out std_ulogic; -- enable clock generator
       clkgen_i    : in  std_ulogic_vector(07 downto 0);

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -1631,6 +1631,9 @@ package neorv32_package is
   -- Component: Watchdog Timer (WDT) --------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   component neorv32_wdt
+    generic (
+      DEBUG_EN : boolean -- CPU debug mode implemented?
+    );
     port (
       -- host access --
       clk_i       : in  std_ulogic; -- global clock line

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -939,6 +939,9 @@ begin
   neorv32_wdt_inst_true:
   if (IO_WDT_EN = true) generate
     neorv32_wdt_inst: neorv32_wdt
+    generic map(
+      DEBUG_EN => ON_CHIP_DEBUGGER_EN -- CPU debug mode implemented?
+    )
     port map (
       -- host access --
       clk_i       => clk_i,                    -- global clock line

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -340,6 +340,7 @@ architecture neorv32_top_rtl of neorv32_top is
   signal mtime_time  : std_ulogic_vector(63 downto 0); -- current system time from MTIME
   signal ext_timeout : std_ulogic;
   signal ext_access  : std_ulogic;
+  signal debug_mode  : std_ulogic;
 
 begin
 
@@ -492,6 +493,7 @@ begin
     clk_i          => clk_i,        -- global clock, rising edge
     rstn_i         => sys_rstn,     -- global reset, low-active, async
     sleep_o        => open,         -- cpu is in sleep mode when set
+    debug_o        => debug_mode,   -- cpu is in debug mode when set
     -- instruction bus interface --
     i_bus_addr_o   => cpu_i.addr,   -- bus access address
     i_bus_rdata_i  => cpu_i.rdata,  -- bus read data
@@ -947,6 +949,8 @@ begin
       data_i      => p_bus.wdata,              -- data in
       data_o      => resp_bus(RESP_WDT).rdata, -- data out
       ack_o       => resp_bus(RESP_WDT).ack,   -- transfer acknowledge
+      -- CPU in debug mode? --
+      cpu_debug_i => debug_mode,
       -- clock generator --
       clkgen_en_o => wdt_cg_en,                -- enable clock generator
       clkgen_i    => clk_gen,

--- a/rtl/core/neorv32_wdt.vhd
+++ b/rtl/core/neorv32_wdt.vhd
@@ -48,6 +48,9 @@ library neorv32;
 use neorv32.neorv32_package.all;
 
 entity neorv32_wdt is
+  generic (
+    DEBUG_EN : boolean -- CPU debug mode implemented?
+  );
   port (
     -- host access --
     clk_i       : in  std_ulogic; -- global clock line
@@ -161,7 +164,7 @@ begin
             ctrl.mode    <= data_i(ctrl_mode_c);
             ctrl.clk_sel <= data_i(ctrl_clksel2_c downto ctrl_clksel0_c);
             ctrl.lock    <= data_i(ctrl_lock_c);
-            ctrl.dben    <= data_i(ctrl_dben_c);
+            ctrl.dben    <= data_i(ctrl_dben_c) and bool_to_ulogic_f(DEBUG_EN);
           end if;
         end if;
       end if;

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -1101,15 +1101,17 @@ typedef struct __attribute__((packed,aligned(4))) {
 
 /** WTD control register bits */
 enum NEORV32_WDT_CTRL_enum {
-  WDT_CTRL_EN       = 0, /**< WDT control register(0) (r/w): Watchdog enable */
-  WDT_CTRL_CLK_SEL0 = 1, /**< WDT control register(1) (r/w): Clock prescaler select bit 0 */
-  WDT_CTRL_CLK_SEL1 = 2, /**< WDT control register(2) (r/w): Clock prescaler select bit 1 */
-  WDT_CTRL_CLK_SEL2 = 3, /**< WDT control register(3) (r/w): Clock prescaler select bit 2 */
-  WDT_CTRL_MODE     = 4, /**< WDT control register(4) (r/w): Watchdog mode: 0=timeout causes interrupt, 1=timeout causes processor reset */
-  WDT_CTRL_RCAUSE   = 5, /**< WDT control register(5) (r/-): Cause of last system reset: 0=external reset, 1=watchdog */
-  WDT_CTRL_RESET    = 6, /**< WDT control register(6) (-/w): Reset WDT counter when set, auto-clears */
-  WDT_CTRL_FORCE    = 7, /**< WDT control register(7) (-/w): Force WDT action, auto-clears */
-  WDT_CTRL_LOCK     = 8  /**< WDT control register(8) (r/w): Lock write access to control register, clears on reset (HW or WDT) only */
+  WDT_CTRL_EN       =  0, /**< WDT control register(0) (r/w): Watchdog enable */
+  WDT_CTRL_CLK_SEL0 =  1, /**< WDT control register(1) (r/w): Clock prescaler select bit 0 */
+  WDT_CTRL_CLK_SEL1 =  2, /**< WDT control register(2) (r/w): Clock prescaler select bit 1 */
+  WDT_CTRL_CLK_SEL2 =  3, /**< WDT control register(3) (r/w): Clock prescaler select bit 2 */
+  WDT_CTRL_MODE     =  4, /**< WDT control register(4) (r/w): Watchdog mode: 0=timeout causes interrupt, 1=timeout causes processor reset */
+  WDT_CTRL_RCAUSE   =  5, /**< WDT control register(5) (r/-): Cause of last system reset: 0=external reset, 1=watchdog */
+  WDT_CTRL_RESET    =  6, /**< WDT control register(6) (-/w): Reset WDT counter when set, auto-clears */
+  WDT_CTRL_FORCE    =  7, /**< WDT control register(7) (-/w): Force WDT action, auto-clears */
+  WDT_CTRL_LOCK     =  8, /**< WDT control register(8) (r/w): Lock write access to control register, clears on reset (HW or WDT) only */
+  WDT_CTRL_DBEN     =  9, /**< WDT control register(9) (r/w): Allow WDT to continue operation even when in debug mode */
+  WDT_CTRL_HALF     = 10  /**< WDT control register(10) (r/-): Set if at least half of the max. timeout counter value has been reached */
 };
 /**@}*/
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -920,6 +920,17 @@
               <bitRange>[8:8]</bitRange>
               <description>Lock write access to control register, clears on reset (HW or WDT) only</description>
             </field>
+            <field>
+              <name>WDT_CTRL_DBEN</name>
+              <bitRange>[9:9]</bitRange>
+              <description>Allow WDT to continue operation even when in debug mode</description>
+            </field>
+            <field>
+              <name>WDT_CTRL_HALF</name>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+              <description>Set if at least half of the max. timeout counter value has been reached</description>
+            </field>
           </fields>
         </register>
       </registers>


### PR DESCRIPTION
This PR adds two new flags to the Watchdog (WDT) control register (the bits were previously unused):

* `NEORV32_WDT.CTRL` bit 9: _WDT_CTRL_DBEN_ [r/w] - set to 1 to allow watchdog operation (timeout counter increment) even when the CPU is in debug mode (active OCD session), :warning: in the current version the WDT _always_ increments it's counter
* `NEORV32_WDT.CTRL` bit 10: _WDT_CTRL_HALF_ [r/-] - set when at least half of the max. timeout value has been reached

✔️ the changes in this PR are fully backwards-compatible