### PR TITLE
Add newlib example program and documentation

### DIFF
--- a/docs/datasheet/software.adoc
+++ b/docs/datasheet/software.adoc
@@ -1,13 +1,16 @@
 :sectnums:
 == Software Framework
 
-To make actual use of the NEORV32 processor, the project comes with a complete software eco-system. This
+To make actual use of the NEORV32 processor, the project comes with a complete software ecosystem. This
 ecosystem is based on the RISC-V port of the GCC GNU Compiler Collection and consists of the following elementary parts:
 
 * <<_compiler_toolchain>>
 * <<_core_libraries>>
 * <<_application_makefile>>
 * <<_executable_image_format>>
+** <<_linker_script>>
+** <<_ram_layout>>
+** <<_c_standard_library>>
 ** <<_start_up_code_crt0>>
 * <<_bootloader>>
 * <<_neorv32_runtime_environment>>
@@ -18,13 +21,21 @@ files and folders is shown below:
 [cols="<6,<4"]
 [grid="none"]
 |=======================
-| Application/bootloader start-up code | `sw/common/crt0.S`
-| Application/bootloader linker script | `sw/common/neorv32.ld`
-| Core hardware driver libraries | `sw/lib/include/` & `sw/lib/source/`
-| Central makefile | `sw/common/common.mk`
-| Auxiliary tool for generating NEORV32 executables | `sw/image_gen/`
-| Default bootloader | `sw/bootloader/bootloader.c`
+| Application start-up code               | `sw/common/crt0.S`
+| Application linker script               | `sw/common/neorv32.ld`
+| Core hardware driver libraries ("HAL")  | `sw/lib/include/` & `sw/lib/source/`
+| Central application makefile            | `sw/common/common.mk`
+| Tool for generating NEORV32 executables | `sw/image_gen/`
+| Default bootloader                      | `sw/bootloader/bootloader.c`
+| Example programs                        | `sw/example`
 |=======================
+
+.Software Documentation
+[TIP]
+All core libraries and example programs are highly documented using **Doxygen**.
+See section <<Building the Software Framework Documentation>>.
+The documentation is automatically built and deployed to GitHub pages and is available online
+at https://stnolting.github.io/neorv32/sw/files.html .
 
 
 
@@ -35,12 +46,16 @@ files and folders is shown below:
 The toolchain for this project is based on the free RISC-V GCC-port. You can find the compiler sources and
 build instructions on the official RISC-V GNU toolchain GitHub page: https://github.com/riscv/riscv-gnutoolchain.
 
-The NEORV32 implements a 32-bit base integer architecture (`rv32i`) and a 32-bit integer and soft-float ABI
-(ilp32), so make sure you build an according toolchain.
+The NEORV32 implements a 32-bit RISC-V architecture and uses a 32-bit integer and soft-float ABI by default.
+Make sure the toolchain / toolchain build is configured accordingly.
+
+* MARCH = `rv32i`
+* MABI = `ilp32`
 
 Alternatively, you can download my prebuilt `rv32i/e` toolchains for 64-bit x86 Linux from: https://github.com/stnolting/riscv-gcc-prebuilt
 
-The default toolchain prefix used by the project's makefiles is (can be changed in the makefiles): **`riscv32-unknown-elf`**
+The default toolchain prefix used by the project's makefiles is **`riscv32-unknown-elf`**, which can be changes
+using makefile flags at any time.
 
 [TIP]
 More information regarding the toolchain (building from scratch or downloading the prebuilt ones)
@@ -53,37 +68,31 @@ can be found in the user guides' section https://stnolting.github.io/neorv32/ug/
 :sectnums:
 === Core Libraries
 
-The NEORV32 project provides a set of C libraries that allows an easy usage of the processor/CPU features.
-Just include the main NEORV32 library file in your application's source file(s):
+The NEORV32 project provides a set of C libraries that allows an easy usage of the processor/CPU features
+(also called "HAL" - hardware abstraction layer). All driver and runtime-related files are located in
+`sw/lib`. These are automatically included and linked by adding the following _include statement_:
 
 [source,c]
 ----
