### PR TITLE
[B ISA extension] add single-bit instructions (Zbs) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 26.01.2022 | 1.6.6.7 | :sparkles: added HW support for RISC-V bit-manipulation (`B`) **single-bit instructions `Zbs`** sub-extension; added test cases and intrinsics; see [PR #259](https://github.com/stnolting/neorv32/pull/259) |
 | 26.01.2022 | 1.6.6.6 | minor logic optimizations in **CPU control unit** |
 | 25.01.2022 | 1.6.6.5 | :lock: **on-chip debugger:** the memory-mapped registers of the debug module (DM) are only accessible/visible when the CPU is actually in debug mode; any access outside of debug mode will now raise a bus exception |
 | 22.01.2022 | 1.6.6.4 | minor logic optimizations in **CPU control unit**, minor improvement of critical path |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -271,8 +271,8 @@ However, these instructions are sufficient to emulate all further atomic memory 
 
 .Bit-Manipulation ISA Extension
 [IMPORTANT]
-The NEORV32 `B` extension only implements the _basic bit-manipulation instructions_ (`Zbb`) subset
-and the _address generation instructions_ (`Zba`) subset yet.
+The NEORV32 `B` extension only implements the _basic bit-manipulation instructions_ (`Zbb`) subset,
+the _address generation instructions_ (`Zba`) subset and the _single-bit instructions_ (`Zbs`) subset yet.
 
 
 
@@ -424,8 +424,8 @@ The `B` ISA extension adds instructions for bit-manipulation operations. This ex
 The official RISC-V specifications can be found here: https://github.com/riscv/riscv-bitmanip
 
 [IMPORTANT]
-The NEORV32 `B` extension only implements the _basic bit-manipulation instructions_ (`Zbb`) subset
-and the _address generation instructions_ (`Zba`) subset yet.
+The NEORV32 `B` extension only implements the _basic bit-manipulation instructions_ (`Zbb`) subset,
+the _address generation instructions_ (`Zba`) subset and the _single-bit instructions_ (`Zbs`) subset yet.
 
 The `Zbb` sub-extension adds the following instructions:
 
@@ -440,6 +440,13 @@ The `Zba` sub-extension adds the following instructions:
 
 * `sh1add` `sh2add` `sh3add`
 
+The `Zbs` sub-extension adds the following instructions:
+
+* `bclr` `bclri`
+* `bext` `bexti`
+* `bext` `binvi`
+* `bset` `bseti`
+
 [TIP]
 By default, the bit-manipulation unit uses an _iterative_ approach to compute shift-related operations
 like `clz` and `rol`. To increase performance (at the cost of additional hardware resources) the 
@@ -447,10 +454,10 @@ like `clz` and `rol`. To increase performance (at the cost of additional hardwar
 shift-related `B` instructions.
 
 [WARNING]
-The `B` extension is frozen but not officially ratified yet. There is no
-software support for this extension in the upstream GCC RISC-V port yet. However, an
+The `B` extension is frozen and officially ratified. However, there is no
+software support for this extension in the upstream GCC RISC-V port yet. An
 intrinsic library is provided to utilize the provided `B` extension features from C-language
-code (see `sw/example/bitmanip_test`).
+code (see `sw/example/bitmanip_test`) to circumvent this.
 
 
 ==== **`C`** - Compressed Instructions
@@ -795,7 +802,7 @@ configurations are presented in <<_cpu_performance>>.
 | Bit-manipulation - shifts | `B(Zbb)` | `clz` `ctz` | 3 + 0..32
 | Bit-manipulation - shifts | `B(Zbb)` | `cpop` | 3 + 32
 | Bit-manipulation - shifts | `B(Zbb)` | `rol` `ror` `rori` | 3 + SA
-| Bit-manipulation - single-bit | `B(Zbs)` | `sbset[i]` `sbclr[i]` `sbinv[i]` `sbext[i]` | 3
+| Bit-manipulation - single-bit  | `B(Zbs)` | `sbset[i]` `sbclr[i]` `sbinv[i]` `sbext[i]` | 3
 | Bit-manipulation - shifted-add | `B(Zba)` | `sh1add` `sh2add` `sh3add` | 3
 |=======================
 

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1183,7 +1183,7 @@ begin
       when ALU_WAIT => -- wait for multi-cycle ALU operation (co-processor) to finish
       -- ------------------------------------------------------------
         ctrl_nxt(ctrl_alu_func1_c downto ctrl_alu_func0_c) <= alu_func_copro_c;
-        if (alu_idone_i = '1') or (trap_ctrl.exc_buf(exception_iillegal_c) = '1') then -- completed or exception
+        if (alu_idone_i = '1') then -- wait for completion (even if there is an illegal instruction exception to prevent faulty CP op. in background)
           ctrl_nxt(ctrl_rf_wb_en_c) <= '1'; -- valid RF write-back
           execute_engine.state_nxt  <= DISPATCH;
         end if;

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -188,17 +188,17 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
 
   -- instruction decoding helper logic --
   type decode_aux_t is record
-    is_atomic_lr    : std_ulogic;
-    is_atomic_sc    : std_ulogic;
-    is_float_op     : std_ulogic;
-    sys_env_cmd     : std_ulogic_vector(11 downto 0);
-    is_m_mul        : std_ulogic;
-    is_m_div        : std_ulogic;
-    is_bitmanip_imm : std_ulogic;
-    is_bitmanip_reg : std_ulogic;
-    rs1_zero        : std_ulogic;
-    rs2_zero        : std_ulogic;
-    rd_zero         : std_ulogic;
+    is_a_lr     : std_ulogic;
+    is_a_sc     : std_ulogic;
+    is_f_op     : std_ulogic;
+    sys_env_cmd : std_ulogic_vector(11 downto 0);
+    is_m_mul    : std_ulogic;
+    is_m_div    : std_ulogic;
+    is_b_imm    : std_ulogic;
+    is_b_reg    : std_ulogic;
+    rs1_zero    : std_ulogic;
+    rs2_zero    : std_ulogic;
+    rd_zero     : std_ulogic;
   end record;
   signal decode_aux : decode_aux_t;
 
@@ -810,21 +810,21 @@ begin
     variable sys_env_cmd_mask_v : std_ulogic_vector(11 downto 0);
   begin
     -- defaults --
-    decode_aux.is_atomic_lr    <= '0';
-    decode_aux.is_atomic_sc    <= '0';
-    decode_aux.is_float_op     <= '0';
-    decode_aux.is_m_mul        <= '0';
-    decode_aux.is_m_div        <= '0';
-    decode_aux.is_bitmanip_imm <= '0';
-    decode_aux.is_bitmanip_reg <= '0';
-    decode_aux.rs1_zero        <= '0';
-    decode_aux.rs2_zero        <= '0';
-    decode_aux.rd_zero         <= '0';
+    decode_aux.is_a_lr  <= '0';
+    decode_aux.is_a_sc  <= '0';
+    decode_aux.is_f_op  <= '0';
+    decode_aux.is_m_mul <= '0';
+    decode_aux.is_m_div <= '0';
+    decode_aux.is_b_imm <= '0';
+    decode_aux.is_b_reg <= '0';
+    decode_aux.rs1_zero <= '0';
+    decode_aux.rs2_zero <= '0';
+    decode_aux.rd_zero  <= '0';
 
     -- is atomic load-reservate/store-conditional? --
     if (CPU_EXTENSION_RISCV_A = true) and (execute_engine.i_reg(instr_opcode_lsb_c+2) = '1') then -- valid atomic sub-opcode
-      decode_aux.is_atomic_lr <= not execute_engine.i_reg(instr_funct5_lsb_c);
-      decode_aux.is_atomic_sc <=     execute_engine.i_reg(instr_funct5_lsb_c);
+      decode_aux.is_a_lr <= not execute_engine.i_reg(instr_funct5_lsb_c);
+      decode_aux.is_a_sc <=     execute_engine.i_reg(instr_funct5_lsb_c);
     end if;
 
     -- is BITMANIP instruction? --
@@ -841,13 +841,21 @@ begin
        ) or
        ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0110000") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "101")) or -- RORI
        ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0010100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "101") and (execute_engine.i_reg(instr_funct12_lsb_c+4 downto instr_funct12_lsb_c) = "00111")) or -- ORCB
