### PR TITLE
[SPI & XIP] add high-speed SPI mode option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 07.01.2022 | 1.6.5.6 | :sparkles: **XIP & SPI: added high-speed SPI mode** (SPI clocking at half of the processor clock), see [PR #251](https://github.com/stnolting/neorv32/pull/251) |
 | 06.01.2022 | 1.6.5.5 | :warning: optimized/reworked XIP (execute in place) module, see [PR #249](https://github.com/stnolting/neorv32/pull/249) |
 | 04.01.2022 | 1.6.5.4 | **BUSKEEPER** can now optionally check for NULL address accesses (address `0x00000000`), see [PR #247](https://github.com/stnolting/neorv32/pull/247) |
 | 02.01.2022 | 1.6.5.3 | :sparkles: **added Execute In Place (XIP) module** allowing code to be directly executed from an external SPI flash, see [PR #244](https://github.com/stnolting/neorv32/pull/244) |

--- a/docs/datasheet/soc_spi.adoc
+++ b/docs/datasheet/soc_spi.adoc
@@ -104,6 +104,12 @@ _**f~SPI~**_ = _f~main~[Hz]_ / (2 * `clock_prescaler`)
 
 Hence, the maximum SPI clock is f~main~ / 4.
 
+.High-Speed SPI mode
+[TIP]
+The module provides a "high-speed" SPI mode. In this mode the clock prescaler configuration (SPI_CTRL_PRSCx) is ignored
+and the SPI clock operates at f~main~ / 2 (half of the processor's main clock). High speed SPI mode is enabled by setting
+the control register's _SPI_CTRL_HIGHSPEED_ bit.
+
 
 **SPI Interrupt**
 
@@ -117,23 +123,24 @@ by setting the according `mip` CSR bit.
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.18+<| `0xffffffa8` .18+<| `NEORV32_SPI.CTRL` <|`0` _SPI_CTRL_CS0_    ^| r/w .8+<| Direct chip-select 0..7; setting `spi_csn_o(x)` low when set
-                                              <|`1` _SPI_CTRL_CS1_    ^| r/w 
-                                              <|`2` _SPI_CTRL_CS2_    ^| r/w 
-                                              <|`3` _SPI_CTRL_CS3_    ^| r/w 
-                                              <|`4` _SPI_CTRL_CS4_    ^| r/w 
-                                              <|`5` _SPI_CTRL_CS5_    ^| r/w 
-                                              <|`6` _SPI_CTRL_CS6_    ^| r/w 
-                                              <|`7` _SPI_CTRL_CS7_    ^| r/w 
-                                              <|`8` _SPI_CTRL_EN_     ^| r/w <| SPI enable
-                                              <|`9` _SPI_CTRL_CPHA_   ^| r/w <| clock phase (`0`=sample RX on rising edge & update TX on falling edge; `1`=sample RX on falling edge & update TX on rising edge)
-                                              <|`10` _SPI_CTRL_PRSC0_ ^| r/w .3+| 3-bit clock prescaler select
-                                              <|`11` _SPI_CTRL_PRSC1_ ^| r/w
-                                              <|`12` _SPI_CTRL_PRSC2_ ^| r/w
-                                              <|`13` _SPI_CTRL_SIZE0_ ^| r/w .2+<| transfer size (`00`=8-bit, `01`=16-bit, `10`=24-bit, `11`=32-bit)
-                                              <|`14` _SPI_CTRL_SIZE1_ ^| r/w
-                                              <|`15` _SPI_CTRL_CPOL_  ^| r/w <| clock polarity
-                                              <|`16` .. `30`          ^| r/- <| _reserved, read as zero
-                                              <|`31` _SPI_CTRL_BUSY_  ^| r/- <| transmission in progress when set
+.19+<| `0xffffffa8` .19+<| `NEORV32_SPI.CTRL` <|`0` _SPI_CTRL_CS0_        ^| r/w .8+<| Direct chip-select 0..7; setting `spi_csn_o(x)` low when set
+                                              <|`1` _SPI_CTRL_CS1_        ^| r/w 
+                                              <|`2` _SPI_CTRL_CS2_        ^| r/w 
+                                              <|`3` _SPI_CTRL_CS3_        ^| r/w 
+                                              <|`4` _SPI_CTRL_CS4_        ^| r/w 
+                                              <|`5` _SPI_CTRL_CS5_        ^| r/w 
+                                              <|`6` _SPI_CTRL_CS6_        ^| r/w 
+                                              <|`7` _SPI_CTRL_CS7_        ^| r/w 
+                                              <|`8` _SPI_CTRL_EN_         ^| r/w <| SPI enable
+                                              <|`9` _SPI_CTRL_CPHA_       ^| r/w <| clock phase (`0`=sample RX on rising edge & update TX on falling edge; `1`=sample RX on falling edge & update TX on rising edge)
+                                              <|`10` _SPI_CTRL_PRSC0_     ^| r/w .3+| 3-bit clock prescaler select
+                                              <|`11` _SPI_CTRL_PRSC1_     ^| r/w
+                                              <|`12` _SPI_CTRL_PRSC2_     ^| r/w
+                                              <|`13` _SPI_CTRL_SIZE0_     ^| r/w .2+<| transfer size (`00`=8-bit, `01`=16-bit, `10`=24-bit, `11`=32-bit)
+                                              <|`14` _SPI_CTRL_SIZE1_     ^| r/w
+                                              <|`15` _SPI_CTRL_CPOL_      ^| r/w <| clock polarity
+                                              <|`16` _SPI_CTRL_HIGHSPEED_ ^| r/w <| enable SPI high-speed mode (ignoring _SPI_CTRL_PRSC_)
+                                              <|`17:30`                   ^| r/- <| _reserved, read as zero
+                                              <|`31` _SPI_CTRL_BUSY_      ^| r/- <| transmission in progress when set
 | `0xffffffac` | `NEORV32_SPI.DATA` |`31:0` | r/w | receive/transmit data, LSB-aligned
 |=======================

--- a/docs/datasheet/soc_xip.adoc
+++ b/docs/datasheet/soc_xip.adoc
@@ -39,7 +39,10 @@ An example program for the XIP module is available in `sw/example/demo_xip`.
 
 [WARNING]
 Debugging XIP code execution using the on-chip debugger is constrained. The debugger cannot insert breakpoints
-(`ebreak` instructions) into XIP code as the XIP access is read-only. 
+(`ebreak` instructions) into XIP code as the XIP access is read-only.
+
+[NOTE]
+Quad-SPI (QSPI) support, which is about 4x times faster, is planned for the future. 😉
 
 
 **SPI Protocol**
@@ -64,11 +67,14 @@ _**f~XIP~**_ = _f~main~[Hz]_ / (2 * `clock_prescaler`)
 
 Hence, the maximum XIP clock speed is f~main~ / 4.
 
+.High-Speed SPI mode
+[TIP]
+The module provides a "high-speed" SPI mode. In this mode the clock prescaler configuration (_XIP_CTRL_PRSCx_) is ignored
+and the SPI clock operates at f~main~ / 2 (half of the processor's main clock). High speed SPI mode is enabled by setting
+the control register's _XIP_CTRL_HIGHSPEED_ bit.
+
 The flash's "read command", which initiates a read access, is defined by the _XIP_CTRL_RD_CMD_ control register bits.
 For most SPI flash memories this is `0x03` for normal SPI mode.
-
-[NOTE]
-Quad-SPI (QSPI) support, which is about 4x times faster, is planned for the future. 😉
 
 
 **Direct SPI Access**
@@ -137,6 +143,9 @@ control register bits. Note that the 72-bit transmission size is only available 
 size of the direct SPI accesses is limited to 64-bit.
 
 [NOTE]
+There is no _continuous read_ feature (i.e. a burst SPI transmission fetching several data words at once) implemented yet.
+
+[NOTE]
 When using four SPI flash address bytes, the most significant 4 bits of the address are always hardwired
 to zero allowing a maximum **accessible** flash size of 256MB.
 
@@ -164,7 +173,7 @@ of the SPI access latency.
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.15+<| `0xffffff40` .15+<| `NEORV32_XIP.CTRL` <|`0`  _XIP_CTRL_EN_    ^| r/w <| XIP module enable
+.16+<| `0xffffff40` .16+<| `NEORV32_XIP.CTRL` <|`0`  _XIP_CTRL_EN_    ^| r/w <| XIP module enable
                                               <|`1`  _XIP_CTRL_PRSC0_ ^| r/w .3+| 3-bit SPI clock prescaler select
                                               <|`2`  _XIP_CTRL_PRSC1_ ^| r/w
                                               <|`3`  _XIP_CTRL_PRSC2_ ^| r/w
@@ -176,7 +185,8 @@ of the SPI access latency.
                                               <|`20:13` _XIP_CTRL_RD_CMD_MSB_ : _XIP_CTRL_RD_CMD_LSB_ ^| r/w <| Flash read command
                                               <|`24:21` _XIP_CTRL_XIP_PAGE_MSB_ : _XIP_CTRL_XIP_PAGE_LSB_ ^| r/w <| XIP memory page
                                               <|`25` _XIP_CTRL_SPI_CSEN_  ^| r/w <| Allow SPI chip-select to be actually asserted when set
-                                              <|`29:26`                   ^| r/- <| _reserved_, read as zero
+                                              <|`26` _XIP_CTRL_HIGHSPEED_ ^| r/w <| enable SPI high-speed mode (ignoring _XIP_CTRL_PRSC_)
+                                              <|`29:27`                   ^| r/- <| _reserved_, read as zero
                                               <|`30` _XIP_CTRL_PHY_BUSY_  ^| r/- <| SPI PHY busy when set
                                               <|`31` _XIP_CTRL_XIP_BUSY_  ^| r/- <| XIP access in progress when set
 | `0xffffff44` | _reserved_            |`31:0` | r/- | _reserved_, read as zero

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060505"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060506"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -149,7 +149,7 @@ package neorv32_package is
   constant dm_sreg_base_c       : std_ulogic_vector(data_width_c-1 downto 0) := x"fffff980";
 
   -- IO: Peripheral Devices ("IO") Area --
-  -- Control register(s) (including the device-enable) should be located at the base address of each device
+  -- Control register(s) (including the device-enable flag) should be located at the base address of each device
   constant io_base_c            : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe00";
   constant io_size_c            : natural := 512; -- IO address space size in bytes, fixed!
 

--- a/rtl/core/neorv32_spi.vhd
+++ b/rtl/core/neorv32_spi.vhd
@@ -7,7 +7,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -73,27 +73,27 @@ architecture neorv32_spi_rtl of neorv32_spi is
   constant lo_abb_c : natural := index_size_f(spi_size_c); -- low address boundary bit
 
   -- control register --
-  constant ctrl_cs0_c   : natural :=  0; -- r/w: spi CS 0
-  constant ctrl_cs1_c   : natural :=  1; -- r/w: spi CS 1
-  constant ctrl_cs2_c   : natural :=  2; -- r/w: spi CS 2
-  constant ctrl_cs3_c   : natural :=  3; -- r/w: spi CS 3
-  constant ctrl_cs4_c   : natural :=  4; -- r/w: spi CS 4
-  constant ctrl_cs5_c   : natural :=  5; -- r/w: spi CS 5
-  constant ctrl_cs6_c   : natural :=  6; -- r/w: spi CS 6
-  constant ctrl_cs7_c   : natural :=  7; -- r/w: spi CS 7
+  constant ctrl_cs0_c       : natural :=  0; -- r/w: spi CS 0
+  constant ctrl_cs1_c       : natural :=  1; -- r/w: spi CS 1
+  constant ctrl_cs2_c       : natural :=  2; -- r/w: spi CS 2
+  constant ctrl_cs3_c       : natural :=  3; -- r/w: spi CS 3
+  constant ctrl_cs4_c       : natural :=  4; -- r/w: spi CS 4
+  constant ctrl_cs5_c       : natural :=  5; -- r/w: spi CS 5
+  constant ctrl_cs6_c       : natural :=  6; -- r/w: spi CS 6
+  constant ctrl_cs7_c       : natural :=  7; -- r/w: spi CS 7
+  constant ctrl_en_c        : natural :=  8; -- r/w: spi enable
+  constant ctrl_cpha_c      : natural :=  9; -- r/w: spi clock phase
+  constant ctrl_prsc0_c     : natural := 10; -- r/w: spi prescaler select bit 0
+  constant ctrl_prsc1_c     : natural := 11; -- r/w: spi prescaler select bit 1
+  constant ctrl_prsc2_c     : natural := 12; -- r/w: spi prescaler select bit 2
+  constant ctrl_size0_c     : natural := 13; -- r/w: data size lsb (00:  8-bit, 01: 16-bit)
+  constant ctrl_size1_c     : natural := 14; -- r/w: data size msb (10: 24-bit, 11: 32-bit)
+  constant ctrl_cpol_c      : natural := 15; -- r/w: spi clock polarity
+  constant ctrl_highspeed_c : natural := 16; -- r/w: spi high-speed mode enable (ignoring ctrl_prsc)
   --
-  constant ctrl_en_c    : natural :=  8; -- r/w: spi enable
-  constant ctrl_cpha_c  : natural :=  9; -- r/w: spi clock phase
-  constant ctrl_prsc0_c : natural := 10; -- r/w: spi prescaler select bit 0
-  constant ctrl_prsc1_c : natural := 11; -- r/w: spi prescaler select bit 1
-  constant ctrl_prsc2_c : natural := 12; -- r/w: spi prescaler select bit 2
-  constant ctrl_size0_c : natural := 13; -- r/w: data size lsb (00:  8-bit, 01: 16-bit)
-  constant ctrl_size1_c : natural := 14; -- r/w: data size msb (10: 24-bit, 11: 32-bit)
-  constant ctrl_cpol_c  : natural := 15; -- r/w: spi clock polarity
+  constant ctrl_busy_c      : natural := 31; -- r/-: spi transceiver is busy
   --
-  constant ctrl_busy_c  : natural := 31; -- r/-: spi transceiver is busy
-  --
-  signal ctrl : std_ulogic_vector(15 downto 0);
+  signal ctrl : std_ulogic_vector(16 downto 0);
 
   -- access control --
   signal acc_en : std_ulogic; -- module access enable
@@ -137,23 +137,23 @@ begin
       -- write access --
       if (wren = '1') then
         if (addr = spi_ctrl_addr_c) then -- control register
-          ctrl(ctrl_cs0_c)   <= data_i(ctrl_cs0_c);
-          ctrl(ctrl_cs1_c)   <= data_i(ctrl_cs1_c);
-          ctrl(ctrl_cs2_c)   <= data_i(ctrl_cs2_c);
-          ctrl(ctrl_cs3_c)   <= data_i(ctrl_cs3_c);
-          ctrl(ctrl_cs4_c)   <= data_i(ctrl_cs4_c);
-          ctrl(ctrl_cs5_c)   <= data_i(ctrl_cs5_c);
-          ctrl(ctrl_cs6_c)   <= data_i(ctrl_cs6_c);
-          ctrl(ctrl_cs7_c)   <= data_i(ctrl_cs7_c);
-          --
-          ctrl(ctrl_en_c)    <= data_i(ctrl_en_c);
-          ctrl(ctrl_cpha_c)  <= data_i(ctrl_cpha_c);
-          ctrl(ctrl_prsc0_c) <= data_i(ctrl_prsc0_c);
-          ctrl(ctrl_prsc1_c) <= data_i(ctrl_prsc1_c);
-          ctrl(ctrl_prsc2_c) <= data_i(ctrl_prsc2_c);
-          ctrl(ctrl_size0_c) <= data_i(ctrl_size0_c);
-          ctrl(ctrl_size1_c) <= data_i(ctrl_size1_c);
-          ctrl(ctrl_cpol_c)  <= data_i(ctrl_cpol_c);
+          ctrl(ctrl_cs0_c)       <= data_i(ctrl_cs0_c);
+          ctrl(ctrl_cs1_c)       <= data_i(ctrl_cs1_c);
+          ctrl(ctrl_cs2_c)       <= data_i(ctrl_cs2_c);
+          ctrl(ctrl_cs3_c)       <= data_i(ctrl_cs3_c);
+          ctrl(ctrl_cs4_c)       <= data_i(ctrl_cs4_c);
+          ctrl(ctrl_cs5_c)       <= data_i(ctrl_cs5_c);
+          ctrl(ctrl_cs6_c)       <= data_i(ctrl_cs6_c);
+          ctrl(ctrl_cs7_c)       <= data_i(ctrl_cs7_c);
+          ctrl(ctrl_en_c)        <= data_i(ctrl_en_c);
+          ctrl(ctrl_cpha_c)      <= data_i(ctrl_cpha_c);
+          ctrl(ctrl_prsc0_c)     <= data_i(ctrl_prsc0_c);
+          ctrl(ctrl_prsc1_c)     <= data_i(ctrl_prsc1_c);
+          ctrl(ctrl_prsc2_c)     <= data_i(ctrl_prsc2_c);
+          ctrl(ctrl_size0_c)     <= data_i(ctrl_size0_c);
+          ctrl(ctrl_size1_c)     <= data_i(ctrl_size1_c);
+          ctrl(ctrl_cpol_c)      <= data_i(ctrl_cpol_c);
+          ctrl(ctrl_highspeed_c) <= data_i(ctrl_highspeed_c);
         end if;
       end if;
 
@@ -161,25 +161,25 @@ begin
       data_o <= (others => '0');
       if (rden = '1') then
         if (addr = spi_ctrl_addr_c) then -- control register
-          data_o(ctrl_cs0_c)   <= ctrl(ctrl_cs0_c);
-          data_o(ctrl_cs1_c)   <= ctrl(ctrl_cs1_c);
-          data_o(ctrl_cs2_c)   <= ctrl(ctrl_cs2_c);
-          data_o(ctrl_cs3_c)   <= ctrl(ctrl_cs3_c);
-          data_o(ctrl_cs4_c)   <= ctrl(ctrl_cs4_c);
-          data_o(ctrl_cs5_c)   <= ctrl(ctrl_cs5_c);
-          data_o(ctrl_cs6_c)   <= ctrl(ctrl_cs6_c);
-          data_o(ctrl_cs7_c)   <= ctrl(ctrl_cs7_c);
+          data_o(ctrl_cs0_c)       <= ctrl(ctrl_cs0_c);
+          data_o(ctrl_cs1_c)       <= ctrl(ctrl_cs1_c);
+          data_o(ctrl_cs2_c)       <= ctrl(ctrl_cs2_c);
+          data_o(ctrl_cs3_c)       <= ctrl(ctrl_cs3_c);
+          data_o(ctrl_cs4_c)       <= ctrl(ctrl_cs4_c);
+          data_o(ctrl_cs5_c)       <= ctrl(ctrl_cs5_c);
+          data_o(ctrl_cs6_c)       <= ctrl(ctrl_cs6_c);
+          data_o(ctrl_cs7_c)       <= ctrl(ctrl_cs7_c);
+          data_o(ctrl_en_c)        <= ctrl(ctrl_en_c);
+          data_o(ctrl_cpha_c)      <= ctrl(ctrl_cpha_c);
+          data_o(ctrl_prsc0_c)     <= ctrl(ctrl_prsc0_c);
+          data_o(ctrl_prsc1_c)     <= ctrl(ctrl_prsc1_c);
+          data_o(ctrl_prsc2_c)     <= ctrl(ctrl_prsc2_c);
+          data_o(ctrl_size0_c)     <= ctrl(ctrl_size0_c);
+          data_o(ctrl_size1_c)     <= ctrl(ctrl_size1_c);
+          data_o(ctrl_cpol_c)      <= ctrl(ctrl_cpol_c);
+          data_o(ctrl_highspeed_c) <= ctrl(ctrl_highspeed_c);
           --
-          data_o(ctrl_en_c)    <= ctrl(ctrl_en_c);
-          data_o(ctrl_cpha_c)  <= ctrl(ctrl_cpha_c);
-          data_o(ctrl_prsc0_c) <= ctrl(ctrl_prsc0_c);
-          data_o(ctrl_prsc1_c) <= ctrl(ctrl_prsc1_c);
-          data_o(ctrl_prsc2_c) <= ctrl(ctrl_prsc2_c);
-          data_o(ctrl_size0_c) <= ctrl(ctrl_size0_c);
-          data_o(ctrl_size1_c) <= ctrl(ctrl_size1_c);
-          data_o(ctrl_cpol_c)  <= ctrl(ctrl_cpol_c);
-          --
-          data_o(ctrl_busy_c)  <= rtx_engine.busy;
+          data_o(ctrl_busy_c)      <= rtx_engine.busy;
         else -- data register (spi_rtx_addr_c)
           data_o <= rtx_engine.sreg;
         end if;
@@ -197,7 +197,7 @@ begin
   -- Clock Selection ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   clkgen_en_o <= ctrl(ctrl_en_c); -- clock generator enable
-  spi_clk_en  <= clkgen_i(to_integer(unsigned(ctrl(ctrl_prsc2_c downto ctrl_prsc0_c)))); -- clock select
+  spi_clk_en  <= clkgen_i(to_integer(unsigned(ctrl(ctrl_prsc2_c downto ctrl_prsc0_c)))) or ctrl(ctrl_highspeed_c); -- clock select
 
 
   -- Transmission Data Size -----------------------------------------------------------------

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -859,6 +859,7 @@ enum NEORV32_XIP_CTRL_enum {
   XIP_CTRL_PAGE_LSB       = 21, /**< XIP control register(21) (r/w): XIP memory page, LSB */
   XIP_CTRL_PAGE_MSB       = 24, /**< XIP control register(24) (r/w): XIP memory page, MSB */
   XIP_CTRL_SPI_CSEN       = 25, /**< XIP control register(25) (r/w): SPI chip-select enable */
+  XIP_CTRL_HIGHSPEED      = 26, /**< XIP control register(26) (r/w): SPI high-speed mode enable (ignoring XIP_CTRL_PRSC) */
 
   XIP_CTRL_PHY_BUSY       = 30, /**< XIP control register(20) (r/-): SPI PHY is busy */
   XIP_CTRL_XIP_BUSY       = 31  /**< XIP control register(31) (r/-): XIP access in progress */
@@ -1049,24 +1050,25 @@ typedef struct __attribute__((packed,aligned(4))) {
 
 /** SPI control register bits */
 enum NEORV32_SPI_CTRL_enum {
-  SPI_CTRL_CS0    =  0, /**< SPI control register(0)  (r/w): Direct chip select line 0 (output is low when set) */
-  SPI_CTRL_CS1    =  1, /**< SPI control register(1)  (r/w): Direct chip select line 1 (output is low when set) */
-  SPI_CTRL_CS2    =  2, /**< SPI control register(2)  (r/w): Direct chip select line 2 (output is low when set) */
-  SPI_CTRL_CS3    =  3, /**< SPI control register(3)  (r/w): Direct chip select line 3 (output is low when set) */
-  SPI_CTRL_CS4    =  4, /**< SPI control register(4)  (r/w): Direct chip select line 4 (output is low when set) */
-  SPI_CTRL_CS5    =  5, /**< SPI control register(5)  (r/w): Direct chip select line 5 (output is low when set) */
-  SPI_CTRL_CS6    =  6, /**< SPI control register(6)  (r/w): Direct chip select line 6 (output is low when set) */
-  SPI_CTRL_CS7    =  7, /**< SPI control register(7)  (r/w): Direct chip select line 7 (output is low when set) */
-  SPI_CTRL_EN     =  8, /**< SPI control register(8)  (r/w): SPI unit enable */
-  SPI_CTRL_CPHA   =  9, /**< SPI control register(9)  (r/w): Clock phase */
-  SPI_CTRL_PRSC0  = 10, /**< SPI control register(10) (r/w): Clock prescaler select bit 0 */
-  SPI_CTRL_PRSC1  = 11, /**< SPI control register(11) (r/w): Clock prescaler select bit 1 */
-  SPI_CTRL_PRSC2  = 12, /**< SPI control register(12) (r/w): Clock prescaler select bit 2 */
-  SPI_CTRL_SIZE0  = 13, /**< SPI control register(13) (r/w): Transfer data size lsb (00: 8-bit, 01: 16-bit, 10: 24-bit, 11: 32-bit) */
-  SPI_CTRL_SIZE1  = 14, /**< SPI control register(14) (r/w): Transfer data size msb (00: 8-bit, 01: 16-bit, 10: 24-bit, 11: 32-bit) */
-  SPI_CTRL_CPOL   = 15, /**< SPI control register(15) (r/w): Clock polarity */
+  SPI_CTRL_CS0       =  0, /**< SPI control register(0)  (r/w): Direct chip select line 0 (output is low when set) */
+  SPI_CTRL_CS1       =  1, /**< SPI control register(1)  (r/w): Direct chip select line 1 (output is low when set) */
+  SPI_CTRL_CS2       =  2, /**< SPI control register(2)  (r/w): Direct chip select line 2 (output is low when set) */
+  SPI_CTRL_CS3       =  3, /**< SPI control register(3)  (r/w): Direct chip select line 3 (output is low when set) */
+  SPI_CTRL_CS4       =  4, /**< SPI control register(4)  (r/w): Direct chip select line 4 (output is low when set) */
+  SPI_CTRL_CS5       =  5, /**< SPI control register(5)  (r/w): Direct chip select line 5 (output is low when set) */
+  SPI_CTRL_CS6       =  6, /**< SPI control register(6)  (r/w): Direct chip select line 6 (output is low when set) */
+  SPI_CTRL_CS7       =  7, /**< SPI control register(7)  (r/w): Direct chip select line 7 (output is low when set) */
+  SPI_CTRL_EN        =  8, /**< SPI control register(8)  (r/w): SPI unit enable */
+  SPI_CTRL_CPHA      =  9, /**< SPI control register(9)  (r/w): Clock phase */
+  SPI_CTRL_PRSC0     = 10, /**< SPI control register(10) (r/w): Clock prescaler select bit 0 */
+  SPI_CTRL_PRSC1     = 11, /**< SPI control register(11) (r/w): Clock prescaler select bit 1 */
+  SPI_CTRL_PRSC2     = 12, /**< SPI control register(12) (r/w): Clock prescaler select bit 2 */
+  SPI_CTRL_SIZE0     = 13, /**< SPI control register(13) (r/w): Transfer data size lsb (00: 8-bit, 01: 16-bit, 10: 24-bit, 11: 32-bit) */
+  SPI_CTRL_SIZE1     = 14, /**< SPI control register(14) (r/w): Transfer data size msb (00: 8-bit, 01: 16-bit, 10: 24-bit, 11: 32-bit) */
+  SPI_CTRL_CPOL      = 15, /**< SPI control register(15) (r/w): Clock polarity */
+  SPI_CTRL_HIGHSPEED = 16, /**< SPI control register(16) (r/w): SPI high-speed mode enable (ignoring SPI_CTRL_PRSC) */
 
-  SPI_CTRL_BUSY   = 31  /**< SPI control register(31) (r/-): SPI busy flag */
+  SPI_CTRL_BUSY      = 31  /**< SPI control register(31) (r/-): SPI busy flag */
 };
 /**@}*/
 

--- a/sw/lib/include/neorv32_spi.h
+++ b/sw/lib/include/neorv32_spi.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -49,6 +49,8 @@ int neorv32_spi_available(void);
 void neorv32_spi_setup(uint8_t prsc, uint8_t clk_phase, uint8_t clk_polarity, uint8_t data_size);
 void neorv32_spi_disable(void);
 void neorv32_spi_enable(void);
+void neorv32_spi_highspeed_enable(void);
+void neorv32_spi_highspeed_disable(void);
 void neorv32_spi_cs_en(uint8_t cs);
 void neorv32_spi_cs_dis(uint8_t cs);
 uint32_t neorv32_spi_trans(uint32_t tx_data);

--- a/sw/lib/include/neorv32_xip.h
+++ b/sw/lib/include/neorv32_xip.h
@@ -48,6 +48,8 @@
 int neorv32_xip_available(void);
 int neorv32_xip_init(uint8_t prsc, uint8_t cpol, uint8_t cpha, uint8_t rd_cmd);
 int neorv32_xip_start(uint8_t abytes, uint32_t page_base);
+void neorv32_xip_highspeed_enable(void);
+void neorv32_xip_highspeed_disable(void);
 int neorv32_xip_spi_trans(uint8_t nbytes, uint64_t *rtx_data);
 
 #endif // neorv32_xip_h

--- a/sw/lib/source/neorv32_spi.c
+++ b/sw/lib/source/neorv32_spi.c
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -107,6 +107,28 @@ void neorv32_spi_disable(void) {
 void neorv32_spi_enable(void) {
 
   NEORV32_SPI.CTRL |= ((uint32_t)(1 << SPI_CTRL_EN));
+}
+
+
+/**********************************************************************//**
+ * Enable high-speed SPI mode (running at half of the processor clock).
+ *
+ * @note High-speed SPI mode ignores the programmed clock prescaler configuration.
+ **************************************************************************/
+void neorv32_spi_highspeed_enable(void) {
+
+  NEORV32_SPI.CTRL |= 1 << SPI_CTRL_HIGHSPEED;
+}
+
+
+/**********************************************************************//**
+ * Disable high-speed SPI mode.
+ *
+ * @note High-speed SPI mode ignores the programmed clock prescaler configuration.
+ **************************************************************************/
+void neorv32_spi_highspeed_disable(void) {
+
+  NEORV32_SPI.CTRL &= ~(1 << SPI_CTRL_HIGHSPEED);
 }
 
 

--- a/sw/lib/source/neorv32_xip.c
+++ b/sw/lib/source/neorv32_xip.c
@@ -152,6 +152,28 @@ int neorv32_xip_start(uint8_t abytes, uint32_t page_base) {
 
 
 /**********************************************************************//**
+ * Enable high-speed SPI mode (running at half of the processor clock).
+ *
+ * @note High-speed SPI mode ignores the programmed clock prescaler configuration.
+ **************************************************************************/
+void neorv32_xip_highspeed_enable(void) {
+
+  NEORV32_XIP.CTRL |= 1 << XIP_CTRL_HIGHSPEED;
+}
+
+
+/**********************************************************************//**
+ * Disable high-speed SPI mode.
+ *
+ * @note High-speed SPI mode ignores the programmed clock prescaler configuration.
+ **************************************************************************/
+void neorv32_xip_highspeed_disable(void) {
+
+  NEORV32_XIP.CTRL &= ~(1 << XIP_CTRL_HIGHSPEED);
+}
+
+
+/**********************************************************************//**
  * Direct SPI access to the XIP flash.
  *
  * @warning This function can only be used BEFORE the XIP-mode is activated!

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -414,6 +414,11 @@
               <description>SPI chip-select enable</description>
             </field>
             <field>
+              <name>XIP_CTRL_HIGHSPEED</name>
+              <bitRange>[26:26]</bitRange>
+              <description>SPI high-speed mode enable (ignoring XIP_CTRL_PRSC)</description>
+            </field>
+            <field>
               <name>XIP_CTRL_PHY_BUSY</name>
               <bitRange>[30:30]</bitRange>
               <access>read-only</access>
@@ -831,6 +836,11 @@
               <name>SPI_CTRL_CPOL</name>
               <bitRange>[15:15]</bitRange>
               <description>Clock polarity</description>
+            </field>
+            <field>
+              <name>SPI_CTRL_HIGHSPEED</name>
+              <bitRange>[16:16]</bitRange>
+              <description>SPI high-speed mode enable (ignoring SPI_CTRL_PRSC)</description>
             </field>
             <field>
               <name>SPI_CTRL_BUSY</name>


### PR DESCRIPTION
This PR adds a "high-speed" SPI mode to the SPI and the XIP module. When enabled, the default three-bit clock prescaler select is ignored and the SPI clock operates at maximum speed, which is half of the processor clock (`processor_clk / 2`). Note: using only the clock prescaler select the maximum SPI clock frequency is `processor_clk / 4`.

To enable the high-speed SPI mode a new flag has been added to the modules control register (those bits were previously unused):
* `NEORV32_SPI.CTRL` bit 16 "_SPI_CTRL_HIGHSPEED_"
* `NEORV32_XIP.CTRL` bit 26 "_XIP_CTRL_HIGHSPEED_"

High-speed mode enable and disable functions have been added to the according software libraries.

✔️ This PR is fully backwards-compatible.