-#include <neorv32.h>
+#include <neorv32.h> // add NEORV32 HAL and runtime libraries
 ----
-
-[TIP]
-A CMSIS-SVD-compatible **System View Description (SVD)** file including all peripherals is available in `sw/svd`.
-
-Together with the makefile, this will automatically include all the processor's header files located in
-`sw/lib/include` into your application. The actual source files of the core libraries are located in
-`sw/lib/source` and are automatically included into the source list of your software project. The following
-files are currently part of the NEORV32 core library:
 
 [cols="<3,<4,<8"]
 [options="header",grid="rows"]
 |=======================
 | C source file | C header file | Description
 | -                   | `neorv32.h`            | main NEORV32 definitions and library file
-| `neorv32_cfs.c`     | `neorv32_cfs.h`        | HW driver (stub)footnote:[This driver file only represents a stub, since the real CFS drivers are defined by the actual CFS implementation.] functions for the custom functions subsystem
+| `neorv32_cfs.c`     | `neorv32_cfs.h`        | HW driver (stubs) functions for the custom functions subsystem
+footnote:[This driver file only represents a stub, since the real CFS drivers are defined by the actual CFS implementation.]
 | `neorv32_cpu.c`     | `neorv32_cpu.h`        | HW driver functions for the NEORV32 **CPU**
 | `neorv32_cpu_cfu.c` | `neorv32_cpu_cfu.h`    | HW driver functions for the NEORV32 **CFU** (custom instructions)
 | `neorv32_gpio.c`    | `neorv32_gpio.h`       | HW driver functions for the **GPIO**
 | `neorv32_gptmr.c`   | `neorv32_gptmr.h`      | HW driver functions for the **GPTRM**
-| -                   | `neorv32_intrinsics.h` | macros for (custom) intrinsics/instructions
+| -                   | `neorv32_intrinsics.h` | macros for custom intrinsics & instructions
 | `neorv32_mtime.c`   | `neorv32_mtime.h`      | HW driver functions for the **MTIME**
 | `neorv32_neoled.c`  | `neorv32_neoled.h`     | HW driver functions for the **NEOLED**
 | `neorv32_pwm.c`     | `neorv32_pwm.h`        | HW driver functions for the **PWM**
-| `neorv32_rte.c`     | `neorv32_rte.h`        | NEORV32 **runtime environment** and helpers
+| `neorv32_rte.c`     | `neorv32_rte.h`        | NEORV32 **runtime environment** and helper functions
 | `neorv32_slink.c`   | `neorv32_slink.h`      | HW driver functions for the **SLINK**
 | `neorv32_spi.c`     | `neorv32_spi.h`        | HW driver functions for the **SPI**
 | `neorv32_trng.c`    | `neorv32_trng.h`       | HW driver functions for the **TRNG**
@@ -92,12 +101,12 @@ files are currently part of the NEORV32 core library:
 | `neorv32_wdt.c`     | `neorv32_wdt.h`        | HW driver functions for the **WDT**
 | `neorv32_xip.c`     | `neorv32_xip.h`        | HW driver functions for the **XIP**
 | `neorv32_xirq.c`    | `neorv32_xirq.h`       | HW driver functions for the **XIRQ**
+| `syscalls.c`        | -                      | newlib system calls
 |=======================
 
-.Documentation
 [TIP]
