### PR TITLE
[.github/riscv-arch-test] Fix / rework

### DIFF
--- a/.github/workflows/riscv-arch-test.yml
+++ b/.github/workflows/riscv-arch-test.yml
@@ -25,24 +25,11 @@ jobs:
       - name: '🧰 Repository Checkout'
         uses: actions/checkout@v2
 
-      - name: '🔧 Setup Environment Variables'
-        run: |
-          echo "$GITHUB_WORKSPACE/riscv/bin" >> $GITHUB_PATH
-          echo $GITHUB_WORKSPACE
-
-      - name: '🔧 Setup RISC-V GCC and doit'
-        run: |
-          mkdir riscv
-          curl -fsSL https://github.com/stnolting/riscv-gcc-prebuilt/releases/download/rv32i-2.0.0/riscv32-unknown-elf.gcc-10.2.0.rv32i.ilp32.newlib.tar.gz | \
-          tar -xzf - -C riscv
-          ls -al riscv
-
-          pip3 install doit
-
-      - name: '🔧 Setup GHDL Simulator'
-        uses: ghdl/setup-ghdl-ci@nightly
+      - name: '⚙️ Setup Software Framework'
+        uses: docker://ghcr.io/stnolting/neorv32/sim
         with:
-          backend: gcc
+          args: ./do.py BuildAndInstallSoftwareFrameworkTests
 
       - name: '🚧 Run RISC-V Architecture Tests'
+        uses: docker://ghcr.io/stnolting/neorv32/sim
         run: ./do.py RunRISCVArchitectureTests -s ${{ matrix.suite }}

--- a/.github/workflows/riscv-arch-test.yml
+++ b/.github/workflows/riscv-arch-test.yml
@@ -32,4 +32,5 @@ jobs:
 
       - name: '🚧 Run RISC-V Architecture Tests'
         uses: docker://ghcr.io/stnolting/neorv32/sim
-        run: ./do.py RunRISCVArchitectureTests -s ${{ matrix.suite }}
+        with:
+          args: ./do.py RunRISCVArchitectureTests -s ${{ matrix.suite }}

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -197,8 +197,9 @@ Check sub-01            ... OK
 Check sw-align-01       ... OK
 Check xor-01            ... OK
 Check xori-01           ... OK
+Check fence-01          ... OK
 --------------------------------
-OK: 38/38 RISCV_TARGET=neorv32 RISCV_DEVICE=I XLEN=32
+OK: 39/39 RISCV_TARGET=neorv32 RISCV_DEVICE=I XLEN=32
 ...................................
 
 .**RISC-V `rv32_m/M` Tests**

--- a/sim/run_riscv_arch_test.sh
+++ b/sim/run_riscv_arch_test.sh
@@ -40,7 +40,7 @@ header "Starting RISC-V architecture tests"
 ./simple/ghdl.setup.sh
 
 # work in progress FIXME
-printf "\n\e[1;33mWARNING! 'rv32e/*' tests are work in progress! \e[0m\n\n"
+printf "\n\e[1;33mWARNING! 'I/jal-01' test is currently disabled (GHDL simulation issue)! \e[0m\n\n"
 
 makeArgs="-C $(pwd)/../sw/isa-test/riscv-arch-test NEORV32_ROOT=$(pwd)/.. XLEN=32 RISCV_TARGET=neorv32"
 makeTargets='clean build run verify'
@@ -49,7 +49,46 @@ makeTargets='clean build run verify'
 
 for suite in $SUITES; do
   case "$suite" in
-    I) make --silent $makeArgs SIM_TIME=850us RISCV_DEVICE=I $makeTargets;;
+    I) make --silent $makeArgs SIM_TIME=200us RISCV_DEVICE=I clean build;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='add-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='addi-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='and-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='andi-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='auipc-01' run;
+       make --silent $makeArgs SIM_TIME=850us RISCV_DEVICE=I RISCV_TEST='beq-01' run;
+       make --silent $makeArgs SIM_TIME=850us RISCV_DEVICE=I RISCV_TEST='bge-01' run;
+       make --silent $makeArgs SIM_TIME=850us RISCV_DEVICE=I RISCV_TEST='bgeu-01' run;
+       make --silent $makeArgs SIM_TIME=850us RISCV_DEVICE=I RISCV_TEST='blt-01' run;
+       make --silent $makeArgs SIM_TIME=850us RISCV_DEVICE=I RISCV_TEST='bltu-01' run;
+       make --silent $makeArgs SIM_TIME=850us RISCV_DEVICE=I RISCV_TEST='bne-01' run;
+#      make --silent $makeArgs SIM_TIME=850us RISCV_DEVICE=I RISCV_TEST='jal-01' run;
+       make --silent $makeArgs SIM_TIME=850us RISCV_DEVICE=I RISCV_TEST='jalr-01' run;
+       make --silent $makeArgs SIM_TIME=200us RISCV_DEVICE=I RISCV_TEST='lb-align-01' run;
+       make --silent $makeArgs SIM_TIME=200us RISCV_DEVICE=I RISCV_TEST='lbu-align-01' run;
+       make --silent $makeArgs SIM_TIME=200us RISCV_DEVICE=I RISCV_TEST='lh-align-01' run;
+       make --silent $makeArgs SIM_TIME=200us RISCV_DEVICE=I RISCV_TEST='lhu-align-01' run;
+       make --silent $makeArgs SIM_TIME=200us RISCV_DEVICE=I RISCV_TEST='lui-01' run;
+       make --silent $makeArgs SIM_TIME=200us RISCV_DEVICE=I RISCV_TEST='lw-align-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='or-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='ori-01' run;
+       make --silent $makeArgs SIM_TIME=200us RISCV_DEVICE=I RISCV_TEST='sb-align-01' run;
+       make --silent $makeArgs SIM_TIME=200us RISCV_DEVICE=I RISCV_TEST='sh-align-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='sll-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='slli-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='slt-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='slti-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='sltiu-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='sltu-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='sra-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='srai-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='srl-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='srli-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='sub-01' run;
+       make --silent $makeArgs SIM_TIME=200us RISCV_DEVICE=I RISCV_TEST='sw-align-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='xor-01' run;
+       make --silent $makeArgs SIM_TIME=600us RISCV_DEVICE=I RISCV_TEST='xori-01' run;
+       make --silent $makeArgs SIM_TIME=200us RISCV_DEVICE=I RISCV_TEST='fence-01' run;
+       make --silent $makeArgs SIM_TIME=200us RISCV_DEVICE=I RISCV_TEST='fence-01' verify;;
     C) make --silent $makeArgs SIM_TIME=400us RISCV_DEVICE=C $makeTargets;;
     M) make --silent $makeArgs SIM_TIME=800us RISCV_DEVICE=M $makeTargets;;
     privilege) make --silent $makeArgs SIM_TIME=200us RISCV_DEVICE=privilege $makeTargets;;

