### PR TITLE
[rtl] add err_o signal to IMEM modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The version number is globally defined by the `hw_version_c` constant in the mai
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
-| 05.02.2022 | 1.6.7.4 | added `err_o` signal to IMEM module; if the IMEM is implemented as true ROM any write attempt will raise a _store access fault_ (with a `[DEVICE_ERR]` error); see [PR #273](https://github.com/stnolting/neorv32/pull/273) |
+| 05.02.2022 | 1.6.7.4 | added `err_o` signal to **IMEM** module; if the IMEM is implemented as true ROM any write attempt will raise a _store access fault_ exception (with a `[DEVICE_ERR]` error); see [PR #273](https://github.com/stnolting/neorv32/pull/273) |
 | 03.02.2022 | 1.6.7.3 | using `LTO` (link-time-optimization) option for **bootloader**; improved bootloader user console; see [PR #268](https://github.com/stnolting/neorv32/pull/268) |
 | 31.01.2022 | 1.6.7.2 | :bug: fixed minor bug in **bootloader'd MTIME handling** (bootloader crashed if `Zicntr` ISA extension not enabled), fixed minor issues in MTIME and `time` CSRs handling; added MTIME example program; see [PR #267](https://github.com/stnolting/neorv32/pull/267) |
 | 30.01.2022 | 1.6.7.1 | :sparkles: added **`Zxcfu` ISA extension for user-defined custom RISC-V instructions**; see [PR #264](https://github.com/stnolting/neorv32/pull/264) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The version number is globally defined by the `hw_version_c` constant in the mai
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 05.02.2022 | 1.6.7.4 | added `err_o` signal to IMEM module; if the IMEM is implemented as true ROM any write attempt will raise a _store access fault_ (with a `[DEVICE_ERR]` error); see [PR #273](https://github.com/stnolting/neorv32/pull/273) |
 | 03.02.2022 | 1.6.7.3 | using `LTO` (link-time-optimization) option for **bootloader**; improved bootloader user console; see [PR #268](https://github.com/stnolting/neorv32/pull/268) |
 | 31.01.2022 | 1.6.7.2 | :bug: fixed minor bug in **bootloader'd MTIME handling** (bootloader crashed if `Zicntr` ISA extension not enabled), fixed minor issues in MTIME and `time` CSRs handling; added MTIME example program; see [PR #267](https://github.com/stnolting/neorv32/pull/267) |
 | 30.01.2022 | 1.6.7.1 | :sparkles: added **`Zxcfu` ISA extension for user-defined custom RISC-V instructions**; see [PR #264](https://github.com/stnolting/neorv32/pull/264) |

--- a/docs/datasheet/soc_bootrom.adoc
+++ b/docs/datasheet/soc_bootrom.adoc
@@ -30,6 +30,9 @@ The bootloader memory is _read-only_ and is automatically initialized with the b
 determined via synthesis and expanded to the next power of two. For example, if the bootloader code requires
 10kB of storage, a ROM with 16kB will be generated. The maximum size must not exceed 32kB.
 
+[NOTE]
+Any write access to the BOOTROM will raise a _store access fault_ exception.
+
 .Bootloader - Software
 [TIP]
 See section <<_bootloader>> for more information regarding the actual bootloader software/executable itself.

--- a/docs/datasheet/soc_imem.adoc
+++ b/docs/datasheet/soc_imem.adoc
@@ -38,5 +38,5 @@ _platform independent_ memory design that (should) infers embedded memory block.
 source file in order to use platform-specific features (like advanced memory resources) or to improve technology mapping
 and/or timing.
 
-[IMPORTANT]
+[NOTE]
 If the IMEM is implemented as true ROM any write attempt to it will raise a _store access fault_ exception.

--- a/docs/datasheet/soc_imem.adoc
+++ b/docs/datasheet/soc_imem.adoc
@@ -11,7 +11,7 @@
 | Top entity port:         | none                         | 
 | Configuration generics:  | _MEM_INT_IMEM_EN_            | implement processor-internal IMEM when _true_
 |                          | _MEM_INT_IMEM_SIZE_          | IMEM size in bytes
-|                          | _INT_BOOTLOADER_EN_          | use internal bootloader when _true_ (implements IMEM as _uninitialized_ RAM)
+|                          | _INT_BOOTLOADER_EN_          | use internal bootloader when _true_ (implements IMEM as _uninitialized_ RAM, otherwise the IMEM is implemented an _pre-intialized_ ROM)
 | CPU interrupts:          | none                         | 
 |=======================
 
@@ -37,3 +37,6 @@ architecture definition (`mem/neorv32_imem.default.vhd`). This **default archite
 _platform independent_ memory design that (should) infers embedded memory block. You can replace/modify the architecture
 source file in order to use platform-specific features (like advanced memory resources) or to improve technology mapping
 and/or timing.
+
+[IMPORTANT]
+If the IMEM is implemented as true ROM any write attempt to it will raise a _store access fault_ exception.

--- a/rtl/core/mem/neorv32_imem.default.vhd
+++ b/rtl/core/mem/neorv32_imem.default.vhd
@@ -6,7 +6,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -166,8 +166,10 @@ begin
       rden <= acc_en and rden_i;
       if (IMEM_AS_IROM = true) then
         ack_o <= acc_en and rden_i;
+        err_o <= acc_en and wren_i;
       else
         ack_o <= acc_en and (rden_i or wren_i);
+        err_o <= '0';
       end if;
     end if;
   end process bus_feedback;

--- a/rtl/core/mem/neorv32_imem.legacy.vhd
+++ b/rtl/core/mem/neorv32_imem.legacy.vhd
@@ -6,7 +6,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -163,8 +163,10 @@ begin
       rden <= acc_en and rden_i;
       if (IMEM_AS_IROM = true) then
         ack_o <= acc_en and rden_i;
+        err_o <= acc_en and wren_i;
       else
         ack_o <= acc_en and (rden_i or wren_i);
+        err_o <= '0';
       end if;
     end if;
   end process bus_feedback;

--- a/rtl/core/neorv32_boot_rom.vhd
+++ b/rtl/core/neorv32_boot_rom.vhd
@@ -3,7 +3,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2020, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -47,9 +47,11 @@ entity neorv32_boot_rom is
   port (
     clk_i  : in  std_ulogic; -- global clock line
     rden_i : in  std_ulogic; -- read enable
+    wren_i : in  std_ulogic; -- write enable
     addr_i : in  std_ulogic_vector(31 downto 0); -- address
     data_o : out std_ulogic_vector(31 downto 0); -- data out
-    ack_o  : out std_ulogic -- transfer acknowledge
+    ack_o  : out std_ulogic; -- transfer acknowledge
+    err_o  : out std_ulogic  -- transfer error
   );
 end neorv32_boot_rom;
 
@@ -91,7 +93,8 @@ begin
   mem_file_access: process(clk_i)
   begin
     if rising_edge(clk_i) then
-      rden <= rden_i and acc_en;
+      rden  <= acc_en and rden_i;
+      err_o <= acc_en and wren_i;
       if (acc_en = '1') then -- reduce switching activity when not accessed
         rdata <= mem_rom(to_integer(unsigned(addr)));
       end if;

--- a/rtl/core/neorv32_imem.entity.vhd
+++ b/rtl/core/neorv32_imem.entity.vhd
@@ -6,7 +6,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -53,6 +53,7 @@ entity neorv32_imem is
     addr_i : in  std_ulogic_vector(31 downto 0); -- address
     data_i : in  std_ulogic_vector(31 downto 0); -- data in
     data_o : out std_ulogic_vector(31 downto 0); -- data out
-    ack_o  : out std_ulogic  -- transfer acknowledge
+    ack_o  : out std_ulogic; -- transfer acknowledge
+    err_o  : out std_ulogic  -- transfer error
   );
 end neorv32_imem;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -1632,9 +1632,11 @@ package neorv32_package is
     port (
       clk_i  : in  std_ulogic; -- global clock line
       rden_i : in  std_ulogic; -- read enable
+      wren_i : in  std_ulogic; -- write enable
       addr_i : in  std_ulogic_vector(31 downto 0); -- address
       data_o : out std_ulogic_vector(31 downto 0); -- data out
-      ack_o  : out std_ulogic -- transfer acknowledge
+      ack_o  : out std_ulogic; -- transfer acknowledge
+      err_o  : out std_ulogic  -- transfer error
     );
   end component;
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -63,7 +63,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060703"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060704"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -1599,7 +1599,8 @@ package neorv32_package is
       addr_i : in  std_ulogic_vector(31 downto 0); -- address
       data_i : in  std_ulogic_vector(31 downto 0); -- data in
       data_o : out std_ulogic_vector(31 downto 0); -- data out
-      ack_o  : out std_ulogic -- transfer acknowledge
+      ack_o  : out std_ulogic; -- transfer acknowledge
+      err_o  : out std_ulogic  -- transfer error
     );
   end component;
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -798,11 +798,12 @@ begin
     port map (
       clk_i  => clk_i,                        -- global clock line
       rden_i => p_bus.re,                     -- read enable
+      wren_i => p_bus.we,                     -- write enable
       addr_i => p_bus.addr,                   -- address
       data_o => resp_bus(RESP_BOOTROM).rdata, -- data out
-      ack_o  => resp_bus(RESP_BOOTROM).ack    -- transfer acknowledge
+      ack_o  => resp_bus(RESP_BOOTROM).ack,   -- transfer acknowledge
+      err_o  => resp_bus(RESP_BOOTROM).err    -- transfer error
     );
-    resp_bus(RESP_BOOTROM).err <= '0'; -- no access error possible
   end generate;
 
   neorv32_boot_rom_inst_false:

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -748,9 +748,9 @@ begin
       addr_i => p_bus.addr,                -- address
       data_i => p_bus.wdata,               -- data in
       data_o => resp_bus(RESP_IMEM).rdata, -- data out
-      ack_o  => resp_bus(RESP_IMEM).ack    -- transfer acknowledge
+      ack_o  => resp_bus(RESP_IMEM).ack,   -- transfer acknowledge
+      err_o  => resp_bus(RESP_IMEM).err    -- transfer error
     );
-    resp_bus(RESP_IMEM).err <= '0'; -- no access error possible
   end generate;
 
   neorv32_int_imem_inst_false:

--- a/sim/simple/neorv32_imem.iram.simple.vhd
+++ b/sim/simple/neorv32_imem.iram.simple.vhd
@@ -6,7 +6,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -125,6 +125,7 @@ begin
   begin
     if rising_edge(clk_i) then
       rden  <= acc_en and rden_i;
+      err_o <= '0';
       ack_o <= acc_en and (rden_i or wren_i);
     end if;
   end process bus_feedback;

--- a/sim/simple/neorv32_imem.simple.vhd
+++ b/sim/simple/neorv32_imem.simple.vhd
@@ -78,7 +78,8 @@ begin
   begin
     if rising_edge(clk_i) then
       rden   <= acc_en and rden_i;
-      ack_o  <= acc_en and (rden_i or wren_i);
+      ack_o  <= acc_en and rden_i;
+      err_o  <= acc_en and wren_i;
       addr_v := to_integer(unsigned(addr));
       --
       rdata <= (others => '0');


### PR DESCRIPTION
This PR adds the `err_o` signal to the IMEM module(s). This signal is set if the IMEM is implemented as true ROM and software attempts to perform a write access to it, which will create a "device error".

If there is a write access to a read-only IMEM the [📚 default runtime environment trap handler](https://stnolting.github.io/neorv32/#_default_rte_trap_handlers) will output an error message (in this example: store 32-bit word to address 0x0000_0004):
```
<RTE> Store access fault [DEVICE_ERR] @ PC=0x0000016E, MTVAL=0x00000004 </RTE>
```

**edit**

This PR also add the `err_o` signal to the processor's BOOTROM.

---------

ℹ️ **Before this PR** write access to the IMEM also raised a bus exception by not asserting the IMEM's `ack_o` signal, which resulted in a "device timeout error":
```
<RTE> Store access fault [TIMEOUT_ERR] @ PC=0x0000016E, MTVAL=0x00000004 </RTE>
```