### PR TITLE
[CFS] add demo program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 27.01.2022 | 1.6.6.9 | reworked **CFS** "user" logic; added CFS demo program; see [PR #261](https://github.com/stnolting/neorv32/pull/261) |
 | 27.01.2022 | 1.6.6.8 | :sparkles: added support for RISC-V bit-manipulation (`B`) **carry-less multiplication instructions `Zbc`** sub-extension; added test cases and intrinsics; the NEORV32 bit-manipulation ISA extension (`B`) now fully complies to the RISC-V specs. v0.93; see [PR #260](https://github.com/stnolting/neorv32/pull/260) |
 | 26.01.2022 | 1.6.6.7 | :sparkles: added support for RISC-V bit-manipulation (`B`) **single-bit instructions `Zbs`** sub-extension; added test cases and intrinsics; see [PR #259](https://github.com/stnolting/neorv32/pull/259) |
 | 26.01.2022 | 1.6.6.6 | minor logic optimizations in **CPU control unit** |

--- a/docs/datasheet/soc_cfs.adoc
+++ b/docs/datasheet/soc_cfs.adoc
@@ -19,9 +19,9 @@
 
 **Theory of Operation**
 
-The custom functions subsystem is meant for implementing application-specific user-defined co-processors
-IP footnote:[Intellectual IP; proprietary circuit blocks.] blocks. The CFS provides up to 32x 32-bit memory-mapped
-registers (`REG`, see register map table below) that can be accessed by the CPU via normal load/store operations.
+The custom functions subsystem is meant for implementing custom and application-specific logic.
+The CFS provides up to 32x 32-bit memory-mapped
+registers (`REG`, see register map below) that can be accessed by the CPU via normal load/store operations.
 The actual functionality of these register has to be defined by the hardware designer. Furthermore, the CFS
 provides two IO conduits to implement custom module- or chip-external interfaces.
 
@@ -52,10 +52,13 @@ NEORV32_CFS.REG[0] = (uint32_t)some_data_array(i); // write to CFS register 0
 uint32_t temp = NEORV32_CFS.REG[20]; // read from CFS register 20
 ----
 
+[TIP]
+A very simple example program that uses the _default_ CFS hardware module can be found in `sw/example/cfs_demo`.
+
 
 **CFS Interrupt**
 
-The CFS provides a single rising-edge-triggered interrupt request signal mapped to the CPU's fast interrupt channel 1.
+The CFS provides a single high-level-triggered interrupt request signal mapped to the CPU's fast interrupt channel 1.
 Once triggered, the interrupt becomes pending (if enabled in the `mis` CSR) and has to be explicitly cleared again by setting
 the according `mip` CSR bit. See section <<_processor_interrupts>> for more information.
 
@@ -64,7 +67,7 @@ the according `mip` CSR bit. See section <<_processor_interrupts>> for more info
 
 By default, the CFS provides a single 32-bit `std_(u)logic_vector` configuration generic _IO_CFS_CONFIG_
 that is available in the processor's top entity. This generic can be used to pass custom configuration options
-from the top entity directly down to the CFS. The actual definition of the generics and it'S usage inside the
+from the top entity directly down to the CFS. The actual definition of the generic and it's usage inside the
 CFS is left to the hardware designer.
 
 
@@ -72,7 +75,7 @@ CFS is left to the hardware designer.
 
 By default, the CFS also provides two unidirectional input and output conduits `cfs_in_i` and `cfs_out_o`.
 These signals are directly propagated to the processor's top entity. These conduits can be used to implement
-application-specific interfaces like memory or network connections. The actual use case of these signals
+application-specific interfaces like memory or peripheral connections. The actual use case of these signals
 has to be defined by the hardware designer.
 
 The size of the input signal conduit `cfs_in_i` is defined via the top's _IO_CFS_IN_SIZE_ configuration

--- a/rtl/core/neorv32_cfs.vhd
+++ b/rtl/core/neorv32_cfs.vhd
@@ -244,15 +244,16 @@ begin
 
   -- CFS Function Core ----------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  -- This is where the actual functionality can be implemented.
-  -- In this example we are just implementing four r/w registers that invert any value written to them.
 
+  -- This is where the actual functionality can be implemented.
+  -- The logic below is just a very simple example that transforms data
+  -- from an inpout register into data in an output register.
   cfs_core_logic: process(cfs_reg_wr)
   begin
-    cfs_reg_rd(0) <= not cfs_reg_wr(0);
-    cfs_reg_rd(1) <= not cfs_reg_wr(1);
-    cfs_reg_rd(2) <= not cfs_reg_wr(2);
-    cfs_reg_rd(3) <= not cfs_reg_wr(3);
+    cfs_reg_rd(0) <= bin_to_gray_f(cfs_reg_wr(0)); -- convert binary to gray code
+    cfs_reg_rd(1) <= gray_to_bin_f(cfs_reg_wr(1)); -- convert gray to binary code
+    cfs_reg_rd(2) <= bit_rev_f(cfs_reg_wr(2)); -- bit reversal
+    cfs_reg_rd(3) <= bswap32_f(cfs_reg_wr(3)); -- byte swap (endianness conversion)
   end process cfs_core_logic;
 
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -64,7 +64,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060608"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060609"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/example/demo_cfs/main.c
+++ b/sw/example/demo_cfs/main.c
@@ -1,0 +1,153 @@
+// #################################################################################################
+// # << NEORV32 - CFS Demo Program >>                                                              #
+// # ********************************************************************************************* #
+// # BSD 3-Clause License                                                                          #
+// #                                                                                               #
+// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+// #                                                                                               #
+// # Redistribution and use in source and binary forms, with or without modification, are          #
+// # permitted provided that the following conditions are met:                                     #
+// #                                                                                               #
+// # 1. Redistributions of source code must retain the above copyright notice, this list of        #
+// #    conditions and the following disclaimer.                                                   #
+// #                                                                                               #
+// # 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
+// #    conditions and the following disclaimer in the documentation and/or other materials        #
+// #    provided with the distribution.                                                            #
+// #                                                                                               #
+// # 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
+// #    endorse or promote products derived from this software without specific prior written      #
+// #    permission.                                                                                #
+// #                                                                                               #
+// # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
+// # OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
+// # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
+// # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
+// # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
+// # GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
+// # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
+// # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
+// # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
+// # ********************************************************************************************* #
+// # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+// #################################################################################################
+
+
+/**********************************************************************//**
+ * @file demo_cfs/main.c
+ * @author Stephan Nolting
+ * @brief Simple demo program for the _default_ custom functions subsystem (CFS) module.
+ **************************************************************************/
+
+#include <neorv32.h>
+
+
+/**********************************************************************//**
+ * @name User configuration
+ **************************************************************************/
+/**@{*/
+/** UART BAUD rate */
+#define BAUD_RATE 19200
+/** Number of test cases per CFS function */
+#define TESTCASES 4
+/**@}*/
+
+
+/**********************************************************************//**
+ * @name Prototypes
+ **************************************************************************/
+uint32_t xorshift32(void);
+
+
+/**********************************************************************//**
+ * Main function
+ *
+ * @note This program requires the CFS and UART0.
+ *
+ * @return 0 if execution was successful
+ **************************************************************************/
+int main() {
+
+  uint32_t i, tmp;
+
+
+  // init UART0 at default baud rate, no parity bits, no HW flow control
+  neorv32_uart0_setup(BAUD_RATE, PARITY_NONE, FLOW_CONTROL_NONE);
+
+  // capture all exceptions and give debug info via UART0
+  // this is not required, but keeps us safe
+  neorv32_rte_setup();
+
+
+  // check if CFS is implemented at all
+  if (neorv32_cfs_available() == 0) {
+    neorv32_uart0_printf("Error! No CFS synthesized!\n");
+    return 1;
+  }
+
+
+  // intro
+  neorv32_uart0_printf("<<< NEORV32 Custom Functions Subsystem (CFS) Demo Program >>>\n\n");
+
+  neorv32_uart0_printf("NOTE: This program assumes the _default_ CFS hardware module, which implements\n"
+                       "      simple data conversion functions using four memory-mapped registers.\n\n");
+
+  neorv32_uart0_printf("Default CFS memory-mapped registers:\n"
+                       " * NEORV32_CFS.REG[0] (r/w): convert binary to gray code\n"
+                       " * NEORV32_CFS.REG[1] (r/w): convert gray to binary code\n"
+                       " * NEORV32_CFS.REG[2] (r/w): bit reversal\n"
+                       " * NEORV32_CFS.REG[3] (r/w): byte swap\n"
+                       "The remaining 28 CFS registers are unused and will return 0 when read.\n");
+
+
+  // function examples
+  neorv32_uart0_printf("\n--- CFS 'binary to gray' function ---\n");
+  for (i=0; i<TESTCASES; i++) {
+    tmp = xorshift32(); // get random test data
+    NEORV32_CFS.REG[0] = tmp; // write to CFS memory-mapped register 0
+    neorv32_uart0_printf("%u: IN = 0x%x, OUT = 0x%x\n", i, tmp, NEORV32_CFS.REG[0]); // read from CFS memory-mapped register 0
+  }
+
+  neorv32_uart0_printf("\n--- CFS 'gray to binary' function ---\n");
+  for (i=0; i<TESTCASES; i++) {
+    tmp = xorshift32(); // get random test data
+    NEORV32_CFS.REG[1] = tmp; // write to CFS memory-mapped register 1
+    neorv32_uart0_printf("%u: IN = 0x%x, OUT = 0x%x\n", i, tmp, NEORV32_CFS.REG[1]); // read from CFS memory-mapped register 1
+  }
+
+  neorv32_uart0_printf("\n--- CFS 'bit reversal' function ---\n");
+  for (i=0; i<TESTCASES; i++) {
+    tmp = xorshift32(); // get random test data
+    NEORV32_CFS.REG[2] = tmp; // write to CFS memory-mapped register 2
+    neorv32_uart0_printf("%u: IN = 0x%x, OUT = 0x%x\n", i, tmp, NEORV32_CFS.REG[2]); // read from CFS memory-mapped register 2
+  }
+
+  neorv32_uart0_printf("\n--- CFS 'byte swap' function ---\n");
+  for (i=0; i<TESTCASES; i++) {
+    tmp = xorshift32(); // get random test data
+    NEORV32_CFS.REG[3] = tmp; // write to CFS memory-mapped register 3
+    neorv32_uart0_printf("%u: IN = 0x%x, OUT = 0x%x\n", i, tmp, NEORV32_CFS.REG[3]); // read from CFS memory-mapped register 3
+  }
+
+
+  neorv32_uart0_printf("\nCFS demo program completed.\n");
+
+  return 0;
+}
+
+
+/**********************************************************************//**
+ * Pseudo-Random Number Generator (to generate deterministic test vectors).
+ *
+ * @return Random data (32-bit).
+ **************************************************************************/
+uint32_t xorshift32(void) {
+
+  static uint32_t x32 = 314159265;
+
+  x32 ^= x32 << 13;
+  x32 ^= x32 >> 17;
+  x32 ^= x32 << 5;
+
+  return x32;
+}

--- a/sw/example/demo_cfs/makefile
+++ b/sw/example/demo_cfs/makefile
@@ -1,0 +1,40 @@
+#################################################################################################
+# << NEORV32 - Application Makefile >>                                                          #
+# ********************************************************************************************* #
+# Make sure to add the RISC-V GCC compiler's bin folder to your PATH environment variable.      #
+# ********************************************************************************************* #
+# BSD 3-Clause License                                                                          #
+#                                                                                               #
+# Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+#                                                                                               #
+# Redistribution and use in source and binary forms, with or without modification, are          #
+# permitted provided that the following conditions are met:                                     #
+#                                                                                               #
+# 1. Redistributions of source code must retain the above copyright notice, this list of        #
+#    conditions and the following disclaimer.                                                   #
+#                                                                                               #
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
+#    conditions and the following disclaimer in the documentation and/or other materials        #
+#    provided with the distribution.                                                            #
+#                                                                                               #
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
+#    endorse or promote products derived from this software without specific prior written      #
+#    permission.                                                                                #
+#                                                                                               #
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
+# OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
+# GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
+# OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
+# ********************************************************************************************* #
+# The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+#################################################################################################
+
+# Modify this variable to fit your NEORV32 setup (neorv32 home folder)
+NEORV32_HOME ?= ../../..
+
+include $(NEORV32_HOME)/sw/common/common.mk


### PR DESCRIPTION
This PR reworks the "user" logic of the default _Custom Functions Subsystem (CFS)_ hardware module and also adds a simple example program to illustrate how to use/access the CFS from software (-> `sw/example/demo_cfs`).

The default CFS now implements four exemplary memory-mapped registers that perform simple, combinatorial data transformations:
* binary to gray conversion
* gray to binary conversion
* bit reversal
* byte swap (Endianness conversion)