-All core library software sources are highly documented using _doxygen_. See section <<Building the Software Framework Documentation>>.
-The documentation is automatically built and deployed to GitHub pages by the CI workflow (:https://stnolting.github.io/neorv32/sw/files.html).
+A CMSIS-SVD-compatible **System View Description (SVD)** file including all peripherals is available in `sw/svd`.
+`sw/lib/include`. Currently, the following library files are available:
 
 
 
@@ -107,17 +116,17 @@ The documentation is automatically built and deployed to GitHub pages by the CI 
 === Application Makefile
 
 Application compilation is based on a single, centralized **GNU makefiles** `sw/common/common.mk`. Each project in the
-`sw/example` folder features a makefile that just includes this central makefile. When creating a new project, copy an existing project folder or
-at least the makefile to your new project folder. I suggest to create new projects also in `sw/example` to keep
-the file dependencies. Of course, these dependencies can be manually configured via makefiles variables
-when your project is located somewhere else.
+`sw/example` folder features a makefile that just includes this central makefile. When creating a new project copy an
+existing project folder or at least the makefile to the new project folder. It is suggested to create new projects also
+in `sw/example` to keep the file dependencies. However, these dependencies can be manually configured via makefiles
+variables when the new project is located somewhere else.
 
 [NOTE]
-Before you can use the makefiles, you need to install the RISC-V GCC toolchain. Also, you have to add the
-installation folder of the compiler to your system's `PATH` variable. More information can be found in
+Before the makefile can be used to compile applications, the RISC-V GCC toolchain needs to be installed. Furthermore,
+the `bin` folder of the compiler needs to be added to the system's `PATH` variable. More information can be found in
 https://stnolting.github.io/neorv32/ug/#_software_toolchain_setup[User Guide: Software Toolchain Setup].
 
-The makefile is invoked by simply executing make in your console:
+The makefile is invoked by simply executing `make` in the console. For example:
 
 [source,bash]
 ----
@@ -166,14 +175,16 @@ Make sure to add the bin folder of RISC-V GCC to your PATH variable.
 :sectnums:
 ==== Configuration
 
-The compilation flow is configured via variables right at the beginning of the **central**
+The compilation flow is configured via variables right at the beginning of the central
 makefile (`sw/common/common.mk`):
 
 [TIP]
-The makefile configuration variables can be (re-)defined directly when invoking the makefile. For
-example via `$ make MARCH=rv32ic clean_all exe`. You can also make project-specific definitions
-of all variables inside the project's actual makefile (e.g., `sw/example/blink_led/makefile`).
+The makefile configuration variables can be overridden or extended directly when invoking the makefile. For
+example `$ make MARCH=rv32ic clean_all exe` overrides the default `MARCH` variable definitions.
+Permanent modifications/definitions can be made in the project-local makefile
+(e.g., `sw/example/blink_led/makefile`).
 
+.Default Makefile Configuration
 [source,makefile]
 ----
 # *****************************************************************************
@@ -200,37 +211,42 @@ NEORV32_HOME ?= ../../..
 # *****************************************************************************
 ----
 
+.Variables Description
 [cols="<3,<10"]
 [grid="none"]
 |=======================
-| _APP_SRC_         | The source files of the application (`*.c`, `*.cpp`, `*.S` and `*.s` files are allowed; file of these types in the project folder are automatically added via wildcards). Additional files can be added; separated by white spaces
-| _APP_INC_         | Include file folders; separated by white spaces; must be defined with `-I` prefix
-| _ASM_INC_         | Include file folders that are used only for the assembly source files (`*.S`/`*.s`).
-| _EFFORT_          | Optimization level, optimize for size (`-Os`) is default; legal values: `-O0`, `-O1`, `-O2`, `-O3`, `-Os`
-| _RISCV_PREFIX_    | The toolchain prefix to be used; follows the naming convention "architecture-vendor-output-"
-| _MARCH_           | The targeted RISC-V architecture/ISA. Only `rv32` is supported by the NEORV32. Enable compiler support of optional CPU extension by adding the according extension letter (e.g. `rv32im` for _M_ CPU extension). See https://stnolting.github.io/neorv32/ug/#_enabling_risc_v_cpu_extensions[User Guide: Enabling RISC-V CPU Extensions] for more information.
-| _MABI_            | The default 32-bit integer ABI.
-| _USER_FLAGS_      | Additional flags that will be forwarded to the compiler tools
-| _NEORV32_HOME_    | Relative or absolute path to the NEORV32 project home folder. Adapt this if the makefile/project is not in the project's `sw/example folder`.
+| `APP_SRC`      | The source files of the application (`*.c`, `*.cpp`, `*.S` and `*.s` files are allowed;
+files of these types in the project folder are automatically added via wild cards). Additional files can be added separated by white spaces
+| `APP_INC`      | Include file folders; separated by white spaces; must be defined with `-I` prefix
+| `ASM_INC`      | Include file folders that are used only for the assembly source files (`*.S`/`*.s`).
+| `EFFORT`       | Optimization level, optimize for size (`-Os`) is default; legal values: `-O0`, `-O1`, `-O2`, `-O3`, `-Os`, `-Ofast`, ...
+| `RISCV_PREFIX` | The toolchain prefix to be used; follows the triplet naming convention `[architecture]-[host_system]-[output]-...`
+| `MARCH`        | The targeted RISC-V architecture/ISA; enable compiler support of optional CPU extension by adding the according extension
+name (e.g. `rv32im` for `M` CPU extension; see https://stnolting.github.io/neorv32/ug/#_enabling_risc_v_cpu_extensions[User Guide: Enabling RISC-V CPU Extensions]
+for more information
+| `MABI`         | Application binary interface (default: 32-bit integer ABI `ilp32`)
+| `USER_FLAGS`   | Additional flags that will be forwarded to the compiler tools
+| `NEORV32_HOME` | Relative or absolute path to the NEORV32 project home folder; adapt this if the makefile/project is not in the project's
+default `sw/example` folder
 |=======================
 
 :sectnums:
 ==== Default Compiler Flags
 
 The following default compiler flags are used for compiling an application. These flags are defined via the
-`CC_OPTS` variable. Custom flags can be appended via the `USER_FLAGS` variable to the `CC_OPTS` variable.
+`CC_OPTS` variable. Custom flags can be _appended_ to it using the `USER_FLAGS` variable.
 
 [cols="<3,<9"]
 [grid="none"]
 |=======================
-| `-Wall` | Enable all compiler warnings.
-| `-ffunction-sections` | Put functions and data segment in independent sections. This allows a code optimization as dead code and unused data can be easily removed.
-| `-nostartfiles` | Do not use the default start code. The makefiles use the NEORV32-specific start-up code instead (`sw/common/crt0.S`).
-| `-Wl,--gc-sections` | Make the linker perform dead code elimination.
-| `-lm` | Include/link with `math.h`.
-| `-lc` | Search for the standard C library when linking.
-| `-lgcc` | Make sure we have no unresolved references to internal GCC library subroutines.
-| `-mno-fdiv` | Use built-in software functions for floating-point divisions and square roots (since the according instructions are not supported yet).
+| `-Wall`                  | Enable all compiler warnings.
+| `-ffunction-sections`    | Put functions and data segment in independent sections. This allows a code optimization as dead code and unused data can be easily removed.
+| `-nostartfiles`          | Do not use the default start code. Instead, use the NEORV32-specific start-up code (`sw/common/crt0.S`).
+| `-Wl,--gc-sections`      | Make the linker perform dead code elimination.
+| `-lm`                    | Include/link with `math.h`.
+| `-lc`                    | Search for the standard C library when linking.
+| `-lgcc`                  | Make sure we have no unresolved references to internal GCC library subroutines.
+| `-mno-fdiv`              | Use built-in software functions for floating-point divisions and square roots (since the according instructions are not supported yet).
 | `-falign-functions=4` .4+| Force a 32-bit alignment of functions and labels (branch/jump/call targets). This increases performance as it simplifies instruction fetch when using the C extension. As a drawback this will also slightly increase the program code.
 | `-falign-labels=4`
 | `-falign-loops=4`
@@ -353,6 +369,34 @@ By default, the maximum heap size is 1/4 of the total RAM size.
 Take care when using dynamic memory to avoid collision of the heap and stack memory areas. There is no compile-time protection
 mechanism available as the actual heap and stack size are defined by _runtime_ data. Also beware of fragmentation when
 using dynamic memory allocation.
+
+
+:sectnums:
+==== C Standard Library
+
+The NEORV32 is a processor for _embedded_ applications. Hence, it is not capable of running desktop OSs like Linux
+(at least not without emulation). Hence, the software framework relies on a "bare-metal" setup that uses **newlib**
+as default C standard library.
+
+.RTOS Support
+[NOTE]
+The NEORV32 CPU and processor **do support** embedded RTOS like FreeRTOS and Zephyr. See the User guide section
+https://stnolting.github.io/neorv32/ug/#_zephyr_rtos_support[Zephyr RTOS Support] and
+https://stnolting.github.io/neorv32/ug/#_freertos_support[FreeRTOS Support]
+for more information.
+
+Newlib provides stubs for common "system calls" (like file handling and standard input/output) that are used by other
+C libraries like `stdio`. These stubs are available in `sw/source/syscalls.c` and were adapted for the NEORV32 processor.
+
+.Standard Console(s)
+[NOTE]
+<<_primary_universal_asynchronous_receiver_and_transmitter_uart0, UART0>>
+is used to implement all the standard input, output and error consoles (`STDIN`, `STDOUT` and `STDERR`).
+
+.Newlib Test/Demo Program
+[TIP]
+A simple test and demo program, which uses some of newlib's core functions (like `malloc`/`free` and `read`/`write`)
+is available in `sw/example_newlib_demo`
 
 
 :sectnums:

--- a/docs/datasheet/software_rte.adoc
+++ b/docs/datasheet/software_rte.adoc
@@ -17,6 +17,9 @@ traps to application-specific handlers while making sure that all traps (even th
 by the application) are handled correctly. Performance-optimized applications or embedded operating systems should
 not use the RTE for delegating traps.
 
+[NOTE]
+For the **C standard runtime library** see section <<c_standard_library>>.
+
 
 ==== RTE Operation
 

--- a/docs/userguide/sw_toolchain_setup.adoc
+++ b/docs/userguide/sw_toolchain_setup.adoc
@@ -34,6 +34,9 @@ Keep in mind that - for instance - a toolchain build with `--with-arch=rv32imc` 
 compressed (`C`) and `mul`/`div` instructions (`M`)! Hence, this code cannot be executed (without
 emulation) on an architecture without these extensions!
 
+[IMPORTANT]
+Make sure to use "newlib" as C standard library as the NEORV32 has no native support for Linus-like operating systems.
+
 
 :sectnums:
 === Downloading and Installing a Prebuilt Toolchain

--- a/sw/example/newlib_demo/main.c
+++ b/sw/example/newlib_demo/main.c
@@ -1,0 +1,125 @@
+// #################################################################################################
+// # << NEORV32 - Newlib Demo/Test Program >>                                                      #
+// # ********************************************************************************************* #
+// # BSD 3-Clause License                                                                          #
+// #                                                                                               #
+// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+// #                                                                                               #
+// # Redistribution and use in source and binary forms, with or without modification, are          #
+// # permitted provided that the following conditions are met:                                     #
+// #                                                                                               #
+// # 1. Redistributions of source code must retain the above copyright notice, this list of        #
+// #    conditions and the following disclaimer.                                                   #
+// #                                                                                               #
+// # 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
+// #    conditions and the following disclaimer in the documentation and/or other materials        #
+// #    provided with the distribution.                                                            #
+// #                                                                                               #
+// # 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
+// #    endorse or promote products derived from this software without specific prior written      #
+// #    permission.                                                                                #
+// #                                                                                               #
+// # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
+// # OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
+// # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
+// # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
+// # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
+// # GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
+// # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
+// # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
+// # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
+// # ********************************************************************************************* #
+// # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+// #################################################################################################
+
+
+/**********************************************************************//**
+ * @file newlib_demo/main.c
+ * @author Stephan Nolting
+ * @brief Demo/test program for NEORV32's newlib C standard library support.
+ **************************************************************************/
+#include <neorv32.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+
+/**********************************************************************//**
+ * @name User configuration
+ **************************************************************************/
+/**@{*/
+/** UART BAUD rate */
+#define BAUD_RATE 19200
+/**@}*/
+
+
+/**********************************************************************//**
+ * Main function: Check some of newlib's core functions.
+ *
+ * @note This program requires UART.
+ *
+ * @return 0 if execution was successful
+ **************************************************************************/
+int main() {
+
+  // setup NEORV32 runtime environment to keep us safe
+  // -> catch all traps and give debug information via UART0
+  neorv32_rte_setup();
+
+  // setup UART0 at default baud rate, no parity bits, no HW flow control
+  neorv32_uart0_setup(BAUD_RATE, PARITY_NONE, FLOW_CONTROL_NONE);
+
+  // check if UART0 is implemented at all
+  if (neorv32_uart0_available() == 0) {
+    neorv32_uart0_printf("Error! UART0 not synthesized!\n");
+    return 1;
+  }
+
+
+  // say hello
+  neorv32_uart0_printf("<<< Newlib demo/test program >>>\n\n");
+
+
+  // check if newlib is really available
+#ifndef __NEWLIB__
+  neorv32_uart0_printf("ERROR! Seems like the compiler toolchain does not support newlib...\n");
+  return -1;
+#endif
+
+  neorv32_uart0_printf("newlib version %i.%i\n\n", (int32_t)__NEWLIB__, (int32_t)__NEWLIB_MINOR__);
+
+
+  char *char_buffer; // pointer for dynamic memory allocation
+
+  neorv32_uart0_printf("<MALLOC> test...\n");
+  char_buffer = (char *) malloc(4 * sizeof(char)); // 4 bytes
+
+  neorv32_uart0_printf("<READ> test... (waiting for 4 chars via UART0)\n");
+  read((int)STDIN_FILENO, char_buffer, 4 * sizeof(char)); // get 4 chars from "STDIN" (UART0.RX)
+
+  neorv32_uart0_printf("<WRITE> test... (outputting the chars you have send)\n");
+  write((int)STDOUT_FILENO, char_buffer, 4 * sizeof(char)); // send 4 chars to "STDOUT" (UART0.TX)
+  neorv32_uart0_printf("\n");
+
+  neorv32_uart0_printf("<FREE> test...\n");
+  free(char_buffer);
+
+
+  neorv32_uart0_printf("<EXIT> test...\n");
+  exit(0);
+
+  return 0; // should never be reached
+}
+
+
+/**********************************************************************//**
+ * "after-main" handler that is executed after the application's
+ * main function returns (called by crt0.S start-up code)
+ *
+ * @note This function should be never executed as we are leaving "main" via "exit" and not "return".
+ **************************************************************************/
+int __neorv32_crt0_after_main(int32_t return_code) {
+
+  neorv32_uart0_printf("\n<RTE> main function returned with exit code %i. </RTE>\n", return_code);
+
+  return 0;
+}

--- a/sw/example/newlib_demo/makefile
+++ b/sw/example/newlib_demo/makefile
@@ -1,0 +1,40 @@
+#################################################################################################
+# << NEORV32 - Application Makefile >>                                                          #
+# ********************************************************************************************* #
+# Make sure to add the RISC-V GCC compiler's bin folder to your PATH environment variable.      #
+# ********************************************************************************************* #
+# BSD 3-Clause License                                                                          #
+#                                                                                               #
+# Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+#                                                                                               #
+# Redistribution and use in source and binary forms, with or without modification, are          #
+# permitted provided that the following conditions are met:                                     #
+#                                                                                               #
+# 1. Redistributions of source code must retain the above copyright notice, this list of        #
+#    conditions and the following disclaimer.                                                   #
+#                                                                                               #
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
+#    conditions and the following disclaimer in the documentation and/or other materials        #
+#    provided with the distribution.                                                            #
+#                                                                                               #
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
+#    endorse or promote products derived from this software without specific prior written      #
+#    permission.                                                                                #
+#                                                                                               #
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
+# OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
+# GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
+# OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
+# ********************************************************************************************* #
+# The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+#################################################################################################
+
+# Modify this variable to fit your NEORV32 setup (neorv32 home folder)
+NEORV32_HOME ?= ../../..
+
+include $(NEORV32_HOME)/sw/common/common.mk

--- a/sw/lib/source/syscalls.c
+++ b/sw/lib/source/syscalls.c
@@ -22,10 +22,11 @@
  * @author Modified for the NEORV32 RISC-V Processor by Stephan Nolting
  * @brief Newlib system calls
  *
- * @warning UART0 (if available) is used to read/write STDOUT data
+ * @warning UART0 (if available) is used to read/write console data (STDIN, STDOUT, STDERR, ...).
  *
  * @note Original source file: https://github.com/openhwgroup/cv32e40p/blob/master/example_tb/core/custom/syscalls.c
  * @note Original license: SOLDERPAD HARDWARE LICENSE version 0.51
+ * @note More information was derived from: https://interrupt.memfault.com/blog/boostrapping-libc-with-newlib#implementing-newlib
  **************************************************************************/
 
 #include <sys/stat.h>
@@ -39,15 +40,6 @@
 
 #undef errno
 extern int errno;
-
-// /* write to this reg for outputting strings */
-// #define STDOUT_REG 0x10000000 - use NEORV32.UART0 for output
-// /* write test result of program to this reg */
-// #define RESULT_REG 0x20000000
-// /* write exit value of program to this reg */
-// #define EXIT_REG 0x20000004 - use NEORV32.UART0 for output
-
-#define STDOUT_FILENO 1
 
 /* It turns out that older newlib versions use different symbol names which goes
  * against newlib recommendations. Anyway this is fixed in later version.
@@ -64,9 +56,6 @@ extern int errno;
 
 void unimplemented_syscall()
 {
-  // const char *p = "Unimplemented system call called!\n";
-  // while (*p)
-  //     *(volatile int *)STDOUT_REG = *(p++);
   if (neorv32_uart0_available()) {
     neorv32_uart0_print("<syscalls.c> Unimplemented system call called!\n");
   }
@@ -115,11 +104,12 @@ int _execve(const char *name, char *const argv[], char *const env[])
 
 void _exit(int exit_status)
 {
-    //*(volatile int *)EXIT_REG = exit_status;
+    // output exit status via UART0 (if available) and put core into endless sleep mode
     if (neorv32_uart0_available()) {
-      neorv32_uart0_printf("<syscalls.c> Exit status: %i\n", (int32_t)exit_status);
+      neorv32_uart0_printf("<syscalls.c> Exit status %i, shutting down core\n", (int32_t)exit_status);
     }
-    asm volatile("wfi");
+    asm volatile("csrci mstatus, 8\n" // disable interrupts
+                 "wfi");              // go to sleep mode
     while(1);
 }
 
@@ -137,10 +127,8 @@ int _fork(void)
 
 int _fstat(int file, struct stat *st)
 {
-    st->st_mode = S_IFCHR;
+    st->st_mode = S_IFCHR; // all files are "character special files"
     return 0;
-    // errno = -ENOSYS;
-    // return -1;
 }
 
 int _fstatat(int dirfd, const char *file, struct stat *st, int flags)
@@ -215,6 +203,7 @@ ssize_t _read(int file, void *ptr, size_t len)
 {
     int read_cnt = 0;
 
+    // read everything (STDIN, ...) from NEORV32.UART0 (if available)
     if (neorv32_uart0_available()) {
       char *char_ptr;
       char_ptr = (char *)ptr;
@@ -267,20 +256,17 @@ int _wait(int *status)
 
 ssize_t _write(int file, const void *ptr, size_t len)
 {
-    if (file != STDOUT_FILENO) {
-        errno = ENOSYS;
-        return -1;
-    }
-
+    // write everything (STDOUT, STDERR, ...) to NEORV32.UART0 (if available)
     const void *eptr = ptr + len;
-    //while (ptr != eptr)
-    //    *(volatile int *)STDOUT_REG = *(char *)(ptr++);
     if (neorv32_uart0_available()) {
       while (ptr != eptr) {
         neorv32_uart0_putc(*(char *)(ptr++));
       }
+      return len;
     }
-    return len;
+    else {
+      return (size_t)0; // nothing sent
+    }
 }
 
 extern char __heap_start[];


### PR DESCRIPTION
This PR is an addition of #275 and adds the following:

* a demo/test example program for newlib's system call functions (like `malloc` and `write`) in `sw/example/newlib_demo`
* new documentation for the _C Standard Library_ (which is newlib by default)
* some notes regarding newlib (especially when building the compiler toolchain from scratch)