### PR TITLE
Update neorv32_gptmr.c

### DIFF
--- a/sw/lib/source/neorv32_gptmr.c
+++ b/sw/lib/source/neorv32_gptmr.c
@@ -34,7 +34,7 @@
 
 
 /**********************************************************************//**
- * @file neorv32_spi.c
+ * @file neorv32_gptmr.c
  * @author Stephan Nolting
  * @brief General purpose timer (GPTMR) HW driver source file.
  *


### PR DESCRIPTION
correct timer source file name, previously clashed in doxygen output