### PR TITLE
[rtl] CPU code clean-up; add RISC-V mstatus.TW CSR bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,9 @@ The version number is globally defined by the `hw_version_c` constant in the mai
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 05.03.2022 | 1.6.8.9 | CPU core: minor optimizations, code clean-ups and edits; :sparkles: added RISC-V `mstatus.TW` bit to allow/disallow execution of `wfi` instruction in user mode |
 | 02.03.2022 | 1.6.8.8 | :bug: fixed bug in layout of CPU's `pmpaddr` CSRs (**physical memory protection**); [PR #283](https://github.com/stnolting/neorv32/pull/283) |
-| 01.03.2022 | 1.6.8.7 | minor optimizations, code clean-ups and edits |
+| 01.03.2022 | 1.6.8.7 | CPU core: minor optimizations, code clean-ups and edits |
 | 26.02.2022 | 1.6.8.6 | :warning: :lock: **reworked Physical Memory Protection (PMP)**: replacing `NAPOT` mode by `TOR` mode and fixing several minor PMP CSR-access bugs; maximum number of PMP regions is now limited to 16 entries; :warning: removed **BUSKEEPER's NULL address check** (introduced in version `1.6.5.4`) - use a single PMP entry instead; see [PR #281](https://github.com/stnolting/neorv32/pull/281) |
 | 25.02.2022 | 1.6.8.5 | minor BUSMUX (bus multiplexer for CPU's instruction and data buses) and CPU control edits (pipeline front-end) |
 | 24.02.2022 | 1.6.8.4 | :bug: **fixed bug in `mip` CSR** (introduced in version `1.6.4.6` with [#236](https://github.com/stnolting/neorv32/pull/236)): to clear/ack a pending interrupt software needs to **clear** the according `mip` bit; see [PR #280](https://github.com/stnolting/neorv32/pull/280) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The version number is globally defined by the `hw_version_c` constant in the mai
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
-| 05.03.2022 | 1.6.8.9 | CPU core: minor optimizations, code clean-ups and edits; :sparkles: added RISC-V `mstatus.TW` bit to allow/disallow execution of `wfi` instruction in user mode |
+| 05.03.2022 | 1.6.8.9 | CPU core: minor optimizations, code clean-ups and edits; :sparkles: added RISC-V `mstatus.TW` bit to allow/disallow execution of `wfi` instruction in user mode; [PR #285](https://github.com/stnolting/neorv32/pull/285) |
 | 02.03.2022 | 1.6.8.8 | :bug: fixed bug in layout of CPU's `pmpaddr` CSRs (**physical memory protection**); [PR #283](https://github.com/stnolting/neorv32/pull/283) |
 | 01.03.2022 | 1.6.8.7 | CPU core: minor optimizations, code clean-ups and edits |
 | 26.02.2022 | 1.6.8.6 | :warning: :lock: **reworked Physical Memory Protection (PMP)**: replacing `NAPOT` mode by `TOR` mode and fixing several minor PMP CSR-access bugs; maximum number of PMP regions is now limited to 16 entries; :warning: removed **BUSKEEPER's NULL address check** (introduced in version `1.6.5.4`) - use a single PMP entry instead; see [PR #281](https://github.com/stnolting/neorv32/pull/281) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -3,6 +3,16 @@
 
 image::neorv32_cpu_block.png[width=600,align=center]
 
+**Section Structure**
+
+* <<_architecture>>, <<_full_virtualization>> and <<_risc_v_compatibility>>
+* <<_cpu_top_entity_signals>> and <<_cpu_top_entity_generics>>
+* <<_instruction_sets_and_extensions>>, <<_custom_functions_unit_cfu>> and <<_instruction_timing>>
+* <<_control_and_status_registers_csrs>>
+* <<_traps_exceptions_and_interrupts>>
+* <<_bus_interface>>
+
+
 **Key Features**
 
 * 32-bit little-endian, multi-cycle, in-order `rv32` RISC-V CPU
@@ -260,8 +270,9 @@ side-effects to maintain RISC-V compatibility.
 .Physical Memory Protection
 [IMPORTANT]
 The RISC-V-compatible NEORV32 <<_machine_physical_memory_protection_csrs>> only implements the **TOR**
-(top of region) mode and only up to 16 PMP regions. Furthermore, the <<_pmpcfg>>'s
-_lock bits_ only lock the according PMP entry and not the entries below.
+(top of region) mode and only up to 16 PMP regions. Furthermore, the <<_pmpcfg>>'s _lock bits_ only lock
+the according PMP entry and not the entries below. All region rules are checked in parallel **without**
+prioritization so for identical memory regions the most restrictive PMP rule will be enforced.
 
 .Atomic Memory Operations
 [IMPORTANT]
@@ -640,13 +651,15 @@ If `rd=x0` for the `csrrw[i]` instructions there will be no actual read access t
 However, access privileges are still enforced so these instruction variants _do_ cause side-effects
 (the RISC-V spec. state that these combinations "_shall_ not cause any side-effects").
 
-[NOTE]
-The "wait for interrupt instruction" `wfi` acts like a sleep command. When executed, the CPU is
-halted until a valid interrupt request occurs. To wake up again, the according interrupt source has to
-be enabled via the <<_mie>> CSR and the global interrupt enable flag in <<_mstatus>> has to be set.
-The `wfi` instruction may also be executed in user-mode without causing an exception as <<_mstatus>> bit
-`TW` (timeout wait) is _hardwired_ to zero.
+** `wfi` Instruction **
 
+The "wait for interrupt instruction" `wfi` acts like a sleep command. When executed, the CPU is
+halted until a valid interrupt request occurs. To wake up again, at least one interrupt source has to
+be enabled via the <<_mie>> CSR and the global interrupt enable flag in <<_mstatus>> has to be set.
+
+If the <<_mstatus>> `TW` bis is cleared the `wfi` instruction is also allowed to execute when in user-mode.
+This is always the case if user-mode is not implemented. If the `TW` bit is set the execution of `wfi` in
+user-mode will raise an illegal instruction exception.
 
 
 ==== **`Zicntr`** CPU Base Counters
@@ -768,6 +781,11 @@ By default, all PMP checks are enforced for user-mode only. However, PMP rules c
 machine-mode when the according PMP region has the "LOCK" bit set. This will also prevent any write access
 to according region's PMP CSRs until the CPU is reset.
 
+.Rule Prioritization
+[IMPORTANT]
+All rules are checked in parallel **without** prioritization so for identical memory regions the most restrictive
+PMP rule will be enforced.
+
 .PMP Example Program
 [TIP]
 A simple PMP example program can be found in `sw/example/demo_pmp`.
@@ -791,6 +809,11 @@ constant pmp_num_regions_critical_c : natural := 8;
 Reducing the minimal PMP region size / granularity via the <<_pmp_min_granularity>> to entity generic
 will also reduce hardware utilization and impact on critical path.
 
+
+<<<
+// ####################################################################################################################
+
+include::cpu_cfu.adoc[]
 
 
 <<<
@@ -1216,9 +1239,3 @@ be enabled by enabling a constant in the main VHDL package file (`rtl/core/neorv
 -- FALSE=reset value is irrelevant (might simplify HW), default; TRUE=defined LOW reset value
 constant dedicated_reset_c : boolean := false;
 ----
-
-
-<<<
-// ####################################################################################################################
-
-include::cpu_cfu.adoc[]

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -510,7 +510,7 @@ The actual number of available `pmpcfg` CSRs and CSR entries is defined by the <
 |=======================
 | Bit | Name [C] | R/W | Function
 | 7   | _PMPCFG_L_     | r/w | **L**: Lock bit, prevents further write accesses, also enforces access rights in machine-mode, can only be cleared by CPU reset
-| 6:5 | -              | r/- | reserved, read as zero
+| 6:5 | -              | r/- | _reserved_, read as zero
 | 4   | _PMPCFG_A_MSB_ | r/- .2+<| **A**: Mode configuration; only **OFF** (`00`) and **TOR** (`01`) modes are supported, any other value will map back to OFF/TOR
 as the MSB is hardwired to zero
 | 3   | _PMPCFG_A_LSB_ | r/w 

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -220,9 +220,10 @@ The following bits are implemented (all remaining bits are always zero and are r
 [options="header",grid="rows"]
 |=======================
 | Bit   | Name [C] | R/W | Function
-| 12:11 | _CSR_MSTATUS_MPP_H_ : _CSR_MSTATUS_MPP_L_ | r/w | Previous machine privilege level, 11 = machine (M) level, 00 = user (U) level
-| 7     | _CSR_MSTATUS_MPIE_ | r/w | Previous machine global interrupt enable flag state
-| 3     | _CSR_MSTATUS_MIE_  | r/w | Machine global interrupt enable flag
+| 21    | _CSR_MSTATUS_TW_   | r/w | **TW**: Disallows execution of `wfi` instruction in user mode when set; hardwired to zero if user-mode not implemented
+| 12:11 | _CSR_MSTATUS_MPP_H_ : _CSR_MSTATUS_MPP_L_ | r/w | **MPP*: Previous machine privilege level, 11 = machine (M) level, 00 = user (U) level
+| 7     | _CSR_MSTATUS_MPIE_ | r/w | **MPIE**: Previous machine global interrupt enable flag state
+| 3     | _CSR_MSTATUS_MIE_  | r/w | **MIE**: Machine global interrupt enable flag
 |=======================
 
 When entering an exception/interrupt, the `MIE` flag is copied to `MPIE` and cleared afterwards. When leaving
@@ -251,14 +252,14 @@ CSR is simply ignored and will _NOT_ cause an illegal instruction exception.
 [options="header",grid="rows"]
 |=======================
 | Bit   | Name [C] | R/W | Function
-| 31:30 | _CSR_MISA_MXL_HI_EXT_ : _CSR_MISA_MXL_LO_EXT_ | r/- | 32-bit architecture indicator (always _01_)
-| 23    | _CSR_MISA_X_EXT_ | r/- | `X` extension bit is always set to indicate custom non-standard extensions
-| 20    | _CSR_MISA_U_EXT_ | r/- | `U` CPU extension (user mode) available, set when _CPU_EXTENSION_RISCV_U_ enabled
-| 12    | _CSR_MISA_M_EXT_ | r/- | `M` CPU extension (mul/div) available, set when _CPU_EXTENSION_RISCV_M_ enabled
-| 8     | _CSR_MISA_I_EXT_ | r/- | `I` CPU base ISA, cleared when _CPU_EXTENSION_RISCV_E_ enabled
-| 4     | _CSR_MISA_E_EXT_ | r/- | `E` CPU extension (embedded) available, set when _CPU_EXTENSION_RISCV_E_ enabled
-| 2     | _CSR_MISA_C_EXT_ | r/- | `C` CPU extension (compressed instruction) available, set when _CPU_EXTENSION_RISCV_C_ enabled
-| 0     | _CSR_MISA_A_EXT_ | r/- | `A` CPU extension (atomic memory access) available, set when _CPU_EXTENSION_RISCV_A_ enabled
+| 31:30 | _CSR_MISA_MXL_HI_EXT_ : _CSR_MISA_MXL_LO_EXT_ | r/- | **MXL**: 32-bit architecture indicator (always _01_)
+| 23    | _CSR_MISA_X_EXT_ | r/- | **X**: extension bit is always set to indicate custom non-standard extensions
+| 20    | _CSR_MISA_U_EXT_ | r/- | **U**: CPU extension (user mode) available, set when _CPU_EXTENSION_RISCV_U_ enabled
+| 12    | _CSR_MISA_M_EXT_ | r/- | **M**: CPU extension (mul/div) available, set when _CPU_EXTENSION_RISCV_M_ enabled
+| 8     | _CSR_MISA_I_EXT_ | r/- | **I**: CPU base ISA, cleared when _CPU_EXTENSION_RISCV_E_ enabled
+| 4     | _CSR_MISA_E_EXT_ | r/- | **E**: CPU extension (embedded) available, set when _CPU_EXTENSION_RISCV_E_ enabled
+| 2     | _CSR_MISA_C_EXT_ | r/- | **C**: CPU extension (compressed instruction) available, set when _CPU_EXTENSION_RISCV_C_ enabled
+| 0     | _CSR_MISA_A_EXT_ | r/- | **A**: CPU extension (atomic memory access) available, set when _CPU_EXTENSION_RISCV_A_ enabled
 |=======================
 
 [TIP]
@@ -286,9 +287,9 @@ globally enabled via the `CSR_MSTATUS_MIE` flag of the `mstatus` CSR. The follow
 |=======================
 | Bit   | Name [C] | R/W | Function
 | 31:16 | _CSR_MIE_FIRQ15E_ : _CSR_MIE_FIRQ0E_ | r/w | Fast interrupt channel 15..0 enable
-| 11    | _CSR_MIE_MEIE_ | r/w | Machine _external_ interrupt enable
-| 7     | _CSR_MIE_MTIE_ | r/w | Machine _timer_ interrupt enable (from _MTIME_)
-| 3     | _CSR_MIE_MSIE_ | r/w | Machine _software_ interrupt enable
+| 11    | _CSR_MIE_MEIE_ | r/w | **MEIE**: Machine _external_ interrupt enable
+| 7     | _CSR_MIE_MTIE_ | r/w | **MTIE**: Machine _timer_ interrupt enable (from _MTIME_)
+| 3     | _CSR_MIE_MSIE_ | r/w | **MSIE**: Machine _software_ interrupt enable
 |=======================
 
 
@@ -310,8 +311,8 @@ source. The lowest two bits of this register are always zero and cannot be modif
 [options="header",grid="rows"]
 |=======================
 | Bit  | R/W | Function
-| 31:2 | r/w | 4-byte aligned base address of trap base handler
-| 1:0  | r/- | Always zero
+| 31:2 | r/w | **BASE**: 4-byte aligned base address of trap base handler
+| 1:0  | r/- | **MODE**: Always zero; BASE defined entry for _all_ traps
 |=======================
 
 
@@ -335,9 +336,9 @@ exception is raised. NOTE: If the `U` ISA extension is not enabled this CSR does
 |=======================
 | Bit   | Name [C] | R/W | Function
 | 31:3  | `0`                 | r/- | Always zero: user-level code is **not** allowed to read HPM counters
-| 2     | _CSR_MCOUNTEREN_IR_ | r/w | User-level code is allowed to read `cycle[h]` CSRs when set
-| 1     | _CSR_MCOUNTEREN_TM_ | r/w | User-level code is allowed to read `time[h]` CSRs when set
-| 0     | _CSR_MCOUNTEREN_CY_ | r/w | User-level code is allowed to read `instret[h]` CSRs when set
+| 2     | _CSR_MCOUNTEREN_IR_ | r/w | **IR**: User-level code is allowed to read `cycle[h]` CSRs when set
+| 1     | _CSR_MCOUNTEREN_TM_ | r/w | **TM**: User-level code is allowed to read `time[h]` CSRs when set
+| 0     | _CSR_MCOUNTEREN_CY_ | r/w | **CY**: User-level code is allowed to read `instret[h]` CSRs when set
 |=======================
 
 .HPM Access
@@ -407,9 +408,9 @@ interrupt) this register provides the address of the next not-yet-executed instr
 [options="header",grid="rows"]
 |=======================
 | Bit  | R/W | Function
-| 31   | r/w | `1` if the trap is caused by an interrupt (`0` if the trap is caused by an exception)
+| 31   | r/w | **Interrupt**: `1` if the trap is caused by an interrupt (`0` if the trap is caused by an exception)
 | 30:5 | r/- | _Reserved_, read as zero
-| 4:0  | r/w | Trap ID, see <<_neorv32_trap_listing>>
+| 4:0  | r/w | **Trap ID**: see <<_neorv32_trap_listing>>
 |=======================
 
 :sectnums!:
@@ -460,10 +461,10 @@ writing zero to the according `mip` bits (in the interrupt handler routine) to c
 [options="header",grid="rows"]
 |=======================
 | Bit | Name [C] | R/W | Function
-| 31:16 | _CSR_MIP_FIRQ15P_ : _CSR_MIP_FIRQ0P_ | r/c | fast interrupt channel 15..0 pending; cleared request by writing 1
-| 11    | _CSR_MIP_MEIP_                       | r/- | machine _external_ interrupt pending; _cleared by user-defined mechanism_
-| 7     | _CSR_MIP_MTIP_                       | r/- | machine _timer_ interrupt pending; cleared by incrementing MTIME's time compare register
-| 3     | _CSR_MIP_MSIP_                       | r/- | machine _software_ interrupt pending; _cleared by user-defined mechanism_
+| 31:16 | _CSR_MIP_FIRQ15P_ : _CSR_MIP_FIRQ0P_ | r/c | **FIRQxP**: Fast interrupt channel 15..0 pending; cleared request by writing 1
+| 11    | _CSR_MIP_MEIP_                       | r/- | **MEIP**: Machine _external_ interrupt pending; _cleared by user-defined mechanism_
+| 7     | _CSR_MIP_MTIP_                       | r/- | **MTIP**: Machine _timer_ interrupt pending; cleared by incrementing MTIME's time compare register
+| 3     | _CSR_MIP_MSIP_                       | r/- | **MSIP**: Machine _software_ interrupt pending; _cleared by user-defined mechanism_
 |=======================
 
 .FIRQ Channel Mapping
@@ -507,13 +508,15 @@ The actual number of available `pmpcfg` CSRs and CSR entries is defined by the <
 [cols="^1,^3,^1,<11"]
 [options="header",grid="rows"]
 |=======================
-| Bit | RISC-V name | R/W | Function
-| 7   | `L` | r/w | lock bit, prevents further write accesses, also enforces access rights in machine-mode, can only be cleared by CPU reset
-| 6:5 |  -  | r/- | reserved, read as zero
-| 4:3 | `A` | r/w | mode configuration; only **OFF** (`00`) and **TOR** (`01`) modes are supported, any other value will map back to OFF/TOR
-| 2   | `X` | r/w | execute permission
-| 1   | `W` | r/w | write permission
-| 0   | `R` | r/w | read permission
+| Bit | Name [C] | R/W | Function
+| 7   | _PMPCFG_L_     | r/w | **L**: Lock bit, prevents further write accesses, also enforces access rights in machine-mode, can only be cleared by CPU reset
+| 6:5 | -              | r/- | reserved, read as zero
+| 4   | _PMPCFG_A_MSB_ | r/- .2+<| **A**: Mode configuration; only **OFF** (`00`) and **TOR** (`01`) modes are supported, any other value will map back to OFF/TOR
+as the MSB is hardwired to zero
+| 3   | _PMPCFG_A_LSB_ | r/w 
+| 2   | _PMPCFG_X_     | r/w | **X**: Execute permission
+| 1   | _PMPCFG_W_     | r/w | **W**: Write permission
+| 0   | _PMPCFG_R_     | r/w | **R**: Read permission
 |=======================
 
 [WARNING]
@@ -769,9 +772,9 @@ always zero and are read-only).
 [options="header",grid="rows"]
 |=======================
 | Bit  | Name [C] | R/W | Event
-| 0    | _CSR_MCOUNTINHIBIT_IR_ | r/w | the `[m]instret[h]` CSRs will auto-increment with each committed instruction when set
-| 2    | _CSR_MCOUNTINHIBIT_IR_ | r/w | the `[m]cycle[h]` CSRs will auto-increment with each clock cycle (if CPU is not in sleep state) when set
-| 3:31 | _CSR_MCOUNTINHIBIT_HPM3_ _: _CSR_MCOUNTINHIBIT_HPM31_ | r/w | the `mhpmcount*[h]` CSRs will auto-increment according to the configured `mhpmevent*` selector
+| 0    | _CSR_MCOUNTINHIBIT_IR_ | r/w | **IR**: The `[m]instret[h]` CSRs will auto-increment with each committed instruction when set
+| 2    | _CSR_MCOUNTINHIBIT_CY_ | r/w | **CY**: The `[m]cycle[h]` CSRs will auto-increment with each clock cycle (if CPU is not in sleep state) when set
+| 3:31 | _CSR_MCOUNTINHIBIT_HPM3_ : _CSR_MCOUNTINHIBIT_HPM31_ | r/w | **HPMx**: The `mhpmcount*[h]` CSRs will auto-increment according to the configured `mhpmevent*` selector
 |=======================
 
 

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1870,7 +1870,7 @@ begin
       --
       csr.mstatus_mie       <= '0';
       csr.mstatus_mpie      <= '0';
-      csr.mstatus_mpp       <= (others => '0');
+      csr.mstatus_mpp       <= priv_mode_m_c;
       csr.mstatus_tw        <= '0';
       csr.privilege         <= priv_mode_m_c; -- start in MACHINE mode
       csr.mie_msie          <= def_rst_val_c;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -65,7 +65,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060808"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060809"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -724,9 +724,70 @@ package neorv32_package is
   constant csr_cycle_c          : std_ulogic_vector(11 downto 0) := x"c00";
   constant csr_time_c           : std_ulogic_vector(11 downto 0) := x"c01";
   constant csr_instret_c        : std_ulogic_vector(11 downto 0) := x"c02";
+  --
+  constant csr_hpmcounter3_c    : std_ulogic_vector(11 downto 0) := x"c03";
+  constant csr_hpmcounter4_c    : std_ulogic_vector(11 downto 0) := x"c04";
+  constant csr_hpmcounter5_c    : std_ulogic_vector(11 downto 0) := x"c05";
+  constant csr_hpmcounter6_c    : std_ulogic_vector(11 downto 0) := x"c06";
+  constant csr_hpmcounter7_c    : std_ulogic_vector(11 downto 0) := x"c07";
+  constant csr_hpmcounter8_c    : std_ulogic_vector(11 downto 0) := x"c08";
+  constant csr_hpmcounter9_c    : std_ulogic_vector(11 downto 0) := x"c09";
+  constant csr_hpmcounter10_c   : std_ulogic_vector(11 downto 0) := x"c0a";
+  constant csr_hpmcounter11_c   : std_ulogic_vector(11 downto 0) := x"c0b";
+  constant csr_hpmcounter12_c   : std_ulogic_vector(11 downto 0) := x"c0c";
+  constant csr_hpmcounter13_c   : std_ulogic_vector(11 downto 0) := x"c0d";
+  constant csr_hpmcounter14_c   : std_ulogic_vector(11 downto 0) := x"c0e";
+  constant csr_hpmcounter15_c   : std_ulogic_vector(11 downto 0) := x"c0f";
+  constant csr_hpmcounter16_c   : std_ulogic_vector(11 downto 0) := x"c10";
+  constant csr_hpmcounter17_c   : std_ulogic_vector(11 downto 0) := x"c11";
+  constant csr_hpmcounter18_c   : std_ulogic_vector(11 downto 0) := x"c12";
+  constant csr_hpmcounter19_c   : std_ulogic_vector(11 downto 0) := x"c13";
+  constant csr_hpmcounter20_c   : std_ulogic_vector(11 downto 0) := x"c14";
+  constant csr_hpmcounter21_c   : std_ulogic_vector(11 downto 0) := x"c15";
+  constant csr_hpmcounter22_c   : std_ulogic_vector(11 downto 0) := x"c16";
+  constant csr_hpmcounter23_c   : std_ulogic_vector(11 downto 0) := x"c17";
+  constant csr_hpmcounter24_c   : std_ulogic_vector(11 downto 0) := x"c18";
+  constant csr_hpmcounter25_c   : std_ulogic_vector(11 downto 0) := x"c19";
+  constant csr_hpmcounter26_c   : std_ulogic_vector(11 downto 0) := x"c1a";
+  constant csr_hpmcounter27_c   : std_ulogic_vector(11 downto 0) := x"c1b";
+  constant csr_hpmcounter28_c   : std_ulogic_vector(11 downto 0) := x"c1c";
+  constant csr_hpmcounter29_c   : std_ulogic_vector(11 downto 0) := x"c1d";
+  constant csr_hpmcounter30_c   : std_ulogic_vector(11 downto 0) := x"c1e";
+  constant csr_hpmcounter31_c   : std_ulogic_vector(11 downto 0) := x"c1f";
+  --
   constant csr_cycleh_c         : std_ulogic_vector(11 downto 0) := x"c80";
   constant csr_timeh_c          : std_ulogic_vector(11 downto 0) := x"c81";
   constant csr_instreth_c       : std_ulogic_vector(11 downto 0) := x"c82";
+  --
+  constant csr_hpmcounter3h_c   : std_ulogic_vector(11 downto 0) := x"c83";
+  constant csr_hpmcounter4h_c   : std_ulogic_vector(11 downto 0) := x"c84";
+  constant csr_hpmcounter5h_c   : std_ulogic_vector(11 downto 0) := x"c85";
+  constant csr_hpmcounter6h_c   : std_ulogic_vector(11 downto 0) := x"c86";
+  constant csr_hpmcounter7h_c   : std_ulogic_vector(11 downto 0) := x"c87";
+  constant csr_hpmcounter8h_c   : std_ulogic_vector(11 downto 0) := x"c88";
+  constant csr_hpmcounter9h_c   : std_ulogic_vector(11 downto 0) := x"c89";
+  constant csr_hpmcounter10h_c  : std_ulogic_vector(11 downto 0) := x"c8a";
+  constant csr_hpmcounter11h_c  : std_ulogic_vector(11 downto 0) := x"c8b";
+  constant csr_hpmcounter12h_c  : std_ulogic_vector(11 downto 0) := x"c8c";
+  constant csr_hpmcounter13h_c  : std_ulogic_vector(11 downto 0) := x"c8d";
+  constant csr_hpmcounter14h_c  : std_ulogic_vector(11 downto 0) := x"c8e";
+  constant csr_hpmcounter15h_c  : std_ulogic_vector(11 downto 0) := x"c8f";
+  constant csr_hpmcounter16h_c  : std_ulogic_vector(11 downto 0) := x"c90";
+  constant csr_hpmcounter17h_c  : std_ulogic_vector(11 downto 0) := x"c91";
+  constant csr_hpmcounter18h_c  : std_ulogic_vector(11 downto 0) := x"c92";
+  constant csr_hpmcounter19h_c  : std_ulogic_vector(11 downto 0) := x"c93";
+  constant csr_hpmcounter20h_c  : std_ulogic_vector(11 downto 0) := x"c94";
+  constant csr_hpmcounter21h_c  : std_ulogic_vector(11 downto 0) := x"c95";
+  constant csr_hpmcounter22h_c  : std_ulogic_vector(11 downto 0) := x"c96";
+  constant csr_hpmcounter23h_c  : std_ulogic_vector(11 downto 0) := x"c97";
+  constant csr_hpmcounter24h_c  : std_ulogic_vector(11 downto 0) := x"c98";
+  constant csr_hpmcounter25h_c  : std_ulogic_vector(11 downto 0) := x"c99";
+  constant csr_hpmcounter26h_c  : std_ulogic_vector(11 downto 0) := x"c9a";
+  constant csr_hpmcounter27h_c  : std_ulogic_vector(11 downto 0) := x"c9b";
+  constant csr_hpmcounter28h_c  : std_ulogic_vector(11 downto 0) := x"c9c";
+  constant csr_hpmcounter29h_c  : std_ulogic_vector(11 downto 0) := x"c9d";
+  constant csr_hpmcounter30h_c  : std_ulogic_vector(11 downto 0) := x"c9e";
+  constant csr_hpmcounter31h_c  : std_ulogic_vector(11 downto 0) := x"c9f";
   -- machine information registers --
   constant csr_mvendorid_c      : std_ulogic_vector(11 downto 0) := x"f11";
   constant csr_marchid_c        : std_ulogic_vector(11 downto 0) := x"f12";

--- a/sw/common/crt0.S
+++ b/sw/common/crt0.S
@@ -74,7 +74,7 @@ __crt0_cpu_csr_init:
   csrw mtvec, x10
   csrw mepc,  x10                       // just to init mepc
 
-  csrw mstatus, zero                    // disable global IRQ
+  csrw mstatus, zero                    // clear all control flags, also disable global IRQ
   csrw mie,     zero                    // absolutely no interrupt sources, thanks
   csrw mip,     zero                    // clear all pending interrupts
 
@@ -219,7 +219,7 @@ __crt0_main_aftermath_end:
 __crt0_shutdown:
   csrci mstatus, 8                   // disable global IRQs (clear mstatus.mie)
   wfi                                // go to sleep mode
-  j __crt0_shutdown                  // endless loop
+  j .                                // endless loop
 
 
 // ************************************************************************************************

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -145,6 +145,7 @@ enum NEORV32_CSR_enum {
   CSR_MCONTEXT       = 0x7a8, /**< 0x7a8 - mcontext (r/(w)): Machine context register */
   CSR_SCONTEXT       = 0x7aa, /**< 0x7aa - scontext (r/(w)): Supervisor context register */
 
+  /* not accessible by m-mode software */
 //CSR_DCSR           = 0x7b0, /**< 0x7b0 - dcsr     (-/-): Debug status and control register */
 //CSR_DPC            = 0x7b1, /**< 0x7b1 - dpc      (-/-): Debug program counter */
 //CSR_DSCRATCH       = 0x7b2, /**< 0x7b2 - dscratch (-/-): Debug scratch register */
@@ -219,9 +220,71 @@ enum NEORV32_CSR_enum {
   CSR_TIME           = 0xc01, /**< 0xc01 - time    (r/-): Timer low word (from MTIME.TIME_LO) */
   CSR_INSTRET        = 0xc02, /**< 0xc02 - instret (r/-): Instructions-retired counter low word (from MINSTRET) */
 
+  /* not implemented */
+//CSR_HPMCOUNTER3    = 0xc03, /**< 0xc03 - hpmcounter3  (r/-): User hardware performance monitor 3  counter low word */
+//CSR_HPMCOUNTER4    = 0xc04, /**< 0xc04 - hpmcounter4  (r/-): User hardware performance monitor 4  counter low word */
+//CSR_HPMCOUNTER5    = 0xc05, /**< 0xc05 - hpmcounter5  (r/-): User hardware performance monitor 5  counter low word */
+//CSR_HPMCOUNTER6    = 0xc06, /**< 0xc06 - hpmcounter6  (r/-): User hardware performance monitor 6  counter low word */
+//CSR_HPMCOUNTER7    = 0xc07, /**< 0xc07 - hpmcounter7  (r/-): User hardware performance monitor 7  counter low word */
+//CSR_HPMCOUNTER8    = 0xc08, /**< 0xc08 - hpmcounter8  (r/-): User hardware performance monitor 8  counter low word */
+//CSR_HPMCOUNTER9    = 0xc09, /**< 0xc09 - hpmcounter9  (r/-): User hardware performance monitor 9  counter low word */
+//CSR_HPMCOUNTER10   = 0xc0a, /**< 0xc0a - hpmcounter10 (r/-): User hardware performance monitor 10 counter low word */
+//CSR_HPMCOUNTER11   = 0xc0b, /**< 0xc0b - hpmcounter11 (r/-): User hardware performance monitor 11 counter low word */
+//CSR_HPMCOUNTER12   = 0xc0c, /**< 0xc0c - hpmcounter12 (r/-): User hardware performance monitor 12 counter low word */
+//CSR_HPMCOUNTER13   = 0xc0d, /**< 0xc0d - hpmcounter13 (r/-): User hardware performance monitor 13 counter low word */
+//CSR_HPMCOUNTER14   = 0xc0e, /**< 0xc0e - hpmcounter14 (r/-): User hardware performance monitor 14 counter low word */
+//CSR_HPMCOUNTER15   = 0xc0f, /**< 0xc0f - hpmcounter15 (r/-): User hardware performance monitor 15 counter low word */
+//CSR_HPMCOUNTER16   = 0xc10, /**< 0xc10 - hpmcounter16 (r/-): User hardware performance monitor 16 counter low word */
+//CSR_HPMCOUNTER17   = 0xc11, /**< 0xc11 - hpmcounter17 (r/-): User hardware performance monitor 17 counter low word */
+//CSR_HPMCOUNTER18   = 0xc12, /**< 0xc12 - hpmcounter18 (r/-): User hardware performance monitor 18 counter low word */
+//CSR_HPMCOUNTER19   = 0xc13, /**< 0xc13 - hpmcounter19 (r/-): User hardware performance monitor 19 counter low word */
+//CSR_HPMCOUNTER20   = 0xc14, /**< 0xc14 - hpmcounter20 (r/-): User hardware performance monitor 20 counter low word */
+//CSR_HPMCOUNTER21   = 0xc15, /**< 0xc15 - hpmcounter21 (r/-): User hardware performance monitor 21 counter low word */
+//CSR_HPMCOUNTER22   = 0xc16, /**< 0xc16 - hpmcounter22 (r/-): User hardware performance monitor 22 counter low word */
+//CSR_HPMCOUNTER23   = 0xc17, /**< 0xc17 - hpmcounter23 (r/-): User hardware performance monitor 23 counter low word */
+//CSR_HPMCOUNTER24   = 0xc18, /**< 0xc18 - hpmcounter24 (r/-): User hardware performance monitor 24 counter low word */
+//CSR_HPMCOUNTER25   = 0xc19, /**< 0xc19 - hpmcounter25 (r/-): User hardware performance monitor 25 counter low word */
+//CSR_HPMCOUNTER26   = 0xc1a, /**< 0xc1a - hpmcounter26 (r/-): User hardware performance monitor 26 counter low word */
+//CSR_HPMCOUNTER27   = 0xc1b, /**< 0xc1b - hpmcounter27 (r/-): User hardware performance monitor 27 counter low word */
+//CSR_HPMCOUNTER28   = 0xc1c, /**< 0xc1c - hpmcounter28 (r/-): User hardware performance monitor 28 counter low word */
+//CSR_HPMCOUNTER29   = 0xc1d, /**< 0xc1d - hpmcounter29 (r/-): User hardware performance monitor 29 counter low word */
+//CSR_HPMCOUNTER30   = 0xc1e, /**< 0xc1e - hpmcounter30 (r/-): User hardware performance monitor 30 counter low word */
+//CSR_HPMCOUNTER31   = 0xc1f, /**< 0xc1f - hpmcounter31 (r/-): User hardware performance monitor 31 counter low word */
+
   CSR_CYCLEH         = 0xc80, /**< 0xc80 - cycleh   (r/-): Cycle counter high word (from MCYCLEH) */
   CSR_TIMEH          = 0xc81, /**< 0xc81 - timeh    (r/-): Timer high word (from MTIME.TIME_HI) */
   CSR_INSTRETH       = 0xc82, /**< 0xc82 - instreth (r/-): Instructions-retired counter high word (from MINSTRETH) */
+
+  /* not implemented */
+//CSR_HPMCOUNTER3H   = 0xc83, /**< 0xc83 - hpmcounter3h  (r/-): User hardware performance monitor 3  counter high word */
+//CSR_HPMCOUNTER4H   = 0xc84, /**< 0xc84 - hpmcounter4h  (r/-): User hardware performance monitor 4  counter high word */
+//CSR_HPMCOUNTER5H   = 0xc85, /**< 0xc85 - hpmcounter5h  (r/-): User hardware performance monitor 5  counter high word */
+//CSR_HPMCOUNTER6H   = 0xc86, /**< 0xc86 - hpmcounter6h  (r/-): User hardware performance monitor 6  counter high word */
+//CSR_HPMCOUNTER7H   = 0xc87, /**< 0xc87 - hpmcounter7h  (r/-): User hardware performance monitor 7  counter high word */
+//CSR_HPMCOUNTER8H   = 0xc88, /**< 0xc88 - hpmcounter8h  (r/-): User hardware performance monitor 8  counter high word */
+//CSR_HPMCOUNTER9H   = 0xc89, /**< 0xc89 - hpmcounter9h  (r/-): User hardware performance monitor 9  counter high word */
+//CSR_HPMCOUNTER10H  = 0xc8a, /**< 0xc8a - hpmcounter10h (r/-): User hardware performance monitor 10 counter high word */
+//CSR_HPMCOUNTER11H  = 0xc8b, /**< 0xc8b - hpmcounter11h (r/-): User hardware performance monitor 11 counter high word */
+//CSR_HPMCOUNTER12H  = 0xc8c, /**< 0xc8c - hpmcounter12h (r/-): User hardware performance monitor 12 counter high word */
+//CSR_HPMCOUNTER13H  = 0xc8d, /**< 0xc8d - hpmcounter13h (r/-): User hardware performance monitor 13 counter high word */
+//CSR_HPMCOUNTER14H  = 0xc8e, /**< 0xc8e - hpmcounter14h (r/-): User hardware performance monitor 14 counter high word */
+//CSR_HPMCOUNTER15H  = 0xc8f, /**< 0xc8f - hpmcounter15h (r/-): User hardware performance monitor 15 counter high word */
+//CSR_HPMCOUNTER16H  = 0xc90, /**< 0xc90 - hpmcounter16h (r/-): User hardware performance monitor 16 counter high word */
+//CSR_HPMCOUNTER17H  = 0xc91, /**< 0xc91 - hpmcounter17h (r/-): User hardware performance monitor 17 counter high word */
+//CSR_HPMCOUNTER18H  = 0xc92, /**< 0xc92 - hpmcounter18h (r/-): User hardware performance monitor 18 counter high word */
+//CSR_HPMCOUNTER19H  = 0xc93, /**< 0xc93 - hpmcounter19h (r/-): User hardware performance monitor 19 counter high word */
+//CSR_HPMCOUNTER20H  = 0xc94, /**< 0xc94 - hpmcounter20h (r/-): User hardware performance monitor 20 counter high word */
+//CSR_HPMCOUNTER21H  = 0xc95, /**< 0xc95 - hpmcounter21h (r/-): User hardware performance monitor 21 counter high word */
+//CSR_HPMCOUNTER22H  = 0xc96, /**< 0xc96 - hpmcounter22h (r/-): User hardware performance monitor 22 counter high word */
+//CSR_HPMCOUNTER23H  = 0xc97, /**< 0xc97 - hpmcounter23h (r/-): User hardware performance monitor 23 counter high word */
+//CSR_HPMCOUNTER24H  = 0xc98, /**< 0xc98 - hpmcounter24h (r/-): User hardware performance monitor 24 counter high word */
+//CSR_HPMCOUNTER25H  = 0xc99, /**< 0xc99 - hpmcounter25h (r/-): User hardware performance monitor 25 counter high word */
+//CSR_HPMCOUNTER26H  = 0xc9a, /**< 0xc9a - hpmcounter26h (r/-): User hardware performance monitor 26 counter high word */
+//CSR_HPMCOUNTER27H  = 0xc9b, /**< 0xc9b - hpmcounter27h (r/-): User hardware performance monitor 27 counter high word */
+//CSR_HPMCOUNTER28H  = 0xc9c, /**< 0xc9c - hpmcounter28h (r/-): User hardware performance monitor 28 counter high word */
+//CSR_HPMCOUNTER29H  = 0xc9d, /**< 0xc9d - hpmcounter29h (r/-): User hardware performance monitor 29 counter high word */
+//CSR_HPMCOUNTER30H  = 0xc9e, /**< 0xc9e - hpmcounter30h (r/-): User hardware performance monitor 30 counter high word */
+//CSR_HPMCOUNTER31H  = 0xc9f, /**< 0xc9f - hpmcounter31h (r/-): User hardware performance monitor 31 counter high word */
 
   CSR_MVENDORID      = 0xf11, /**< 0xf11 - mvendorid  (r/-): Vendor ID */
   CSR_MARCHID        = 0xf12, /**< 0xf12 - marchid    (r/-): Architecture ID */
@@ -240,7 +303,8 @@ enum NEORV32_CSR_MSTATUS_enum {
   CSR_MSTATUS_MIE   =  3, /**< CPU mstatus CSR  (3): MIE - Machine interrupt enable bit (r/w) */
   CSR_MSTATUS_MPIE  =  7, /**< CPU mstatus CSR  (7): MPIE - Machine previous interrupt enable bit (r/w) */
   CSR_MSTATUS_MPP_L = 11, /**< CPU mstatus CSR (11): MPP_L - Machine previous privilege mode bit low (r/w) */
-  CSR_MSTATUS_MPP_H = 12  /**< CPU mstatus CSR (12): MPP_H - Machine previous privilege mode bit high (r/w) */
+  CSR_MSTATUS_MPP_H = 12, /**< CPU mstatus CSR (12): MPP_H - Machine previous privilege mode bit high (r/w) */
+  CSR_MSTATUS_TW    = 21  /**< CPU mstatus CSR (21): TW - Disallow execution of wfi instruction in user mode when set (r/w) */
 };
 
 

--- a/sw/lib/include/neorv32_cpu.h
+++ b/sw/lib/include/neorv32_cpu.h
@@ -51,7 +51,6 @@ uint64_t neorv32_cpu_get_instret(void);
 void neorv32_cpu_set_minstret(uint64_t value);
 uint64_t neorv32_cpu_get_systime(void);
 void neorv32_cpu_delay_ms(uint32_t time_ms);
-void __attribute__((naked)) neorv32_cpu_goto_user_mode(void);
 uint32_t neorv32_cpu_pmp_get_num_regions(void);
 uint32_t neorv32_cpu_pmp_get_granularity(void);
 int neorv32_cpu_pmp_configure_region(uint32_t index, uint32_t base, uint8_t config);

--- a/sw/lib/source/neorv32_cpu.c
+++ b/sw/lib/source/neorv32_cpu.c
@@ -313,23 +313,6 @@ void neorv32_cpu_delay_ms(uint32_t time_ms) {
 
 
 /**********************************************************************//**
- * Switch from privilege mode MACHINE to privilege mode USER.
- *
- * @warning This function requires the U extension to be implemented.
- **************************************************************************/
-void __attribute__((naked)) neorv32_cpu_goto_user_mode(void) {
-
-  // make sure to use NO registers in here! -> naked
-
-  asm volatile ("csrw mepc, ra           \n" // move return address to mepc so we can return using "mret". also, we can now use ra as general purpose register in here
-                "li ra, %[input_imm]     \n" // bit mask to clear the two MPP bits
-                "csrrc zero, mstatus, ra \n" // clear MPP bits -> MPP=u-mode
-                "mret                    \n" // return and switch to user mode
-                :  : [input_imm] "i" ((1<<CSR_MSTATUS_MPP_H) | (1<<CSR_MSTATUS_MPP_L)));
-}
-
-
-/**********************************************************************//**
  * Physical memory protection (PMP): Get number of available regions.
  *
  * @warning This function overrides all available PMPCFG* CSRs!


### PR DESCRIPTION
This PR is another clean-up and optimization of the CPU's control unit.

✨ Additionally, this PR adds support for the RISC-V `mstatus.TW` flag. This flag is is used to control the execution of the `wfi` (wait for interrupt / sleep) instruction in less-privileged user-mode. When set, executing `wfi` in user-mode will raise an illegal instruction exception. When cleared, user-mode is allowed to execute `wfi`. If user-mode is not implemented the `mstatus.TW` flag is hardwired to zero.

ℹ️ The user-level hardware performance monitor CSRs are added to the hardware in order to simplifiy CSR address decoding. However, the user-level HPM CSRs `hpmcounter*[h]` are **NOT** implemented. Any access from any operation mode will raise an exception. Only machine-mode is allowed to use the HPMs via the dedicated `mhpmcounter*[h]` CSRs.