### PR TITLE
[rtl/core] rework CPU issue engine (area optimization)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 21.01.2022 | 1.6.6.3 | reworked **CPU's instruction issue engine** (area optimization: ~100 LUTs less on an Intel Cyclone IV), [PR #256](https://github.com/stnolting/neorv32/pull/256); minor CPU control unit code clean-ups and logic optimizations |
 | 18.01.2022 | 1.6.6.2 | :warning: moved `setups` folder to new [neorv32-setups](https://github.com/stnolting/neorv32-setups) repository, [PR #254](https://github.com/stnolting/neorv32/pull/254) |
 | 18.01.2022 | 1.6.6.1 | minor **MTIME** VHDL code clean-up; minor logic optimization of **CPU's bus unit** |
 | 17.01.2022 |[**:rocket:1.6.6**](https://github.com/stnolting/neorv32/releases/tag/v1.6.6) | **New release** |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060602"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060603"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------


### PR DESCRIPTION
This PR provides a rework of the CPU's issue engine to reduce it's resource requirements.

The issue engine is located right between the pipeline front end (instruction fetch and instruction prefetch buffer) and the actual execution unit. The issue engine is responsible for decoding compressed 16-bit instruction (RISC-V `C` extension) and for handling unaligned 32-bit instructions. The changes from this PR highly reduce the size of this engine (~100 LUTs less on an Intel Cyclone IV FPGA). Note: the issue engine is only relevant if the `C` ISA extension is implemented (enabled via the `CPU_EXTENSION_RISCV_C` generic).

Furthermore, this PR includes some minor code clean-up of the CPU's control engine.

✔️ Changes in this PR are fully backwards-compatible.