### PR TITLE
[rtl/core/mem] Rename legacy-style memory files

### DIFF
--- a/rtl/core/mem/README.md
+++ b/rtl/core/mem/README.md
@@ -7,7 +7,7 @@ only **one** version of each (IMEM and DMEM) has to be added as actual source fi
 For the first implementation the `*.default.vhd` files should be selected. The HDL style for describing
 memories used by these files has proven **platform-independence** across several FPGA architectures and toolchains.
 
-If synthesis fails to infer actual block RAM resources from these default files, try the legacy `*.cyclone2.vhd` files, which
+If synthesis fails to infer actual block RAM resources from these default files, try the legacy `*.legacy.vhd` files, which
 provide a different HDL style. These files are intended for legacy support of older Intel/Altera Quartus versions (13.0 and older). However,
 these files do **not** use platform-specific macros or primitives - so they might also work for other FPGAs and toolchains.
 

--- a/rtl/core/mem/neorv32_dmem.legacy.vhd
+++ b/rtl/core/mem/neorv32_dmem.legacy.vhd
@@ -70,7 +70,7 @@ begin
 
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  assert false report "NEORV32 PROCESSOR CONFIG NOTE: Using CYCLONE-2-optimized HDL style DMEM." severity note;
+  assert false report "NEORV32 PROCESSOR CONFIG NOTE: Using legacy HDL style DMEM." severity note;
   assert false report "NEORV32 PROCESSOR CONFIG NOTE: Implementing processor-internal DMEM (RAM, " & natural'image(DMEM_SIZE) & " bytes)." severity note;
 
 

--- a/rtl/core/mem/neorv32_imem.legacy.vhd
+++ b/rtl/core/mem/neorv32_imem.legacy.vhd
@@ -87,7 +87,7 @@ begin
 
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  assert false report "NEORV32 PROCESSOR CONFIG NOTE: Using CYCLONE-2-optimized HDL style IMEM." severity note;
+  assert false report "NEORV32 PROCESSOR CONFIG NOTE: Using legacy HDL style IMEM." severity note;
   assert not (IMEM_AS_IROM = true)  report "NEORV32 PROCESSOR CONFIG NOTE: Implementing processor-internal IMEM as ROM (" & natural'image(IMEM_SIZE) &
   " bytes), pre-initialized with application (" & natural'image(imem_app_size_c) & " bytes)." severity note;
   --


### PR DESCRIPTION
This PR renames the legacy HDL style memory files in `rtl/core/mem` from `*.cyclone2.vhd` to `*.legacy.vhd` to avoid confusion. These files are also platform-agnostic and _not_ optimized for a certain FPGA architecture.