### PR TITLE
[BUSKEEPER] Add NULL address check option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The latest release is [![release](https://img.shields.io/github/v/release/stnolt
 A list of all releases can be found [here](https://github.com/stnolting/neorv32/releases). The most recent version of the *NEORV32 data sheet*
 can be found [online at GitHub-pages](https://stnolting.github.io/neorv32).
 
-:information_source: Starting with version `1.5.7` this project uses [semantic versioning](https://semver.org) syntax for official releases.
+:information_source: Starting with version `1.5.7` this project uses [semantic versioning](https://semver.org) for official releases.
 The _hardware version identifier_ uses an additional custom version element (i.e. `MAJOR.MINOR.PATCH.individual`) to track individual changes.
 The identifier number is incremented with every core RTL modification and also by major framework modifications.
 
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 04.01.2022 | 1.6.5.4 | **BUSKEEPER** can now optionally check for NULL address accesses (address `0x00000000`), see [PR #247](https://github.com/stnolting/neorv32/pull/247) |
 | 02.01.2022 | 1.6.5.3 | :sparkles: **added Execute In Place (XIP) module** allowing code to be directly executed from an external SPI flash, see [PR #244](https://github.com/stnolting/neorv32/pull/244) |
 | 02.01.2022 | 1.6.5.2 | :bug: fixed minor bug in CPU's instruction fetch unit (only issue new instruction fetch request when the previous one has been completed) |
 | 16.12.2021 |[**:rocket:1.6.5**](https://github.com/stnolting/neorv32/releases/tag/v1.6.5) | **New release** |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ A list of all releases can be found [here](https://github.com/stnolting/neorv32/
 can be found [online at GitHub-pages](https://stnolting.github.io/neorv32).
 
 :information_source: Starting with version `1.5.7` this project uses [semantic versioning](https://semver.org) for official releases.
-The _hardware version identifier_ uses an additional custom version element (i.e. `MAJOR.MINOR.PATCH.individual`) to track individual changes.
+The _hardware version identifier_ uses an additional custom version element (i.e. `MAJOR.MINOR.PATCH.individual`) to track _individual_ changes.
 The identifier number is incremented with every core RTL modification and also by major framework modifications.
 
 :information_source: The processor can determine its version from the `mimpid` CSR (at CSR address 0xf13). A 8x4-bit BCD representation is used.

--- a/docs/datasheet/soc_buskeeper.adoc
+++ b/docs/datasheet/soc_buskeeper.adoc
@@ -34,13 +34,13 @@ In case of a bus access fault exception application software can evaluate the Bu
 that an actual bus access fault has occurred. The bit is sticky once set and is automatically cleared when reading or
 writing the `NEORV32_BUSKEEPER.CTRL` register. The _BUSKEEPER_ERR_TYPE_ bits define the type of the bus fault:
 
-* _BUSKEEPER_ERR_TYPE_ = `00` - "Device Error": The bus access exception was cause by the memory-mapped device that
+* `00` - "Device Error": The bus access exception was cause by the memory-mapped device that
 has been accessed (the device asserted it's `err_o`).
-* _BUSKEEPER_ERR_TYPE_ = `01` - "Timeout Error": The bus access exception was caused by the Bus Keeper because the
+* `01` - "Timeout Error": The bus access exception was caused by the Bus Keeper because the
 accessed memory-mapped device did not respond within the access time window. Note that this error type can also be raised
 by the optional timeout feature of the <<_processor_external_memory_interface_wishbone_axi4_lite>>).
-* _BUSKEEPER_ERR_TYPE_ = `10` - "Unexpected ACK": There was an ACK signal received while there was no pending transfer.
-* _BUSKEEPER_ERR_TYPE_ = `11` - "Unexpected ERR": There was an ERR signal received while there was no pending transfer.
+* `10` - "Unexpected ACK": There was an ACK signal received while there was no pending transfer.
+* `11` - "Unexpected ERR": There was an ERR signal received while there was no pending transfer.
 
 [NOTE]
 Bus access fault exceptions are also raised if a physical memory protection rule is violated. In this case
@@ -65,7 +65,7 @@ at all.
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.3+<| `0xffffff7C` .3+<| `NEORV32_BUSKEEPER.CTRL` <|`1:0`  _BUSKEEPER_ERR_TYPE_MSB_ : _BUSKEEPER_ERR_TYPE_LSB_  ^| r/- | Bus error type, valid if _BUSKEEPER_ERR_FLAG_
+.3+<| `0xffffff7C` .3+<| `NEORV32_BUSKEEPER.CTRL` <|`1:0` _BUSKEEPER_ERR_TYPE_MSB_ : _BUSKEEPER_ERR_TYPE_LSB_ ^| r/- | Bus error type, valid if _BUSKEEPER_ERR_FLAG_
                                                   <|`16` _BUSKEEPER_NULL_CHECK_EN_ ^| r/w <| Enable NULL address check when set
                                                   <|`31` _BUSKEEPER_ERR_FLAG_      ^| r/- <| Sticky error flag, clears after read or write access
 |=======================

--- a/docs/datasheet/soc_buskeeper.adoc
+++ b/docs/datasheet/soc_buskeeper.adoc
@@ -6,7 +6,7 @@
 [frame="topbot",grid="none"]
 |=======================
 | Hardware source file(s): | neorv32_buskeeper.vhd | 
-| Software driver file(s): | none | explicitly used
+| Software driver file(s): | none | 
 | Top entity port:         | none | 
 | Configuration generics:  | none | 
 | Package constants:       | `max_proc_int_response_time_c` | Access time window (#cycles)
@@ -32,19 +32,32 @@ constant from the processor's VHDL package file (`rtl/neorv32_package.vhd`). The
 In case of a bus access fault exception application software can evaluate the Bus Keeper's control register
 `NEORV32_BUSKEEPER.CTRL` to retrieve further details of the bus exception. The _BUSKEEPER_ERR_FLAG_ bit indicates
 that an actual bus access fault has occurred. The bit is sticky once set and is automatically cleared when reading or
-writing the `NEORV32_BUSKEEPER.CTRL` register. The _BUSKEEPER_ERR_TYPE_ bits indicate the tape of the bus fault:
+writing the `NEORV32_BUSKEEPER.CTRL` register. The _BUSKEEPER_ERR_TYPE_ bits define the type of the bus fault:
 
-* _BUSKEEPER_ERR_TYPE_ = 0 - "Device Error": The bus access exception was cause by the memory-mapped device that
+* _BUSKEEPER_ERR_TYPE_ = `00` - "Device Error": The bus access exception was cause by the memory-mapped device that
 has been accessed (the device asserted it's `err_o`).
-* _BUSKEEPER_ERR_TYPE_ = 1 - "Timeout Error": The bus access exception was caused by the Bus Keeper because the
+* _BUSKEEPER_ERR_TYPE_ = `01` - "Timeout Error": The bus access exception was caused by the Bus Keeper because the
 accessed memory-mapped device did not respond within the access time window. Note that this error type can also be raised
 by the optional timeout feature of the <<_processor_external_memory_interface_wishbone_axi4_lite>>).
-* _BUSKEEPER_ERR_TYPE_ = 2 - "Unexpected ACK": There was an ACK signal received while there was no pending transfer.
-* _BUSKEEPER_ERR_TYPE_ = 3 - "Unexpected ERR": There was an ERR signal received while there was no pending transfer.
+* _BUSKEEPER_ERR_TYPE_ = `10` - "Unexpected ACK": There was an ACK signal received while there was no pending transfer.
+* _BUSKEEPER_ERR_TYPE_ = `11` - "Unexpected ERR": There was an ERR signal received while there was no pending transfer.
 
 [NOTE]
 Bus access fault exceptions are also raised if a physical memory protection rule is violated. In this case
 the _BUSKEEPER_ERR_FLAG_ bit remains zero.
+
+
+**NULL Address Check**
+
+The bus keeper can ensure that no accesses are permitted to NULL addresses (`addr = 0x00000000`). These kind of
+access often occur when using uninitialized pointers. If the _BUSKEEPER_NULL_CHECK_EN_ bit is set, any access to
+address zero (instruction fetch, load data, store data) will raise an according bus exception. This flag
+automatically clears on a hardware reset.
+
+[NOTE]
+Address 0 is normally used by the IMEM and contains boot code instructions that are executed _once_ right after
+hardware reset. Hence, activating the bus keeper's NULL check in application code will not corrupt code execution
+at all.
 
 
 .BUSKEEPER register map (`struct NEORV32_BUSKEEPER`)
@@ -52,7 +65,7 @@ the _BUSKEEPER_ERR_FLAG_ bit remains zero.
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.3+<| `0xffffff7C` .3+<| `NEORV32_BUSKEEPER.CTRL` <|`0`  _BUSKEEPER_ERR_TYPE_LSB_ ^| r/- .8+<| Bus error type, valid if _BUSKEEPER_ERR_FLAG_ is set: 0=device error, 1=access timeout, 2=unexpected ACK, 3=unexpected ERR
-                                                  <|`1`  _BUSKEEPER_ERR_TYPE_MSB_ ^| r/- 
-                                                  <|`31` _BUSKEEPER_ERR_FLAG_     ^| r/- <| Sticky error flag, clears after read or write access
+.3+<| `0xffffff7C` .3+<| `NEORV32_BUSKEEPER.CTRL` <|`1:0`  _BUSKEEPER_ERR_TYPE_MSB_ : _BUSKEEPER_ERR_TYPE_LSB_  ^| r/- | Bus error type, valid if _BUSKEEPER_ERR_FLAG_
+                                                  <|`16` _BUSKEEPER_NULL_CHECK_EN_ ^| r/w <| Enable NULL address check when set
+                                                  <|`31` _BUSKEEPER_ERR_FLAG_      ^| r/- <| Sticky error flag, clears after read or write access
 |=======================

--- a/rtl/core/neorv32_bus_keeper.vhd
+++ b/rtl/core/neorv32_bus_keeper.vhd
@@ -152,9 +152,10 @@ begin
       if (control.bus_err = '1') then -- sticky error flag
         err_flag <= '1';
         err_type <= control.err_type;
-      elsif ((wren or rden) = '1') then -- clear on read or write
-        err_flag <= '0';
-        err_type <= (others => '0');
+      else
+        if ((wren or rden) = '1') then -- clear on read or write acces
+          err_flag <= '0';
+        end if;
       end if;
     end if;
   end process rw_access;

--- a/rtl/core/neorv32_cpu_bus.vhd
+++ b/rtl/core/neorv32_cpu_bus.vhd
@@ -321,7 +321,7 @@ begin
         d_arbiter.err_align <= (d_arbiter.err_align or d_misaligned) and (not ctrl_i(ctrl_bus_derr_ack_c));
         d_arbiter.err_bus   <= (d_arbiter.err_bus or d_bus_err_i or (st_pmp_fault and d_arbiter.wr_req) or (ld_pmp_fault and d_arbiter.rd_req)) and
                                (not ctrl_i(ctrl_bus_derr_ack_c));
-        if (d_bus_ack_i = '1') or (ctrl_i(ctrl_bus_derr_ack_c) = '1') then -- wait for normal termination / CPU abort
+        if ((d_bus_ack_i = '1') and (d_bus_err_i = '0')) or (ctrl_i(ctrl_bus_derr_ack_c) = '1') then -- wait for normal termination / CPU abort
           d_arbiter.wr_req <= '0';
           d_arbiter.rd_req <= '0';
         end if;
@@ -410,7 +410,7 @@ begin
       else -- in progres
         i_arbiter.err_align <= (i_arbiter.err_align or i_misaligned) and (not ctrl_i(ctrl_bus_ierr_ack_c));
         i_arbiter.err_bus   <= (i_arbiter.err_bus or i_bus_err_i or if_pmp_fault) and (not ctrl_i(ctrl_bus_ierr_ack_c));
-        if (i_bus_ack_i = '1') or (ctrl_i(ctrl_bus_ierr_ack_c) = '1') then -- wait for normal termination / CPU abort
+        if ((i_bus_ack_i = '1') and (i_bus_err_i = '0')) or (ctrl_i(ctrl_bus_ierr_ack_c) = '1') then -- wait for normal termination / CPU abort
           i_arbiter.rd_req <= '0';
         end if;
       end if;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060503"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060504"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -1446,6 +1446,7 @@ package neorv32_package is
       addr_i     : in  std_ulogic_vector(31 downto 0); -- address
       rden_i     : in  std_ulogic; -- read enable
       wren_i     : in  std_ulogic; -- write enable
+      data_i     : in  std_ulogic_vector(31 downto 0); -- data in
       data_o     : out std_ulogic_vector(31 downto 0); -- data out
       ack_o      : out std_ulogic; -- transfer acknowledge
       err_o      : out std_ulogic; -- transfer error

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -676,7 +676,7 @@ begin
   p_bus.fence <= cpu_d.fence or cpu_i.fence;
 
   -- bus response --
-  bus_response: process(resp_bus)
+  bus_response: process(resp_bus, bus_error)
     variable rdata_v : std_ulogic_vector(data_width_c-1 downto 0);
     variable ack_v   : std_ulogic;
     variable err_v   : std_ulogic;
@@ -690,8 +690,8 @@ begin
       err_v   := err_v   or resp_bus(i).err;   -- error
     end loop; -- i
     p_bus.rdata <= rdata_v; -- processor bus: CPU transfer data input
-    p_bus.ack   <= ack_v;   -- processor bus: CPU transfer ACK input
-    p_bus.err   <= err_v;   -- processor bus: CPU transfer data bus error input
+    p_bus.ack   <= ack_v and (not bus_error); -- processor bus: CPU transfer ACK input (can be overridden by BUSKEEPER)
+    p_bus.err   <= err_v; -- processor bus: CPU transfer data bus error input
   end process;
 
 
@@ -705,6 +705,7 @@ begin
     addr_i     => p_bus.addr,                     -- address
     rden_i     => io_rden,                        -- read enable
     wren_i     => io_wren,                        -- byte write enable
+    data_i     => p_bus.wdata,                    -- data in
     data_o     => resp_bus(RESP_BUSKEEPER).rdata, -- data out
     ack_o      => resp_bus(RESP_BUSKEEPER).ack,   -- transfer acknowledge
     err_o      => bus_error,                      -- transfer error

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -676,7 +676,7 @@ begin
   p_bus.fence <= cpu_d.fence or cpu_i.fence;
 
   -- bus response --
-  bus_response: process(resp_bus, bus_error)
+  bus_response: process(resp_bus)
     variable rdata_v : std_ulogic_vector(data_width_c-1 downto 0);
     variable ack_v   : std_ulogic;
     variable err_v   : std_ulogic;
@@ -690,8 +690,8 @@ begin
       err_v   := err_v   or resp_bus(i).err;   -- error
     end loop; -- i
     p_bus.rdata <= rdata_v; -- processor bus: CPU transfer data input
-    p_bus.ack   <= ack_v and (not bus_error); -- processor bus: CPU transfer ACK input (can be overridden by BUSKEEPER)
-    p_bus.err   <= err_v; -- processor bus: CPU transfer data bus error input
+    p_bus.ack   <= ack_v;   -- processor bus: CPU transfer ACK input
+    p_bus.err   <= err_v;   -- processor bus: CPU transfer data bus error input
   end process;
 
 

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -907,9 +907,10 @@ typedef struct __attribute__((packed,aligned(4))) {
 
 /** BUSKEEPER control/data register bits */
 enum NEORV32_BUSKEEPER_CTRL_enum {
-  BUSKEEPER_ERR_TYPE_LSB =  0, /**< BUSKEEPER control register( 0) (r/-): Bus error type LSB: 0=device error, 1=access timeout */
-  BUSKEEPER_ERR_TYPE_MSB =  1, /**< BUSKEEPER control register( 1) (r/-): Bus error type MSB: 2=unexpected ACK, 3=unexpected ERR */
-  BUSKEEPER_ERR_FLAG     = 31  /**< BUSKEEPER control register(31) (r/c): Sticky error flag, clears after read or write access */
+  BUSKEEPER_ERR_TYPE_LSB  =  0, /**< BUSKEEPER control register( 0) (r/-): Bus error type LSB: 0=device error, 1=access timeout */
+  BUSKEEPER_ERR_TYPE_MSB  =  1, /**< BUSKEEPER control register( 1) (r/-): Bus error type MSB: 2=unexpected ACK, 3=unexpected ERR */
+  BUSKEEPER_NULL_CHECK_EN = 16, /**< BUSKEEPER control register(16) (r/w): Enable NULL address check */
+  BUSKEEPER_ERR_FLAG      = 31  /**< BUSKEEPER control register(31) (r/-): Sticky error flag, clears after read or write access */
 };
 /**@}*/
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -523,6 +523,11 @@
               <description>Bus error type: 0=device error, 1=access timeout, 2=unexpected ACK, 3=unexpected ERR</description>
             </field>
             <field>
+              <name>BUSKEEPER_NULL_CHECK_EN</name>
+              <bitRange>[16:16]</bitRange>
+              <description>Enable NULL address check when set</description>
+            </field>
+            <field>
               <name>BUSKEEPER_ERR_FLAG</name>
               <bitRange>[31:31]</bitRange>
               <description>Sticky error flag, clears after read or write access</description>


### PR DESCRIPTION
This PR adds a new feature to the BUSKEEPER module (triggered by @emb4fun):

When setting bit 16 (_NEORV32_BUSKEEPER_) of the control register (`NEORV32_BUSKEEPER.CTRL`) the BUSKEEPER will issue a bus exception for all accesses to address `0x00000000` (instruction fetch / load data / store data). This can help to identify program bugs where uninitialized pointers are used.