### PR TITLE
[sw] rework intrinsics (custom instructions)

### DIFF
--- a/sw/example/bitmanip_test/neorv32_b_extension_intrinsics.h
+++ b/sw/example/bitmanip_test/neorv32_b_extension_intrinsics.h
@@ -61,333 +61,189 @@
 /**********************************************************************//**
  * Intrinsic: Bit manipulation CLZ (count leading zeros) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Number of leading zeros in source operand.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clz(uint32_t rs1) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // clz a0, a0
-  CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00000, a0, 0b001, a0, 0b0010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00000, rs1, 0b001, 0b0010011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation CTZ (count trailing zeros) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Number of trailing zeros in source operand.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_ctz(uint32_t rs1) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // ctz a0, a0
-  CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00001, a0, 0b001, a0, 0b0010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00001, rs1, 0b001, 0b0010011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation CPOP (count set bits) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Number of set bits in source operand.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_cpop(uint32_t rs1) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // cpop a0, a0
-  CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00010, a0, 0b001, a0, 0b0010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00010, rs1, 0b001, 0b0010011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation SEXT.B (sign-extend byte) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Sign extended byte (operand(7:0)).
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sextb(uint32_t rs1) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // sext.b a0, a0
-  CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00100, a0, 0b001, a0, 0b0010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00100, rs1, 0b001, 0b0010011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation SEXT.H (sign-extend half-word) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Sign-extended half-word (operand(15:0)).
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sexth(uint32_t rs1) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // sext.h a0, a0
-  CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00101, a0, 0b001, a0, 0b0010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00101, rs1, 0b001, 0b0010011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation ZEXT.H (zero-extend half-word) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Zero-extended half-word (operand(15:0)).
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_zexth(uint32_t rs1) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // sext.h a0, a0
-  CUSTOM_INSTR_R1_TYPE(0b0000100, 0b00000, a0, 0b100, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b0000100, 0b00000, rs1, 0b100, 0b0110011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation MIN (select signed minimum) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Signed minimum.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_min(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // min a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0000101, a1, a0, 0b100, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs2, rs1, 0b100, 0b0110011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation MINU (select unsigned minimum) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Unsigned minimum.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_minu(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // minu a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0000101, a1, a0, 0b101, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs2, rs1, 0b101, 0b0110011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation MAX (select signed maximum) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Signed maximum.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_max(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // max a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0000101, a1, a0, 0b110, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs2, rs1, 0b110, 0b0110011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation MAXU (select unsigned maximum) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Unsigned maximum.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_maxu(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // maxu a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0000101, a1, a0, 0b111, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs2, rs1, 0b111, 0b0110011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation ANDN (logical and-negate) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Operand 1 AND NOT operand 2.
  **************************************************************************/
 inline inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_andn(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // andn a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0100000, a1, a0, 0b111, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0100000, rs2, rs1, 0b111, 0b0110011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation ORN (logical or-negate) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Operand 1 OR NOT operand 2.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_orn(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // orn a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0100000, a1, a0, 0b110, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0100000, rs2, rs1, 0b110, 0b0110011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation XNOR (logical xor-negate) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Operand 1 XOR NOT operand 2.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_xnor(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // xnor a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0100000, a1, a0, 0b100, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0100000, rs2, rs1, 0b100, 0b0110011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation ROL (rotate-left) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Operand 1 rotated left by operand_2(4:0) positions.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_rol(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // rol a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0110000, a1, a0, 0b001, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0110000, rs2, rs1, 0b001, 0b0110011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation ROR (rotate-right) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Operand 1 rotated right by operand_2(4:0) positions.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_ror(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // ror a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0110000, a1, a0, 0b101, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0110000, rs2, rs1, 0b101, 0b0110011);
 }
 
 