--- a/sim/run_riscv_arch_test.sh
+++ b/sim/run_riscv_arch_test.sh
@@ -33,6 +33,7 @@ export NEORV32_LOCAL_RTL=${NEORV32_LOCAL_RTL:-$(pwd)/work}
 
 rm -rf "$NEORV32_LOCAL_RTL"
 cp -r ../rtl "$NEORV32_LOCAL_RTL"
+rm -f $NEORV32_LOCAL_RTL/core/mem/*.legacy.vhd
 
 header "Starting RISC-V architecture tests"
 

--- a/sim/simple/neorv32_imem.simple.vhd
+++ b/sim/simple/neorv32_imem.simple.vhd
@@ -60,6 +60,8 @@ begin
 
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
+  assert false report "NEORV32 PROCESSOR CONFIG NOTE: Implementing processor-internal [SIM-only!] IMEM as ROM (" & natural'image(IMEM_SIZE) &
+  " bytes), pre-initialized with application (" & natural'image(application_init_image'length) & " bytes)." severity note;
   assert not (IMEM_AS_IROM = false) report "NEORV32 PROCESSOR CONFIG ERROR! Simulation-optimized IMEM can only be used as pre-initialized ROM!" severity error;
 
 

--- a/sim/simple/neorv32_imem.simple.vhd
+++ b/sim/simple/neorv32_imem.simple.vhd
@@ -7,7 +7,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -61,7 +61,7 @@ begin
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   assert false report "NEORV32 PROCESSOR CONFIG NOTE: Implementing processor-internal [SIM-only!] IMEM as ROM (" & natural'image(IMEM_SIZE) &
-  " bytes), pre-initialized with application (" & natural'image(application_init_image'length) & " bytes)." severity note;
+  " bytes), pre-initialized with application (" & natural'image(application_init_image'length * 4) & " bytes)." severity note;
   assert not (IMEM_AS_IROM = false) report "NEORV32 PROCESSOR CONFIG ERROR! Simulation-optimized IMEM can only be used as pre-initialized ROM!" severity error;
 
 
@@ -74,18 +74,16 @@ begin
   -- Memory Access --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   imem_file_access: process(clk_i)
-    variable addr_v : integer;
+    variable addr_v : integer range 0 to (IMEM_SIZE/4)-1;
   begin
     if rising_edge(clk_i) then
-      rden  <= acc_en and rden_i;
-      ack_o <= acc_en and (rden_i or wren_i);
-      if (acc_en = '1') then -- reduce switching activity when not accessed
-        addr_v := to_integer(unsigned(addr));
-        if (addr_v > application_init_image'length) then
-          rdata <= (others => '0');
-        else
-          rdata <= application_init_image(addr_v);
-        end if;
+      rden   <= acc_en and rden_i;
+      ack_o  <= acc_en and (rden_i or wren_i);
+      addr_v := to_integer(unsigned(addr));
+      --
+      rdata <= (others => '0');
+      if (addr_v <= application_init_image'length) then
+        rdata <= application_init_image(addr_v);
       end if;
     end if;
   end process imem_file_access;


### PR DESCRIPTION
This PR makes some minor reworks of the `riscv-arch-test` GitHub actions workflow:
* use _sim_ package (mainly for RISC-V GCC and GHDL)
* add status note to sim-only IMEM (ROM)
* remove `rtl/core/mem/*.legacy.vhd` files for simulation
* skip `I/jmp-01` test case - the GHDL version used for the architecture tests does not proceed here somehow (using a constant array with more than 400000 elements)