### PR TITLE
⚠️ Make PWM and XIRQ IOs fixed-sized

### DIFF
--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -47,11 +47,12 @@ the value `U` (unknown) is used. Pulled-down signals will not cause "accidental"
 since all control signals have defined level.
 
 .Configurable Amount of Channels
-[NOTE]
+[IMPORTANT]
 Some peripherals allow to configure the number of channels to-be-implemented by a generic (for example the number
 of PWM or SLINK channels). The according input/output signals have a fixed sized regardless of the actually configured
-amount of channels. If less than the maximum number of channels is configured, only the LSB-aligned channels are used
-while the remaining channels are unconnected.
+amount of channels. If less than the maximum number of channels is configured, only the LSB-aligned channels are used:
+in case of an _input port_ the remaining bits/channels are left unconnected; in case of an _output port_ the remaining
+bits/channels are hardwired to zero.
 
 [cols="<3,^2,^2,<11"]
 [options="header",grid="rows"]

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -39,11 +39,19 @@ image::neorv32_processor.png[align=center]
 The following table shows signals of the processor top entity (`rtl/core/neorv32_top.vhd`).
 The type of all signals is `std_ulogic` or `std_ulogic_vector`, respectively.
 
-[IMPORTAN]
+.Default Values of Ports
+[IMPORTANT]
 All _input signals_ provide default values in case they are not explicitly assigned during instantiation.
 For control signals the value `L` (weak pull-down) is used. For serial and parallel data signals
 the value `U` (unknown) is used. Pulled-down signals will not cause "accidental" system crashes
 since all control signals have defined level.
+
+.Configurable Amount of Channels
+[NOTE]
+Some peripherals allow to configure the number of channels to-be-implemented by a generic (for example the number
+of PWM or SLINK channels). The according input/output signals have a fixed sized regardless of the actually configured
+amount of channels. If less than the maximum number of channels is configured, only the LSB-aligned channels are used
+while the remaining channels are unconnected.
 
 [cols="<3,^2,^2,<11"]
 [options="header",grid="rows"]
@@ -102,7 +110,7 @@ since all control signals have defined level.
 | `twi_sda_io` | 1 | inout | TWI serial data line
 | `twi_scl_io` | 1 | inout | TWI serial clock line
 4+^| **Pulse-Width Modulation Channels (<<_pulse_width_modulation_controller_pwm,PWM>>)**
-| `pwm_o` | 0..60 | out | pulse-width modulated channels
+| `pwm_o` | 60 | out | pulse-width modulated channels
 4+^| **Custom Functions Subsystem (<<_custom_functions_subsystem_cfs,CFS>>)**
 | `cfs_in_i`  | 32 | in | custom CFS input signal conduit
 | `cfs_out_o` | 32 | out | custom CFS output signal conduit

--- a/docs/datasheet/soc_pwm.adoc
+++ b/docs/datasheet/soc_pwm.adoc
@@ -8,7 +8,7 @@
 | Hardware source file(s): | neorv32_pwm.vhd | 
 | Software driver file(s): | neorv32_pwm.c |
 |                          | neorv32_pwm.h |
-| Top entity port:         | `pwm_o` | up to 60 PWM output channels (1-bit per channel)
+| Top entity port:         | `pwm_o` | up to 60 PWM output channels (60-bit, fixed)
 | Configuration generics:  | _IO_PWM_NUM_CH_ | number of PWM channels to implement (0..60)
 | CPU interrupts:          | none | 
 |=======================

--- a/docs/datasheet/soc_pwm.adoc
+++ b/docs/datasheet/soc_pwm.adoc
@@ -17,6 +17,10 @@ The PWM controller implements a pulse-width modulation controller with up to 60 
 bit resolution per channel. The actual number of implemented channels is defined by the _IO_PWM_NUM_CH_ generic.
 Setting this generic to zero will completely remove the PWM controller from the design.
 
+[NOTE]
+The `pwm_o` has a static size of 60-bit. Is less than 60 PWM channels are configured, only the LSB-aligned channels
+(bits) are used while the remaining bits are hardwired to zero.
+
 The PWM controller is based on an 8-bit base counter with a programmable threshold comparators for each channel
 that defines the actual duty cycle. The controller can be used to drive fancy RGB-LEDs with 24-
 bit true color, to dim LCD back-lights or even for "analog" control. An external integrator (RC low-pass filter)