-       ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0110100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "101") and (execute_engine.i_reg(instr_funct12_lsb_c+4 downto instr_funct12_lsb_c) = "11000")) then -- REV8
-      decode_aux.is_bitmanip_imm <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_B); -- BITMANIP implemented at all?
+       ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0110100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "101")) or -- REV8
+       ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0100100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "001")) or -- BCLRI
+       ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0100100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "101")) or -- BEXTI
+       ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0110100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "001")) or -- BINVI
+       ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0010100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "001")) then -- BSETI
+      decode_aux.is_b_imm <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_B); -- BITMANIP implemented at all?
     end if;
     -- register operation --
     if ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0110000") and (execute_engine.i_reg(instr_funct3_msb_c-1 downto instr_funct3_lsb_c) = "01")) or -- ROR / ROL
        ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0000101") and (execute_engine.i_reg(instr_funct3_msb_c) = '1')) or -- MIN[U] / MAX[U]
        ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0000100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "100")) or -- ZEXTH
+       ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0100100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "001")) or -- BCLR
+       ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0100100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "101")) or -- BEXT
+       ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0110100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "001")) or -- BINV
+       ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0010100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "001")) or -- BSET
        ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0100000") and
         (
          (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "111") or -- ANDN
@@ -862,7 +870,7 @@ begin
          (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "110")    -- SH3ADD
         )
        ) then
-      decode_aux.is_bitmanip_reg <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_B); -- BITMANIP implemented at all?
+      decode_aux.is_b_reg <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_B); -- BITMANIP implemented at all?
     end if;
 
     -- floating-point operations (Zfinx) --
@@ -874,7 +882,7 @@ begin
        ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c+2) = "10100") and (execute_engine.i_reg(instr_funct3_msb_c) = '0')) or -- FEQ.S / FLT.S / FLE.S
        ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c+2) = "11010") and (execute_engine.i_reg(instr_funct12_lsb_c+4 downto instr_funct12_lsb_c+1) = "0000")) or -- FCVT.S.W*
        ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c+2) = "11000") and (execute_engine.i_reg(instr_funct12_lsb_c+4 downto instr_funct12_lsb_c+1) = "0000")) then -- FCVT.W*.S
-      decode_aux.is_float_op <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zfinx); -- FPU implemented at all?
+      decode_aux.is_f_op <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zfinx); -- FPU implemented at all?
     end if;
 
     -- system/environment instructions --
@@ -943,7 +951,7 @@ begin
       ctrl_nxt(ctrl_alu_unsigned_c) <= execute_engine.i_reg(instr_funct3_lsb_c+1); -- unsigned branches? (BLTU, BGEU)
     end if;
     -- atomic store-conditional instruction (evaluate lock status) --
-    ctrl_nxt(ctrl_bus_ch_lock_c) <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_A) and decode_aux.is_atomic_sc;
+    ctrl_nxt(ctrl_bus_ch_lock_c) <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_A) and decode_aux.is_a_sc;
 
 
     -- state machine --
@@ -1041,8 +1049,8 @@ begin
               execute_engine.state_nxt                           <= ALU_WAIT;
             -- co-processor BIT-MANIPULATION operation (multi-cycle) --
             elsif (CPU_EXTENSION_RISCV_B = true) and
-                  (((execute_engine.i_reg(instr_opcode_lsb_c+5) = opcode_alu_c(5))  and (decode_aux.is_bitmanip_reg = '1')) or -- register operation
-                   ((execute_engine.i_reg(instr_opcode_lsb_c+5) = opcode_alui_c(5)) and (decode_aux.is_bitmanip_imm = '1'))) then -- immediate operation
+                  (((execute_engine.i_reg(instr_opcode_lsb_c+5) = opcode_alu_c(5))  and (decode_aux.is_b_reg = '1')) or -- register operation
+                   ((execute_engine.i_reg(instr_opcode_lsb_c+5) = opcode_alui_c(5)) and (decode_aux.is_b_imm = '1'))) then -- immediate operation
               ctrl_nxt(ctrl_cp_id_msb_c downto ctrl_cp_id_lsb_c) <= cp_sel_bitmanip_c; -- use BITMANIP CP
               ctrl_nxt(ctrl_alu_func1_c downto ctrl_alu_func0_c) <= alu_func_copro_c;
               execute_engine.state_nxt                           <= ALU_WAIT;
@@ -1201,11 +1209,11 @@ begin
 
       when LOADSTORE_0 => -- trigger memory request
       -- ------------------------------------------------------------
-        ctrl_nxt(ctrl_bus_lock_c) <= decode_aux.is_atomic_lr; -- atomic.LR: set lock
-        if (execute_engine.i_reg(instr_opcode_msb_c-1) = '0') or (decode_aux.is_atomic_lr = '1') then -- normal load or atomic load-reservate
+        ctrl_nxt(ctrl_bus_lock_c) <= decode_aux.is_a_lr; -- atomic.LR: set lock
+        if (execute_engine.i_reg(instr_opcode_msb_c-1) = '0') or (decode_aux.is_a_lr = '1') then -- normal load or atomic load-reservate
           ctrl_nxt(ctrl_bus_rd_c) <= '1'; -- read request
         else -- store
