### PR TITLE
🧪 try to fix *_reduce_f functions usage for gate-level simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The version number is globally defined by the `hw_version_c` constant in the mai
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 19.03.2022 | 1.6.9.4 | :test_tube: change usage of VHDL `*_reduce_f` functions for signals that might effect gate-level simulations; [PR #290](https://github.com/stnolting/neorv32/pull/290) |
 | 19.03.2022 | 1.6.9.3 | :bug: fixed minor bug in **FPU** - incorrect/missing reset (even if reset to `'-'`) of some registers |
 | 18.03.2022 | 1.6.9.2 | fixed minor bug in **TRNG** hand shake (that marked the same RND value as valid for several times); minor optimization of **processor's reset generator** |
 | 14.03.2022 | 1.6.9.1 | `mtval` CSR is set to zero for software breakpoints (`[c.]ebreak` instruction(s)) - this is permitted by the RISC-V machine ISA spec. v1.12; [PR #289](https://github.com/stnolting/neorv32/pull/289) |

--- a/rtl/core/neorv32_cpu_bus.vhd
+++ b/rtl/core/neorv32_cpu_bus.vhd
@@ -486,9 +486,9 @@ begin
   end process pmp_check_permission;
 
   -- final PMP access fault signals --
-  if_pmp_fault <= or_reduce_f(pmp.if_fault) when (PMP_NUM_REGIONS > 0) else '0';
-  ld_pmp_fault <= or_reduce_f(pmp.ld_fault) when (PMP_NUM_REGIONS > 0) else '0';
-  st_pmp_fault <= or_reduce_f(pmp.st_fault) when (PMP_NUM_REGIONS > 0) else '0';
+  if_pmp_fault <= '1' when (or_reduce_f(pmp.if_fault) = '1') and (PMP_NUM_REGIONS > 0) else '0';
+  ld_pmp_fault <= '1' when (or_reduce_f(pmp.ld_fault) = '1') and (PMP_NUM_REGIONS > 0) else '0';
+  st_pmp_fault <= '1' when (or_reduce_f(pmp.st_fault) = '1') and (PMP_NUM_REGIONS > 0) else '0';
 
 
 end neorv32_cpu_bus_rtl;

--- a/rtl/core/neorv32_cpu_cp_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_cp_bitmanip.vhd
@@ -470,7 +470,7 @@ begin
   clmul.rs2 <= bit_rev_f(rs2_reg) when (cmd_buf(op_clmulr_c) = '1') else rs2_reg;
 
   -- multiplier busy? --
-  clmul.busy <= or_reduce_f(clmul.cnt);
+  clmul.busy <= '1' when (or_reduce_f(clmul.cnt) = '1') else '0';
 
 
   -- Operation Results ----------------------------------------------------------------------
@@ -522,7 +522,7 @@ begin
   -- single-bit instructions --
   res_int(op_bclr_c) <= rs1_reg and (not one_hot_core);
   res_int(op_bext_c)(data_width_c-1 downto 1) <= (others => '0');
-  res_int(op_bext_c)(0) <= or_reduce_f(rs1_reg and one_hot_core);
+  res_int(op_bext_c)(0) <= '1' when (or_reduce_f(rs1_reg and one_hot_core) = '1') else '0';
   res_int(op_binv_c) <= rs1_reg xor one_hot_core;
   res_int(op_bset_c) <= rs1_reg or one_hot_core;
 

--- a/rtl/core/neorv32_cpu_cp_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_cp_muldiv.vhd
@@ -91,6 +91,7 @@ architecture neorv32_cpu_cp_muldiv_rtl of neorv32_cpu_cp_muldiv is
   signal rs2_is_signed : std_ulogic;
   signal div_res_corr  : std_ulogic;
   signal out_en        : std_ulogic;
+  signal rs2_zero      : std_ulogic;
 
   -- divider core --
   signal remainder        : std_ulogic_vector(data_width_c-1 downto 0);
@@ -152,7 +153,7 @@ begin
         when DIV_PREPROCESS =>
           -- check relevant input signs for result sign compensation --
           if (cp_op = cp_op_div_c) then -- signed div operation
-            div_res_corr <= (rs1_i(rs1_i'left) xor rs2_i(rs2_i'left)) and or_reduce_f(rs2_i); -- different signs AND rs2 not zero
+            div_res_corr <= (rs1_i(rs1_i'left) xor rs2_i(rs2_i'left)) and (not rs2_zero); -- different signs AND rs2 not zero
           elsif (cp_op = cp_op_rem_c) then -- signed rem operation
             div_res_corr <= rs1_i(rs1_i'left);
           else
@@ -182,6 +183,9 @@ begin
       end case;
     end if;
   end process coprocessor_ctrl;
+
+  -- rs2 zero? --
+  rs2_zero <= '1' when (or_reduce_f(rs2_i) = '0') else '0';
 
   -- co-processor command --
   cp_op <= ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_0_c);

--- a/rtl/core/neorv32_cpu_cp_shifter.vhd
+++ b/rtl/core/neorv32_cpu_cp_shifter.vhd
@@ -119,7 +119,7 @@ begin
   -- shift control/output --
   serial_shifter_ctrl:
   if (FAST_SHIFT_EN = false) generate
-    shifter.done <= not or_reduce_f(shifter.cnt(shifter.cnt'left downto 1));
+    shifter.done <= '1' when (or_reduce_f(shifter.cnt(shifter.cnt'left downto 1)) = '0') else '0';
     valid_o      <= shifter.busy and shifter.done;
     res_o        <= shifter.sreg when (shifter.busy = '0') and (shifter.busy_ff = '1') else (others => '0');
   end generate;

--- a/rtl/core/neorv32_cpu_regfile.vhd
+++ b/rtl/core/neorv32_cpu_regfile.vhd
@@ -116,7 +116,7 @@ begin
     end process rf_access;
 
     -- writing to x0? --
-    rd_is_x0 <= not or_reduce_f(ctrl_i(ctrl_rf_rd_adr4_c downto ctrl_rf_rd_adr0_c));
+    rd_is_x0 <= '1' when (ctrl_i(ctrl_rf_rd_adr4_c downto ctrl_rf_rd_adr0_c) = "00000") else '0';
   end generate;
 
   reg_file_rv32e: -- embedded register file with 16 registers
@@ -133,7 +133,7 @@ begin
     end process rf_access;
 
     -- writing to x0? --
-    rd_is_x0 <= not or_reduce_f(ctrl_i(ctrl_rf_rd_adr3_c downto ctrl_rf_rd_adr0_c));
+    rd_is_x0 <= '1' when (ctrl_i(ctrl_rf_rd_adr3_c downto ctrl_rf_rd_adr0_c) = "0000") else '0';
   end generate;
 
   -- access addresses --

--- a/rtl/core/neorv32_icache.vhd
+++ b/rtl/core/neorv32_icache.vhd
@@ -545,7 +545,7 @@ begin
   end process comparator;
 
   -- global hit --
-  hit_o <= or_reduce_f(hit);
+  hit_o <= '1' when (or_reduce_f(hit) = '1') else '0';
 
 
 	-- Cache Data Memory ----------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -65,7 +65,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060903"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060904"; -- no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/rtl/core/neorv32_slink.vhd
+++ b/rtl/core/neorv32_slink.vhd
@@ -8,7 +8,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -208,7 +208,9 @@ begin
           end if;
           ack_write <= '1';
         else -- TX links
-          ack_write <= or_reduce_f(link_sel and tx_fifo_free);
+          if (or_reduce_f(link_sel and tx_fifo_free) = '1') then
+            ack_write <= '1';
+          end if;
         end if;
       end if;
 
@@ -243,8 +245,10 @@ begin
               data_o <= (others => '0');
           end case;
         else -- RX links
-          data_o   <= rx_fifo_rdata(to_integer(unsigned(addr(4 downto 2))));
-          ack_read <= or_reduce_f(link_sel and rx_fifo_avail);
+          data_o <= rx_fifo_rdata(to_integer(unsigned(addr(4 downto 2))));
+          if (or_reduce_f(link_sel and rx_fifo_avail) = '1') then
+            ack_read <= '1';
+          end if;
         end if;
       end if;
     end if;
@@ -328,8 +332,14 @@ begin
   irq_generator: process(clk_i)
   begin
     if rising_edge(clk_i) then
-      irq_rx_o <= or_reduce_f(rx_irq.set);
-      irq_tx_o <= or_reduce_f(tx_irq.set);
+      irq_rx_o <= '0';
+      irq_tx_o <= '0';
+      if (or_reduce_f(rx_irq.set) = '1') then
+        irq_rx_o <= '1';
+      end if;
+      if (or_reduce_f(tx_irq.set) = '1') then
+        irq_tx_o <= '1';
+      end if;
     end if;
   end process irq_generator;
 

--- a/rtl/core/neorv32_xirq.vhd
+++ b/rtl/core/neorv32_xirq.vhd
@@ -10,7 +10,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -186,7 +186,7 @@ begin
   end process irq_buffer;
 
   -- anyone firing? --
-  irq_fire <= or_reduce_f(irq_buf);
+  irq_fire <= '1' when (or_reduce_f(irq_buf) = '1') else '0';
 
 
   -- IRQ Priority Encoder -----------------------------------------------------


### PR DESCRIPTION
This PR changes the way the `*_reduce_f` functions from the NEORV32 package are used.

If the function result is used for **direct** signal assignment this can cause undefined (`'X'` or `'U'`) signal states, which might corrupt gate-level simulation.

Current (pre-PR):
```vhdl
some_signal <= or_reduce_f(another_signal);
```
Proposed (post-PR):
```vhdl
some_signal <= '1' when (or_reduce_f(another_signal) = '1') else '0';
```

Furthermore, synthesis seems to be able to do better optimizations when using the changes from this PR (at least Intel Quartus).

There are no _functional_ (real hardware) changes caused by this PR.