--- a/docs/datasheet/soc_xirq.adoc
+++ b/docs/datasheet/soc_xirq.adoc
@@ -22,7 +22,8 @@ single _CPU fast interrupt request_.
 **Theory of Operation**
 
 The XIRQ provides up to 32 interrupt _channels_ (configured via the _XIRQ_NUM_CH_ generic). Each bit in the `xirq_i`
-input signal vector represents one interrupt channel. An interrupt channel is enabled by setting the according bit in the
+input signal vector represents one interrupt channel. If less than 32 channels are configure, only the LSB-aligned channels
+are used while the remaining bits are left unconnected. An interrupt channel is enabled by setting the according bit in the
 interrupt enable register `IER`.
 
 If the configured trigger (see below) of an enabled channel fires, the request is stored into an internal buffer.

--- a/docs/datasheet/soc_xirq.adoc
+++ b/docs/datasheet/soc_xirq.adoc
@@ -8,7 +8,7 @@
 | Hardware source file(s): | neorv32_xirq.vhd |
 | Software driver file(s): | neorv32_xirq.c |
 |                          | neorv32_xirq.h |
-| Top entity port:         | `xirq_i` | IRQ input (up to 32-bit)
+| Top entity port:         | `xirq_i` | IRQ input (32-bit, fixed)
 | Configuration generics:  | _XIRQ_NUM_CH_           | Number of IRQs to implement (0..32)
 |                          | _XIRQ_TRIGGER_TYPE_     | IRQ trigger type configuration
 |                          | _XIRQ_TRIGGER_POLARITY_ | IRQ trigger polarity configuration

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060500"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060501"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -200,6 +200,7 @@ package neorv32_package is
   constant pwm_duty4_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe94";
   constant pwm_duty5_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe98";
   constant pwm_duty6_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe9c";
+  
   constant pwm_duty7_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffea0";
   constant pwm_duty8_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffea4";
   constant pwm_duty9_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffea8";
@@ -1046,7 +1047,7 @@ package neorv32_package is
       twi_sda_io     : inout std_logic := 'U'; -- twi serial data line
       twi_scl_io     : inout std_logic := 'U'; -- twi serial clock line
       -- PWM (available if IO_PWM_NUM_CH > 0) --
-      pwm_o          : out std_ulogic_vector(IO_PWM_NUM_CH-1 downto 0); -- pwm channels
+      pwm_o          : out std_ulogic_vector(59 downto 0); -- pwm channels
       -- Custom Functions Subsystem IO --
       cfs_in_i       : in  std_ulogic_vector(IO_CFS_IN_SIZE-1  downto 0) := (others => 'U'); -- custom CFS inputs conduit
       cfs_out_o      : out std_ulogic_vector(IO_CFS_OUT_SIZE-1 downto 0); -- custom CFS outputs conduit
@@ -1056,7 +1057,7 @@ package neorv32_package is
       mtime_i        : in  std_ulogic_vector(63 downto 0) := (others => 'U'); -- current system time from ext. MTIME (if IO_MTIME_EN = false)
       mtime_o        : out std_ulogic_vector(63 downto 0); -- current system time from int. MTIME (if IO_MTIME_EN = true)
       -- External platform interrupts (available if XIRQ_NUM_CH > 0) --
-      xirq_i         : in  std_ulogic_vector(XIRQ_NUM_CH-1 downto 0) := (others => 'L'); -- IRQ channels
+      xirq_i         : in  std_ulogic_vector(31 downto 0) := (others => 'L'); -- IRQ channels
       -- CPU Interrupts --
       mtime_irq_i    : in  std_ulogic := 'L'; -- machine timer interrupt, available if IO_MTIME_EN = false
       msw_irq_i      : in  std_ulogic := 'L'; -- machine software interrupt
@@ -1754,7 +1755,7 @@ package neorv32_package is
       clkgen_en_o : out std_ulogic; -- enable clock generator
       clkgen_i    : in  std_ulogic_vector(07 downto 0);
       -- pwm output channels --