-          if (decode_aux.is_atomic_sc = '0') or (CPU_EXTENSION_RISCV_A = false) then -- (normal) write request
+          if (decode_aux.is_a_sc = '0') or (CPU_EXTENSION_RISCV_A = false) then -- (normal) write request
             ctrl_nxt(ctrl_bus_wr_c) <= '1';
           else -- evaluate lock state
             ctrl_nxt(ctrl_bus_wr_c) <= excl_state_i; -- write request if lock is still ok
@@ -1230,12 +1238,12 @@ begin
         elsif (bus_d_wait_i = '0') then -- wait for bus to finish transaction
           -- data write-back --
           if (execute_engine.i_reg(instr_opcode_msb_c-1) = '0') or -- normal load
-             (decode_aux.is_atomic_lr = '1') or -- atomic load-reservate
-             (decode_aux.is_atomic_sc = '1') then -- atomic store-conditional
+             (decode_aux.is_a_lr = '1') or -- atomic load-reservate
+             (decode_aux.is_a_sc = '1') then -- atomic store-conditional
             ctrl_nxt(ctrl_rf_wb_en_c) <= '1';
           end if;
           -- remove atomic lock if this is NOT the LR.W instruction used to SET the lock --
-          if (decode_aux.is_atomic_lr = '0') then -- execute and evaluate atomic store-conditional
+          if (decode_aux.is_a_lr = '0') then -- execute and evaluate atomic store-conditional
             ctrl_nxt(ctrl_bus_de_lock_c) <= '1';
           end if;
           execute_engine.state_nxt <= DISPATCH;
@@ -1395,7 +1403,7 @@ begin
             illegal_instruction <= '0';
           elsif (CPU_EXTENSION_RISCV_M = true) and (decode_aux.is_m_div = '1') then -- valid DIV instruction?
             illegal_instruction <= '0';
-          elsif (CPU_EXTENSION_RISCV_B = true) and (decode_aux.is_bitmanip_reg = '1') then -- valid BITMANIP instruction?
+          elsif (CPU_EXTENSION_RISCV_B = true) and (decode_aux.is_b_reg = '1') then -- valid BITMANIP instruction?
             illegal_instruction <= '0';
           else
             illegal_instruction <= '1';
@@ -1416,7 +1424,7 @@ begin
              ((execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_sr_c) and -- shift right
               ((execute_engine.i_reg(instr_funct7_msb_c-2 downto instr_funct7_lsb_c) = "00000") and (execute_engine.i_reg(instr_funct7_msb_c) = '0'))) then -- valid base ALUI instruction?
             illegal_instruction <= '0';
-          elsif (CPU_EXTENSION_RISCV_B = true) and (decode_aux.is_bitmanip_imm = '1') then -- valid BITMANIP immediate instruction?
+          elsif (CPU_EXTENSION_RISCV_B = true) and (decode_aux.is_b_imm = '1') then -- valid BITMANIP immediate instruction?
             illegal_instruction <= '0';
           else
             illegal_instruction <= '1';
@@ -1537,7 +1545,7 @@ begin
         -- ------------------------------------------------------------
           if (CPU_EXTENSION_RISCV_Zfinx = true) and -- F extension implemented
              (execute_engine.i_reg(instr_funct7_lsb_c+1 downto instr_funct7_lsb_c) = float_single_c) and -- single-precision operations only
-             (decode_aux.is_float_op = '1') then -- is correct/supported floating-point instruction
+             (decode_aux.is_f_op = '1') then -- is correct/supported floating-point instruction
             illegal_instruction <= '0';
           else
             illegal_instruction <= '1';

--- a/rtl/core/neorv32_cpu_cp_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_cp_bitmanip.vhd
@@ -4,15 +4,16 @@
 -- # The bit manipulation unit is implemented as co-processor that has a processing latency of 1   #
 -- # cycle for logic/arithmetic operations and 3+shamt (=shift amount) cycles for shift(-related)  #
 -- # operations. Use the FAST_SHIFT_EN option to reduce shift-related instruction's latency to a   #
--- # fixed value of 3 cycles latency (using barrel shifters).                                      #
+-- # fixed value of 3 cycles (using barrel shifters).                                              #
 -- #                                                                                               #
--- # Supported sub-extensions (Zb*):                                                               #
--- # - Zba: Address generation instructions                                                        #
+-- # Supported B sub-extensions (Zb*):                                                             #
+-- # - Zba: Address-generation instructions                                                        #
 -- # - Zbb: Basic bit-manipulation instructions                                                    #
+-- # - Zbs: Single-bit instructions                                                                #
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -74,37 +75,44 @@ architecture neorv32_cpu_cp_bitmanip_rtl of neorv32_cpu_cp_bitmanip is
   -- Sub-extension configuration --
   constant zbb_en_c : boolean := true;
   constant zba_en_c : boolean := true;
+  constant zbc_en_c : boolean := false; -- FIXME/TODO
+  constant zbs_en_c : boolean := true;
   -- --------------------------- --
 
-  -- commands: Zbb - logic with negate --
+  -- Zbb - logic with negate --
   constant op_andn_c    : natural := 0;
   constant op_orn_c     : natural := 1;
   constant op_xnor_c    : natural := 2;
-  -- commands: Zbb - count leading/trailing zero bits --
+  -- Zbb - count leading/trailing zero bits --
   constant op_clz_c     : natural := 3;
   constant op_ctz_c     : natural := 4;
-  -- commands: Zbb - count population --
+  -- Zbb - count population --
   constant op_cpop_c    : natural := 5;
-  -- commands: Zbb - integer minimum/maximum --
+  -- Zbb - integer minimum/maximum --
   constant op_max_c     : natural := 6; -- signed/unsigned
   constant op_min_c     : natural := 7; -- signed/unsigned
-  -- commands: Zbb - sign- and zero-extension --
+  -- Zbb - sign- and zero-extension --
   constant op_sextb_c   : natural := 8;
   constant op_sexth_c   : natural := 9;
   constant op_zexth_c   : natural := 10;
-  -- commands: Zbb - bitwise rotation --
+  -- Zbb - bitwise rotation --
   constant op_rol_c     : natural := 11;
   constant op_ror_c     : natural := 12; -- rori
-  -- commands: Zbb - or-combine --
+  -- Zbb - or-combine --
   constant op_orcb_c    : natural := 13;
-  -- commands: Zbb - byte-reverse --
+  -- Zbb - byte-reverse --
   constant op_rev8_c    : natural := 14;
-  -- commands: Zba - shifted add --
+  -- Zba - shifted-add --
   constant op_sh1add_c  : natural := 15;
   constant op_sh2add_c  : natural := 16;
   constant op_sh3add_c  : natural := 17;
+  -- Zbs - single-bit operations --
+  constant op_bclr_c    : natural := 18;
+  constant op_bext_c    : natural := 19;
+  constant op_binv_c    : natural := 20;
+  constant op_bset_c    : natural := 21;
   --
