### PR TITLE
[DOC] User Guide - 1.3. Installation

### DIFF
--- a/docs/userguide/sw_toolchain_setup.adoc
+++ b/docs/userguide/sw_toolchain_setup.adoc
@@ -71,7 +71,7 @@ already done so): make sure to add the _binaries_ folder (`bin`) of your toolcha
 
 [source,bash]
 ----
-$ export PATH:$PATH:/opt/riscv/bin
+$ export PATH=$PATH:/opt/riscv/bin
 ----
 
 You should add this command to your `.bashrc` (if you are using bash) to automatically add the RISC-V


### PR DESCRIPTION
fix(doc): Closes #257 and changes `export PATH:$PATH:/opt/riscv/bin` to
`export PATH=$PATH:/opt/riscv/bin`.