-      pwm_o       : out std_ulogic_vector(NUM_CHANNELS-1 downto 0)
+      pwm_o       : out std_ulogic_vector(59 downto 0)
     );
   end component;
 
@@ -1927,7 +1928,7 @@ package neorv32_package is
       data_o    : out std_ulogic_vector(31 downto 0); -- data out
       ack_o     : out std_ulogic; -- transfer acknowledge
       -- external interrupt lines --
-      xirq_i    : in  std_ulogic_vector(XIRQ_NUM_CH-1 downto 0);
+      xirq_i    : in  std_ulogic_vector(31 downto 0);
       -- CPU interrupt --
       cpu_irq_o : out std_ulogic
     );

--- a/rtl/core/neorv32_pwm.vhd
+++ b/rtl/core/neorv32_pwm.vhd
@@ -59,7 +59,7 @@ entity neorv32_pwm is
     clkgen_en_o : out std_ulogic; -- enable clock generator
     clkgen_i    : in  std_ulogic_vector(07 downto 0);
     -- pwm output channels --
-    pwm_o       : out std_ulogic_vector(NUM_CHANNELS-1 downto 0)
+    pwm_o       : out std_ulogic_vector(59 downto 0)
   );
 end neorv32_pwm;
 
@@ -186,6 +186,7 @@ begin
       end if;
 
       -- channels --
+      pwm_o <= (others => '0');
       for i in 0 to NUM_CHANNELS-1 loop
         if (unsigned(pwm_cnt) >= unsigned(pwm_ch(i))) or (enable = '0') then
           pwm_o(i) <= '0';

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -202,7 +202,7 @@ entity neorv32_top is
     twi_scl_io     : inout std_logic := 'U'; -- twi serial clock line
 
     -- PWM (available if IO_PWM_NUM_CH > 0) --
-    pwm_o          : out std_ulogic_vector(IO_PWM_NUM_CH-1 downto 0); -- pwm channels
+    pwm_o          : out std_ulogic_vector(59 downto 0); -- pwm channels
 
     -- Custom Functions Subsystem IO (available if IO_CFS_EN = true) --
     cfs_in_i       : in  std_ulogic_vector(IO_CFS_IN_SIZE-1  downto 0) := (others => 'U'); -- custom CFS inputs conduit
@@ -216,7 +216,7 @@ entity neorv32_top is
     mtime_o        : out std_ulogic_vector(63 downto 0); -- current system time from int. MTIME (if IO_MTIME_EN = true)
 
     -- External platform interrupts (available if XIRQ_NUM_CH > 0) --
-    xirq_i         : in  std_ulogic_vector(XIRQ_NUM_CH-1 downto 0) := (others => 'L'); -- IRQ channels
+    xirq_i         : in  std_ulogic_vector(31 downto 0) := (others => 'L'); -- IRQ channels
 
     -- CPU interrupts --
     mtime_irq_i    : in  std_ulogic := 'L'; -- machine timer interrupt, available if IO_MTIME_EN = false
@@ -238,7 +238,7 @@ architecture neorv32_top_rtl of neorv32_top is
   constant io_slink_en_c : boolean := boolean(SLINK_NUM_RX > 0) or boolean(SLINK_NUM_TX > 0); -- implement slink at all?
 
   -- reset generator --
-  signal rstn_gen : std_ulogic_vector(7 downto 0) := (others => '0'); -- initialize (=reset) via  (for FPGAs only)
+  signal rstn_gen : std_ulogic_vector(7 downto 0) := (others => '0'); -- initialize (=reset) via bitstream (for FPGAs only)
   signal ext_rstn : std_ulogic;
   signal sys_rstn : std_ulogic;
   signal wdt_rstn : std_ulogic;

--- a/rtl/core/neorv32_xirq.vhd
+++ b/rtl/core/neorv32_xirq.vhd
@@ -62,7 +62,7 @@ entity neorv32_xirq is
     data_o    : out std_ulogic_vector(31 downto 0); -- data out
     ack_o     : out std_ulogic; -- transfer acknowledge
     -- external interrupt lines --
-    xirq_i    : in  std_ulogic_vector(XIRQ_NUM_CH-1 downto 0);
+    xirq_i    : in  std_ulogic_vector(31 downto 0);
     -- CPU interrupt --
     cpu_irq_o : out std_ulogic
   );