-  constant op_width_c   : natural := 18;
+  constant op_width_c   : natural := 22;
 
   -- controller --
   type ctrl_state_t is (S_IDLE, S_START_SHIFT, S_BUSY_SHIFT);
@@ -140,33 +148,38 @@ architecture neorv32_cpu_cp_bitmanip_rtl of neorv32_cpu_cp_bitmanip is
   -- shifted-add unit --
   signal adder_core : std_ulogic_vector(data_width_c-1 downto 0);
 
+  -- one-hot shifter --
+  signal one_hot_core : std_ulogic_vector(data_width_c-1 downto 0);
+
 begin
 
   -- Sub-Extension Configuration ------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   assert false report
-  "Implementing bit-manipulation (B) sub-extensions: " &
-  cond_sel_string_f(zbb_en_c, "Zbb", "") &
+  "NEORV32 CPU: Implementing bit-manipulation (B) sub-extensions: " &
   cond_sel_string_f(zba_en_c, "Zba", "") &
+  cond_sel_string_f(zbb_en_c, "Zbb", "") &
+  cond_sel_string_f(zbc_en_c, "Zbc", "") &
+  cond_sel_string_f(zbs_en_c, "Zbs", "") &
   ""
   severity note;
 
 
   -- Instruction Decoding (One-Hot) ---------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  -- a minimal decoding logic is used here -> just to distinguish between B.Zbb instructions
-  -- a more specific decoding and instruction check is done by the CPU control unit
+  -- a minimal decoding logic is used here just to distinguish between the different B instruction
+  -- a more precise decoding and valid-instruction check is done by the CPU control unit
 
   -- Zbb - Basic bit-manipulation instructions --
-  cmd(op_andn_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "10") and (ctrl_i(ctrl_ir_funct3_1_c downto ctrl_ir_funct3_0_c) = "11") else '0';
-  cmd(op_orn_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "10") and (ctrl_i(ctrl_ir_funct3_1_c downto ctrl_ir_funct3_0_c) = "10") else '0';
-  cmd(op_xnor_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "10") and (ctrl_i(ctrl_ir_funct3_1_c downto ctrl_ir_funct3_0_c) = "00") else '0';
+  cmd(op_andn_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "10") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_1_c downto ctrl_ir_funct3_0_c) = "11") else '0';
+  cmd(op_orn_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "10") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_1_c downto ctrl_ir_funct3_0_c) = "10") else '0';
+  cmd(op_xnor_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "10") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_1_c downto ctrl_ir_funct3_0_c) = "00") else '0';
   --
   cmd(op_max_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "00") and (ctrl_i(ctrl_ir_funct12_5_c) = '1') and (ctrl_i(ctrl_ir_funct3_1_c) = '1') else '0';
   cmd(op_min_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "00") and (ctrl_i(ctrl_ir_funct12_5_c) = '1') and (ctrl_i(ctrl_ir_funct3_1_c) = '0') else '0';
   cmd(op_zexth_c)  <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "00") and (ctrl_i(ctrl_ir_funct12_5_c) = '0') else '0';
   --
-  cmd(op_orcb_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "01") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') else '0';
+  cmd(op_orcb_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "01") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_0_c) = "101") else '0';
   --
   cmd(op_clz_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "000") else '0';
   cmd(op_ctz_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "001") else '0';
@@ -175,12 +188,18 @@ begin
   cmd(op_sexth_c)  <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "101") else '0';
   cmd(op_rol_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_0_c) = "001") and (ctrl_i(ctrl_ir_opcode7_5_c) = '1') else '0';
   cmd(op_ror_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_0_c) = "101") else '0';
-  cmd(op_rev8_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') else '0';
+  cmd(op_rev8_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_0_c) = "101") else '0';
 
   -- Zba - Address generation instructions --
   cmd(op_sh1add_c) <= '1' when (zba_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "01") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_1_c) = "01") else '0';
   cmd(op_sh2add_c) <= '1' when (zba_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "01") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_1_c) = "10") else '0';
   cmd(op_sh3add_c) <= '1' when (zba_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "01") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_1_c) = "11") else '0';