@@ -395,135 +251,78 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_ror(uint32_t rs1
  * Intrinsic: Bit manipulation RORI (rotate-right) by 20 positions. [B.Zbb]
  * @warning Fixed shift amount (20) for now.
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Operand 1 rotated right by 20 positions.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_rori20(uint32_t rs1) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // rori a0, a0, 20
-  CUSTOM_INSTR_R1_TYPE(0b0110000, 0b10100, a0, 0b101, a0, 0b0010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b0110000, 0b10100, rs1, 0b101, 0b0010011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation ORC.B (or-combine byte) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return OR-combined bytes of operand 1.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_orcb(uint32_t rs1) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // gorci a0, a0, 7 (pseudo-instruction: orc.b a0, a0)
-  CUSTOM_INSTR_R1_TYPE(0b0010100, 0b00111, a0, 0b101, a0, 0b0010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b0010100, 0b00111, rs1, 0b101, 0b0010011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation REV8 (byte-swap) [B.Zbb]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Byte swap of operand 1
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_rev8(uint32_t rs1) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // grevi a0, a0, -8 (pseudo-instruction: rev8 a0, a0)
-  CUSTOM_INSTR_R1_TYPE(0b0110100, 0b11000, a0, 0b101, a0, 0b0010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b0110100, 0b11000, rs1, 0b101, 0b0010011);
 }
 
 
 // ================================================================================================
-// Zbb - Base instructions
+// Zba - Address-generation instructions
 // ================================================================================================
 
 /**********************************************************************//**
  * Intrinsic: Address generation instructions SH1ADD (add with logical-1-shift) [B.Zba]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Operand 2 + (Operand 1 << 1)
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sh1add(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // sh1add a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0010000, a1, a0, 0b010, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0010000, rs2, rs1, 0b010, 0b0110011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Address generation instructions SH2ADD (add with logical-2-shift) [B.Zba]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Operand 2 + (Operand 1 << 2)
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sh2add(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // sh2add a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0010000, a1, a0, 0b100, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0010000, rs2, rs1, 0b100, 0b0110011);
 }
 
 /**********************************************************************//**
  * Intrinsic: Address generation instructions SH1ADD (add with logical-3-shift) [B.Zba]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Operand 2 + (Operand 1 << 3)
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sh3add(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // sh3add a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0010000, a1, a0, 0b110, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0010000, rs2, rs1, 0b110, 0b0110011);
 }
 
 
@@ -535,23 +334,13 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sh3add(uint32_t 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation BCLR (bit-clear) [B.Zbs]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Operand 1 with bit cleared indexed by operand_2(4:0).
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bclr(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // bclr a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0100100, a1, a0, 0b001, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0100100, rs2, rs1, 0b001, 0b0110011);
 }
 
 
@@ -559,44 +348,25 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bclr(uint32_t rs
  * Intrinsic: Bit manipulation BCLRI (bit-clear) by 20 positions. [B.Zbs]
  * @warning Fixed shift amount (20) for now.
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Operand 1 with bit cleared at position 20.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bclri20(uint32_t rs1) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // bclri a0, a0, 20
-  CUSTOM_INSTR_R1_TYPE(0b0100100, 0b10100, a0, 0b001, a0, 0b0010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b0100100, 0b10100, rs1, 0b001, 0b0010011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation BEXT (bit-extract) [B.Zbs]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Extract bit from Operand 1 indexed by operand_2(4:0).
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bext(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // bext a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0100100, a1, a0, 0b101, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0100100, rs2, rs1, 0b101, 0b0110011);
 }
 
 
@@ -604,44 +374,25 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bext(uint32_t rs
  * Intrinsic: Bit manipulation BEXTI (bit-extract) by 20 positions. [B.Zbs]
  * @warning Fixed shift amount (20) for now.
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Extract bit from Operand 1 at position 20.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bexti20(uint32_t rs1) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // bexti a0, a0, 20
-  CUSTOM_INSTR_R1_TYPE(0b0100100, 0b10100, a0, 0b101, a0, 0b0010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b0100100, 0b10100, rs1, 0b101, 0b0010011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation BINV (bit-invert) [B.Zbs]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Invert bit from Operand 1 indexed by operand_2(4:0).
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_binv(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // binv a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0110100, a1, a0, 0b001, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0110100, rs2, rs1, 0b001, 0b0110011);
 }
 
 
@@ -649,44 +400,25 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_binv(uint32_t rs
  * Intrinsic: Bit manipulation BINVI (bit-invert) by 20 positions. [B.Zbs]
  * @warning Fixed shift amount (20) for now.
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Invert bit from Operand 1 at position 20.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_binvi20(uint32_t rs1) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // binvi a0, a0, 20
-  CUSTOM_INSTR_R1_TYPE(0b0110100, 0b10100, a0, 0b001, a0, 0b0010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b0110100, 0b10100, rs1, 0b001, 0b0010011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation BSET (bit-set) [B.Zbs]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return set bit from Operand 1 indexed by operand_2(4:0).
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bset(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // bset a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0010100, a1, a0, 0b001, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0010100, rs2, rs1, 0b001, 0b0110011);
 }
 
 
@@ -694,21 +426,12 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bset(uint32_t rs
  * Intrinsic: Bit manipulation BSETI (bit-set) by 20 positions. [B.Zbs]
  * @warning Fixed shift amount (20) for now.
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Set bit from Operand 1 at position 20.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bseti20(uint32_t rs1) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // bseti a0, a0, 20
-  CUSTOM_INSTR_R1_TYPE(0b0010100, 0b10100, a0, 0b001, a0, 0b0010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b0010100, 0b10100, rs1, 0b001, 0b0010011);
 }
 
 
@@ -720,69 +443,39 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bseti20(uint32_t
 /**********************************************************************//**
  * Intrinsic: Bit manipulation CLMUL (carry-less multiplication, low-part) [B.Zbc]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Carry-less product, low part.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clmul(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // clmul a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0000101, a1, a0, 0b001, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs2, rs1, 0b001, 0b0110011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation CLMULH (carry-less multiplication, high-part) [B.Zbc]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Carry-less product, high part.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clmulh(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // clmulh a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0000101, a1, a0, 0b011, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs2, rs1, 0b011, 0b0110011);
 }
 
 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation CLMULR (carry-less multiplication, reversed) [B.Zbc]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Carry-less product, low part, reversed.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clmulr(uint32_t rs1, uint32_t rs2) {
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-  register uint32_t tmp_b  __asm__ ("a1") = rs2;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // clmulr a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0000101, a1, a0, 0b010, a0, 0b0110011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs1, rs2, 0b010, 0b0110011);
 }
 
 
@@ -799,7 +492,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clmulr(uint32_t 
 /**********************************************************************//**
  * Intrinsic: Bit manipulation CLZ (count leading zeros) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Number of leading zeros in source operand.
  **************************************************************************/
 uint32_t riscv_emulate_clz(uint32_t rs1) {
@@ -824,7 +517,7 @@ uint32_t riscv_emulate_clz(uint32_t rs1) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation CTZ (count trailing zeros) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Number of trailing zeros in source operand.
  **************************************************************************/
 uint32_t riscv_emulate_ctz(uint32_t rs1) {
@@ -849,7 +542,7 @@ uint32_t riscv_emulate_ctz(uint32_t rs1) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation CPOP (population count) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Number of set bits in source operand.
  **************************************************************************/
 uint32_t riscv_emulate_cpop(uint32_t rs1) {
@@ -872,7 +565,7 @@ uint32_t riscv_emulate_cpop(uint32_t rs1) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation SEXT.B (sign-extend byte) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Sign-extended byte (operand(7:0)).
  **************************************************************************/
 uint32_t riscv_emulate_sextb(uint32_t rs1) {
@@ -890,7 +583,7 @@ uint32_t riscv_emulate_sextb(uint32_t rs1) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation SEXT.H (sign-extend half-word) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Sign-extended half-word (operand(15:0)).
  **************************************************************************/
 uint32_t riscv_emulate_sexth(uint32_t rs1) {
@@ -908,7 +601,7 @@ uint32_t riscv_emulate_sexth(uint32_t rs1) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation ZEXT.H (zero-extend half-word) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Zero-extended half-word (operand(15:0)).
  **************************************************************************/
 uint32_t riscv_emulate_zexth(uint32_t rs1) {
@@ -920,8 +613,8 @@ uint32_t riscv_emulate_zexth(uint32_t rs1) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation MIN (select signed minimum) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Signed minimum.
  **************************************************************************/
 uint32_t riscv_emulate_min(uint32_t rs1, uint32_t rs2) {
@@ -941,8 +634,8 @@ uint32_t riscv_emulate_min(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation MINU (select unsigned minimum) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Unsigned minimum.
  **************************************************************************/
 uint32_t riscv_emulate_minu(uint32_t rs1, uint32_t rs2) {
@@ -959,8 +652,8 @@ uint32_t riscv_emulate_minu(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation MAX (select signed maximum) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Signed maximum.
  **************************************************************************/
 uint32_t riscv_emulate_max(uint32_t rs1, uint32_t rs2) {
@@ -980,8 +673,8 @@ uint32_t riscv_emulate_max(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation MAXU (select unsigned maximum) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Unsigned maximum.
  **************************************************************************/
 uint32_t riscv_emulate_maxu(uint32_t rs1, uint32_t rs2) {
@@ -998,8 +691,8 @@ uint32_t riscv_emulate_maxu(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation ANDN (logical and-negate) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Operand 1 AND NOT operand 2.
  **************************************************************************/
 uint32_t riscv_emulate_andn(uint32_t rs1, uint32_t rs2) {
@@ -1011,8 +704,8 @@ uint32_t riscv_emulate_andn(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation ORN (logical or-negate) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Operand 1 OR NOT operand 2.
  **************************************************************************/
 uint32_t riscv_emulate_orn(uint32_t rs1, uint32_t rs2) {
@@ -1024,8 +717,8 @@ uint32_t riscv_emulate_orn(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation XNOR (logical xor-negate) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Operand 1 XOR NOT operand 2.
  **************************************************************************/
 uint32_t riscv_emulate_xnor(uint32_t rs1, uint32_t rs2) {
@@ -1037,8 +730,8 @@ uint32_t riscv_emulate_xnor(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation ROL (rotate-left) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Operand 1 rotated left by operand_2(4:0) positions.
  **************************************************************************/
 uint32_t riscv_emulate_rol(uint32_t rs1, uint32_t rs2) {
@@ -1055,8 +748,8 @@ uint32_t riscv_emulate_rol(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation ROR (rotate-right) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Operand 1 rotated right by operand_2(4:0) positions.
  **************************************************************************/
 uint32_t riscv_emulate_ror(uint32_t rs1, uint32_t rs2) {
@@ -1073,7 +766,7 @@ uint32_t riscv_emulate_ror(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation REV8 (byte swap) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Operand 1 byte swapped.
  **************************************************************************/
 uint32_t riscv_emulate_rev8(uint32_t rs1) {
@@ -1090,7 +783,7 @@ uint32_t riscv_emulate_rev8(uint32_t rs1) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation ORCB (or-combine bytes) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return OR-combined bytes of operand 1.
  **************************************************************************/
 uint32_t riscv_emulate_orcb(uint32_t rs1) {
@@ -1122,8 +815,8 @@ uint32_t riscv_emulate_orcb(uint32_t rs1) {
 /**********************************************************************//**
  * Intrinsic: Address generation instructions SH1ADD (add with logical-1-shift) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Operand 2 + (Operand 1 << 1)
  **************************************************************************/
 uint32_t riscv_emulate_sh1add(uint32_t rs1, uint32_t rs2) {
@@ -1135,8 +828,8 @@ uint32_t riscv_emulate_sh1add(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Address generation instructions SH2ADD (add with logical-2-shift) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Operand 2 + (Operand 1 << 2)
  **************************************************************************/
 uint32_t riscv_emulate_sh2add(uint32_t rs1, uint32_t rs2) {
@@ -1148,8 +841,8 @@ uint32_t riscv_emulate_sh2add(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Address generation instructions SH3ADD (add with logical-3-shift) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Operand 2 + (Operand 1 << 3)
  **************************************************************************/
 uint32_t riscv_emulate_sh3add(uint32_t rs1, uint32_t rs2) {
@@ -1166,8 +859,8 @@ uint32_t riscv_emulate_sh3add(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation BCLR (bit-clear) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Operand 1 with cleared bit indexed by operand_2(4:0).
  **************************************************************************/
 uint32_t riscv_emulate_bclr(uint32_t rs1, uint32_t rs2) {
@@ -1182,8 +875,8 @@ uint32_t riscv_emulate_bclr(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation BEXT (bit-extract) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Extract bit from operand 1 indexed by operand_2(4:0).
  **************************************************************************/
 uint32_t riscv_emulate_bext(uint32_t rs1, uint32_t rs2) {
@@ -1198,8 +891,8 @@ uint32_t riscv_emulate_bext(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation BINV (bit-invert) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Invert bit from operand 1 indexed by operand_2(4:0).
  **************************************************************************/
 uint32_t riscv_emulate_binv(uint32_t rs1, uint32_t rs2) {
@@ -1214,8 +907,8 @@ uint32_t riscv_emulate_binv(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation BSET (bit-set) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Set bit from operand 1 indexed by operand_2(4:0).
  **************************************************************************/
 uint32_t riscv_emulate_bset(uint32_t rs1, uint32_t rs2) {
@@ -1235,8 +928,8 @@ uint32_t riscv_emulate_bset(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation CLMUL (carry-less multiply, low-part) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Carry-less multiplication product, low part
  **************************************************************************/
 uint32_t riscv_emulate_clmul(uint32_t rs1, uint32_t rs2) {
@@ -1264,8 +957,8 @@ uint32_t riscv_emulate_clmul(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation CLMULH (carry-less multiply, high-part) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Carry-less multiplication product, high part
  **************************************************************************/
 uint32_t riscv_emulate_clmulh(uint32_t rs1, uint32_t rs2) {
@@ -1293,8 +986,8 @@ uint32_t riscv_emulate_clmulh(uint32_t rs1, uint32_t rs2) {
 /**********************************************************************//**
  * Intrinsic: Bit manipulation CLMUR (carry-less multiply, reversed) [emulation]
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 1.
  * @return Carry-less multiplication product, low part, reversed
  **************************************************************************/
 uint32_t riscv_emulate_clmulr(uint32_t rs1, uint32_t rs2) {

--- a/sw/example/floating_point_test/neorv32_zfinx_extension_intrinsics.h
+++ b/sw/example/floating_point_test/neorv32_zfinx_extension_intrinsics.h
@@ -6,7 +6,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -167,8 +167,8 @@ uint32_t get_sw_exceptions(void) {
 /**********************************************************************//**
  * Single-precision floating-point addition
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a1).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fadds(float rs1, float rs2) {
@@ -177,17 +177,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fadds(float rs1, fl
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // fadd.s a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0000000, a1, a0, 0b000, a0, 0b1010011);
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0000000, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -195,8 +185,8 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fadds(float rs1, fl
 /**********************************************************************//**
  * Single-precision floating-point subtraction
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a1).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fsubs(float rs1, float rs2) {
@@ -205,17 +195,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsubs(float rs1, fl
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // fsub.s a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0000100, a1, a0, 0b000, a0, 0b1010011);
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0000100, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -223,8 +203,8 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsubs(float rs1, fl
 /**********************************************************************//**
  * Single-precision floating-point multiplication
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a1).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fmuls(float rs1, float rs2) {
@@ -233,17 +213,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmuls(float rs1, fl
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // fmul.s a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0001000, a1, a0, 0b000, a0, 0b1010011);
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0001000, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -251,8 +221,8 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmuls(float rs1, fl
 /**********************************************************************//**
  * Single-precision floating-point minimum
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a1).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fmins(float rs1, float rs2) {
@@ -261,17 +231,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmins(float rs1, fl
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // fmin.s a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0010100, a1, a0, 0b000, a0, 0b1010011);
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0010100, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -279,8 +239,8 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmins(float rs1, fl
 /**********************************************************************//**
  * Single-precision floating-point maximum
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a1).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fmaxs(float rs1, float rs2) {
@@ -289,17 +249,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmaxs(float rs1, fl
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // fmax.s a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0010100, a1, a0, 0b001, a0, 0b1010011);
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0010100, opb.binary_value, opa.binary_value, 0b001, 0b1010011);
   return res.float_value;
 }
 
@@ -307,7 +257,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmaxs(float rs1, fl
 /**********************************************************************//**
  * Single-precision floating-point convert float to unsigned integer
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Result.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_fcvt_wus(float rs1) {
@@ -315,23 +265,14 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_fcvt_wus(float r
   float_conv_t opa;
   opa.float_value = rs1;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // fcvt.wu.s a0, a0
-  CUSTOM_INSTR_R2_TYPE(0b1100000, x1, a0, 0b000, a0, 0b1010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b1100000, 0b00001, opa.binary_value, 0b000, 0b1010011);
 }
 
 
 /**********************************************************************//**
  * Single-precision floating-point convert float to signed integer
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Result.
  **************************************************************************/
 inline int32_t __attribute__ ((always_inline)) riscv_intrinsic_fcvt_ws(float rs1) {
@@ -339,39 +280,21 @@ inline int32_t __attribute__ ((always_inline)) riscv_intrinsic_fcvt_ws(float rs1
   float_conv_t opa;
   opa.float_value = rs1;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // fcvt.w.s a0, a0
-  CUSTOM_INSTR_R2_TYPE(0b1100000, x0, a0, 0b000, a0, 0b1010011);
-
-  return (int32_t)result;
+  return (int32_t)CUSTOM_INSTR_R1_TYPE(0b1100000, 0b00000, opa.binary_value, 0b000, 0b1010011);
 }
 
 
 /**********************************************************************//**
  * Single-precision floating-point convert unsigned integer to float
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fcvt_swu(uint32_t rs1) {
 
   float_conv_t res;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // fcvt.s.wu a0, a0
-  CUSTOM_INSTR_R2_TYPE(0b1101000, x1, a0, 0b000, a0, 0b1010011);
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R1_TYPE(0b1101000, 0b00001, rs1, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -379,23 +302,14 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fcvt_swu(uint32_t r
 /**********************************************************************//**
  * Single-precision floating-point convert signed integer to float
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fcvt_sw(int32_t rs1) {
 
   float_conv_t res;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = (uint32_t)rs1;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // fcvt.s.w a0, a0
-  CUSTOM_INSTR_R2_TYPE(0b1101000, x0, a0, 0b000, a0, 0b1010011);
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R1_TYPE(0b1101000, 0b00000, rs1, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -403,8 +317,8 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fcvt_sw(int32_t rs1
 /**********************************************************************//**
  * Single-precision floating-point equal comparison
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a1).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Result.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_feqs(float rs1, float rs2) {
@@ -413,25 +327,15 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_feqs(float rs1, 
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // feq.s a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b1010000, a1, a0, 0b010, a0, 0b1010011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b1010000, opb.binary_value, opa.binary_value, 0b010, 0b1010011);
 }
 
 
 /**********************************************************************//**
  * Single-precision floating-point less-than comparison
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a1).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Result.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_flts(float rs1, float rs2) {
@@ -440,25 +344,15 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_flts(float rs1, 
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // flt.s a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b1010000, a1, a0, 0b001, a0, 0b1010011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b1010000, opb.binary_value, opa.binary_value, 0b001, 0b1010011);
 }
 
 
 /**********************************************************************//**
  * Single-precision floating-point less-than-or-equal comparison
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a1).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Result.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_fles(float rs1, float rs2) {
@@ -467,25 +361,15 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_fles(float rs1, 
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // fle.s a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b1010000, a1, a0, 0b000, a0, 0b1010011);
-
-  return result;
+  return CUSTOM_INSTR_R2_TYPE(0b1010000, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
 }
 
 
 /**********************************************************************//**
  * Single-precision floating-point sign-injection
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a1).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fsgnjs(float rs1, float rs2) {
@@ -494,17 +378,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsgnjs(float rs1, f
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // fsgnj.s a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0010000, a1, a0, 0b000, a0, 0b1010011);
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0010000, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -512,8 +386,8 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsgnjs(float rs1, f
 /**********************************************************************//**
  * Single-precision floating-point sign-injection NOT
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a1).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fsgnjns(float rs1, float rs2) {
@@ -522,17 +396,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsgnjns(float rs1, 
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // fsgnjn.s a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0010000, a1, a0, 0b001, a0, 0b1010011);
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0010000, opb.binary_value, opa.binary_value, 0b001, 0b1010011);
   return res.float_value;
 }
 
@@ -540,8 +404,8 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsgnjns(float rs1, 
 /**********************************************************************//**
  * Single-precision floating-point sign-injection XOR
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a1).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fsgnjxs(float rs1, float rs2) {
@@ -550,17 +414,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsgnjxs(float rs1, 
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // fsgnjx.s a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0010000, a1, a0, 0b010, a0, 0b1010011);
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0010000, opb.binary_value, opa.binary_value, 0b010, 0b1010011);
   return res.float_value;
 }
 
@@ -568,7 +422,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsgnjxs(float rs1, 
 /**********************************************************************//**
  * Single-precision floating-point number classification
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Result.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_fclasss(float rs1) {
@@ -576,16 +430,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_fclasss(float rs
   float_conv_t opa;
   opa.float_value = rs1;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("" : [output] "=r" (result) : [input_i] "r" (tmp_a));
-
-  // fclass.s a0, a0
-  CUSTOM_INSTR_R2_TYPE(0b1110000, x0, a0, 0b001, a0, 0b1010011);
-
-  return result;
+  return CUSTOM_INSTR_R1_TYPE(0b1110000, 0b00000, opa.binary_value, 0b001, 0b1010011);
 }
 
 
@@ -598,8 +443,8 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_fclasss(float rs
  *
  * @warning This instruction is not supported and should raise an illegal instruction exception when executed.
  *
- * @param[in] rs1 Source operand 1 (a0).
- * @param[in] rs2 Source operand 2 (a1).
+ * @param[in] rs1 Source operand 1.
+ * @param[in] rs2 Source operand 2.
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fdivs(float rs1, float rs2) {
@@ -608,20 +453,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fdivs(float rs1, fl
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("add x0, %[input_i], %[input_j]" : : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-
-  // fdiv.s a0, a0, x1
-  CUSTOM_INSTR_R2_TYPE(0b0001100, a1, a0, 0b000, a0, 0b1010011);
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("add %[res], %[input], x0" : [res] "=r" (result) : [input] "r" (result) );
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0001100, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -631,7 +463,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fdivs(float rs1, fl
  *
  * @warning This instruction is not supported and should raise an illegal instruction exception when executed.
  *
- * @param[in] rs1 Source operand 1 (a0).
+ * @param[in] rs1 Source operand 1.
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fsqrts(float rs1) {
@@ -639,19 +471,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsqrts(float rs1) {
   float_conv_t opa, res;
   opa.float_value = rs1;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("add x0, %[input_i], x0" : : [input_i] "r" (tmp_a));
-
-  // fsqrt.s a0, a0, a1
-  CUSTOM_INSTR_R2_TYPE(0b0101100, a1, a0, 0b000, a0, 0b1010011);
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("add %[res], %[input], x0" : [res] "=r" (result) : [input] "r" (result) );
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R1_TYPE(0b0101100, 0b00000, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -661,9 +481,9 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsqrts(float rs1) {
  *
  * @warning This instruction is not supported and should raise an illegal instruction exception when executed.
  *
- * @param[in] rs1 Source operand 1 (a0)
- * @param[in] rs2 Source operand 2 (a1)
- * @param[in] rs3 Source operand 3 (a2)
+ * @param[in] rs1 Source operand 1
+ * @param[in] rs2 Source operand 2
+ * @param[in] rs3 Source operand 3
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fmadds(float rs1, float rs2, float rs3) {
@@ -673,22 +493,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmadds(float rs1, f
   opb.float_value = rs2;
   opc.float_value = rs3;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-  register uint32_t tmp_c  __asm__ ("a2") = opc.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("add x0, %[input_i], %[input_j]" : : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-  asm volatile ("add x0, %[input_i], %[input_j]" : : [input_i] "r" (tmp_b), [input_j] "r" (tmp_c));
-
-  // fmadd.s a0, a0, a1, a2
-  CUSTOM_INSTR_R3_TYPE(a2, a1, a0, 0b000, a0, 0b1000011);
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("add %[res], %[input], x0" : [res] "=r" (result) : [input] "r" (result) );
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R3_TYPE(opc.binary_value, opb.binary_value, opa.binary_value, 0b000, 0b1000011);
   return res.float_value;
 }
 
@@ -698,9 +503,9 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmadds(float rs1, f
  *
  * @warning This instruction is not supported and should raise an illegal instruction exception when executed.
  *
- * @param[in] rs1 Source operand 1 (a0)
- * @param[in] rs2 Source operand 2 (a1)
- * @param[in] rs3 Source operand 3 (a2)
+ * @param[in] rs1 Source operand 1
+ * @param[in] rs2 Source operand 2
+ * @param[in] rs3 Source operand 3
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fmsubs(float rs1, float rs2, float rs3) {
@@ -710,22 +515,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmsubs(float rs1, f
   opb.float_value = rs2;
   opc.float_value = rs3;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-  register uint32_t tmp_c  __asm__ ("a2") = opc.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("add x0, %[input_i], %[input_j]" : : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-  asm volatile ("add x0, %[input_i], %[input_j]" : : [input_i] "r" (tmp_b), [input_j] "r" (tmp_c));
-
-  // fmsub.s a0, a0, a1, a2
-  CUSTOM_INSTR_R3_TYPE(a2, a1, a0, 0b000, a0, 0b1000111);
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("add %[res], %[input], x0" : [res] "=r" (result) : [input] "r" (result) );
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R3_TYPE(opc.binary_value, opb.binary_value, opa.binary_value, 0b000, 0b1000111);
   return res.float_value;
 }
 
@@ -735,9 +525,9 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmsubs(float rs1, f
  *
  * @warning This instruction is not supported and should raise an illegal instruction exception when executed.
  *
- * @param[in] rs1 Source operand 1 (a0)
- * @param[in] rs2 Source operand 2 (a1)
- * @param[in] rs3 Source operand 3 (a2)
+ * @param[in] rs1 Source operand 1
+ * @param[in] rs2 Source operand 2
+ * @param[in] rs3 Source operand 3
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fnmsubs(float rs1, float rs2, float rs3) {
@@ -747,22 +537,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fnmsubs(float rs1, 
   opb.float_value = rs2;
   opc.float_value = rs3;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-  register uint32_t tmp_c  __asm__ ("a2") = opc.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("add x0, %[input_i], %[input_j]" : : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-  asm volatile ("add x0, %[input_i], %[input_j]" : : [input_i] "r" (tmp_b), [input_j] "r" (tmp_c));
-
-  // fnmsub.s a0, a0, a1, a2
-  CUSTOM_INSTR_R3_TYPE(a2, a1, a0, 0b000, a0, 0b1001011);
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("add %[res], %[input], x0" : [res] "=r" (result) : [input] "r" (result) );
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R3_TYPE(opc.binary_value, opb.binary_value, opa.binary_value, 0b000, 0b1001011);
   return res.float_value;
 }
 
@@ -772,9 +547,9 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fnmsubs(float rs1, 
  *
  * @warning This instruction is not supported and should raise an illegal instruction exception when executed.
  *
- * @param[in] rs1 Source operand 1 (a0)
- * @param[in] rs2 Source operand 2 (a1)
- * @param[in] rs3 Source operand 3 (a2)
+ * @param[in] rs1 Source operand 1
+ * @param[in] rs2 Source operand 2
+ * @param[in] rs3 Source operand 3
  * @return Result.
  **************************************************************************/
 inline float __attribute__ ((always_inline)) riscv_intrinsic_fnmadds(float rs1, float rs2, float rs3) {
@@ -784,22 +559,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fnmadds(float rs1, 
   opb.float_value = rs2;
   opc.float_value = rs3;
 
-  register uint32_t result __asm__ ("a0");
-  register uint32_t tmp_a  __asm__ ("a0") = opa.binary_value;
-  register uint32_t tmp_b  __asm__ ("a1") = opb.binary_value;
-  register uint32_t tmp_c  __asm__ ("a2") = opc.binary_value;
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("add x0, %[input_i], %[input_j]" : : [input_i] "r" (tmp_a), [input_j] "r" (tmp_b));
-  asm volatile ("add x0, %[input_i], %[input_j]" : : [input_i] "r" (tmp_b), [input_j] "r" (tmp_c));
-
-  // fnmadd.s a0, a0, a1, a2
-  CUSTOM_INSTR_R3_TYPE(a2, a1, a0, 0b000, a0, 0b1001111);
-
-  // dummy instruction to prevent GCC "constprop" optimization
-  asm volatile ("add %[res], %[input], x0" : [res] "=r" (result) : [input] "r" (result) );
-
-  res.binary_value = result;
+  res.binary_value = CUSTOM_INSTR_R3_TYPE(opc.binary_value, opb.binary_value, opa.binary_value, 0b000, 0b1001111);
   return res.float_value;
 }
 
@@ -1288,8 +1048,6 @@ float __attribute__ ((noinline)) riscv_emulate_fsqrts(float rs1) {
 
 /**********************************************************************//**
  * Single-precision floating-point fused multiply-add
- *
- * @note "noinline" attributed to make sure arguments/return values are in a0 and a1.
  *
  * @warning This instruction is not supported!
  *

--- a/sw/lib/include/neorv32_intrinsics.h
+++ b/sw/lib/include/neorv32_intrinsics.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -35,132 +35,233 @@
 
 /**********************************************************************//**
  * @file neorv32_intrinsics.h
- * @author Stephan Nolting
+ * @author Stephan Nolting, SaxonSoc contributors, Google-CFU
  * @brief Helper functions and macros for custom "intrinsics" / instructions.
  **************************************************************************/
 
 #ifndef neorv32_intrinsics_h
 #define neorv32_intrinsics_h
 
+
+// ****************************************************************************************************************************
+// Custom Instruction Intrinsics
+// Derived from https://github.com/google/CFU-Playground/blob/dfe5c2b75a4540dab62baef1b12fd03bfa78425e/third_party/SaxonSoc/riscv.h
+// Original license header:
+//
+//   From https://github.com/SpinalHDL/SaxonSoc/blob/dev-0.1/software/standalone/driver/riscv.h
+//
+//   Copyright (c) 2019 SaxonSoc contributors
+//
+//   MIT License: https://github.com/SpinalHDL/SaxonSoc/blob/dev-0.1/LICENSE
+//
+// LICENSE:
+//  MIT License
+//  
+//  Copyright (c) 2019 SaxonSoc contributors
+//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//  
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//  
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+// ****************************************************************************************************************************
+
 /**********************************************************************//**
- * @name Custom instructions / intrinsics helper macros
+ * @name Custom Instruction Intrinsics
+ * @note Copied from https://github.com/google/CFU-Playground/blob/dfe5c2b75a4540dab62baef1b12fd03bfa78425e/third_party/SaxonSoc/riscv.h
+ *       Original license header:
+ * // From https://github.com/SpinalHDL/SaxonSoc/blob/dev-0.1/software/standalone/driver/riscv.h
+ * //
+ * // Copyright (c) 2019 SaxonSoc contributors
+ * //
+ * // MIT License: https://github.com/SpinalHDL/SaxonSoc/blob/dev-0.1/LICENSE
  **************************************************************************/
 /**@{*/
+asm(".set regnum_x0  ,  0");
+asm(".set regnum_x1  ,  1");
+asm(".set regnum_x2  ,  2");
+asm(".set regnum_x3  ,  3");
+asm(".set regnum_x4  ,  4");
+asm(".set regnum_x5  ,  5");
+asm(".set regnum_x6  ,  6");
+asm(".set regnum_x7  ,  7");
+asm(".set regnum_x8  ,  8");
+asm(".set regnum_x9  ,  9");
+asm(".set regnum_x10 , 10");
+asm(".set regnum_x11 , 11");
+asm(".set regnum_x12 , 12");
+asm(".set regnum_x13 , 13");
+asm(".set regnum_x14 , 14");
+asm(".set regnum_x15 , 15");
+asm(".set regnum_x16 , 16");
+asm(".set regnum_x17 , 17");
+asm(".set regnum_x18 , 18");
+asm(".set regnum_x19 , 19");
+asm(".set regnum_x20 , 20");
+asm(".set regnum_x21 , 21");
+asm(".set regnum_x22 , 22");
+asm(".set regnum_x23 , 23");
+asm(".set regnum_x24 , 24");
+asm(".set regnum_x25 , 25");
+asm(".set regnum_x26 , 26");
+asm(".set regnum_x27 , 27");
+asm(".set regnum_x28 , 28");
+asm(".set regnum_x29 , 29");
+asm(".set regnum_x30 , 30");
+asm(".set regnum_x31 , 31");
 
-//** Selection helper macro */
-#define STR1(x) #x
-//** Selection helper macro 2 */
-#define STR(x) STR1(x)
-
-//** Register address converter */
-#define GET_REG_ADDR(x) REG_ADDR_##x
-
-#define REG_ADDR_x0   0 /**< register  0 */
-#define REG_ADDR_x1   1 /**< register  1 */
-#define REG_ADDR_x2   2 /**< register  2 */
-#define REG_ADDR_x3   3 /**< register  3 */
-#define REG_ADDR_x4   4 /**< register  4 */
-#define REG_ADDR_x5   5 /**< register  5 */
-#define REG_ADDR_x6   6 /**< register  6 */
-#define REG_ADDR_x7   7 /**< register  7 */
-#define REG_ADDR_x8   8 /**< register  8 */
-#define REG_ADDR_x9   9 /**< register  9 */
-#define REG_ADDR_x10 10 /**< register 10 */
-#define REG_ADDR_x11 11 /**< register 11 */
-#define REG_ADDR_x12 12 /**< register 12 */
-#define REG_ADDR_x13 13 /**< register 13 */
-#define REG_ADDR_x14 14 /**< register 14 */
-#define REG_ADDR_x15 15 /**< register 15 */
-#define REG_ADDR_x16 16 /**< register 16 */
-#define REG_ADDR_x17 17 /**< register 17 */
-#define REG_ADDR_x18 18 /**< register 18 */
-#define REG_ADDR_x19 19 /**< register 19 */
-#define REG_ADDR_x20 20 /**< register 20 */
-#define REG_ADDR_x21 21 /**< register 21 */
-#define REG_ADDR_x22 22 /**< register 22 */
-#define REG_ADDR_x23 23 /**< register 23 */
-#define REG_ADDR_x24 24 /**< register 24 */
-#define REG_ADDR_x25 25 /**< register 25 */
-#define REG_ADDR_x26 26 /**< register 26 */
-#define REG_ADDR_x27 27 /**< register 27 */
-#define REG_ADDR_x28 28 /**< register 28 */
-#define REG_ADDR_x29 29 /**< register 29 */
-#define REG_ADDR_x30 30 /**< register 30 */
-#define REG_ADDR_x31 31 /**< register 31 */
-#define REG_ADDR_zero 0 /**< register  0 - according to calling convention */
-#define REG_ADDR_ra   1 /**< register  1 - according to calling convention */
-#define REG_ADDR_sp   2 /**< register  2 - according to calling convention */
-#define REG_ADDR_gp   3 /**< register  3 - according to calling convention */
-#define REG_ADDR_tp   4 /**< register  4 - according to calling convention */
-#define REG_ADDR_t0   5 /**< register  5 - according to calling convention */
-#define REG_ADDR_t1   6 /**< register  6 - according to calling convention */
-#define REG_ADDR_t2   7 /**< register  7 - according to calling convention */
-#define REG_ADDR_s0   8 /**< register  8 - according to calling convention */
-#define REG_ADDR_s1   9 /**< register  9 - according to calling convention */
-#define REG_ADDR_a0  10 /**< register 10 - according to calling convention */
-#define REG_ADDR_a1  11 /**< register 11 - according to calling convention */
-#define REG_ADDR_a2  12 /**< register 12 - according to calling convention */
-#define REG_ADDR_a3  13 /**< register 13 - according to calling convention */
-#define REG_ADDR_a4  14 /**< register 14 - according to calling convention */
-#define REG_ADDR_a5  15 /**< register 15 - according to calling convention */
-#define REG_ADDR_a6  16 /**< register 16 - according to calling convention */
-#define REG_ADDR_a7  17 /**< register 17 - according to calling convention */
-#define REG_ADDR_s2  18 /**< register 18 - according to calling convention */
-#define REG_ADDR_s3  19 /**< register 19 - according to calling convention */
-#define REG_ADDR_s4  20 /**< register 20 - according to calling convention */
-#define REG_ADDR_s5  21 /**< register 21 - according to calling convention */
-#define REG_ADDR_s6  22 /**< register 22 - according to calling convention */
-#define REG_ADDR_s7  23 /**< register 23 - according to calling convention */
-#define REG_ADDR_s8  24 /**< register 24 - according to calling convention */
-#define REG_ADDR_s9  25 /**< register 25 - according to calling convention */
-#define REG_ADDR_s10 26 /**< register 26 - according to calling convention */
-#define REG_ADDR_s11 27 /**< register 27 - according to calling convention */
-#define REG_ADDR_t3  28 /**< register 28 - according to calling convention */
-#define REG_ADDR_t4  29 /**< register 29 - according to calling convention */
-#define REG_ADDR_t5  30 /**< register 30 - according to calling convention */
-#define REG_ADDR_t6  31 /**< register 31 - according to calling convention */
-
-//** Construct instruction word (32-bit) for R2-type instruction */
-#define CMD_WORD_R2_TYPE(funct7, rs2, rs1, funct3, rd, opcode) \
-  ( (opcode & 0x7f) <<  0 ) + \
-  ( (rd     & 0x1f) <<  7 ) + \
-  ( (funct3 & 0x1f) << 12 ) + \
-  ( (rs1    & 0x1f) << 15 ) + \
-  ( (rs2    & 0x1f) << 20 ) + \
-  ( (funct7 & 0x7f) << 25 )
-
-//** Construct instruction word (32-bit) for R3-type instruction */
-#define CMD_WORD_R3_TYPE(rs3, rs2, rs1, funct3, rd, opcode) \
-  ( (opcode & 0x7f) <<  0 ) + \
-  ( (rd     & 0x1f) <<  7 ) + \
-  ( (funct3 & 0x1f) << 12 ) + \
-  ( (rs1    & 0x1f) << 15 ) + \
-  ( (rs2    & 0x1f) << 20 ) + \
-  ( (rs3    & 0x1f) << 27 )
-
-//** Construct instruction word (32-bit) for I-type instruction */
-#define CMD_WORD_I_TYPE(imm12, rs1_f5, funct3, rd, opcode) \
-  ( (opcode & 0x7f)  <<  0 ) + \
-  ( (rd     & 0x1f)  <<  7 ) + \
-  ( (funct3 & 0x1f)  << 12 ) + \
-  ( (rs1_f5 & 0x1f)  << 15 ) + \
-  ( (imm12  & 0xfff) << 20 )
-
-//** Construct custom R3-type instruction (4 registers, funct3, opcode) */
-#define CUSTOM_INSTR_R3_TYPE(rs3, rs2, rs1, funct3, rd, opcode) \
-  asm volatile (".word " STR(CMD_WORD_R3_TYPE(GET_REG_ADDR(rs3), GET_REG_ADDR(rs2), GET_REG_ADDR(rs1), funct3, GET_REG_ADDR(rd), opcode))"\n");
-
-//** Construct custom R2-type instruction (3 registers, funct3, funct7, opcode) */
-#define CUSTOM_INSTR_R2_TYPE(funct7, rs2, rs1, funct3, rd, opcode) \
-  asm volatile (".word " STR(CMD_WORD_R2_TYPE(funct7, GET_REG_ADDR(rs2), GET_REG_ADDR(rs1), funct3, GET_REG_ADDR(rd), opcode))"\n");
-
-//** Construct custom R1-type instruction (2 registers, funct3, funct7, funct5, opcode) */
-#define CUSTOM_INSTR_R1_TYPE(funct7, funct5, rs1, funct3, rd, opcode) \
-  asm volatile (".word " STR(CMD_WORD_R2_TYPE(funct7, funct5, GET_REG_ADDR(rs1), funct3, GET_REG_ADDR(rd), opcode))"\n");
-  
-//** Construct custom I-type instruction (2 registers, funct3, imm12, opcode) */
-#define CUSTOM_INSTR_I_TYPE(imm12, rs1, funct3, rd, opcode) \
-  asm volatile (".word " STR(CMD_WORD_I_TYPE(imm12, GET_REG_ADDR(rs1), funct3, GET_REG_ADDR(rd), opcode))"\n");
+asm(".set regnum_zero,  0");
+asm(".set regnum_ra  ,  1");
+asm(".set regnum_sp  ,  2");
+asm(".set regnum_gp  ,  3");
+asm(".set regnum_tp  ,  4");
+asm(".set regnum_t0  ,  5");
+asm(".set regnum_t1  ,  6");
+asm(".set regnum_t2  ,  7");
+asm(".set regnum_s0  ,  8");
+asm(".set regnum_s1  ,  9");
+asm(".set regnum_a0  , 10");
+asm(".set regnum_a1  , 11");
+asm(".set regnum_a2  , 12");
+asm(".set regnum_a3  , 13");
+asm(".set regnum_a4  , 14");
+asm(".set regnum_a5  , 15");
+asm(".set regnum_a6  , 16");
+asm(".set regnum_a7  , 17");
+asm(".set regnum_s2  , 18");
+asm(".set regnum_s3  , 19");
+asm(".set regnum_s4  , 20");
+asm(".set regnum_s5  , 21");
+asm(".set regnum_s6  , 22");
+asm(".set regnum_s7  , 23");
+asm(".set regnum_s8  , 24");
+asm(".set regnum_s9  , 25");
+asm(".set regnum_s10 , 26");
+asm(".set regnum_s11 , 27");
+asm(".set regnum_t3  , 28");
+asm(".set regnum_t4  , 29");
+asm(".set regnum_t5  , 30");
+asm(".set regnum_t6  , 31");
 /**@}*/
+
+
+/**********************************************************************//**
+ * @name Custom instruction R1-type format
+ **************************************************************************/
+#define CUSTOM_INSTR_R1_TYPE(funct7, funct5, rs1, funct3, opcode) \
+({                                                                \
+    register uint32_t __return;                                   \
+    asm volatile (                                                \
+      ""                                                          \
+      : [output] "=r" (__return)                                  \
+      : [input_i] "r" (rs1)                                       \
+    );                                                            \
+    asm volatile(                                                 \
+      ".word (                                                    \
+        (((" #funct7 ") & 0x7f) << 25) |                          \
+        (((" #funct5 ") & 0x1f) << 20) |                          \
+        ((( regnum_%1 ) & 0x1f) << 15) |                          \
+        (((" #funct3 ") & 0x07) << 12) |                          \
+        ((( regnum_%0 ) & 0x1f) <<  7) |                          \
+        (((" #opcode ") & 0x7f) <<  0)                            \
+      );"                                                         \
+      : [rd] "=r" (__return)                                      \
+      : "r" (rs1)                                                 \
+    );                                                            \
+    __return;                                                     \
+})
+
+
+/**********************************************************************//**
+ * @name Custom instruction R2-type format
+ **************************************************************************/
+#define CUSTOM_INSTR_R2_TYPE(funct7, rs2, rs1, funct3, opcode) \
+({                                                             \
+    register uint32_t __return;                                \
+    asm volatile (                                             \
+      ""                                                       \
+      : [output] "=r" (__return)                               \
+      : [input_i] "r" (rs1), [input_j] "r" (rs2)               \
+    );                                                         \
+    asm volatile (                                             \
+      ".word (                                                 \
+        (((" #funct7 ") & 0x7f) << 25) |                       \
+        ((( regnum_%2 ) & 0x1f) << 20) |                       \
+        ((( regnum_%1 ) & 0x1f) << 15) |                       \
+        (((" #funct3 ") & 0x07) << 12) |                       \
+        ((( regnum_%0 ) & 0x1f) <<  7) |                       \
+        (((" #opcode ") & 0x7f) <<  0)                         \
+      );"                                                      \
+      : [rd] "=r" (__return)                                   \
+      : "r" (rs1), "r" (rs2)                                   \
+    );                                                         \
+    __return;                                                  \
+})
+
+
+/**********************************************************************//**
+ * @name Custom instruction R3-type format
+ **************************************************************************/
+#define CUSTOM_INSTR_R3_TYPE(rs3, rs2, rs1, funct3, opcode) \
+({                                                          \
+    register uint32_t __return;                             \
+    asm volatile (                                          \
+      ""                                                    \
+      : [output] "=r" (__return)                            \
+      : [input_i] "r" (rs1), [input_j] "r" (rs2), [input_k] "r" (rs3) \
+    );                                                      \
+    asm volatile (                                          \
+      ".word (                                              \
+        ((( regnum_%3 ) & 0x1f) << 25) |                    \
+        ((( regnum_%2 ) & 0x1f) << 20) |                    \
+        ((( regnum_%1 ) & 0x1f) << 15) |                    \
+        (((" #funct3 ") & 0x07) << 12) |                    \
+        ((( regnum_%0 ) & 0x1f) <<  7) |                    \
+        (((" #opcode ") & 0x7f) <<  0)                      \
+      );"                                                   \
+      : [rd] "=r" (__return)                                \
+      : "r" (rs1), "r" (rs2), "r" (rs3)                     \
+    );                                                      \
+    __return;                                               \
+})
+
+
+/**********************************************************************//**
+ * @name Custom instruction I-type format
+ **************************************************************************/
+#define CUSTOM_INSTR_I_TYPE(imm12, rs1, funct3, opcode) \
+({                                                      \
+    register uint32_t __return;                         \
+    asm volatile (                                      \
+      ""                                                \
+      : [output] "=r" (__return)                        \
+      : [input_i] "r" (rs1)                             \
+    );                                                  \
+    asm volatile (                                      \
+      ".word (                                          \
+        (((" #imm12 ")  & 0xfff) << 20) |               \
+        ((( regnum_%1 ) &  0x1f) << 15) |               \
+        (((" #funct3 ") &  0x07) << 12) |               \
+        ((( regnum_%0 ) &  0x1f) <<  7) |               \
+        (((" #opcode ") &  0x7f) <<  0)                 \
+      );"                                               \
+      : [rd] "=r" (__return)                            \
+      : "r" (rs1)                                       \
+    );                                                  \
+    __return;                                           \
+})
+
 
 #endif // neorv32_intrinsics_h


### PR DESCRIPTION
This PR is a rework of the "intrinsics" library (set of macros), which is used to implement custom instructions, and also of the two applications that use these intrinsics (the FPU test program and the bit-manipulation test program).

The new intrinsics are far more convenient to handle as they can be used as plain C function without the need to pay attention to register allocation or any other background assembly issues (= intrinsics). Example:

TODO

Thanks to @google for their [CFU-Playground](https://github.com/google/CFU-Playground) project, which provided the idea for the improved intrinsic macro library and also thanks to @umarcor for pointing that out to me.