### PR TITLE
[OCD] stop CPU counters during debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The version number is globally defined by the `hw_version_c` constant in the mai
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 17.02.2022 | 1.6.7.10 | hardwired `dcsr.stopcount` to `1`: all standard counters (`[m]cycle[h]` and `[m]instret[h]`, but **NOT** `[m]time[h]`!!) and all hardware performance monitor (HPM) counters are _stopped_ when the CPU is in debug mode; [PR #277](https://github.com/stnolting/neorv32/pull/277) |
 | 16.02.2022 | 1.6.7.9 | :warning: **added custom `mxisa` CSR replacing SYSINFO's `NEORV32_SYSINFO.CPU` memory-mapped register**: bit-positions remain but names and the actual access mechanism (CSR vs. memory-mapped) have changed! see [PR #276](https://github.com/stnolting/neorv32/pull/276) |
 | 11.02.2022 | 1.6.7.8 | :test_tube: added newlib's system calls (stubs) and linker script symbols for heap memory to support **dynamic memory allocation**  (e.g. `malloc`) and even **standard IO functions** like `printf`; see [PR #275](https://github.com/stnolting/neorv32/pull/275) |
 | 10.02.2022 | 1.6.7.7 | :sparkles: added **RISC-V hardware trigger module** to CPU - allows to set _hardware breakpoints_ (via gdb's `hb`/`hbreak` command) to debug code from ROM; see [PR #274](https://github.com/stnolting/neorv32/pull/274); :bug: minor bug fix in `ebreak` instruction's `dcsr.cause` value (was 0b010 but has to be 0b001) |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -557,6 +557,11 @@ the <<_mxisa>> CSR. +
 If _CPU_CNT_WIDTH_ is 0, the <<_cycleh>> and <<_instreth>> / <<_mcycleh>> and <<_minstreth>> CSRs are hardwired to zero
 and any write access to them is ignored.
 
+.Counter Increment During Debugging
+[NOTE]
+The `[m]cycle[h]` and `[m]instret[h]` counters do not increment when the CPU is in debug mode.
+See section <<_cpu_debug_mode>> for more information.
+
 
 :sectnums!:
 ===== **`cycle[h]`**
@@ -659,6 +664,12 @@ The total counter width of the HPMs can be configured before synthesis via the <
 The total LSB-aligned HPM counter size (low word CSR + high word CSR) is defined via the
 <<_hpm_num_cnts>> generic (0..64-bit). If <<_hpm_num_cnts>> is less than 64, all unused MSB-aligned
 bits are hardwired to zero.
+
+
+.Counter Increment During Debugging
+[NOTE]
+All HPM counters do not increment when the CPU is in debug mode.
+See section <<_cpu_debug_mode>> for more information.
 
 
 :sectnums!:

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -542,6 +542,9 @@ From a hardware point of view, these "entry conditions" are special synchronous 
    to signal an exception to the DM; the CPU restarts the park loop again afterwards
 * interrupts are disabled; however, they will remain pending and will get executed after the CPU has left debug mode
 * if the DM makes a resume request, the park loop exits and the CPU leaves debug mode (executing `dret`)
+* the standard counters <<_machine_counter_and_timer_csrs>> `[m]cycle[h]` and `[m]instret[h]` are stopped; note that the
+<<_machine_system_timer_mtime>> keep running as well as it's shadowed copies in the `[m]time[h]` CSRs
+* all <<_hardware_performance_monitors_hpm_csrs>> are stopped
 
 Debug mode is left either by executing the `dret` instruction footnote:[`dret` should only be executed _inside_ the debugger
 "park loop" code (-> code ROM in the debug module (DM).)] (_in_ debug mode) or by performing
@@ -592,7 +595,7 @@ The following bits are implemented. The reaming bits are read-only and always re
 | 13    | `ebereaks`    | r/- | `0` - supervisor mode not supported
 | 12    | `ebereaku`    | r/w | `ebreak` instructions in `user` mode will _enter_ debug mode when set
 | 11    | `stepie`      | r/- | `0` - IRQs are disabled during single-stepping
-| 10    | `stopcount`   | r/- | `0` - counters increment as usual
+| 10    | `stopcount`   | r/- | `1` - standard counters and HPMs are stopped when in debug mode
 | 9     | `stoptime`    | r/- | `0` - timers increment as usual
 | 8:6   | `cause`       | r/- | cause identifier - why debug mode was entered (see below)
 | 5     | -             | r/- | `0` - _reserved_

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -2339,8 +2339,7 @@ begin
         csr.mcycle_ovfl(0) <= csr.mcycle_nxt(csr.mcycle_nxt'left) and (not csr.mcountinhibit_cy);
         if (csr.we = '1') and (csr.addr = csr_mcycle_c) then -- write access
           csr.mcycle(cpu_cnt_lo_width_c-1 downto 0) <= csr.wdata(cpu_cnt_lo_width_c-1 downto 0);
-        elsif (csr.mcountinhibit_cy = '0') and (cnt_event(hpmcnt_event_cy_c) = '1') and -- non-inhibited automatic update
-              (debug_ctrl.running = '0') and (debug_ctrl.pending = '0') then -- not entering/in debug mode
+        elsif (csr.mcountinhibit_cy = '0') and (cnt_event(hpmcnt_event_cy_c) = '1') and (debug_ctrl.running = '0') then -- non-inhibited automatic update and not in debug mode
           csr.mcycle(cpu_cnt_lo_width_c-1 downto 0) <= csr.mcycle_nxt(cpu_cnt_lo_width_c-1 downto 0);
         end if;
       else
@@ -2365,8 +2364,7 @@ begin
         csr.minstret_ovfl(0) <= csr.minstret_nxt(csr.minstret_nxt'left) and (not csr.mcountinhibit_ir);
         if (csr.we = '1') and (csr.addr = csr_minstret_c) then -- write access
           csr.minstret(cpu_cnt_lo_width_c-1 downto 0) <= csr.wdata(cpu_cnt_lo_width_c-1 downto 0);
-        elsif (csr.mcountinhibit_ir = '0') and (cnt_event(hpmcnt_event_ir_c) = '1') and -- non-inhibited automatic update
-              (debug_ctrl.running = '0') and (debug_ctrl.pending = '0') then -- not entering/in debug mode
+        elsif (csr.mcountinhibit_ir = '0') and (cnt_event(hpmcnt_event_ir_c) = '1') and (debug_ctrl.running = '0') then -- non-inhibited automatic update and not in debug mode
           csr.minstret(cpu_cnt_lo_width_c-1 downto 0) <= csr.minstret_nxt(cpu_cnt_lo_width_c-1 downto 0);
         end if;
       else
@@ -2460,11 +2458,8 @@ begin
       hpmcnt_trigger <= (others => '0'); -- default
       if (HPM_NUM_CNTS /= 0) then
         for i in 0 to HPM_NUM_CNTS-1 loop
-          if (debug_ctrl.running = '1') or (debug_ctrl.pending = '1') then
-            hpmcnt_trigger(i) <= '0'; -- do not increment HPM counters when entering/in debug mode
-          else
-            hpmcnt_trigger(i) <= or_reduce_f(cnt_event and csr.mhpmevent(i)(cnt_event'left downto 0));
-          end if;
+          -- do not increment if CPU is in debug mode --
+          hpmcnt_trigger(i) <= or_reduce_f(cnt_event and csr.mhpmevent(i)(cnt_event'left downto 0)) and (not debug_ctrl.running);
         end loop; -- i
       end if;
     end if;

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -2339,7 +2339,8 @@ begin
         csr.mcycle_ovfl(0) <= csr.mcycle_nxt(csr.mcycle_nxt'left) and (not csr.mcountinhibit_cy);
         if (csr.we = '1') and (csr.addr = csr_mcycle_c) then -- write access
           csr.mcycle(cpu_cnt_lo_width_c-1 downto 0) <= csr.wdata(cpu_cnt_lo_width_c-1 downto 0);
-        elsif (csr.mcountinhibit_cy = '0') and (cnt_event(hpmcnt_event_cy_c) = '1') then -- non-inhibited automatic update
+        elsif (csr.mcountinhibit_cy = '0') and (cnt_event(hpmcnt_event_cy_c) = '1') and -- non-inhibited automatic update
+              (debug_ctrl.running = '0') and (debug_ctrl.pending = '0') then -- not entering/in debug mode
           csr.mcycle(cpu_cnt_lo_width_c-1 downto 0) <= csr.mcycle_nxt(cpu_cnt_lo_width_c-1 downto 0);
         end if;
       else
@@ -2364,7 +2365,8 @@ begin
         csr.minstret_ovfl(0) <= csr.minstret_nxt(csr.minstret_nxt'left) and (not csr.mcountinhibit_ir);
         if (csr.we = '1') and (csr.addr = csr_minstret_c) then -- write access
           csr.minstret(cpu_cnt_lo_width_c-1 downto 0) <= csr.wdata(cpu_cnt_lo_width_c-1 downto 0);
-        elsif (csr.mcountinhibit_ir = '0') and (cnt_event(hpmcnt_event_ir_c) = '1') then -- non-inhibited automatic update
+        elsif (csr.mcountinhibit_ir = '0') and (cnt_event(hpmcnt_event_ir_c) = '1') and -- non-inhibited automatic update
+              (debug_ctrl.running = '0') and (debug_ctrl.pending = '0') then -- not entering/in debug mode
           csr.minstret(cpu_cnt_lo_width_c-1 downto 0) <= csr.minstret_nxt(cpu_cnt_lo_width_c-1 downto 0);
         end if;
       else
@@ -2458,7 +2460,11 @@ begin
       hpmcnt_trigger <= (others => '0'); -- default
       if (HPM_NUM_CNTS /= 0) then
         for i in 0 to HPM_NUM_CNTS-1 loop
-          hpmcnt_trigger(i) <= or_reduce_f(cnt_event and csr.mhpmevent(i)(cnt_event'left downto 0));
+          if (debug_ctrl.running = '1') or (debug_ctrl.pending = '1') then
+            hpmcnt_trigger(i) <= '0'; -- do not increment HPM counters when entering/in debug mode
+          else
+            hpmcnt_trigger(i) <= or_reduce_f(cnt_event and csr.mhpmevent(i)(cnt_event'left downto 0));
+          end if;
         end loop; -- i
       end if;
     end if;
@@ -2907,7 +2913,7 @@ begin
   csr.dcsr_rd(13)           <= '0'; -- ebreaks: supervisor mode not implemented
   csr.dcsr_rd(12)           <= csr.dcsr_ebreaku when (CPU_EXTENSION_RISCV_U = true) else '0'; -- ebreaku: what happens on ebreak in u-mode? (normal trap OR debug-enter)
   csr.dcsr_rd(11)           <= '0'; -- stepie: interrupts are disabled during single-stepping
-  csr.dcsr_rd(10)           <= '0'; -- stopcount: counters increment as usual
+  csr.dcsr_rd(10)           <= '1'; -- stopcount: standard counters and HPMs are stopped when in debug mode
   csr.dcsr_rd(09)           <= '0'; -- stoptime: timers increment as usual
   csr.dcsr_rd(08 downto 06) <= csr.dcsr_cause; -- debug mode entry cause
   csr.dcsr_rd(05)           <= '0'; -- reserved

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -65,7 +65,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060709"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060710"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------


### PR DESCRIPTION
As illustrated in https://github.com/riscv/riscv-debug-spec/issues/638 this PR hardwires the `dcsr.stopcount` bit to `1`. Thus, all standard CPU counters (`[m]cycle[h]` and `[m]instret[h]`) and all hardware performance monitor (HPM) counters are always _stopped_ during debugging (when the CPU is in debug mode).

Note that the `[m]time[h]` CSRs are not affected by this since they are a shadow copy of the MTIME system timer, which keeps running also during debugging (hence, `dcsr.stoptime` is hardwired to `0`).