### PR TITLE
:warning: [XIP] reworked execute in place module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 06.01.2022 | 1.6.5.5 | :warning: optimized/reworked XIP (execute in place) module, see [PR #249](https://github.com/stnolting/neorv32/pull/249) |
 | 04.01.2022 | 1.6.5.4 | **BUSKEEPER** can now optionally check for NULL address accesses (address `0x00000000`), see [PR #247](https://github.com/stnolting/neorv32/pull/247) |
 | 02.01.2022 | 1.6.5.3 | :sparkles: **added Execute In Place (XIP) module** allowing code to be directly executed from an external SPI flash, see [PR #244](https://github.com/stnolting/neorv32/pull/244) |
 | 02.01.2022 | 1.6.5.2 | :bug: fixed minor bug in CPU's instruction fetch unit (only issue new instruction fetch request when the previous one has been completed) |

--- a/docs/datasheet/overview.adoc
+++ b/docs/datasheet/overview.adoc
@@ -278,10 +278,9 @@ This chapter shows _exemplary_ implementation results of the NEORV32 CPU and NEO
 [cols="<2,<8"]
 [grid="topbot"]
 |=======================
-| Hardware version: | `1.5.7.10`
-| Top entity:       | `rtl/core/neorv32_cpu.vhd`
-| FPGA:             | Intel Cyclone IV E `EP4CE22F17C6`
-| Toolchain:        | Quartus Prime 20.1.0
+| Top entity: | `rtl/core/neorv32_cpu.vhd`
+| FPGA:       | Intel Cyclone IV E `EP4CE22F17C6`
+| Toolchain:  | Quartus Prime 20.1.0
 |=======================
 
 [cols="<5,>1,>1,>1,>1,>1"]
@@ -312,10 +311,9 @@ https://stnolting.github.io/neorv32/ug/#_application_specific_processor_configur
 [cols="<2,<8"]
 [grid="topbot"]
 |=======================
-| Hardware version: | `1.5.7.15`
-| Top entity:       | `rtl/core/neorv32_top.vhd`
-| FPGA:             | Intel Cyclone IV E `EP4CE22F17C6`
-| Toolchain:        | Quartus Prime 20.1.0
+| Top entity: | `rtl/core/neorv32_top.vhd`
+| FPGA:       | Intel Cyclone IV E `EP4CE22F17C6`
+| Toolchain:  | Quartus Prime 20.1.0
 |=======================
 
 .Hardware utilization by the processor modules (mandatory core modules in **bold**)
@@ -346,7 +344,7 @@ https://stnolting.github.io/neorv32/ug/#_application_specific_processor_configur
 | WISHBONE      | External memory interface                             | 114 | 110 |        0 |    0
 | XIRQ          | External interrupt controller (32 channels)           | 241 | 201 |        0 |    0
 | GPTMR         | General Purpose Timer                                 | 153 | 107 |        0 |    0
-| XIP           | Execute in place module                               | 344 | 269 |        0 |    0
+| XIP           | Execute in place module                               | 305 | 243 |        0 |    0
 |=======================
 
 

--- a/docs/datasheet/soc_xip.adoc
+++ b/docs/datasheet/soc_xip.adoc
@@ -46,8 +46,8 @@ Debugging XIP code execution using the on-chip debugger is constrained. The debu
 
 The XIP module accesses external flash using the standard SPI protocol. The module always sends data MSB-first and
 provides all of the standard four clock modes (0..3), which are configured via the _XIP_CTRL_CPOL_ (clock polarity)
-and _XIP_CTRL_CPHA_ (clock phase) control register bits. The clock speed of the interface (`xip_clk_o`) is defined
-by a tree-bit clock pre-scaler using the _XIP_CTRL_PRSCx_ bits.
+and _XIP_CTRL_CPHA_ (clock phase) control register bits, respectively. The clock speed of the interface (`xip_clk_o`)
+is defined by a three-bit clock pre-scaler configured using the _XIP_CTRL_PRSCx_ bits:
 
 .XIP prescaler configuration
 [cols="<4,^1,^1,^1,^1,^1,^1,^1,^1"]
@@ -57,12 +57,12 @@ by a tree-bit clock pre-scaler using the _XIP_CTRL_PRSCx_ bits.
 | Resulting `clock_prescaler` |       2 |       4 |       8 |      64 |     128 |    1024 |    2048 |    4096
 |=======================
 
-Based on the _XIP_CTRL_PRSCx_ configuration, the actual XIP SPI clock frequency f~XIP~ is derived from the processor's
+Based on the _XIP_CTRL_PRSCx_ configuration the actual XIP SPI clock frequency f~XIP~ is derived from the processor's
 main clock f~main~ and is determined by:
 
 _**f~XIP~**_ = _f~main~[Hz]_ / (2 * `clock_prescaler`)
 
-Hence, the maximum XIP clock is f~main~ / 4.
+Hence, the maximum XIP clock speed is f~main~ / 4.
 
 The flash's "read command", which initiates a read access, is defined by the _XIP_CTRL_RD_CMD_ control register bits.
 For most SPI flash memories this is `0x03` for normal SPI mode.
@@ -73,9 +73,10 @@ Quad-SPI (QSPI) support, which is about 4x times faster, is planned for the futu
 
 **Direct SPI Access**
 
-The XIP module allows to initiate direct SPI transactions. This feature can be used to configure the attached SPI
-flash or to perform direct read and write access to the flash memory. Two data registers `NEORV32_XIP.DATA_LO` and
-`NEORV32_XIP.DATA_HI` are provided to transfer up to 64-bit of SPI data. Note that the module handles the chip-select
+The XIP module allows to initiate _direct_ SPI transactions. This feature can be used to configure the attached SPI
+flash or to perform direct read and write accesses to the flash memory. Two data registers `NEORV32_XIP.DATA_LO` and
+`NEORV32_XIP.DATA_HI` are provided to send up to 64-bit of SPI data. The `NEORV32_XIP.DATA_HI` register is write-only,
+so a total of 32-bit receive data is provided. Note that the module handles the chip-select
 line (`xip_csn_o`) by itself so it is not possible to construct larger consecutive transfers.
 
 The actual data transmission size in bytes is defined by the control register's _XIP_CTRL_SPI_NBYTES_ bits.
@@ -85,9 +86,17 @@ Since data is always transferred MSB-first, the data in `DATA_HI:DATA_LO` also h
 available in `DATA_LO` only - `DATA_HI` is write-only. Writing to `DATA_HI` triggers the actual SPI transmission.
 The _XIP_CTRL_PHY_BUSY_ control register flag indicates a transmission being in progress.
 
+The chip-select line of the XIP module (`xip_csn_o`) will only become asserted (enabled, pulled low) if the
+_XIP_CTRL_SPI_CSEN_ control register bit is set. If this bit is cleared, `xip_csn_o` is always disabled
+(pulled high).
+
 [NOTE]
 Direct SPI mode is only possible when the module is enabled (setting _XIP_CTRL_EN_) but **before** the actual
 XIP mode is enabled via _XIP_CTRL_XIP_EN_.
+
+[TIP]
+When the XIP mode is not enabled, the XIP module can also be used as additional general purpose SPI controller
+with a transfer size of up to 64 bits per transmission.
 
 
 **Address Mapping**
@@ -117,22 +126,33 @@ configured using the control register's _XIP_CTRL_XIP_ABYTES_ bits. These two bi
 address bytes (**minus one**). For example for a SPI flash with 24-bit addresses these bits have to be set to
 `0b10`.
 
+The transparent XIP accesses are transformed into SPI transmissions with the following format (starting with the MSB):
+
+* 8-bit command: configured by the _XIP_CTRL_RD_CMD_ control register bits ("SPI read command")
+* 8 to 32 bits address: defined by the _XIP_CTRL_XIP_ABYTES_ control register bits ("number of address bytes")
+* 32-bit data: sending zeros and receiving the according flash word (32-bit)
+
+Hence, the maximum XIP transmission size is 72-bit, which has to be configured via the _XIP_CTRL_SPI_NBYTES_
+control register bits. Note that the 72-bit transmission size is only available in XIP mode. The transmission
+size of the direct SPI accesses is limited to 64-bit.
+
 [NOTE]
 When using four SPI flash address bytes, the most significant 4 bits of the address are always hardwired
-to zero allowing a maximum flash size of 256MB.
+to zero allowing a maximum **accessible** flash size of 256MB.
 
 After the SPI properties (including the amount of address bytes **and** the total amount of SPI transfer bytes)
 and XIP address mapping are configured, the actual XIP mode can be enabled by setting
 the control register's _XIP_CTRL_XIP_EN_ bit. This will enable the "transparent SPI access port" of the module and also
-the _transparent_ conversion of access requests into proper SPI flash transmissions.
+the _transparent_ conversion of access requests into proper SPI flash transmissions. Make sure _XIP_CTRL_SPI_CSEN_
+is also set so the module can actually select/enable the attached SPI flash.
 No more direct SPI accesses via `DATA_HI:DATA_LO` are possible when the XIP mode is enabled. However, the
 XIP mode can be disabled at any time.
 
 [NOTE]
-If the XIP module is disabled (_XIP_CTRL_EN_ = `0`) any access to the programmed XIP memory segment are ignored
-by the module and might be forwarded to the processor's external memory interface (if implemented). If the XIP module
-is enabled (_XIP_CTRL_EN_ = `1`) but XIP mode is not enabled yet (_XIP_CTRL_XIP_EN_ = '0') any to the programmed XIP
-memory segment will raise a bus exception.
+If the XIP module is disabled (_XIP_CTRL_EN_ = `0`) any accesses to the programmed XIP memory segment are ignored
+by the module and might be forwarded to the processor's external memory interface (if implemented) or will cause a bus
+exception. If the XIP module is enabled (_XIP_CTRL_EN_ = `1`) but XIP mode is not enabled yet (_XIP_CTRL_XIP_EN_ = '0')
+any to the programmed XIP memory segment will raise a bus exception.
 
 [NOTE]
 It is highly recommended to use the processor's instruction cache to hide some of the SPI protocol latency.
@@ -143,7 +163,7 @@ It is highly recommended to use the processor's instruction cache to hide some o
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.16+<| `0xffffff40` .16+<| `NEORV32_XIP.CTRL` <|`0`  _XIP_CTRL_EN_    ^| r/w <| XIP module enable
+.15+<| `0xffffff40` .15+<| `NEORV32_XIP.CTRL` <|`0`  _XIP_CTRL_EN_    ^| r/w <| XIP module enable
                                               <|`1`  _XIP_CTRL_PRSC0_ ^| r/w .3+| 3-bit SPI clock prescaler select
                                               <|`2`  _XIP_CTRL_PRSC1_ ^| r/w
                                               <|`3`  _XIP_CTRL_PRSC2_ ^| r/w
@@ -152,12 +172,11 @@ It is highly recommended to use the processor's instruction cache to hide some o
                                               <|`9:6`  _XIP_CTRL_SPI_NBYTES_MSB_ : _XIP_CTRL_SPI_NBYTES_LSB_ ^| r/w <| Number of bytes in SPI transaction (1..9)
                                               <|`10` _XIP_CTRL_XIP_EN_ ^| r/w <| XIP mode enable
                                               <|`12:11` _XIP_CTRL_XIP_ABYTES_MSB_ : _XIP_CTRL_XIP_ABYTES_LSB_ ^| r/w <| Number of address bytes for XIP flash (minus 1)
-                                              <|`13` _XIP_CTRL_QSPI_EN_ ^| r/w <| Enable QSPI mode (🚧 not supported yet!)
-                                              <|`21:14` _XIP_CTRL_RD_CMD_MSB_ : _XIP_CTRL_RD_CMD_LSB_ ^| r/w <| Flash read command
-                                              <|`25:22` _XIP_CTRL_XIP_PAGE_MSB_ : _XIP_CTRL_XIP_PAGE_LSB_ ^| r/w <| XIP memory page
-                                              <|`28:26` -                 ^| r/- <| _reserved_, read as zero
-                                              <|`29` _XIP_CTRL_PHY_BUSY_  ^| r/- <| SPI PHY busy when set
-                                              <|`30` _XIP_CTRL_XIP_READY_ ^| r/- <| XIP access ready (initialization done)
+                                              <|`20:13` _XIP_CTRL_RD_CMD_MSB_ : _XIP_CTRL_RD_CMD_LSB_ ^| r/w <| Flash read command
+                                              <|`24:21` _XIP_CTRL_XIP_PAGE_MSB_ : _XIP_CTRL_XIP_PAGE_LSB_ ^| r/w <| XIP memory page
+                                              <|`25` _XIP_CTRL_SPI_CSEN_  ^| r/w <| Allow SPI chip-select to be actually asserted when set
+                                              <|`29:26` -                 ^| r/- <| _reserved_, read as zero
+                                              <|`30` _XIP_CTRL_PHY_BUSY_  ^| r/- <| SPI PHY busy when set
                                               <|`31` _XIP_CTRL_XIP_BUSY_  ^| r/- <| XIP access in progress when set
 | `0xffffff44` | _reserved_            |`31:0` | r/- | _reserved_, read as zero
 | `0xffffff48` | `NEORV32_XIP.DATA_LO` |`31:0` | r/w | Direct SPI access - data register low

--- a/docs/datasheet/soc_xip.adoc
+++ b/docs/datasheet/soc_xip.adoc
@@ -112,7 +112,7 @@ or modules attached to the external memory interface).
 
 Example: to map the XIP flash to the address space starting at `0x20000000` write a "2" (`0b0010`) to the _XIP_CTRL_XIP_PAGE_
 control register bits. Any access within `0x20000000 .. 0x2fffffff` will be forwarded to the XIP flash.
-Note that the SPI access address will wrap around.
+Note that the SPI access address might wrap around.
 
 
 **Using the XIP Mode**
@@ -142,7 +142,7 @@ to zero allowing a maximum **accessible** flash size of 256MB.
 
 After the SPI properties (including the amount of address bytes **and** the total amount of SPI transfer bytes)
 and XIP address mapping are configured, the actual XIP mode can be enabled by setting
-the control register's _XIP_CTRL_XIP_EN_ bit. This will enable the "transparent SPI access port" of the module and also
+the control register's _XIP_CTRL_XIP_EN_ bit. This will enable the "transparent SPI access port" of the module and thus,
 the _transparent_ conversion of access requests into proper SPI flash transmissions. Make sure _XIP_CTRL_SPI_CSEN_
 is also set so the module can actually select/enable the attached SPI flash.
 No more direct SPI accesses via `DATA_HI:DATA_LO` are possible when the XIP mode is enabled. However, the
@@ -152,10 +152,11 @@ XIP mode can be disabled at any time.
 If the XIP module is disabled (_XIP_CTRL_EN_ = `0`) any accesses to the programmed XIP memory segment are ignored
 by the module and might be forwarded to the processor's external memory interface (if implemented) or will cause a bus
 exception. If the XIP module is enabled (_XIP_CTRL_EN_ = `1`) but XIP mode is not enabled yet (_XIP_CTRL_XIP_EN_ = '0')
-any to the programmed XIP memory segment will raise a bus exception.
+any access to the programmed XIP memory segment will raise a bus exception.
 
-[NOTE]
-It is highly recommended to use the processor's instruction cache to hide some of the SPI protocol latency.
+[TIP]
+It is highly recommended to enable the <<_processor_internal_instruction_cache_icache>> to cover some
+of the SPI access latency.
 
 
 .XIP register map (`struct NEORV32_XIP`)
@@ -175,7 +176,7 @@ It is highly recommended to use the processor's instruction cache to hide some o
                                               <|`20:13` _XIP_CTRL_RD_CMD_MSB_ : _XIP_CTRL_RD_CMD_LSB_ ^| r/w <| Flash read command
                                               <|`24:21` _XIP_CTRL_XIP_PAGE_MSB_ : _XIP_CTRL_XIP_PAGE_LSB_ ^| r/w <| XIP memory page
                                               <|`25` _XIP_CTRL_SPI_CSEN_  ^| r/w <| Allow SPI chip-select to be actually asserted when set
-                                              <|`29:26` -                 ^| r/- <| _reserved_, read as zero
+                                              <|`29:26`                   ^| r/- <| _reserved_, read as zero
                                               <|`30` _XIP_CTRL_PHY_BUSY_  ^| r/- <| SPI PHY busy when set
                                               <|`31` _XIP_CTRL_XIP_BUSY_  ^| r/- <| XIP access in progress when set
 | `0xffffff44` | _reserved_            |`31:0` | r/- | _reserved_, read as zero

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060504"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060505"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/example/demo_xip/main.c
+++ b/sw/example/demo_xip/main.c
@@ -109,11 +109,22 @@ int main() {
   // intro
   neorv32_uart0_printf("<< XIP Demo Program >>\n\n");
 
+
+  // warning if i-cache is not implemented
+  if ((NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_ICACHE)) == 0) {
+    neorv32_uart0_printf("WARNING! No instruction cache implemented. The XIP program will run awfully slow...\n");
+  }
+
+
   // reset XIP module and configure basic SPI properties
   // * 1/64 clock divider
   // * clock mode 0 (cpol = 0, cpha = 0)
   // * flash read command = 0x03
-  neorv32_xip_init(CLK_PRSC_64, 0, 0, 0x03);
+  // -> this function will also send 64 dummy clock cycles via the XIP's SPI port (with CS disabled)
+  if (neorv32_xip_init(CLK_PRSC_64, 0, 0, 0x03)) {
+    neorv32_uart0_printf("Error! XIP module setup error!\n");
+    return 1;
+  }
 
   // use a helper function to store a small example program to the XIP flash
   // NOTE: this (direct SPI access via the XIP module) has to be done before the actual XIP mode is enabled!

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -854,14 +854,13 @@ enum NEORV32_XIP_CTRL_enum {
   XIP_CTRL_XIP_EN         = 10, /**< XIP control register(10) (r/w): XIP access enable */
   XIP_CTRL_XIP_ABYTES_LSB = 11, /**< XIP control register(11) (r/w): Number XIP address bytes (minus 1), LSB */
   XIP_CTRL_XIP_ABYTES_MSB = 12, /**< XIP control register(12) (r/w): Number XIP address bytes (minus 1), MSB */
-  XIP_CTRL_QSPI_EN        = 13, /**< XIP control register(13) (r/w): Enable QSPI mode */
-  XIP_CTRL_RD_CMD_LSB     = 14, /**< XIP control register(14) (r/w): SPI flash read command, LSB */
-  XIP_CTRL_RD_CMD_MSB     = 21, /**< XIP control register(21) (r/w): SPI flash read command, MSB */
-  XIP_CTRL_PAGE_LSB       = 22, /**< XIP control register(22) (r/w): XIP memory page, LSB */
-  XIP_CTRL_PAGE_MSB       = 25, /**< XIP control register(25) (r/w): XIP memory page, MSB */
+  XIP_CTRL_RD_CMD_LSB     = 13, /**< XIP control register(13) (r/w): SPI flash read command, LSB */
+  XIP_CTRL_RD_CMD_MSB     = 20, /**< XIP control register(20) (r/w): SPI flash read command, MSB */
+  XIP_CTRL_PAGE_LSB       = 21, /**< XIP control register(21) (r/w): XIP memory page, LSB */
+  XIP_CTRL_PAGE_MSB       = 24, /**< XIP control register(24) (r/w): XIP memory page, MSB */
+  XIP_CTRL_SPI_CSEN       = 25, /**< XIP control register(25) (r/w): SPI chip-select enable */
 
-  XIP_CTRL_PHY_BUSY       = 29, /**< XIP control register(29) (r/-): SPI PHY is busy */
-  XIP_CTRL_XIP_READY      = 30, /**< XIP control register(30) (r/-): XIP access is ready (setup done) */
+  XIP_CTRL_PHY_BUSY       = 30, /**< XIP control register(20) (r/-): SPI PHY is busy */
   XIP_CTRL_XIP_BUSY       = 31  /**< XIP control register(31) (r/-): XIP access in progress */
 };
 /**@}*/

--- a/sw/lib/include/neorv32_xip.h
+++ b/sw/lib/include/neorv32_xip.h
@@ -46,7 +46,7 @@
 
 // prototypes
 int neorv32_xip_available(void);
-void neorv32_xip_init(uint8_t prsc, uint8_t cpol, uint8_t cpha, uint8_t rd_cmd);
+int neorv32_xip_init(uint8_t prsc, uint8_t cpol, uint8_t cpha, uint8_t rd_cmd);
 int neorv32_xip_start(uint8_t abytes, uint32_t page_base);
 int neorv32_xip_spi_trans(uint8_t nbytes, uint64_t *rtx_data);
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -399,31 +399,25 @@
               <description>Number of XIP address bytes (minus 1)</description>
             </field>
             <field>
-              <name>XIP_CTRL_QSPI_EN</name>
-              <bitRange>[13:13]</bitRange>
-              <description>QSPI mode enable</description>
-            </field>
-            <field>
               <name>XIP_CTRL_RD_CMD</name>
-              <bitRange>[21:14]</bitRange>
+              <bitRange>[20:13]</bitRange>
               <description>SPI flash read command</description>
             </field>
             <field>
               <name>XIP_CTRL_XIP_PAGE</name>
-              <bitRange>[25:22]</bitRange>
+              <bitRange>[24:21]</bitRange>
               <description>XIP memory page</description>
             </field>
             <field>
-              <name>XIP_CTRL_PHY_BUSY</name>
-              <bitRange>[29:29]</bitRange>
-              <access>read-only</access>
-              <description>SPI PHY busy</description>
+              <name>XIP_CTRL_SPI_CSEN</name>
+              <bitRange>[25:25]</bitRange>
+              <description>SPI chip-select enable</description>
             </field>
             <field>
-              <name>XIP_CTRL_XIP_READY</name>
+              <name>XIP_CTRL_PHY_BUSY</name>
               <bitRange>[30:30]</bitRange>
               <access>read-only</access>
-              <description>XIP access ready (setup done)</description>
+              <description>SPI PHY busy</description>
             </field>
             <field>
               <name>XIP_CTRL_XIP_BUSY</name>


### PR DESCRIPTION
This PR is a rework of the processor's **Execute in Place (XIP)** module (#244).

* Control register changes
  * removed QSPI mode enable (not implemented **_yet_** :wink:)
  * rearranged flags
  * removed XIP mode busy flag
  * added flag to explicitly enable the module's SPI chip-select port (allows to send dummy clocks without actually enabling the SPI flash)

Further hardware changes:
* removed hardware-based sending of dummy SPI clocks (is now done by the XIP's software library functions)
* removed "inter-transmission" pause from SPI PHY - faster SPI accesses
* reduces hardware footprint: only ~300 LEs on an Intel Cyclone IV

---------------------------

:gear: "Final" pre-defined software functions for using the XIP module:

```c
int neorv32_xip_available(void);
int neorv32_xip_init(uint8_t prsc, uint8_t cpol, uint8_t cpha, uint8_t rd_cmd);
int neorv32_xip_start(uint8_t abytes, uint32_t page_base);
int neorv32_xip_spi_trans(uint8_t nbytes, uint64_t *rtx_data);
```

:bulb: A demo program using the XIP module is available in [`sw/example/demo_xip/main.c`](https://github.com/stnolting/neorv32/blob/master/sw/example/demo_xip/main.c).