### PR TITLE
[B ISA extension] add carry-less multiply instructions (Zbc) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
-| 26.01.2022 | 1.6.6.7 | :sparkles: added HW support for RISC-V bit-manipulation (`B`) **single-bit instructions `Zbs`** sub-extension; added test cases and intrinsics; see [PR #259](https://github.com/stnolting/neorv32/pull/259) |
+| 27.01.2022 | 1.6.6.8 | :sparkles: added support for RISC-V bit-manipulation (`B`) **carry-less multiplication instructions `Zbc`** sub-extension; added test cases and intrinsics; the NEORV32 bit-manipulation ISA extension (`B`) now fully complies to the RISC-V specs. v0.93; see [PR #260](https://github.com/stnolting/neorv32/pull/260) |
+| 26.01.2022 | 1.6.6.7 | :sparkles: added support for RISC-V bit-manipulation (`B`) **single-bit instructions `Zbs`** sub-extension; added test cases and intrinsics; see [PR #259](https://github.com/stnolting/neorv32/pull/259) |
 | 26.01.2022 | 1.6.6.6 | minor logic optimizations in **CPU control unit** |
 | 25.01.2022 | 1.6.6.5 | :lock: **on-chip debugger:** the memory-mapped registers of the debug module (DM) are only accessible/visible when the CPU is actually in debug mode; any access outside of debug mode will now raise a bus exception |
 | 22.01.2022 | 1.6.6.4 | minor logic optimizations in **CPU control unit**, minor improvement of critical path |

--- a/README.md
+++ b/README.md
@@ -190,8 +190,9 @@ documentation section). Note that the `X` extension is always enabled.
 [[`PMP`](https://stnolting.github.io/neorv32/#_pmp_physical_memory_protection)]
 [[`DEBUG`](https://stnolting.github.io/neorv32/#_cpu_debug_mode)]**
 
-:warning: The `B`, `Zfinx` and `Zmmul` RISC-V are officially ratified but there is no
-upstream gcc support yet. To circumvent this, the NEORV32 software framework provides _intrinsic libraries_ for these extensions.
+:warning: The `B`, `Zfinx` and `Zmmul` RISC-V are frozen and officially ratified but there is no
+upstream gcc support yet. To circumvent this, the NEORV32 software framework provides _intrinsic libraries_ for the
+`B` and `Zfinx` extensions.
 
 [[back to top](#The-NEORV32-RISC-V-Processor)]
 

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -269,12 +269,6 @@ only supports the modes _OFF_ and _NAPOT_ yet and a minimal granularity of 8 byt
 The `A` CPU extension only implements the `lr.w` and `sc.w` instructions yet.
 However, these instructions are sufficient to emulate all further atomic memory operations.
 
-.Bit-Manipulation ISA Extension
-[IMPORTANT]
-The NEORV32 `B` extension only implements the _basic bit-manipulation instructions_ (`Zbb`) subset,
-the _address generation instructions_ (`Zba`) subset and the _single-bit instructions_ (`Zbs`) subset yet.
-
-
 
 <<<
 // ####################################################################################################################
@@ -422,30 +416,27 @@ information can be found in sections <<_bus_interface>> and <<_processor_externa
 The `B` ISA extension adds instructions for bit-manipulation operations. This extension is enabled if the
 `CPU_EXTENSION_RISCV_B` configuration generic is _true_.
 The official RISC-V specifications can be found here: https://github.com/riscv/riscv-bitmanip
+A copy of the spec is also available in `docs/references`.
 
-[IMPORTANT]
-The NEORV32 `B` extension only implements the _basic bit-manipulation instructions_ (`Zbb`) subset,
-the _address generation instructions_ (`Zba`) subset and the _single-bit instructions_ (`Zbs`) subset yet.
+The NEORV32 `B` ISA extension includes the following sub-extensions (according to the RISC-V
+bit-manipulation spec. v.093) and their corresponding instructions:
 
-The `Zbb` sub-extension adds the following instructions:
-
-* `andn` `orn` `xnor`
-* `clz` `ctz` `cpop`
-* `max` `maxu` `min` `minu`
-* `sext.b` `sext.h` `zext.h`
-* `rol` `ror` `rori`
-* `orc.b` `rev8`
-
-The `Zba` sub-extension adds the following instructions:
-
-* `sh1add` `sh2add` `sh3add`
-
-The `Zbs` sub-extension adds the following instructions:
-
-* `bclr` `bclri`
-* `bext` `bexti`
-* `bext` `binvi`
-* `bset` `bseti`
+* **`Zba` - Address-generation instructions**
+** `sh1add` `sh2add` `sh3add`
+* **`Zbb` - Basic bit-manipulation instructions**
+** `andn` `orn` `xnor`
+** `clz` `ctz` `cpop`
+** `max` `maxu` `min` `minu`
+** `sext.b` `sext.h` `zext.h`
+** `rol` `ror` `rori`
+** `orc.b` `rev8`
+* **`Zbc` - Carry-less multiplication instructions**
+** `clmul` `clmulh` `clmulr`
+* **`Zbs` - Single-bit instructions**
+** `bclr` `bclri`
+** `bext` `bexti`
+** `bext` `binvi`
+** `bset` `bseti`
 
 [TIP]
 By default, the bit-manipulation unit uses an _iterative_ approach to compute shift-related operations
@@ -804,6 +795,7 @@ configurations are presented in <<_cpu_performance>>.
 | Bit-manipulation - shifts | `B(Zbb)` | `rol` `ror` `rori` | 3 + SA
 | Bit-manipulation - single-bit  | `B(Zbs)` | `sbset[i]` `sbclr[i]` `sbinv[i]` `sbext[i]` | 3
 | Bit-manipulation - shifted-add | `B(Zba)` | `sh1add` `sh2add` `sh3add` | 3
+| Bit-manipulation - carry-less multiply | `B(Zbc)` | `clmul` `clmulh` `clmulr` | 3 + 32
 |=======================
 
 [NOTE]

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -856,6 +856,9 @@ begin
        ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0100100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "101")) or -- BEXT
        ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0110100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "001")) or -- BINV
        ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0010100") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "001")) or -- BSET
+       ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0000101") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "001")) or -- CLMUL
+       ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0000101") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "011")) or -- CLMULH
+       ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0000101") and (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "010")) or -- CLMULR
        ((execute_engine.i_reg(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0100000") and
         (
          (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = "111") or -- ANDN

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060607"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060608"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/example/bitmanip_test/main.c
+++ b/sw/example/bitmanip_test/main.c
@@ -495,13 +495,12 @@ int main() {
   neorv32_uart0_printf("Zbc - Carry-less multiplication instructions\n");
   neorv32_uart0_printf("--------------------------------------------\n");
 
-  neorv32_uart0_printf("\nWARNING: The NEORV32 CPU hardware does NOT support the Zbc extension yet!");
-  neorv32_uart0_printf("\n         Hence, illegal instruction exceptions should be triggered here.\n");
+  neorv32_uart0_printf("n\NOTE: The emulation functions will take quite some time to execute.\n");
 
   // CLMUL
   neorv32_uart0_printf("\nCLMUL:\n");
   err_cnt = 0;
-  for (i=0;i<1; i++) {
+  for (i=0;i<num_tests; i++) {
     opa = xorshift32();
     opb = xorshift32();
     res_sw = riscv_emulate_clmul(opa, opb);
@@ -513,7 +512,7 @@ int main() {
   // CLMULH
   neorv32_uart0_printf("\nCLMULH:\n");
   err_cnt = 0;
-  for (i=0;i<1; i++) {
+  for (i=0;i<num_tests; i++) {
     opa = xorshift32();
     opb = xorshift32();
     res_sw = riscv_emulate_clmulh(opa, opb);
@@ -525,7 +524,7 @@ int main() {
   // CLMULR
   neorv32_uart0_printf("\nCLMULR:\n");
   err_cnt = 0;
-  for (i=0;i<1; i++) {
+  for (i=0;i<num_tests; i++) {
     opa = xorshift32();
     opb = xorshift32();
     res_sw = riscv_emulate_clmulr(opa, opb);

--- a/sw/example/bitmanip_test/main.c
+++ b/sw/example/bitmanip_test/main.c
@@ -51,13 +51,13 @@
 #define BAUD_RATE      (19200)
 //** Number of test cases for each instruction */
 #define NUM_TEST_CASES (1000000)
-//** Enable Zbb tests */
+//** Enable Zbb tests when 1 */
 #define ENABLE_ZBB     (1)
-//** Enable Zba tests */
+//** Enable Zba tests when 1 */
 #define ENABLE_ZBA     (1)
-//** Enable Zbs tests */
+//** Enable Zbs tests when 1 */
 #define ENABLE_ZBS     (1)
-//** Enable Zbc tests */
+//** Enable Zbc tests when 1 */
 #define ENABLE_ZBC     (1)
 /**@}*/
 
@@ -495,7 +495,7 @@ int main() {
   neorv32_uart0_printf("Zbc - Carry-less multiplication instructions\n");
   neorv32_uart0_printf("--------------------------------------------\n");
 
-  neorv32_uart0_printf("n\NOTE: The emulation functions will take quite some time to execute.\n");
+  neorv32_uart0_printf("\nNOTE: The emulation functions will take quite some time to execute.\n");
 
   // CLMUL
   neorv32_uart0_printf("\nCLMUL:\n");

--- a/sw/example/bitmanip_test/neorv32_b_extension_intrinsics.h
+++ b/sw/example/bitmanip_test/neorv32_b_extension_intrinsics.h
@@ -1245,7 +1245,7 @@ uint32_t riscv_emulate_clmul(uint32_t rs1, uint32_t rs2) {
   uint64_t tmp;
   union {
     uint64_t uint64;
-    uint32_t uint32[sizeof(uint64_t)/2];
+    uint32_t uint32[sizeof(uint64_t)/sizeof(uint32_t)];
   } res;
 
   res.uint64 = 0;
@@ -1274,7 +1274,7 @@ uint32_t riscv_emulate_clmulh(uint32_t rs1, uint32_t rs2) {
   uint64_t tmp;
   union {
     uint64_t uint64;
-    uint32_t uint32[sizeof(uint64_t)/2];
+    uint32_t uint32[sizeof(uint64_t)/sizeof(uint32_t)];
   } res;
 
   res.uint64 = 0;
@@ -1303,20 +1303,20 @@ uint32_t riscv_emulate_clmulr(uint32_t rs1, uint32_t rs2) {
   uint64_t tmp;
   union {
     uint64_t uint64;
-    uint32_t uint32[sizeof(uint64_t)/2];
+    uint32_t uint32[sizeof(uint64_t)/sizeof(uint32_t)];
   } res;
 
   // bit-reversal of input operands
   uint32_t rs1_rev = 0, rs2_rev = 0;
   for (i=0; i<32; i++) {
+    rs1_rev <<= 1;
     if ((rs1 >> i) & 1) {
       rs1_rev |= 1;
     }
-    rs1_rev <<= 1;
+    rs2_rev <<= 1;
     if ((rs2 >> i) & 1) {
       rs2_rev |= 1;
     }
-    rs2_rev <<= 1;
   }
 
   res.uint64 = 0;
@@ -1328,7 +1328,17 @@ uint32_t riscv_emulate_clmulr(uint32_t rs1, uint32_t rs2) {
     }
   }
 
-  return res.uint32[0];
+  // bit-reversal of result
+  uint32_t result = 0;
+  for (i=0; i<32; i++) {
+    result <<= 1;
+    if ((res.uint32[0] >> i) & 1) {
+      result |= 1;
+    }
+  }
+
+  return result;
 }
+
 
 #endif // neorv32_b_extension_intrinsics_h


### PR DESCRIPTION
This PR is a follow-up of #259 and adds the last missing sub-extension to the CPU's **RISC-V bit-manipulation ISA extension "`B`"**:

* `Zbc` - carry-less multiplication instructions

The NEORV32 CPU now supports _all_ four `B` subsets (according to the recently frozen and ratified RISC-V bit-manipulation spec. v0.93/v1.00):
* ✔️ `Zbb` - basic bit-manipulation instructions
* ✔️ `Zba` - address-generation instructions
* ✔️ `Zbs` - single-bit instructions
* ✔️  `Zbc` - carry-less multiplication instructions

:books: A copy of the RISC-V `B` spec (v0.93) can be found in [docs/references](https://github.com/stnolting/neorv32/tree/master/docs/references).

Since there is no upstream gcc support yet, `Zbc` intrinsics and emulation functions have been added to [`sw/example/bitmanip_test/neorv32_b_extension_intrinsics.h`](https://github.com/stnolting/neorv32/blob/master/sw/example/bitmanip_test/neorv32_b_extension_intrinsics.h). Furthermore, according test cases have been added to [`sw/example/bitmanip_test/main.c`](https://github.com/stnolting/neorv32/blob/master/sw/example/bitmanip_test/main.c) to verify correct operations.