### PR TITLE
[GPIO] raise bus exception if writing to INPUT registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 14.01.2022 | 1.6.5.9 | **GPIO** module: write accesses to the GPIO module's "input" registers will now raise a bus exception; [PR #255](https://github.com/stnolting/neorv32/pull/255) |
 | 11.01.2022 | 1.6.5.8 | minor rtl code clean-ups and edits in `rtl/core`; any write access to the SYSINFO module will now show up as a BUSKEEPER's "DEVICE_ERR" |
 | 08.01.2022 | 1.6.5.7 | :bug: fixed bug in BUSKEEPER's error type logic (introduced in version `1.6.5.4`); removed "unexpected ERR/ACK" error codes; [PR #253](https://github.com/stnolting/neorv32/pull/253) |
 | 07.01.2022 | 1.6.5.6 | :sparkles: **XIP & SPI: added high-speed SPI mode** (SPI clocking at half of the processor clock), see [PR #251](https://github.com/stnolting/neorv32/pull/251) |

--- a/docs/datasheet/soc_gpio.adoc
+++ b/docs/datasheet/soc_gpio.adoc
@@ -19,20 +19,25 @@ output port. These ports can be used chip-externally (for example to drive statu
 or chip-internally to provide control signals for other IP modules. The component is disabled for
 implementation when the _IO_GPIO_EN_ generic is set _false_. In this case the GPIO output port `gpio_o` is tied to all-zero.
 
-.Access atomicity
+.Access Atomicity
 [NOTE]
 The GPIO modules uses two memory-mapped registers (each 32-bit) each for accessing the input and
 output signals. Since the CPU can only process 32-bit "at once" updating the entire output cannot
 be performed within a single clock cycle.
+
+.INPUT is read-only
+[NOTE]
+Write accesses to the `NEORV32_GPIO.INPUT_LO` and `NEORV32_GPIO.INPUT_HI` registers will raise a store bus
+error exception. The BUSKEEPER will indicate a "DEVICE_ERR" in this case.
 
 
 .GPIO unit register map (`struct NEORV32_GPIO`)
 [cols="<2,<2,^1,^1,<6"]
 [options="header",grid="rows"]
 |=======================
-| Address      | Name [C]         | Bit(s) | R/W | Function
-| `0xffffffc0` | `NEORV32_GPIO.INPUT_LO`  | 31:0   | r/- | parallel input port pins 31:0 (write accesses are ignored)
-| `0xffffffc4` | `NEORV32_GPIO.INPUT_HI`  | 31:0   | r/- | parallel input port pins 63:32 (write accesses are ignored)
+| Address      | Name [C]                 | Bit(s) | R/W | Function
+| `0xffffffc0` | `NEORV32_GPIO.INPUT_LO`  | 31:0   | r/- | parallel input port pins 31:0
+| `0xffffffc4` | `NEORV32_GPIO.INPUT_HI`  | 31:0   | r/- | parallel input port pins 63:32
 | `0xffffffc8` | `NEORV32_GPIO.OUTPUT_LO` | 31:0   | r/w | parallel output port pins 31:0
 | `0xffffffcc` | `NEORV32_GPIO.OUTPUT_HI` | 31:0   | r/w | parallel output port pins 63:32
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060508"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060509"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -1638,6 +1638,7 @@ package neorv32_package is
       data_i : in  std_ulogic_vector(31 downto 0); -- data in
       data_o : out std_ulogic_vector(31 downto 0); -- data out
       ack_o  : out std_ulogic; -- transfer acknowledge
+      err_o  : out std_ulogic; -- transfer error
       -- parallel io --
       gpio_o : out std_ulogic_vector(63 downto 0);
       gpio_i : in  std_ulogic_vector(63 downto 0)

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -1000,11 +1000,11 @@ begin
       data_i => p_bus.wdata,               -- data in
       data_o => resp_bus(RESP_GPIO).rdata, -- data out
       ack_o  => resp_bus(RESP_GPIO).ack,   -- transfer acknowledge
+      err_o  => resp_bus(RESP_GPIO).err,   -- transfer error
       -- parallel io --
       gpio_o => gpio_o,
       gpio_i => gpio_i
     );
-    resp_bus(RESP_GPIO).err <= '0'; -- no access error possible
   end generate;
 
   neorv32_gpio_inst_false:

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -1165,8 +1165,8 @@ enum NEORV32_WDT_CTRL_enum {
 /**@{*/
 /** GPIO module prototype */
 typedef struct __attribute__((packed,aligned(4))) {
-	const uint32_t INPUT_LO;  /**< offset 0:  parallel input port lower 32-bit */
-	const uint32_t INPUT_HI;  /**< offset 4:  parallel input port upper 32-bit */
+	const uint32_t INPUT_LO;  /**< offset 0:  parallel input port lower 32-bit, read-only */
+	const uint32_t INPUT_HI;  /**< offset 4:  parallel input port upper 32-bit, read-only */
 	uint32_t       OUTPUT_LO; /**< offset 8:  parallel output port lower 32-bit */
 	uint32_t       OUTPUT_HI; /**< offset 12: parallel output port upper 32-bit */
 } neorv32_gpio_t;
@@ -1234,7 +1234,7 @@ enum NEORV32_NEOLED_CTRL_enum {
  * @name IO Device: System Configuration Information Memory (SYSINFO)
  **************************************************************************/
 /**@{*/
-/** SYSINFO module prototype */
+/** SYSINFO module prototype - whole module is read-only */
 typedef struct __attribute__((packed,aligned(4))) {
 	const uint32_t CLK;         /**< offset 0:  clock speed in Hz */
 	const uint32_t CPU;         /**< offset 4:  CPU core features (#NEORV32_SYSINFO_CPU_enum) */


### PR DESCRIPTION
This PR modifies the GPIO module to raise a _store bus access error exception_ if software tries to write to the read-only INPUT registers (`NEORV32_GPIO.INPUT_LO` and `NEORV32_GPIO.INPUT_HI`). The BUSKEEPER will indidcate a device error ("DEVICE_ERR") in this case.