@@ -155,7 +155,7 @@ begin
   irq_trigger: process(clk_i)
   begin
     if rising_edge(clk_i) then
-      irq_sync  <= xirq_i;
+      irq_sync  <= xirq_i(XIRQ_NUM_CH-1 downto 0);
       irq_sync2 <= irq_sync;
     end if;
   end process irq_trigger;

--- a/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
@@ -96,7 +96,17 @@ end entity;
 
 architecture neorv32_ProcessorTop_Minimal_rtl of neorv32_ProcessorTop_Minimal is
 
+  -- internal IO connection --
+  signal con_pwm_o  : std_ulogic_vector(59 downto 0);
+
 begin
+
+  -- IO Connection --------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+
+  -- PWM --
+  pwm_o <= con_pwm_o(IO_PWM_NUM_CH-1 downto 0);
+
 
   -- The core of the problem ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -224,7 +234,7 @@ begin
     twi_scl_io  => open,                         -- twi serial clock line
 
     -- PWM (available if IO_PWM_NUM_CH > 0) --
-    pwm_o       => pwm_o,                        -- pwm channels
+    pwm_o       => con_pwm_o,                    -- pwm channels
 
     -- Custom Functions Subsystem IO --
     cfs_in_i    => (others => '0'),              -- custom CFS inputs conduit

--- a/rtl/processor_templates/neorv32_ProcessorTop_MinimalBoot.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_MinimalBoot.vhd
@@ -110,6 +110,7 @@ architecture neorv32_ProcessorTop_MinimalBoot_rtl of neorv32_ProcessorTop_Minima
 
   -- internal IO connection --
   signal con_gpio_o : std_ulogic_vector(63 downto 0);
+  signal con_pwm_o  : std_ulogic_vector(59 downto 0);
 
 begin
 
@@ -118,6 +119,10 @@ begin
 
   -- GPIO --
   gpio_o <= con_gpio_o(3 downto 0);
+
+  -- PWM --
+  pwm_o <= con_pwm_o(IO_PWM_NUM_CH-1 downto 0);
+
 
   -- The core of the problem ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -245,7 +250,7 @@ begin
     twi_scl_io  => open,                         -- twi serial clock line
 
     -- PWM (available if IO_PWM_NUM_CH > 0) --
-    pwm_o       => pwm_o,                        -- pwm channels
+    pwm_o       => con_pwm_o,                    -- pwm channels
 
     -- Custom Functions Subsystem IO --
     cfs_in_i    => (others => '0'),              -- custom CFS inputs conduit

--- a/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
@@ -132,6 +132,7 @@ architecture neorv32_ProcessorTop_UP5KDemo_rtl of neorv32_ProcessorTop_UP5KDemo 
   -- internal IO connection --
   signal con_gpio_o   : std_ulogic_vector(63 downto 0);
   signal con_gpio_i   : std_ulogic_vector(63 downto 0);
+  signal con_pwm_o    : std_ulogic_vector(59 downto 0);
   signal con_spi_sck  : std_ulogic;
   signal con_spi_sdi  : std_ulogic;
   signal con_spi_sdo  : std_ulogic;
@@ -158,6 +159,10 @@ begin
   gpio_o <= con_gpio_o(3 downto 0);
   con_gpio_i(03 downto 0) <= gpio_i;
   con_gpio_i(63 downto 4) <= (others => '0');
+
+  -- PWM --
+  pwm_o <= con_pwm_o(IO_PWM_NUM_CH-1 downto 0);
+
 
   -- The core of the problem ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -285,7 +290,7 @@ begin
     twi_scl_io  => twi_scl_io,                   -- twi serial clock line
 
     -- PWM (available if IO_PWM_NUM_CH > 0) --
-    pwm_o       => pwm_o,                        -- pwm channels
+    pwm_o       => con_pwm_o,                    -- pwm channels
 
     -- Custom Functions Subsystem IO --
     cfs_in_i    => (others => '0'),              -- custom CFS inputs conduit

