### PR TITLE
[rtl/core] add 4 additional CPU CP slots; fix bugs in CP arbitration logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ defined by the `hw_version_c` constant in the main VHDL package file [`rtl/core/
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 28.01.2022 | 1.6.6.10 | :bug: fixed bug in **bit-manipulation co-processor**: decoding collision between `cpop` and `rol` instructions; :bug: fixed bug in co-processor arbitration when an illegal instruction is detected; added four additional (yet unused) **CPU** co-processor slots; [PR #262](https://github.com/stnolting/neorv32/pull/262) |
 | 27.01.2022 | 1.6.6.9 | reworked **CFS** "user" logic; added CFS demo program; see [PR #261](https://github.com/stnolting/neorv32/pull/261) |
 | 27.01.2022 | 1.6.6.8 | :sparkles: added support for RISC-V bit-manipulation (`B`) **carry-less multiplication instructions `Zbc`** sub-extension; added test cases and intrinsics; the NEORV32 bit-manipulation ISA extension (`B`) now fully complies to the RISC-V specs. v0.93; see [PR #260](https://github.com/stnolting/neorv32/pull/260) |
 | 26.01.2022 | 1.6.6.7 | :sparkles: added support for RISC-V bit-manipulation (`B`) **single-bit instructions `Zbs`** sub-extension; added test cases and intrinsics; see [PR #259](https://github.com/stnolting/neorv32/pull/259) |

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -210,9 +210,6 @@ begin
   -- Instruction prefetch buffer size --
   assert not (is_power_of_two_f(CPU_IPB_ENTRIES) = false) report "NEORV32 CPU CONFIG ERROR! Number of entries in instruction prefetch buffer <CPU_IPB_ENTRIES> has to be a power of two." severity error;
 
-  -- Co-processor timeout counter (for debugging only) --
-  assert not (cp_timeout_en_c = true) report "NEORV32 CPU CONFIG WARNING! Co-processor timeout counter enabled. This should be used for debugging/simulation only." severity warning;
-
   -- PMP regions check --
   assert not (PMP_NUM_REGIONS > 64) report "NEORV32 CPU CONFIG ERROR! Number of PMP regions <PMP_NUM_REGIONS> out of valid range (0..64)." severity error;
   -- PMP granularity --

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1186,7 +1186,8 @@ begin
       when ALU_WAIT => -- wait for multi-cycle ALU operation (co-processor) to finish
       -- ------------------------------------------------------------
         ctrl_nxt(ctrl_alu_func1_c downto ctrl_alu_func0_c) <= alu_func_copro_c;
-        if (alu_idone_i = '1') then -- wait for completion (even if there is an illegal instruction exception to prevent faulty CP op. in background)
+        -- wait for completion or abort on illegal instruction exception (the co-processor will also terminate operations)
+        if (alu_idone_i = '1') or (trap_ctrl.exc_buf(exception_iillegal_c) = '1') then
           ctrl_nxt(ctrl_rf_wb_en_c) <= '1'; -- valid RF write-back
           execute_engine.state_nxt  <= DISPATCH;
         end if;

--- a/rtl/core/neorv32_cpu_cp_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_cp_bitmanip.vhd
@@ -197,7 +197,7 @@ begin
   --
   cmd(op_clz_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "000") else '0';
   cmd(op_ctz_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "001") else '0';
-  cmd(op_cpop_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "010") else '0';
+  cmd(op_cpop_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "010") and (ctrl_i(ctrl_ir_opcode7_5_c) = '0') else '0';
   cmd(op_sextb_c)  <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "100") else '0';
   cmd(op_sexth_c)  <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "101") else '0';
   cmd(op_rol_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_0_c) = "001") and (ctrl_i(ctrl_ir_opcode7_5_c) = '1') else '0';
@@ -274,7 +274,7 @@ begin
 
         when S_BUSY_SHIFT => -- wait for multi-cycle shift operation to finish
         -- ------------------------------------------------------------
-          if (shifter.run = '0') then
+          if (shifter.run = '0') or (ctrl_i(ctrl_trap_c) = '1') then -- abort on trap
             valid      <= '1';
             ctrl_state <= S_IDLE;
           end if;
@@ -285,7 +285,7 @@ begin
 
         when S_BUSY_CLMUL => -- wait for multi-cycle clmul operation to finish
         -- ------------------------------------------------------------
-          if (clmul.busy = '0') then
+          if (clmul.busy = '0') or (ctrl_i(ctrl_trap_c) = '1') then -- abort on trap
             valid      <= '1';
             ctrl_state <= S_IDLE;
           end if;

--- a/rtl/core/neorv32_cpu_cp_fpu.vhd
+++ b/rtl/core/neorv32_cpu_cp_fpu.vhd
@@ -19,7 +19,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -384,7 +384,7 @@ begin
 
         when S_BUSY => -- operation in progress (multi-cycle)
         -- -----------------------------------------------------------
-          if (fu_core_done = '1') then -- processing done?
+          if (fu_core_done = '1') or (ctrl_i(ctrl_trap_c) = '1') then -- processing done? abort if trap
             ctrl_engine.valid <= '1';
             ctrl_engine.state <= S_IDLE;
           end if;

--- a/rtl/core/neorv32_cpu_cp_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_cp_muldiv.vhd
@@ -10,7 +10,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -174,7 +174,7 @@ begin
 
         when PROCESSING =>
           cnt <= std_ulogic_vector(unsigned(cnt) - 1);
-          if (cnt = "00000") then
+          if (cnt = "00000") or (ctrl_i(ctrl_trap_c) = '1') then -- abort on trap
             valid_o <= '1';
             state   <= FINALIZE;
           end if;

--- a/rtl/core/neorv32_cpu_cp_shifter.vhd
+++ b/rtl/core/neorv32_cpu_cp_shifter.vhd
@@ -7,7 +7,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -97,7 +97,7 @@ begin
         shifter.busy_ff <= shifter.busy;
         if (start_i = '1') then
           shifter.busy <= '1';
-        elsif (shifter.done = '1') then
+        elsif (shifter.done = '1') or (ctrl_i(ctrl_trap_c) = '1') then -- abort on trap
           shifter.busy <= '0';
         end if;
         --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -46,7 +46,6 @@ package neorv32_package is
 
   -- CPU core --
   constant dedicated_reset_c : boolean := false; -- use dedicated hardware reset value for UNCRITICAL registers (FALSE=reset value is irrelevant (might simplify HW), default; TRUE=defined LOW reset value)
-  constant cp_timeout_en_c   : boolean := false; -- auto-terminate pending co-processor operations after 256 cycles (for debugging only), default = false
 
   -- "critical" number of implemented PMP regions --
   -- if more PMP regions (> pmp_num_regions_critical_c) are defined, another register stage is automatically inserted into the memory interfaces
@@ -64,7 +63,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060609"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060610"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -90,7 +89,6 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   type pmp_ctrl_if_t is array (0 to 63) of std_ulogic_vector(07 downto 0);
   type pmp_addr_if_t is array (0 to 63) of std_ulogic_vector(33 downto 0);
-  type cp_data_if_t  is array (0 to 3)  of std_ulogic_vector(data_width_c-1 downto 0);
 
   -- Internal Memory Types Configuration Types ----------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -371,38 +369,39 @@ package neorv32_package is
   constant ctrl_bus_ch_lock_c   : natural := 44; -- evaluate atomic/exclusive lock (SC operation)
   -- co-processors --
   constant ctrl_cp_id_lsb_c     : natural := 45; -- cp select ID lsb
-  constant ctrl_cp_id_msb_c     : natural := 46; -- cp select ID msb
+  constant ctrl_cp_id_hsb_c     : natural := 46; -- cp select ID "half" significant bit
+  constant ctrl_cp_id_msb_c     : natural := 47; -- cp select ID msb
   -- instruction's control blocks (used by cpu co-processors) --
-  constant ctrl_ir_funct3_0_c   : natural := 47; -- funct3 bit 0
-  constant ctrl_ir_funct3_1_c   : natural := 48; -- funct3 bit 1
-  constant ctrl_ir_funct3_2_c   : natural := 49; -- funct3 bit 2
-  constant ctrl_ir_funct12_0_c  : natural := 50; -- funct12 bit 0
-  constant ctrl_ir_funct12_1_c  : natural := 51; -- funct12 bit 1
-  constant ctrl_ir_funct12_2_c  : natural := 52; -- funct12 bit 2
-  constant ctrl_ir_funct12_3_c  : natural := 53; -- funct12 bit 3
-  constant ctrl_ir_funct12_4_c  : natural := 54; -- funct12 bit 4
-  constant ctrl_ir_funct12_5_c  : natural := 55; -- funct12 bit 5
-  constant ctrl_ir_funct12_6_c  : natural := 56; -- funct12 bit 6
-  constant ctrl_ir_funct12_7_c  : natural := 57; -- funct12 bit 7
-  constant ctrl_ir_funct12_8_c  : natural := 58; -- funct12 bit 8
-  constant ctrl_ir_funct12_9_c  : natural := 59; -- funct12 bit 9
-  constant ctrl_ir_funct12_10_c : natural := 60; -- funct12 bit 10
-  constant ctrl_ir_funct12_11_c : natural := 61; -- funct12 bit 11
-  constant ctrl_ir_opcode7_0_c  : natural := 62; -- opcode7 bit 0
-  constant ctrl_ir_opcode7_1_c  : natural := 63; -- opcode7 bit 1
-  constant ctrl_ir_opcode7_2_c  : natural := 64; -- opcode7 bit 2
-  constant ctrl_ir_opcode7_3_c  : natural := 65; -- opcode7 bit 3
-  constant ctrl_ir_opcode7_4_c  : natural := 66; -- opcode7 bit 4
-  constant ctrl_ir_opcode7_5_c  : natural := 67; -- opcode7 bit 5
-  constant ctrl_ir_opcode7_6_c  : natural := 68; -- opcode7 bit 6
+  constant ctrl_ir_funct3_0_c   : natural := 48; -- funct3 bit 0
+  constant ctrl_ir_funct3_1_c   : natural := 49; -- funct3 bit 1
+  constant ctrl_ir_funct3_2_c   : natural := 50; -- funct3 bit 2
+  constant ctrl_ir_funct12_0_c  : natural := 51; -- funct12 bit 0
+  constant ctrl_ir_funct12_1_c  : natural := 52; -- funct12 bit 1
+  constant ctrl_ir_funct12_2_c  : natural := 53; -- funct12 bit 2
+  constant ctrl_ir_funct12_3_c  : natural := 54; -- funct12 bit 3
+  constant ctrl_ir_funct12_4_c  : natural := 55; -- funct12 bit 4
+  constant ctrl_ir_funct12_5_c  : natural := 56; -- funct12 bit 5
+  constant ctrl_ir_funct12_6_c  : natural := 57; -- funct12 bit 6
+  constant ctrl_ir_funct12_7_c  : natural := 58; -- funct12 bit 7
+  constant ctrl_ir_funct12_8_c  : natural := 59; -- funct12 bit 8
+  constant ctrl_ir_funct12_9_c  : natural := 60; -- funct12 bit 9
+  constant ctrl_ir_funct12_10_c : natural := 61; -- funct12 bit 10
+  constant ctrl_ir_funct12_11_c : natural := 62; -- funct12 bit 11
+  constant ctrl_ir_opcode7_0_c  : natural := 63; -- opcode7 bit 0
+  constant ctrl_ir_opcode7_1_c  : natural := 64; -- opcode7 bit 1
+  constant ctrl_ir_opcode7_2_c  : natural := 65; -- opcode7 bit 2
+  constant ctrl_ir_opcode7_3_c  : natural := 66; -- opcode7 bit 3
+  constant ctrl_ir_opcode7_4_c  : natural := 67; -- opcode7 bit 4
+  constant ctrl_ir_opcode7_5_c  : natural := 68; -- opcode7 bit 5
+  constant ctrl_ir_opcode7_6_c  : natural := 69; -- opcode7 bit 6
   -- CPU status --
-  constant ctrl_priv_lvl_lsb_c  : natural := 69; -- privilege level lsb
-  constant ctrl_priv_lvl_msb_c  : natural := 70; -- privilege level msb
-  constant ctrl_sleep_c         : natural := 71; -- set when CPU is in sleep mode
-  constant ctrl_trap_c          : natural := 72; -- set when CPU is entering trap execution
-  constant ctrl_debug_running_c : natural := 73; -- CPU is in debug mode when set
+  constant ctrl_priv_lvl_lsb_c  : natural := 70; -- privilege level lsb
+  constant ctrl_priv_lvl_msb_c  : natural := 71; -- privilege level msb
+  constant ctrl_sleep_c         : natural := 72; -- set when CPU is in sleep mode
+  constant ctrl_trap_c          : natural := 73; -- set when CPU is entering trap execution
+  constant ctrl_debug_running_c : natural := 74; -- CPU is in debug mode when set
   -- control bus size --
-  constant ctrl_width_c         : natural := 74; -- control bus size
+  constant ctrl_width_c         : natural := 75; -- control bus size
 
   -- Comparator Bus -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -777,10 +776,14 @@ package neorv32_package is
 
   -- Co-Processor IDs -----------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant cp_sel_shifter_c  : std_ulogic_vector(1 downto 0) := "00"; -- shift operations (base ISA)
-  constant cp_sel_muldiv_c   : std_ulogic_vector(1 downto 0) := "01"; -- multiplication/division operations ('M' extensions)
-  constant cp_sel_bitmanip_c : std_ulogic_vector(1 downto 0) := "10"; -- bit manipulation ('B' extensions)
-  constant cp_sel_fpu_c      : std_ulogic_vector(1 downto 0) := "11"; -- floating-point unit ('Zfinx' extension)
+  constant cp_sel_shifter_c  : std_ulogic_vector(2 downto 0) := "000"; -- CP0: shift operations (base ISA)
+  constant cp_sel_muldiv_c   : std_ulogic_vector(2 downto 0) := "001"; -- CP1: multiplication/division operations ('M' extensions)
+  constant cp_sel_bitmanip_c : std_ulogic_vector(2 downto 0) := "010"; -- CP2: bit manipulation ('B' extensions)
+  constant cp_sel_fpu_c      : std_ulogic_vector(2 downto 0) := "011"; -- CP3: floating-point unit ('Zfinx' extension)
+--constant cp_sel_res0_c     : std_ulogic_vector(2 downto 0) := "100"; -- CP4: reserved
+--constant cp_sel_res1_c     : std_ulogic_vector(2 downto 0) := "101"; -- CP5: reserved
+--constant cp_sel_res2_c     : std_ulogic_vector(2 downto 0) := "110"; -- CP6: reserved
+--constant cp_sel_res3_c     : std_ulogic_vector(2 downto 0) := "111"; -- CP7: reserved
 
   -- ALU Function Codes ---------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds four additional co-processor slots (4..7) to the CPU's ALU. The new co-processor slots are not used yet and are reserved for future (ISA) extensions. Slot 4 is going to be used to implement a **Custom Functions Unit (CFU)** that allows to implement _custom RISC-V instructions_.

With this PR the ALU contains up to eight co-processors:

* **CP0**: shift operation, `I`/`E` base ISA, _mandatory_
* **CP1**: multiply/divide, `M` ISA extension, _optional_
* **CP2**: bit-manipulation, `B` ISA extension, _optional_
* **CP3**: floating-point unit, `Zfinx` ISA extensions, _optional_
* **CP4**: empty slot, _reserved_
* **CP5**: empty slot, _reserved_
* **CP6**: empty slot, _reserved_
* **CP7**: empty slot, _reserved_

------------------------------

:bug: This PR also fixes a bug in the co-processor arbitration logic: if a co-processor operation is triggered by an illegal instruction (the instruction itself is fine - it just triggers an illegal/unsupported co-processor function) the according co-processor has to terminate any internal operation that has been incorrectly triggered. Otherwise, an instruction right at the beginning of the illegal instruction trap handler that uses that specific co-processor might get an incorrect co-processor result.

------------------------------

:bug: Another small bug is fixed by this PR: there was an instruction decoding collision in the bit-manipulation co-processor between the `cpop` and `rol` instructions.