### PR TITLE
🐛 [rtl/core] fix bug in mip CSR clear/acknowledge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The version number is globally defined by the `hw_version_c` constant in the mai
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 24.02.2022 | 1.6.8.4 | :bug: **fixed bug in `mip` CSR** (introduced in version `1.6.4.6` with [#236](https://github.com/stnolting/neorv32/pull/236)): to clear/ack a pending interrupt software needs to **clear** the according `mip` bit; see [PR #280](https://github.com/stnolting/neorv32/pull/280) |
 | 24.02.2022 | 1.6.8.3 | reworked CPU's data path (use a few _wide_ multiplexers instead of many small ones); [PR #279](https://github.com/stnolting/neorv32/pull/279) |
 | 23.02.2022 | 1.6.8.2 | CPU logic optimizations (less area): simplified CPU co-processor interface; minor optimization of bus unit access arbiters; optimized `M` extension's (mul/div co-processor) divider unit |
 | 18.02.2022 | 1.6.8.1 | minor CPU control logic optimizations: simplified execute engine; faster execution of SYSTEM instructions (one cycle less) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -557,9 +557,9 @@ Any kind of privilege rights violation will raise an exception to allow <<_full_
 The NEORV32-specific extensions are always enabled and are indicated by the set `X` bit in the <<_misa>> CSR.
 
 The most important points of the NEORV32-specific extensions are:
-* The CPU provides 16 _fast interrupt_ interrupts (`FIRQ)`, which are controlled via custom bits in the `mie`
-and <<_mip>> CSR. This extension is mapped to CSR bits, that are available for custom use (according to the
-RISC-V specs). Also, custom trap codes for <<_mcause>> are implemented.
+* The CPU provides 16 _fast interrupt_ interrupts (`FIRQ`), which are controlled via custom bits in the <<_mie>>
+and <<_mip>> CSRs. These extensions are mapped to CSR bits, that are available for custom use according to the
+RISC-V specs. Also, custom trap codes for <<_mcause>> are implemented.
 * All undefined/unimplemented/malformed/illegal instructions do raise an illegal instruction exception (see <<_full_virtualization>>).
 * There are <<_neorv32_specific_csrs>>.
 
@@ -871,8 +871,8 @@ until it is explicitly acknowledged by the CPU software (for example by writing 
 .Interrupt Signal Requirements - Fast Interrupt Requests
 [IMPORTANT]
 The NEORV32-specific FIRQ request lines are triggered by a one-shot high-level (i.e. rising edge). Each request is buffered in the CPU control
-unit until the channel is either disabled (by clearing the according <<_mie>> CSR bit) or the request is explicitly cleared (by setting
-the according <<_mip>> CSR bit).
+unit until the channel is either disabled (by clearing the according <<_mie>> CSR bit) or the request is explicitly cleared (by writing
+zero to the according <<_mip>> CSR bit).
 
 .Instruction Atomicity
 [NOTE]
@@ -1043,6 +1043,7 @@ completed when the accessed peripheral/memory either sets the `*_bus_ack_i` sign
 An error indicated by the `*_bus_err_i` signal will raise the according "instruction bus access fault" or
 "load/store bus access fault" exception.
 
+
 **Minimal Response Latency**
 
 The transfer can be completed directly in the same cycle as it was initiated (via the `*_bus_re_o` or `*_bus_we_o`
@@ -1050,12 +1051,14 @@ signal) if the peripheral sets `*_bus_ack_i` or `*_bus_err_i` high for one cycle
 critical path such "asynchronous" completion should be avoided. The default NEORV32 processor-internal modules provide
 exactly **one cycle delay** between initiation and completion of transfers.
 
+
 **Maximal Response Latency**
 
 Processor-internal peripherals or memories do not have to respond within one cycle after a bus request has been initiated.
 However, the bus transaction has to be completed (= acknowledged) within a certain **response time window**. This time window
 is defined by the global `max_proc_int_response_time_c` constant (default = 15 cycles; processor's VHDL package file `rtl/neorv32_package.vhd`).
-It defines the maximum number of cycles after which an _unacknowledged_ (`*_bus_ack_i` or `*_bus_err_i` both not set) processor-internal bus
+It defines the maximum number of cycles after which an _unacknowledged_ (`*_bus_ack_i` or `*_bus_err_i` signal from the **processor-internal bus**
+both not set) processor-internal bus
 transfer will time out and raises a **bus fault exception**. The <<_internal_bus_monitor_buskeeper>> keeps track of all _internal_ bus
 transactions to enforce this time window.
 
@@ -1063,6 +1066,13 @@ If any bus operations times out (for example when accessing "address space holes
 error to the CPU that will raise the according instruction fetch or data access bus exception.
 Note that **the bus keeper does not track external accesses via the external memory bus interface**. However,
 the external memory bus interface also provides an _optional_ bus timeout (see section <<_processor_external_memory_interface_wishbone_axi4_lite>>).
+
+.Interface Response
+[NOTE]
+Please note that any CPU access via the data or instruction interface has to be terminated either by asserting the
+CPU's *_bus_ack_i` or `*_bus_err_i` signal. Otherwise the CPU will be stalled permanently. The BUSKEEPER ensures that
+any kind of access is always properly terminated.
+
 
 **Exemplary Bus Accesses**
 
@@ -1075,6 +1085,7 @@ a| image::cpu_interface_write_long.png[write,300,150]
 | Read access | Write access
 |=======================
 
+
 **Write Access**
 
 For a write access, the access address (`bus_addr_o`), the data to be written (`bus_wdata_o`) and the byte
@@ -1082,6 +1093,7 @@ enable signals (`bus_ben_o`) are set when bus_we_o goes high. These three signal
 transaction is completed. In the example the accessed peripheral cannot answer directly in the next
 cycle after issuing. Here, the transaction is successful and the peripheral sets the `bus_ack_i` signal several
 cycles after issuing.
+
 
 **Read Access**
 
@@ -1091,11 +1103,13 @@ directly in the next cycle after issuing. The peripheral hast to apply the read 
 the bus transaction is completed (here, the transaction is successful and the peripheral sets the `bus_ack_i`
 signal).
 
+
 **Access Boundaries**
 
 The instruction interface will always access memory on word (= 32-bit) boundaries even if fetching
 compressed (16-bit) instructions. The data interface can access memory on byte (= 8-bit), half-word (= 16-
 bit) and word (= 32-bit) boundaries.
+
 
 **Exclusive (Atomic) Access**
 
@@ -1122,6 +1136,7 @@ The CPU-internal exclusive access lock is broken if at least one of the situatio
 For more information regarding the SoC-level behavior and requirements of atomic operations see
 section <<_processor_external_memory_interface_wishbone_axi4_lite>>.
 
+
 **Memory Barriers**
 
 Whenever the CPU executes a _fence_ instruction, the according interface signal is set high for one cycle
@@ -1140,6 +1155,7 @@ registers of the NEORV32 CPU as well as most register of the whole NEORV32 Proce
 dedicated hardware reset**. "Uncritical registers" in this context means that the initial value of these registers
 after power-up is not relevant for a defined CPU boot process.
 
+
 **Rationale**
 
 A good example to illustrate the concept of uncritical registers is a pipelined processing engine. Each stage
@@ -1150,6 +1166,7 @@ irrelevant as long as the status registers are all reset to a defined value that
 the pipeline's data register. Therefore, the pipeline data register do no require a dedicated reset as they do not
 control the actual operation (in contrast to the status register). This makes the pipeline data registers from
 this example "uncritical registers".
+
 
 **NEORV32 CPU Reset**
 
@@ -1164,6 +1181,7 @@ the lack of dedicated hardware resets of certain CSRs. For example the machine i
 does not provide a dedicated reset. The value after reset of this register is uncritical as interrupts cannot fire
 because the global interrupt enabled flag in the status register (`mstatsus(mie)`) _do_ provide a dedicated
 hardware reset setting this bit to low (globally disabling interrupts).
+
 
 **Reset Configuration**
 

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -450,8 +450,8 @@ The NEORV32 `mtval` CSR is read-only. However, a write access will _NOT_ raise a
 3+| The `mip` CSR is compatible to the RISC-V specifications and also provides custom extensions. It shows currently _pending_ interrupts.
 The bits for the standard RISC-V interrupts are read-only. Hence, these interrupts cannot be cleared using the `mip` register and must
 be cleared/acknowledged within the according interrupt-generating device.
-The upper 16 bits represent the status of the CPU's fast interrupt request lines (FIRQ). Once triggered, these _have to be cleared_ again by setting
-the according `mip` bit in the interrupt handler routine to clear the current interrupt request.
+The upper 16 bits represent the status of the CPU's fast interrupt request lines (FIRQ). Once triggered, these bit have to be cleared manually by
+writing zero to the according `mip` bits (in the interrupt handler routine) to clear the current interrupt request.
 |=======================
 
 .Machine interrupt pending register
@@ -459,11 +459,16 @@ the according `mip` bit in the interrupt handler routine to clear the current in
 [options="header",grid="rows"]
 |=======================
 | Bit | Name [C] | R/W | Function
-| 31:16 | _CSR_MIP_FIRQ15P_ : _CSR_MIP_FIRQ0P_ | r/w | fast interrupt channel 15..0 pending; cleared request by writing 1
+| 31:16 | _CSR_MIP_FIRQ15P_ : _CSR_MIP_FIRQ0P_ | r/c | fast interrupt channel 15..0 pending; cleared request by writing 1
 | 11    | _CSR_MIP_MEIP_                       | r/- | machine _external_ interrupt pending; _cleared by user-defined mechanism_
 | 7     | _CSR_MIP_MTIP_                       | r/- | machine _timer_ interrupt pending; cleared by incrementing MTIME's time compare register
 | 3     | _CSR_MIP_MSIP_                       | r/- | machine _software_ interrupt pending; _cleared by user-defined mechanism_
 |=======================
+
+.FIRQ Channel Mapping
+[TIP]
+See section <<_neorv32_specific_fast_interrupt_requests>> for the mapping of the FIRQ channels and the according
+interrupt-triggering processor module.
 
 
 <<<

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -1101,7 +1101,7 @@ specifications. However, bare-metal system can also repurpose these interrupts. 
 .Trigger type
 [IMPORTANT]
 The fast interrupt request channels become pending after being triggering by **a rising edge**. A pending FIRQ has to
-be explicitly cleared by setting the according <<_mip>> CSR bit.
+be explicitly cleared by writing zero to the according <<_mip>> CSR bit.
 
 
 :sectnums:
@@ -1160,7 +1160,7 @@ the according FIRQ priority; 0 = highest, 15 = lowest):
 .Trigger type
 [IMPORTANT]
 The fast interrupt request channels become pending after being triggering by **a rising edge**. A pending FIRQ has to
-be explicitly cleared by setting the according <<_mip>> CSR bit.
+be explicitly cleared by writing zero to the according <<_mip>> CSR bit.
 
 
 

--- a/docs/datasheet/soc_cfs.adoc
+++ b/docs/datasheet/soc_cfs.adoc
@@ -63,8 +63,8 @@ A very simple example program that uses the _default_ CFS hardware module can be
 **CFS Interrupt**
 
 The CFS provides a single high-level-triggered interrupt request signal mapped to the CPU's fast interrupt channel 1.
-Once triggered, the interrupt becomes pending (if enabled in the `mis` CSR) and has to be explicitly cleared again by setting
-the according `mip` CSR bit. See section <<_processor_interrupts>> for more information.
+Once triggered, the interrupt becomes pending (if enabled in the `mis` CSR) and has to be explicitly cleared again by
+writing zero to the according <<_mip>> CSR bit. See section <<_processor_interrupts>> for more information.
 
 
 **CFS Configuration Generic**

--- a/docs/datasheet/soc_gptmr.adoc
+++ b/docs/datasheet/soc_gptmr.adoc
@@ -9,7 +9,7 @@
 | Software driver file(s): | neorv32_gptmr.c |
 |                          | neorv32_gptmr.h |
 | Top entity port:         | none | 
-| Configuration generics:  | _IO_GPTMR_EN_ | implement timer when _true_
+| Configuration generics:  | _IO_GPTMR_EN_ | implement general purpose timer when _true_
 | CPU interrupts:          | fast IRQ channel 12 | transmission done interrupt (see <<_processor_interrupts>>)
 |=======================
 
@@ -47,7 +47,7 @@ writing zero to it.
 **Timer Interrupt**
 
 The timer interrupt is triggered when the timer is enabled and `COUNT` matches `THRES`. The interrupt
-remains pending until explicitly cleared by writing the according `mip` CSR bit.
+remains pending until explicitly cleared by writing zero to the according <<_mip>> CSR bit.
 
 
 .GPTMR register map (`struct NEORV32_GPTMR`)

--- a/docs/datasheet/soc_neoled.adoc
+++ b/docs/datasheet/soc_neoled.adoc
@@ -173,8 +173,8 @@ If _NEOLED_CTRL_IRQ_CONF_ is cleared, an interrupt is generated whenever the TX 
 In this case software can write up to _IO_NEOLED_TX_FIFO_/2 new data words to `DATA` without checking the FIFO
 status flags. If _NEOLED_CTRL_IRQ_CONF_ is set, an interrupt is generated whenever the TX FIFO _becomes_ empty.
 
-One the NEOLED interrupt has been triggered and became pending, it has to explicitly cleared again by setting the
-according `mip` CSR bit.
+One the NEOLED interrupt has been triggered and became pending, it has to explicitly cleared again by
+writing zero to according <<_mip>> CSR bit.
 
 [NOTE]
 The _NEOLED_CTRL_IRQ_CONF_ is hardwired to one if _IO_NEOLED_TX_FIFO_ = 1 (-> IRQ if FIFO is empty).

--- a/docs/datasheet/soc_slink.adoc
+++ b/docs/datasheet/soc_slink.adoc
@@ -144,8 +144,8 @@ The **TX link's** _SLINK_IRQ_TX_MODE_ flags define the FIFO fill-level condition
 * If a link's interrupt mode flag is `0` an IRQ is generated when the link's FIFO _becomes_ not full ("space left in FIFO for new TX data").
 * If a link's interrupt mode flag is `1` an IRQ is generated when the link's FIFO _becomes_ less than half-full ("SW can send _SLINK_TX_FIFO_/2 data words without checking any flags"). 
 
-Once the SLINK's RX or TX interrupt has become pending, it has to be explicitly cleared again by setting the according
-`mip` CSR bit.
+Once the SLINK's RX or TX interrupt has become pending, it has to be explicitly cleared again by writing
+zero to the according <<_mip>> CSR bit.
 
 [IMPORTANT]
 The interrupt configuration register `NEORV32_SLINK.IRQ` should we written _before_ the SLINK

--- a/docs/datasheet/soc_spi.adoc
+++ b/docs/datasheet/soc_spi.adoc
@@ -115,7 +115,7 @@ the control register's _SPI_CTRL_HIGHSPEED_ bit.
 
 The SPI module provides a single interrupt to signal "transmission done" to the CPU. Whenever the SPI
 module completes the current transfer operation, the interrupt is triggered and has to be explicitly cleared again
-by setting the according `mip` CSR bit.
+by writing zero to the according <<_mip>> CSR bit.
 
 
 .SPI register map (`struct NEORV32_SPI`)

--- a/docs/datasheet/soc_twi.adoc
+++ b/docs/datasheet/soc_twi.adoc
@@ -74,8 +74,8 @@ _**f~SCL~**_ = _f~main~[Hz]_ / (4 * `clock_prescaler`)
 
 The SPI module provides a single interrupt to signal "operation done" to the CPU. Whenever the TWI
 module completes the current operation (generate stop condition, generate start conditions or transfer byte),
-the interrupt is triggered. Once triggered, the interrupt has to be explicitly cleared again by setting the according
-`mip` CSR bit.
+the interrupt is triggered. Once triggered, the interrupt has to be explicitly cleared again by
+writing zero to the according <<_mip>> CSR bit.
 
 
 .TWI register map (`struct NEORV32_TWI`)

--- a/docs/datasheet/soc_uart.adoc
+++ b/docs/datasheet/soc_uart.adoc
@@ -129,8 +129,8 @@ the RX FIFO _becomes_ at least half-full (-> _UART_CTRL_RX_HALF_ sets).
 in the TX FIFO _becomes_ free (-> _UART_CTRL_TX_FULL_ clears). If _UART_CTRL_TX_IRQ_ is `1` the TX interrupt goes pending
 when the RX FIFO _becomes_ less than half-full (-> _UART_CTRL_TX_HALF_ clears).
 
-Once the RX or TX interrupt has become pending, it has to be explicitly cleared again by setting the
-according `mip` CSR bit.
+Once the RX or TX interrupt has become pending, it has to be explicitly cleared again by
+writing zero to the according <<_mip>> CSR bit.
 
 
 **Simulation Mode**

--- a/docs/datasheet/soc_wdt.adoc
+++ b/docs/datasheet/soc_wdt.adoc
@@ -9,7 +9,7 @@
 | Software driver file(s): | neorv32_wdt.c |
 |                          | neorv32_wdt.h |
 | Top entity port:         | none | 
-| Configuration generics:  | _IO_WDT_EN_ | implement GPIO port when _true_
+| Configuration generics:  | _IO_WDT_EN_ | implement watchdog when _true_
 | CPU interrupts:          | fast IRQ channel 0 | watchdog timer overflow (see <<_processor_interrupts>>)
 |=======================
 
@@ -46,7 +46,7 @@ IRQ, when set the WDT will cause a system reset. The configured action can also 
 any time by setting the _WDT_CTRL_FORCE_ bit. The watchdog is reset by setting the _WDT_CTRL_RESET_ bit.
 
 A watchdog interrupt can only occur if the watchdog is enabled and interrupt mode is enabled.
-A triggered interrupt has to be cleared again by setting the according `mip` CSR bit.
+A triggered interrupt has to be cleared again by writing zero to the according <<_mip>> CSR bit.
 
 The cause of the last action of the watchdog can be determined via the _WDT_CTRL_RCAUSE_ flag. If this flag is
 zero, the processor has been reset via the external reset signal. If this flag is set the last system reset was

--- a/docs/datasheet/soc_xirq.adoc
+++ b/docs/datasheet/soc_xirq.adoc
@@ -43,8 +43,8 @@ This priority assignment is fixed and cannot be altered by software.
 The CPU can use the ID from `SCR` to service IRQ according to their priority. To acknowledge the according
 interrupt the CPU can write `1 << SCR` to `IPR`.
 
-In order to clear a pending FIRQ interrupt from the external interrupt controller again, the according `mip` CSR bit has
-to be set. Additionally, the XIRQ interrupt has to be acknowledged by writing _any_
+In order to clear a pending FIRQ interrupt from the external interrupt controller again, the according <<_mip>> CSR bit has
+to be cleared. Additionally, the XIRQ interrupt has to be acknowledged by writing _any_
 value to the interrupt source register `SRC`.
 
 [NOTE]

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -65,7 +65,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060803"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060804"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/example/demo_gptmr/main.c
+++ b/sw/example/demo_gptmr/main.c
@@ -113,7 +113,7 @@ int main() {
  **************************************************************************/
 void gptmr_firq_handler(void) {
 
-  neorv32_cpu_csr_write(CSR_MIP, 1<<GPTMR_FIRQ_PENDING); // clear/ack pending FIRQ
+  neorv32_cpu_csr_write(CSR_MIP, ~(1<<GPTMR_FIRQ_PENDING)); // clear/ack pending FIRQ
 
   neorv32_uart0_putc('.'); // send tick symbol via UART0
   neorv32_gpio_pin_toggle(0); // toggle output port bit 0

--- a/sw/example/demo_slink/main.c
+++ b/sw/example/demo_slink/main.c
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -475,7 +475,7 @@ void slink_write(void) {
  **************************************************************************/
 void slink_rx_firq_handler(void) {
 
-  neorv32_cpu_csr_write(CSR_MIP, 1 << SLINK_RX_FIRQ_PENDING); // ACK interrupt
+  neorv32_cpu_csr_write(CSR_MIP, ~(1 << SLINK_RX_FIRQ_PENDING)); // ACK interrupt
   neorv32_uart0_printf("\n<SLINK_RX_IRQ>\n");
 }
 
@@ -485,7 +485,7 @@ void slink_rx_firq_handler(void) {
  **************************************************************************/
 void slink_tx_firq_handler(void) {
 
-  neorv32_cpu_csr_write(CSR_MIP, 1 << SLINK_TX_FIRQ_PENDING); // ACK interrupt
+  neorv32_cpu_csr_write(CSR_MIP, ~(1 << SLINK_TX_FIRQ_PENDING)); // ACK interrupt
   neorv32_uart0_printf("\n<SLINK_TX_IRQ>\n");
 }
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1804,7 +1804,7 @@ void sim_irq_trigger(uint32_t sel) {
 void global_trap_handler(void) {
 
   // clear all pending FIRQs
-  neorv32_cpu_csr_write(CSR_MIP, -1);
+  neorv32_cpu_csr_write(CSR_MIP, 0);
 
   // hack: always come back in MACHINE MODE
   register uint32_t mask = (1<<CSR_MSTATUS_MPP_H) | (1<<CSR_MSTATUS_MPP_L);

--- a/sw/lib/source/neorv32_xirq.c
+++ b/sw/lib/source/neorv32_xirq.c
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -238,7 +238,7 @@ static void __attribute__((aligned(16))) __neorv32_xirq_core(void) {
   uint32_t mask = 1 << src;
   NEORV32_XIRQ.IPR = ~mask; // clear current pending interrupt
 
-  neorv32_cpu_csr_write(CSR_MIP, 1 << XIRQ_FIRQ_PENDING); // acknowledge XIRQ FIRQ
+  neorv32_cpu_csr_write(CSR_MIP, ~(1 << XIRQ_FIRQ_PENDING)); // acknowledge XIRQ FIRQ
 
   NEORV32_XIRQ.SCR = 0; // acknowledge current XIRQ interrupt source
 


### PR DESCRIPTION
This PR fixes a bug that has been introduced in version `1.6.4.6` / PR #236: to clear a pending interrupt application software has to write **ZERO** (and not one!) to the according `mip` bit (according to the RISC-V privilege architecture specifications). Hence, the acknowledge/clear mask needs to be inverted.