--- a/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
+++ b/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
@@ -171,7 +171,7 @@ entity neorv32_ProcessorTop_stdlogic is
     twi_sda_io     : inout std_logic; -- twi serial data line
     twi_scl_io     : inout std_logic; -- twi serial clock line
     -- PWM (available if IO_PWM_NUM_CH > 0) --
-    pwm_o          : out std_logic_vector(IO_PWM_NUM_CH-1 downto 0); -- pwm channels
+    pwm_o          : out std_logic_vector(59 downto 0); -- pwm channels
     -- Custom Functions Subsystem IO (available if IO_CFS_EN = true) --
     cfs_in_i       : in  std_logic_vector(IO_CFS_IN_SIZE-1  downto 0); -- custom inputs
     cfs_out_o      : out std_logic_vector(IO_CFS_OUT_SIZE-1 downto 0); -- custom outputs
@@ -181,7 +181,7 @@ entity neorv32_ProcessorTop_stdlogic is
     mtime_i        : in  std_logic_vector(63 downto 0) := (others => '0'); -- current system time from ext. MTIME (if IO_MTIME_EN = false)
     mtime_o        : out std_logic_vector(63 downto 0); -- current system time from int. MTIME (if IO_MTIME_EN = true)
     -- External platform interrupts (available if XIRQ_NUM_CH > 0) --
-    xirq_i         : in  std_logic_vector(XIRQ_NUM_CH-1 downto 0) := (others => '0'); -- IRQ channels
+    xirq_i         : in  std_logic_vector(31 downto 0) := (others => '0'); -- IRQ channels
     -- CPU Interrupts --
     mtime_irq_i    : in  std_logic := '0'; -- machine timer interrupt, available if IO_MTIME_EN = false
     msw_irq_i      : in  std_logic := '0'; -- machine software interrupt
@@ -245,7 +245,7 @@ architecture neorv32_ProcessorTop_stdlogic_rtl of neorv32_ProcessorTop_stdlogic 
   signal spi_sdi_i_int   : std_ulogic;
   signal spi_csn_o_int   : std_ulogic_vector(07 downto 0);
   --
-  signal pwm_o_int       : std_ulogic_vector(IO_PWM_NUM_CH-1 downto 0);
+  signal pwm_o_int       : std_ulogic_vector(59 downto 0);
   --
   signal cfs_in_i_int    : std_ulogic_vector(IO_CFS_IN_SIZE-1  downto 0);
   signal cfs_out_o_int   : std_ulogic_vector(IO_CFS_OUT_SIZE-1 downto 0);
@@ -255,7 +255,7 @@ architecture neorv32_ProcessorTop_stdlogic_rtl of neorv32_ProcessorTop_stdlogic 
   signal mtime_i_int     : std_ulogic_vector(63 downto 0);
   signal mtime_o_int     : std_ulogic_vector(63 downto 0);
   --
-  signal xirq_i_int      : std_ulogic_vector(XIRQ_NUM_CH-1 downto 0);
+  signal xirq_i_int      : std_ulogic_vector(31 downto 0);
   --
   signal mtime_irq_i_int : std_ulogic;
   signal msw_irq_i_int   : std_ulogic;

--- a/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
@@ -189,7 +189,7 @@ entity neorv32_top_avalonmm is
     twi_scl_io     : inout std_logic := 'U'; -- twi serial clock line
 
     -- PWM (available if IO_PWM_NUM_CH > 0) --
-    pwm_o          : out std_ulogic_vector(IO_PWM_NUM_CH-1 downto 0); -- pwm channels
+    pwm_o          : out std_ulogic_vector(59 downto 0); -- pwm channels
 
     -- Custom Functions Subsystem IO (available if IO_CFS_EN = true) --
     cfs_in_i       : in  std_ulogic_vector(IO_CFS_IN_SIZE-1  downto 0) := (others => 'U'); -- custom CFS inputs conduit
@@ -203,7 +203,7 @@ entity neorv32_top_avalonmm is
     mtime_o        : out std_ulogic_vector(63 downto 0); -- current system time from int. MTIME (if IO_MTIME_EN = true)
 
     -- External platform interrupts (available if XIRQ_NUM_CH > 0) --
