### PR TITLE
setups/osflow/synthesis: recent versions of yosys need command 'read_verilog'

### DIFF
--- a/setups/osflow/synthesis.mk
+++ b/setups/osflow/synthesis.mk
@@ -7,10 +7,16 @@ neorv32-obj08.cf: ${DEVICE_LIB}-obj08.cf ${NEORV32_SRC}
 work-obj08.cf: neorv32-obj08.cf ${DESIGN_SRC} ${BOARD_SRC}
 	ghdl -a $(GHDL_FLAGS) --work=work ${DESIGN_SRC} ${BOARD_SRC}
 
+ifeq ($(strip $(NEORV32_VERILOG_ALL)),)
+READ_VERILOG =
+else
+READ_VERILOG = read_verilog ${NEORV32_VERILOG_ALL};
+endif
+
 ${IMPL}.json: work-obj08.cf $(NEORV32_VERILOG_ALL)
 	$(YOSYS) $(YOSYSFLAGS) \
 	  -p \
 	  "$(GHDLSYNTH) $(GHDL_FLAGS) --no-formal $(TOP); \
-	  synth_${YOSYSSYNTH} \
+	  $(READ_VERILOG) synth_${YOSYSSYNTH} \
 	  -top $(TOP) $(YOSYSPIPE) \
-	  -json $@" $(NEORV32_VERILOG_ALL) 2>&1 | tee yosys-report.txt
+	  -json $@" 2>&1 | tee yosys-report.txt


### PR DESCRIPTION
Close #245

Refs:

- im-tomu/fomu-workshop#600
- YosysHQ/yosys#3137
- YosysHQ/yosys#3109