+
+  -- Zbs - Single-bit instructions --
+  cmd(op_bclr_c)   <= '1' when (zbs_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "10") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') else '0';
+  cmd(op_bext_c)   <= '1' when (zbs_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "10") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c) = '1') else '0';
+  cmd(op_binv_c)   <= '1' when (zbs_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') else '0';
+  cmd(op_bset_c)   <= '1' when (zbs_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "01") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') else '0';
 
 
   -- Co-Processor Controller ----------------------------------------------------------------
@@ -372,6 +391,17 @@ begin
   end process shift_adder;
 
 
+  -- One-Hot Generator Core -----------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  shift_one_hot: process(sha_reg)
+  begin
+    one_hot_core <= (others => '0');
+    if (zbs_en_c = true) then
+      one_hot_core(to_integer(unsigned(sha_reg))) <= '1';
+    end if;
+  end process shift_one_hot;
+
+
   -- Operation Results ----------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   -- logic with negate --
@@ -418,6 +448,13 @@ begin
   res_int(op_sh2add_c) <= (others => '0'); -- unused/redundant
   res_int(op_sh3add_c) <= (others => '0'); -- unused/redundant
 
+  -- single-bit instructions --
+  res_int(op_bclr_c) <= rs1_reg and (not one_hot_core);
+  res_int(op_bext_c)(data_width_c-1 downto 1) <= (others => '0');
+  res_int(op_bext_c)(0) <= or_reduce_f(rs1_reg and one_hot_core);
+  res_int(op_binv_c) <= rs1_reg xor one_hot_core;
+  res_int(op_bset_c) <= rs1_reg or one_hot_core;
+
 
   -- Output Selector ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -440,6 +477,11 @@ begin
   res_out(op_sh1add_c) <= res_int(op_sh1add_c) when ((cmd_buf(op_sh1add_c) or cmd_buf(op_sh2add_c) or cmd_buf(op_sh3add_c))  = '1') else (others => '0');
   res_out(op_sh2add_c) <= (others => '0'); -- unused/redundant
   res_out(op_sh3add_c) <= (others => '0'); -- unused/redundant
+  --
+  res_out(op_bclr_c) <= res_int(op_bclr_c) when (cmd_buf(op_bclr_c) = '1') else (others => '0');
+  res_out(op_bext_c) <= res_int(op_bext_c) when (cmd_buf(op_bext_c) = '1') else (others => '0');
+  res_out(op_binv_c) <= res_int(op_binv_c) when (cmd_buf(op_binv_c) = '1') else (others => '0');
+  res_out(op_bset_c) <= res_int(op_bset_c) when (cmd_buf(op_bset_c) = '1') else (others => '0');
 
 
   -- Output Gate ----------------------------------------------------------------------------
@@ -451,13 +493,14 @@ begin
     elsif rising_edge(clk_i) then
       res_o <= (others => '0');
       if (valid = '1') then
-        res_o <= res_out(op_andn_c)  or res_out(op_orn_c)   or res_out(op_xnor_c) or
-                 res_out(op_clz_c)   or res_out(op_cpop_c)  or -- res_out(op_ctz_c) is unused here
-                 res_out(op_min_c)   or -- res_out(op_max_c) is unused here
-                 res_out(op_sextb_c) or res_out(op_sexth_c) or res_out(op_zexth_c) or
-                 res_out(op_ror_c)   or res_out(op_rol_c)   or
-                 res_out(op_orcb_c)  or res_out(op_rev8_c)  or
-                 res_out(op_sh1add_c); -- res_out(op_sh2add_c) and res_out(op_sh3add_c) are unused here
+        res_o <= res_out(op_andn_c)   or res_out(op_orn_c)   or res_out(op_xnor_c)  or
+                 res_out(op_clz_c)    or res_out(op_cpop_c)  or -- res_out(op_ctz_c) is unused here
+                 res_out(op_min_c)    or -- res_out(op_max_c) is unused here
+                 res_out(op_sextb_c)  or res_out(op_sexth_c) or res_out(op_zexth_c) or
+                 res_out(op_ror_c)    or res_out(op_rol_c)   or
+                 res_out(op_orcb_c)   or res_out(op_rev8_c)  or
+                 res_out(op_sh1add_c) or -- res_out(op_sh2add_c) and res_out(op_sh3add_c) are unused here
+                 res_out(op_bclr_c)   or res_out(op_bext_c)  or res_out(op_binv_c)  or res_out(op_bset_c);
       end if;
     end if;
   end process output_gate;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060606"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060607"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/example/bitmanip_test/main.c
+++ b/sw/example/bitmanip_test/main.c
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -51,6 +51,14 @@
 #define BAUD_RATE      (19200)
 //** Number of test cases for each instruction */
 #define NUM_TEST_CASES (1000000)
+//** Enable Zbb tests */
+#define ENABLE_ZBB     (1)
+//** Enable Zba tests */
+#define ENABLE_ZBA     (1)
+//** Enable Zbs tests */
+#define ENABLE_ZBS     (1)
+//** Enable Zbc tests */
+#define ENABLE_ZBC     (1)
 /**@}*/
 
 
@@ -61,7 +69,7 @@ void print_report(int num_err, int num_tests);
 
 
 /**********************************************************************//**
- * Main function; test all available operations of the NEORV32 'Zbb' extensions
+ * Main function; test all available operations of the NEORV32 'B' extension
  * using bit manipulation intrinsics and software-only reference functions (emulation).
  *
  * @note This program requires the bit-manipulation CPU extension.
@@ -77,7 +85,7 @@ int main() {
   // capture all exceptions and give debug info via UART
   neorv32_rte_setup();
 
-  // init UART at default baud rate, no parity bits, ho hw flow control
+  // init UART at default baud rate, no parity bits, no hw flow control
   neorv32_uart0_setup(BAUD_RATE, PARITY_NONE, FLOW_CONTROL_NONE);
 
 // Disable compilation by default
@@ -91,22 +99,23 @@ int main() {
 #endif
 
   // intro
-  neorv32_uart0_printf("NEORV32 Bit-Manipulation Extension Test (Zba, Zbb)\n\n");
+  neorv32_uart0_printf("<<< NEORV32 Bit-Manipulation Extension ('B') Test >>>\n\n");
 
   // check available hardware extensions and compare with compiler flags
   neorv32_rte_check_isa(0); // silent = 0 -> show message if isa mismatch
 
-  // check if Zbb extension is implemented at all
+  // check if B extension is implemented at all
   if ((neorv32_cpu_csr_read(CSR_MISA) & (1<<CSR_MISA_B)) == 0) {
-    neorv32_uart0_print("Error! <B> extension not synthesized!\n");
+    neorv32_uart0_print("Error! B extension not synthesized!\n");
     return 1;
   }
 
   neorv32_uart0_printf("Starting bit-manipulation extension tests (%i test cases per instruction)...\n\n", num_tests);
 
-  neorv32_uart0_printf("-----------------------------------------\n");
+#if (ENABLE_ZBB != 0)
+  neorv32_uart0_printf("--------------------------------------------\n");
   neorv32_uart0_printf("Zbb - Basic bit-manipulation instructions\n");
-  neorv32_uart0_printf("-----------------------------------------\n");
+  neorv32_uart0_printf("--------------------------------------------\n");
 
   // ANDN
   neorv32_uart0_printf("\nANDN:\n");
@@ -328,13 +337,14 @@ int main() {
     err_cnt += check_result(i, opa, 0, res_sw, res_hw);
   }
   print_report(err_cnt, num_tests);
+#endif
 
 
-
+#if (ENABLE_ZBA != 0)
   neorv32_uart0_printf("\n\n");
-  neorv32_uart0_printf("-----------------------------------------\n");
-  neorv32_uart0_printf("Zba - Address generation instructions\n");
-  neorv32_uart0_printf("-----------------------------------------\n");
+  neorv32_uart0_printf("--------------------------------------------\n");
+  neorv32_uart0_printf("Zba - Address-generation instructions\n");
+  neorv32_uart0_printf("--------------------------------------------\n");
 
   // SH1ADD
   neorv32_uart0_printf("\nSH1ADD:\n");
@@ -370,16 +380,169 @@ int main() {
     err_cnt += check_result(i, opa, opb, res_sw, res_hw);
   }
   print_report(err_cnt, num_tests);
+#endif
 
 
-  neorv32_uart0_printf("\nBit manipulation extension tests done.\n");
+#if (ENABLE_ZBS != 0)
+  neorv32_uart0_printf("\n\n");
+  neorv32_uart0_printf("--------------------------------------------\n");
+  neorv32_uart0_printf("Zbs - Single-bit instructions\n");
+  neorv32_uart0_printf("--------------------------------------------\n");
 
+  // BCLR
+  neorv32_uart0_printf("\nBCLR:\n");
+  err_cnt = 0;
+  for (i=0;i<num_tests; i++) {
+    opa = xorshift32();
+    opb = xorshift32();
+    res_sw = riscv_emulate_bclr(opa, opb);
+    res_hw = riscv_intrinsic_bclr(opa, opb);
+    err_cnt += check_result(i, opa, opb, res_sw, res_hw);
+  }
+  print_report(err_cnt, num_tests);
+
+  // BCLRI
+  neorv32_uart0_printf("\nBCLRI (imm=20):\n"); // FIXME: static immediate
+  err_cnt = 0;
+  for (i=0;i<num_tests; i++) {
+    opa = xorshift32();
+    res_sw = riscv_emulate_bclr(opa, 20);
+    res_hw = riscv_intrinsic_bclri20(opa);
+    err_cnt += check_result(i, opa, opb, res_sw, res_hw);
+  }
+  print_report(err_cnt, num_tests);
+
+
+
+  // BEXT
+  neorv32_uart0_printf("\nBEXT:\n");
+  err_cnt = 0;
+  for (i=0;i<num_tests; i++) {
+    opa = xorshift32();
+    opb = xorshift32();
+    res_sw = riscv_emulate_bext(opa, opb);
+    res_hw = riscv_intrinsic_bext(opa, opb);
+    err_cnt += check_result(i, opa, opb, res_sw, res_hw);
+  }
+  print_report(err_cnt, num_tests);
+
+  // BEXTI
+  neorv32_uart0_printf("\nBEXTI (imm=20):\n"); // FIXME: static immediate
+  err_cnt = 0;
+  for (i=0;i<num_tests; i++) {
+    opa = xorshift32();
+    res_sw = riscv_emulate_bext(opa, 20);
+    res_hw = riscv_intrinsic_bexti20(opa);
+    err_cnt += check_result(i, opa, opb, res_sw, res_hw);
+  }
+  print_report(err_cnt, num_tests);
+
+
+
+  // BINV
+  neorv32_uart0_printf("\nBINV:\n");
+  err_cnt = 0;
+  for (i=0;i<num_tests; i++) {
+    opa = xorshift32();
+    opb = xorshift32();
+    res_sw = riscv_emulate_binv(opa, opb);
+    res_hw = riscv_intrinsic_binv(opa, opb);
+    err_cnt += check_result(i, opa, opb, res_sw, res_hw);
+  }
+  print_report(err_cnt, num_tests);
+
+  // BINVI
+  neorv32_uart0_printf("\nBINVI (imm=20):\n"); // FIXME: static immediate
+  err_cnt = 0;
+  for (i=0;i<num_tests; i++) {
+    opa = xorshift32();
+    res_sw = riscv_emulate_binv(opa, 20);
+    res_hw = riscv_intrinsic_binvi20(opa);
+    err_cnt += check_result(i, opa, opb, res_sw, res_hw);
+  }
+  print_report(err_cnt, num_tests);
+
+
+
+  // BSET
+  neorv32_uart0_printf("\nBSET:\n");
+  err_cnt = 0;
+  for (i=0;i<num_tests; i++) {
+    opa = xorshift32();
+    opb = xorshift32();
+    res_sw = riscv_emulate_bset(opa, opb);
+    res_hw = riscv_intrinsic_bset(opa, opb);
+    err_cnt += check_result(i, opa, opb, res_sw, res_hw);
+  }
+  print_report(err_cnt, num_tests);
+
+  // BSETI
+  neorv32_uart0_printf("\nBSETI (imm=20):\n"); // FIXME: static immediate
+  err_cnt = 0;
+  for (i=0;i<num_tests; i++) {
+    opa = xorshift32();
+    res_sw = riscv_emulate_bset(opa, 20);
+    res_hw = riscv_intrinsic_bseti20(opa);
+    err_cnt += check_result(i, opa, opb, res_sw, res_hw);
+  }
+  print_report(err_cnt, num_tests);
+#endif
+
+
+#if (ENABLE_ZBC != 0)
+  neorv32_uart0_printf("\n\n");
+  neorv32_uart0_printf("--------------------------------------------\n");
+  neorv32_uart0_printf("Zbc - Carry-less multiplication instructions\n");
+  neorv32_uart0_printf("--------------------------------------------\n");
+
+  neorv32_uart0_printf("\nWARNING: The NEORV32 CPU hardware does NOT support the Zbc extension yet!");
+  neorv32_uart0_printf("\n         Hence, illegal instruction exceptions should be triggered here.\n");
+
+  // CLMUL
+  neorv32_uart0_printf("\nCLMUL:\n");
+  err_cnt = 0;
+  for (i=0;i<1; i++) {
+    opa = xorshift32();
+    opb = xorshift32();
+    res_sw = riscv_emulate_clmul(opa, opb);
+    res_hw = riscv_intrinsic_clmul(opa, opb);
+    err_cnt += check_result(i, opa, opb, res_sw, res_hw);
+  }
+  print_report(err_cnt, num_tests);
+
+  // CLMULH
+  neorv32_uart0_printf("\nCLMULH:\n");
+  err_cnt = 0;
+  for (i=0;i<1; i++) {
+    opa = xorshift32();
+    opb = xorshift32();
+    res_sw = riscv_emulate_clmulh(opa, opb);
+    res_hw = riscv_intrinsic_clmulh(opa, opb);
+    err_cnt += check_result(i, opa, opb, res_sw, res_hw);
+  }
+  print_report(err_cnt, num_tests);
+
+  // CLMULR
+  neorv32_uart0_printf("\nCLMULR:\n");
+  err_cnt = 0;
+  for (i=0;i<1; i++) {
+    opa = xorshift32();
+    opb = xorshift32();
+    res_sw = riscv_emulate_clmulr(opa, opb);
+    res_hw = riscv_intrinsic_clmulr(opa, opb);
+    err_cnt += check_result(i, opa, opb, res_sw, res_hw);
+  }
+  print_report(err_cnt, num_tests);
+#endif
+
+
+  neorv32_uart0_printf("\n\nB extension tests completed.\n");
   return 0;
 }
 
 
 /**********************************************************************//**
- * Pseudo-Random Number Generator (to generate test vectors).
+ * Pseudo-Random Number Generator (to generate deterministic test vectors).
  *
  * @return Random data (32-bit).
  **************************************************************************/
@@ -434,4 +597,18 @@ void print_report(int num_err, int num_tests) {
   else {
     neorv32_uart0_printf("%c[1m[FAILED]%c[0m\n", 27, 27);
   }
+}
+
+
+/**********************************************************************//**
+ * "after-main" handler that is executed after the application's
+ * main function returns (called by crt0.S start-up code)
+ **************************************************************************/
+int __neorv32_crt0_after_main(int32_t return_code) {
+
+  if (return_code) {
+    neorv32_uart0_printf("\n<RTE> main function returned with exit code (%i) </RTE>\n", return_code);
+  }
+
+  return 0;
 }

--- a/sw/example/bitmanip_test/neorv32_b_extension_intrinsics.h
+++ b/sw/example/bitmanip_test/neorv32_b_extension_intrinsics.h
@@ -6,7 +6,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -527,6 +527,264 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sh3add(uint32_t 
 }
 
 
+// ================================================================================================
+// Zbs - Single-bit instructions
+// ================================================================================================
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation BCLR (bit-clear) [B.Zbs]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 2 (a0).
+ * @return Operand 1 with bit cleared indexed by operand_2(4:0).
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bclr(uint32_t rs1, uint32_t rs2) {
+
+  register uint32_t result __asm__ ("a0");
+  register uint32_t tmp_a  __asm__ ("a0") = rs1;
+  register uint32_t tmp_b  __asm__ ("a1") = rs2;
+
+  // dummy instruction to prevent GCC "constprop" optimization
+  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
+
+  // bclr a0, a0, a1
+  CUSTOM_INSTR_R2_TYPE(0b0100100, a1, a0, 0b001, a0, 0b0110011);
+
+  return result;
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation BCLRI (bit-clear) by 20 positions. [B.Zbs]
+ * @warning Fixed shift amount (20) for now.
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @return Operand 1 with bit cleared at position 20.
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bclri20(uint32_t rs1) {
+
+  register uint32_t result __asm__ ("a0");
+  register uint32_t tmp_a  __asm__ ("a0") = rs1;
+
+  // dummy instruction to prevent GCC "constprop" optimization
+  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
+
+  // bclri a0, a0, 20
+  CUSTOM_INSTR_R1_TYPE(0b0100100, 0b10100, a0, 0b001, a0, 0b0010011);
+
+  return result;
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation BEXT (bit-extract) [B.Zbs]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 2 (a0).
+ * @return Extract bit from Operand 1 indexed by operand_2(4:0).
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bext(uint32_t rs1, uint32_t rs2) {
+
+  register uint32_t result __asm__ ("a0");
+  register uint32_t tmp_a  __asm__ ("a0") = rs1;
+  register uint32_t tmp_b  __asm__ ("a1") = rs2;
+
+  // dummy instruction to prevent GCC "constprop" optimization
+  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
+
+  // bext a0, a0, a1
+  CUSTOM_INSTR_R2_TYPE(0b0100100, a1, a0, 0b101, a0, 0b0110011);
+
+  return result;
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation BEXTI (bit-extract) by 20 positions. [B.Zbs]
+ * @warning Fixed shift amount (20) for now.
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @return Extract bit from Operand 1 at position 20.
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bexti20(uint32_t rs1) {
+
+  register uint32_t result __asm__ ("a0");
+  register uint32_t tmp_a  __asm__ ("a0") = rs1;
+
+  // dummy instruction to prevent GCC "constprop" optimization
+  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
+
+  // bexti a0, a0, 20
+  CUSTOM_INSTR_R1_TYPE(0b0100100, 0b10100, a0, 0b101, a0, 0b0010011);
+
+  return result;
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation BINV (bit-invert) [B.Zbs]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 2 (a0).
+ * @return Invert bit from Operand 1 indexed by operand_2(4:0).
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_binv(uint32_t rs1, uint32_t rs2) {
+
+  register uint32_t result __asm__ ("a0");
+  register uint32_t tmp_a  __asm__ ("a0") = rs1;
+  register uint32_t tmp_b  __asm__ ("a1") = rs2;
+
+  // dummy instruction to prevent GCC "constprop" optimization
+  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
+
+  // binv a0, a0, a1
+  CUSTOM_INSTR_R2_TYPE(0b0110100, a1, a0, 0b001, a0, 0b0110011);
+
+  return result;
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation BINVI (bit-invert) by 20 positions. [B.Zbs]
+ * @warning Fixed shift amount (20) for now.
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @return Invert bit from Operand 1 at position 20.
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_binvi20(uint32_t rs1) {
+
+  register uint32_t result __asm__ ("a0");
+  register uint32_t tmp_a  __asm__ ("a0") = rs1;
+
+  // dummy instruction to prevent GCC "constprop" optimization
+  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
+
+  // binvi a0, a0, 20
+  CUSTOM_INSTR_R1_TYPE(0b0110100, 0b10100, a0, 0b001, a0, 0b0010011);
+
+  return result;
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation BSET (bit-set) [B.Zbs]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 2 (a0).
+ * @return set bit from Operand 1 indexed by operand_2(4:0).
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bset(uint32_t rs1, uint32_t rs2) {
+
+  register uint32_t result __asm__ ("a0");
+  register uint32_t tmp_a  __asm__ ("a0") = rs1;
+  register uint32_t tmp_b  __asm__ ("a1") = rs2;
+
+  // dummy instruction to prevent GCC "constprop" optimization
+  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
+
+  // bset a0, a0, a1
+  CUSTOM_INSTR_R2_TYPE(0b0010100, a1, a0, 0b001, a0, 0b0110011);
+
+  return result;
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation BSETI (bit-set) by 20 positions. [B.Zbs]
+ * @warning Fixed shift amount (20) for now.
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @return Set bit from Operand 1 at position 20.
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bseti20(uint32_t rs1) {
+
+  register uint32_t result __asm__ ("a0");
+  register uint32_t tmp_a  __asm__ ("a0") = rs1;
+
+  // dummy instruction to prevent GCC "constprop" optimization
+  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
+
+  // bseti a0, a0, 20
+  CUSTOM_INSTR_R1_TYPE(0b0010100, 0b10100, a0, 0b001, a0, 0b0010011);
+
+  return result;
+}
+
+
+// ================================================================================================
+// Zbc - Carry-less multiplication instructions
+// ================================================================================================
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation CLMUL (carry-less multiplication, low-part) [B.Zbc]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 2 (a0).
+ * @return Carry-less product, low part.
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clmul(uint32_t rs1, uint32_t rs2) {
+
+  register uint32_t result __asm__ ("a0");
+  register uint32_t tmp_a  __asm__ ("a0") = rs1;
+  register uint32_t tmp_b  __asm__ ("a1") = rs2;
+
+  // dummy instruction to prevent GCC "constprop" optimization
+  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
+
+  // clmul a0, a0, a1
+  CUSTOM_INSTR_R2_TYPE(0b0000101, a1, a0, 0b001, a0, 0b0110011);
+
+  return result;
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation CLMULH (carry-less multiplication, high-part) [B.Zbc]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 2 (a0).
+ * @return Carry-less product, high part.
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clmulh(uint32_t rs1, uint32_t rs2) {
+
+  register uint32_t result __asm__ ("a0");
+  register uint32_t tmp_a  __asm__ ("a0") = rs1;
+  register uint32_t tmp_b  __asm__ ("a1") = rs2;
+
+  // dummy instruction to prevent GCC "constprop" optimization
+  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
+
+  // clmulh a0, a0, a1
+  CUSTOM_INSTR_R2_TYPE(0b0000101, a1, a0, 0b011, a0, 0b0110011);
+
+  return result;
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation CLMULR (carry-less multiplication, reversed) [B.Zbc]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 2 (a0).
+ * @return Carry-less product, low part, reversed.
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clmulr(uint32_t rs1, uint32_t rs2) {
+
+  register uint32_t result __asm__ ("a0");
+  register uint32_t tmp_a  __asm__ ("a0") = rs1;
+  register uint32_t tmp_b  __asm__ ("a1") = rs2;
+
+  // dummy instruction to prevent GCC "constprop" optimization
+  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
+
+  // clmulr a0, a0, a1
+  CUSTOM_INSTR_R2_TYPE(0b0000101, a1, a0, 0b010, a0, 0b0110011);
+
+  return result;
+}
+
 
 // ################################################################################################
 // Emulation functions
@@ -899,5 +1157,178 @@ uint32_t riscv_emulate_sh3add(uint32_t rs1, uint32_t rs2) {
   return rs2 + (rs1 << 3);
 }
 
+
+// ================================================================================================
+// Zbs - Single-bit instructions
+// ================================================================================================
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation BCLR (bit-clear) [emulation]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 1 (a0).
+ * @return Operand 1 with cleared bit indexed by operand_2(4:0).
+ **************************************************************************/
+uint32_t riscv_emulate_bclr(uint32_t rs1, uint32_t rs2) {
+
+  uint32_t shamt = rs2 & 0x1f;
+  uint32_t tmp = 1 << shamt;
+
+  return rs1 & (~tmp);
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation BEXT (bit-extract) [emulation]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 1 (a0).
+ * @return Extract bit from operand 1 indexed by operand_2(4:0).
+ **************************************************************************/
+uint32_t riscv_emulate_bext(uint32_t rs1, uint32_t rs2) {
+
+  uint32_t shamt = rs2 & 0x1f;
+  uint32_t tmp = rs1 >> shamt;
+
+  return tmp & 1;
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation BINV (bit-invert) [emulation]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 1 (a0).
+ * @return Invert bit from operand 1 indexed by operand_2(4:0).
+ **************************************************************************/
+uint32_t riscv_emulate_binv(uint32_t rs1, uint32_t rs2) {
+
+  uint32_t shamt = rs2 & 0x1f;
+  uint32_t tmp = 1 << shamt;
+
+  return rs1 ^ tmp;
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation BSET (bit-set) [emulation]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 1 (a0).
+ * @return Set bit from operand 1 indexed by operand_2(4:0).
+ **************************************************************************/
+uint32_t riscv_emulate_bset(uint32_t rs1, uint32_t rs2) {
+
+  uint32_t shamt = rs2 & 0x1f;
+  uint32_t tmp = 1 << shamt;
+
+  return rs1 | tmp;
+}
+
+
+// ================================================================================================
+// Zbc - Carry-less multiplication instructions
+// ================================================================================================
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation CLMUL (carry-less multiply, low-part) [emulation]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 1 (a0).
+ * @return Carry-less multiplication product, low part
+ **************************************************************************/
+uint32_t riscv_emulate_clmul(uint32_t rs1, uint32_t rs2) {
+
+  uint32_t i;
+  uint64_t tmp;
+  union {
+    uint64_t uint64;
+    uint32_t uint32[sizeof(uint64_t)/2];
+  } res;
+
+  res.uint64 = 0;
+  for (i=0; i<32; i++) {
+    if ((rs2 >> i) & 1) {
+      tmp = (uint64_t)rs1;
+      tmp = tmp << i;
+      res.uint64 = res.uint64 ^ tmp;
+    }
+  }
+
+  return res.uint32[0];
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation CLMULH (carry-less multiply, high-part) [emulation]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 1 (a0).
+ * @return Carry-less multiplication product, high part
+ **************************************************************************/
+uint32_t riscv_emulate_clmulh(uint32_t rs1, uint32_t rs2) {
+
+  uint32_t i;
+  uint64_t tmp;
+  union {
+    uint64_t uint64;
+    uint32_t uint32[sizeof(uint64_t)/2];
+  } res;
+
+  res.uint64 = 0;
+  for (i=0; i<32; i++) {
+    if ((rs2 >> i) & 1) {
+      tmp = (uint64_t)rs1;
+      tmp = tmp << i;
+      res.uint64 = res.uint64 ^ tmp;
+    }
+  }
+
+  return res.uint32[1];
+}
+
+
+/**********************************************************************//**
+ * Intrinsic: Bit manipulation CLMUR (carry-less multiply, reversed) [emulation]
+ *
+ * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs2 Source operand 1 (a0).
+ * @return Carry-less multiplication product, low part, reversed
+ **************************************************************************/
+uint32_t riscv_emulate_clmulr(uint32_t rs1, uint32_t rs2) {
+
+  uint32_t i;
+  uint64_t tmp;
+  union {
+    uint64_t uint64;
+    uint32_t uint32[sizeof(uint64_t)/2];
+  } res;
+
+  // bit-reversal of input operands
+  uint32_t rs1_rev = 0, rs2_rev = 0;
+  for (i=0; i<32; i++) {
+    if ((rs1 >> i) & 1) {
+      rs1_rev |= 1;
+    }
+    rs1_rev <<= 1;
+    if ((rs2 >> i) & 1) {
+      rs2_rev |= 1;
+    }
+    rs2_rev <<= 1;
+  }
+
+  res.uint64 = 0;
+  for (i=0; i<32; i++) {
+    if ((rs2_rev >> i) & 1) {
+      tmp = (uint64_t)rs1_rev;
+      tmp = tmp << i;
+      res.uint64 = res.uint64 ^ tmp;
+    }
+  }
+
+  return res.uint32[0];
+}
 
 #endif // neorv32_b_extension_intrinsics_h


### PR DESCRIPTION
This PR adds another sub-extension to the recently ratified **RISC-V bit-manipulation ISA extension "`B`"**:

* `Zbs` - single-bit instructions

The NEORV32 CPU now supports three of the four `B` subsets (if the bit-manipulation is enabled by setting the `CPU_EXTENSION_RISCV_B` top generic _true_):
* ✔️ `Zbb` - basic bit-manipulation instructions
* ✔️ `Zba` - address-computation instructions
* ✔️ `Zbs` - single-bit instructions
* ❌ `Zbc` - carry-less multiplication instructions - not supported yet (but coming soon)

Since there is no upstream gcc support yet, `Zbs` intrinsics and emulation functions have been added to [`sw/example/bitmanip_test/neorv32_b_extension_intrinsics.h`](https://github.com/stnolting/neorv32/blob/master/sw/example/bitmanip_test/neorv32_b_extension_intrinsics.h) to verify correct operations. Furthermore, according test cases have been added to [`sw/example/bitmanip_test/main.c`](https://github.com/stnolting/neorv32/blob/master/sw/example/bitmanip_test/main.c). The new testcases also check that instructions from the `Zbc` subset do raise an illegal instruction exception (as they are not supported yet).

----------------------------

🐛 This PR also fixes a minor bug in the CPU's co-processor arbitration logic: multi-cycle ALU operations (= CPU co-processor operations) that are triggered by an illegal instruction are allowed to complete execution even though there will be no data committed (for example no register file write-back). This is required to ensure that no co-processor operation is still in progress when the CPU enters trap state.