-    xirq_i         : in  std_ulogic_vector(XIRQ_NUM_CH-1 downto 0) := (others => 'L'); -- IRQ channels
+    xirq_i         : in  std_ulogic_vector(31 downto 0) := (others => 'L'); -- IRQ channels
 
     -- CPU interrupts --
     mtime_irq_i    : in  std_ulogic := 'L'; -- machine timer interrupt, available if IO_MTIME_EN = false

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -176,14 +176,14 @@ entity neorv32_SystemTop_axi4lite is
     twi_sda_io    : inout std_logic; -- twi serial data line
     twi_scl_io    : inout std_logic; -- twi serial clock line
     -- PWM (available if IO_PWM_NUM_CH > 0) --
-    pwm_o         : out std_logic_vector(IO_PWM_NUM_CH-1 downto 0);  -- pwm channels
+    pwm_o         : out std_logic_vector(59 downto 0);  -- pwm channels
     -- Custom Functions Subsystem IO (available if IO_CFS_EN = true) --
     cfs_in_i      : in  std_logic_vector(IO_CFS_IN_SIZE-1  downto 0); -- custom inputs
     cfs_out_o     : out std_logic_vector(IO_CFS_OUT_SIZE-1 downto 0); -- custom outputs
     -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
     neoled_o      : out std_logic; -- async serial data line
     -- External platform interrupts (available if XIRQ_NUM_CH > 0) --
-    xirq_i        : in  std_logic_vector(XIRQ_NUM_CH-1 downto 0) := (others => '0'); -- IRQ channels
+    xirq_i        : in  std_logic_vector(31 downto 0) := (others => '0'); -- IRQ channels
     -- CPU Interrupts --
     msw_irq_i     : in  std_logic := '0'; -- machine software interrupt
     mext_irq_i    : in  std_logic := '0'  -- machine external interrupt
@@ -224,14 +224,14 @@ architecture neorv32_SystemTop_axi4lite_rtl of neorv32_SystemTop_axi4lite is
   signal spi_sdi_i_int   : std_ulogic;
   signal spi_csn_o_int   : std_ulogic_vector(07 downto 0);
   --
-  signal pwm_o_int       : std_ulogic_vector(IO_PWM_NUM_CH-1 downto 0);
+  signal pwm_o_int       : std_ulogic_vector(59 downto 0);
   --
   signal cfs_in_i_int    : std_ulogic_vector(IO_CFS_IN_SIZE-1  downto 0);
   signal cfs_out_o_int   : std_ulogic_vector(IO_CFS_OUT_SIZE-1 downto 0);
   --
   signal neoled_o_int    : std_ulogic;
   --
-  signal xirq_i_int      : std_ulogic_vector(XIRQ_NUM_CH-1 downto 0);
+  signal xirq_i_int      : std_ulogic_vector(31 downto 0);
   --
   signal msw_irq_i_int   : std_ulogic;
   signal mext_irq_i_int  : std_ulogic;

--- a/setups/radiant/UPduino_v3/neorv32_upduino_v3_top.vhd
+++ b/setups/radiant/UPduino_v3/neorv32_upduino_v3_top.vhd
@@ -98,7 +98,7 @@ architecture neorv32_upduino_v3_top_rtl of neorv32_upduino_v3_top is
   signal cpu_rstn : std_ulogic;
 
   -- internal IO connection --
-  signal con_pwm     : std_ulogic_vector(02 downto 0);
+  signal con_pwm     : std_ulogic_vector(59 downto 0);
   signal con_spi_sck : std_ulogic;
   signal con_spi_sdi : std_ulogic;
   signal con_spi_sdo : std_ulogic;


### PR DESCRIPTION
This PR modifies the top entity's `pwm_o` and `xirq_i` ports. Both ports have now a **_fixed size_** that corresponds to the maximum value of the according configuration generics (rather than being size-defined by those generics). I think this is more straight-forward as all other IOs (except for the CFS ones) have a fixed size, too.

```vhdl
-- PWM (available if IO_PWM_NUM_CH > 0) --
pwm_o : out std_ulogic_vector(59 downto 0); -- pwm channels
```

```vhdl
-- External platform interrupts (available if XIRQ_NUM_CH > 0) --
xirq_i : in  std_ulogic_vector(31 downto 0) := (others => 'L'); -- IRQ channels
```