### PR TITLE
[CPU] area and timing optimization; closing further illegal instruction holes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The version number is globally defined by the `hw_version_c` constant in the mai
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 04.04.2022 | 1.6.9.7 | **major CPU logic optimization**: reduced area costs and shortened critical path (higher f_max!); :lock: closed further illegal instruction encoding holes; [PR #293](https://github.com/stnolting/neorv32/pull/293) |
 | 01.04.2022 | 1.6.9.6 | rework **CPU front-end**: instruction issue engine; much cleaner code, slightly less HW required; [PR #292](https://github.com/stnolting/neorv32/pull/292) |
 | 29.03.2022 | 1.6.9.5 | minor clock generator edits: reset **clock generator** explicitly if not being used by _any_ peripheral/IO device |
 | 19.03.2022 | 1.6.9.4 | :test_tube: change usage of VHDL `*_reduce_f` functions for signals that might effect gate-level simulations; [PR #290](https://github.com/stnolting/neorv32/pull/290) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The version number is globally defined by the `hw_version_c` constant in the mai
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
-| 04.04.2022 | 1.6.9.7 | **major CPU logic optimization**: reduced area costs and shortened critical path (higher f_max!); :lock: closed further illegal instruction encoding holes; [PR #293](https://github.com/stnolting/neorv32/pull/293) |
+| 04.04.2022 | 1.6.9.7 | **major CPU logic optimization**: reduced area costs and shortened critical path (higher f_max!); :bug: fixed rare bug in RTE (if C-extension is not implemented); :lock: closed further illegal instruction encoding holes; [PR #293](https://github.com/stnolting/neorv32/pull/293) |
 | 01.04.2022 | 1.6.9.6 | rework **CPU front-end**: instruction issue engine; much cleaner code, slightly less HW required; [PR #292](https://github.com/stnolting/neorv32/pull/292) |
 | 29.03.2022 | 1.6.9.5 | minor clock generator edits: reset **clock generator** explicitly if not being used by _any_ peripheral/IO device |
 | 19.03.2022 | 1.6.9.4 | :test_tube: change usage of VHDL `*_reduce_f` functions for signals that might effect gate-level simulations; [PR #290](https://github.com/stnolting/neorv32/pull/290) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -844,15 +844,15 @@ configurations are presented in <<_cpu_performance>>.
 | Memory access  | `I/E` | `lb` `lh` `lw` `lbu` `lhu` `sb` `sh` `sw` | 5 + (ML-2)
 | Memory access  | `C`   | `c.lw` `c.sw` `c.lwsp` `c.swsp`           | 5 + (ML-2)
 | Memory access  | `A`   | `lr.w` `sc.w`                             | 5 + (ML-2)
-| Multiplication | `M`   | `mul` `mulh` `mulhsu` `mulhu` | 2+32+2; FAST_MULfootnote:[DSP-based multiplication; enabled via `FAST_MUL_EN`.]: 4
-| Division       | `M`   | `div` `divu` `rem` `remu`     | 2+32+2
-| CSR access     | `Zicsr`     | `csrrw` `csrrs` `csrrc` `csrrwi` `csrrsi` `csrrci` | 3
-| System         | `I/E`       | `fence` | 4 + ML
+| MulDiv         | `M`   | `mul` `mulh` `mulhsu` `mulhu` | 2+32+2; FAST_MULfootnote:[DSP-based multiplication; enabled via `FAST_MUL_EN`.]: 4
+| MulDiv         | `M`   | `div` `divu` `rem` `remu`     | 2+32+2
+| System         | `Zicsr`     | `csrrw` `csrrs` `csrrc` `csrrwi` `csrrsi` `csrrci` | 3
 | System         | `Zicsr`     | `ecall` `ebreak` | 3
-| System         | `Zicsr`+`C` | `c.break` | 3
-| System         | `Zicsr`     | `mret` | 4
-| System         | `Zicsr`     | `wfi` | 3
-| System         | `Zifencei`  | `fence.i` | 4 + ML
+| System         | `Zicsr`+`C` | `c.break`        | 3
+| System         | `Zicsr`     | `wfi`            | 3
+| System         | `Zicsr`     | `mret` `dret`    | 5
+| Fence          | `I/E`       | `fence`   | 4 + ML
+| Fence          | `Zifencei`  | `fence.i` | 4 + ML
 | Floating-point - artihmetic | `Zfinx` | `fadd.s` | 110
 | Floating-point - artihmetic | `Zfinx` | `fsub.s` | 112
 | Floating-point - artihmetic | `Zfinx` | `fmul.s` | 22

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -837,21 +837,22 @@ configurations are presented in <<_cpu_performance>>.
 | ALU            | `C`   | `c.addi4spn` `c.nop` `c.addi` `c.li` `c.addi16sp` `c.lui` `c.andi` `c.sub` `c.xor` `c.or` `c.and` `c.add` `c.mv` | 2
 | ALU            | `I/E` | `slli` `srli` `srai` `sll` `srl` `sra` | 3 + SAfootnote:[Shift amount.]/4 + SA%4; FAST_SHIFTfootnote:[Barrel shift when `FAST_SHIFT_EN` is enabled.]: 4; TINY_SHIFTfootnote:[Serial shift when `TINY_SHIFT_EN` is enabled.]: 2..32
 | ALU            | `C`   | `c.srli` `c.srai` `c.slli` | 3 + SAfootnote:[Shift amount (0..31).]; FAST_SHIFTfootnote:[Barrel shifter when `FAST_SHIFT_EN` is enabled.]:
-| Branches       | `I/E` | `beq` `bne` `blt` `bge` `bltu` `bgeu` | Taken: 5 + MLfootnote:[Memory latency.]; Not taken: 3
-| Branches       | `C`   | `c.beqz` `c.bnez`                     | Taken: 5 + MLfootnote:[Memory latency.]; Not taken: 3
-| Jumps / Calls  | `I/E` | `jal` `jalr`                  | 4 + ML
-| Jumps / Calls  | `C`   | `c.jal` `c.j` `c.jr` `c.jalr` | 4 + ML
-| Memory access  | `I/E` | `lb` `lh` `lw` `lbu` `lhu` `sb` `sh` `sw` | 4 + ML
-| Memory access  | `C`   | `c.lw` `c.sw` `c.lwsp` `c.swsp`           | 4 + ML
-| Memory access  | `A`   | `lr.w` `sc.w`                             | 4 + ML
+| Branches       | `I/E` | `beq` `bne` `blt` `bge` `bltu` `bgeu` | Taken: 5 + (ML-1)footnote:[Memory latency.]; Not taken: 3
+| Branches       | `C`   | `c.beqz` `c.bnez`                     | Taken: 5 + (ML-1); Not taken: 3
+| Jumps / Calls  | `I/E` | `jal` `jalr`                  | 5 + (ML-1)
+| Jumps / Calls  | `C`   | `c.jal` `c.j` `c.jr` `c.jalr` | 5 + (ML-1)
+| Memory access  | `I/E` | `lb` `lh` `lw` `lbu` `lhu` `sb` `sh` `sw` | 5 + (ML-2)
+| Memory access  | `C`   | `c.lw` `c.sw` `c.lwsp` `c.swsp`           | 5 + (ML-2)
+| Memory access  | `A`   | `lr.w` `sc.w`                             | 5 + (ML-2)
 | Multiplication | `M`   | `mul` `mulh` `mulhsu` `mulhu` | 2+32+2; FAST_MULfootnote:[DSP-based multiplication; enabled via `FAST_MUL_EN`.]: 4
 | Division       | `M`   | `div` `divu` `rem` `remu`     | 2+32+2
 | CSR access     | `Zicsr`     | `csrrw` `csrrs` `csrrc` `csrrwi` `csrrsi` `csrrci` | 3
-| System         | `I/E`       | `fence` | 3
+| System         | `I/E`       | `fence` | 4 + ML
 | System         | `Zicsr`     | `ecall` `ebreak` | 3
 | System         | `Zicsr`+`C` | `c.break` | 3
-| System         | `Zicsr`     | `mret` `wfi` | 6
-| System         | `Zifencei`  | `fence.i` | 3 + ML
+| System         | `Zicsr`     | `mret` | 4
+| System         | `Zicsr`     | `wfi` | 3
+| System         | `Zifencei`  | `fence.i` | 4 + ML
 | Floating-point - artihmetic | `Zfinx` | `fadd.s` | 110
 | Floating-point - artihmetic | `Zfinx` | `fsub.s` | 112
 | Floating-point - artihmetic | `Zfinx` | `fmul.s` | 22
@@ -869,7 +870,7 @@ configurations are presented in <<_cpu_performance>>.
 | Bit-manipulation - carry-less multiply | `B(Zbc)` | `clmul` `clmulh` `clmulr` | 3 + 32
 | Custom instructions (CFU) | `Zxcfu` | - | min. 4
 | | | | 
-| _Illegal instructions_    | `Zicsr` | - | 2
+| _Illegal instructions_    | `Zicsr` | - | min. 2
 |=======================
 
 [NOTE]

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -164,7 +164,6 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
   -- instruction prefetch buffer (FIFO) interface --
   type ipb_data_t is array (0 to 1) of std_ulogic_vector((2+16)-1 downto 0); -- status (bus_error, align_error) + 16-bit instruction
   type ipb_t is record
-    clear : std_ulogic; -- clear all entries
     wdata : ipb_data_t;
     we    : std_ulogic_vector(1 downto 0); -- trigger write
     free  : std_ulogic_vector(1 downto 0); -- free entry available?
@@ -203,7 +202,7 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
 
   -- instruction execution engine --
   type execute_engine_state_t is (DISPATCH, TRAP_ENTER, TRAP_EXIT, TRAP_EXECUTE, EXECUTE, ALU_WAIT,
-                                  BRANCH, LOADSTORE_0, LOADSTORE_1, LOADSTORE_2, SYS_ENV, CSR_ACCESS);
+                                  BRANCH, BRANCHED, LOADSTORE_0, LOADSTORE_1, LOADSTORE_2, CSR_ACCESS);
   type execute_engine_t is record
     state        : execute_engine_state_t;
     state_nxt    : execute_engine_state_t;
@@ -369,10 +368,8 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
   signal hpmcnt_trigger : std_ulogic_vector(HPM_NUM_CNTS-1 downto 0);
 
   -- illegal instruction check --
-  signal illegal_opcode_lsbs : std_ulogic; -- opcode != rv32
   signal illegal_instruction : std_ulogic;
   signal illegal_register    : std_ulogic; -- illegal register (>x15) - E-extension
-  signal illegal_compressed  : std_ulogic; -- illegal compressed instruction - C-extension
 
   -- access (privilege) check --
   signal csr_acc_valid : std_ulogic; -- valid CSR access (implemented and valid access rights)
@@ -435,7 +432,7 @@ begin
         fetch_engine.bus_if    <= '1'; -- instruction fetch request
         fetch_engine.state_nxt <= IFETCH_ISSUE;
       end if;
-      fetch_engine.restart_nxt <= '0';
+      fetch_engine.restart_nxt <= '0'; -- restart done
 
     else -- ISSUE: store instruction data to prefetch buffer
     -- ------------------------------------------------------------
@@ -451,9 +448,6 @@ begin
 
     end if;
   end process fetch_engine_fsm_comb;
-
-  -- clear instruction prefetch buffer while being reset --
-  ipb.clear <= fetch_engine.restart or fetch_engine.reset;
 
 
 -- ****************************************************************************************************************************
@@ -473,19 +467,19 @@ begin
     )
     port map (
       -- control --
-      clk_i   => clk_i,        -- clock, rising edge
-      rstn_i  => '1',          -- async reset, low-active
-      clear_i => ipb.clear,    -- sync reset, high-active
+      clk_i   => clk_i,                -- clock, rising edge
+      rstn_i  => '1',                  -- async reset, low-active
+      clear_i => fetch_engine.restart, -- sync reset, high-active
       level_o => open,
       half_o  => open,
       -- write port --
-      wdata_i => ipb.wdata(i), -- write data
-      we_i    => ipb.we(i),    -- write enable
-      free_o  => ipb.free(i),  -- at least one entry is free when set
+      wdata_i => ipb.wdata(i),         -- write data
+      we_i    => ipb.we(i),            -- write enable
+      free_o  => ipb.free(i),          -- at least one entry is free when set
       -- read port --
-      re_i    => ipb.re(i),    -- read enable
-      rdata_o => ipb.rdata(i), -- read data
-      avail_o => ipb.avail(i)  -- data available when set
+      re_i    => ipb.re(i),            -- read enable
+      rdata_o => ipb.rdata(i),         -- read data
+      avail_o => ipb.avail(i)          -- data available when set
     );
   end generate;
 
@@ -502,7 +496,7 @@ begin
       issue_engine.align <= '0'; -- always start aligned after reset
     elsif rising_edge(clk_i) then
       if (CPU_EXTENSION_RISCV_C = true) then
-        if (ipb.clear = '1') then
+        if (fetch_engine.restart = '1') then
           issue_engine.align <= execute_engine.pc(1); -- branch to unaligned address?
         elsif (execute_engine.state = DISPATCH) then
           issue_engine.align <= (issue_engine.align and (not issue_engine.align_clr)) or issue_engine.align_set;
@@ -655,7 +649,7 @@ begin
   begin
     if (rstn_i = '0') then
       -- no dedicated reset required --
-      execute_engine.state_prev <= DISPATCH; -- actual reset value is not relevant
+      execute_engine.state_prev <= BRANCHED; -- actual reset value is not relevant
       execute_engine.i_reg      <= (others => def_rst_val_c);
       execute_engine.is_ci      <= def_rst_val_c;
       execute_engine.is_ici     <= def_rst_val_c;
@@ -665,7 +659,7 @@ begin
       -- registers that DO require a specific RESET state --
       execute_engine.pc         <= CPU_BOOT_ADDR(data_width_c-1 downto 2) & "00"; -- 32-bit aligned!
       execute_engine.pc_last    <= CPU_BOOT_ADDR(data_width_c-1 downto 2) & "00";
-      execute_engine.state      <= DISPATCH;
+      execute_engine.state      <= BRANCHED;
       execute_engine.sleep      <= '0';
       execute_engine.branched   <= '1'; -- reset is a branch from "somewhere"
       ctrl(ctrl_bus_rd_c)       <= '0';
@@ -980,18 +974,19 @@ begin
         execute_engine.state_nxt <= TRAP_EXECUTE;
 
 
-      when TRAP_EXECUTE => -- Process trap environment -> jump to xTVEC / return from trap environment -> jump to xEPC
+      when TRAP_EXECUTE => -- Process trap environment
       -- ------------------------------------------------------------
         execute_engine.pc_mux_sel <= '0'; -- next_PC
         fetch_engine.reset        <= '1';
         execute_engine.pc_we      <= '1';
         execute_engine.sleep_nxt  <= '0'; -- disable sleep mode
-        execute_engine.state_nxt  <= DISPATCH;
+        execute_engine.state_nxt  <= BRANCHED;
 
 
       when EXECUTE => -- Decode and execute instruction (control has to be here for exactly 1 cycle in any case!)
       -- ------------------------------------------------------------
-        opcode_v := execute_engine.i_reg(instr_opcode_msb_c downto instr_opcode_lsb_c+2) & "11"; -- save some bits here, LSBs are always 11 for rv32
+        -- save some bits: opcode LSBs are always "11" for the (de-compressed) 32-bit rv32 instruction words here
+        opcode_v := execute_engine.i_reg(instr_opcode_msb_c downto instr_opcode_lsb_c+2) & "11";
         case opcode_v is
 
           when opcode_alu_c | opcode_alui_c => -- (register/immediate) ALU operation
@@ -1072,13 +1067,10 @@ begin
 
           when opcode_fence_c => -- fence operations
           -- ------------------------------------------------------------
-            if (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_fence_c) then -- FENCE
-              ctrl_nxt(ctrl_bus_fence_c)  <= '1';
-              execute_engine.state_nxt    <= DISPATCH;
-            elsif (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_fencei_c) and (CPU_EXTENSION_RISCV_Zifencei = true) then -- FENCE.I
-              ctrl_nxt(ctrl_bus_fencei_c) <= '1';
-              execute_engine.branched_nxt <= '1'; -- this is an actual branch
-              execute_engine.state_nxt    <= TRAP_EXECUTE; -- use TRAP_EXECUTE to "modify" PC (PC <= PC)
+            if (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c+1) = funct3_fence_c(2 downto 1)) then -- FENCE / FENCE.I
+              ctrl_nxt(ctrl_bus_fence_c)  <= not execute_engine.i_reg(instr_funct3_lsb_c); -- FENCE
+              ctrl_nxt(ctrl_bus_fencei_c) <= execute_engine.i_reg(instr_funct3_lsb_c) and bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zifencei); -- FENCE.I
+              execute_engine.state_nxt    <= TRAP_EXECUTE; -- use TRAP_EXECUTE to "modify" PC (PC <= PC); actually, this not required for FENCE
             else -- illegal fence instruction
               execute_engine.state_nxt    <= DISPATCH;
             end if;
@@ -1104,11 +1096,26 @@ begin
             end if;
 
 
-          when others => -- system/csr access OR illegal opcode
+          when opcode_system_c => -- environment/csr access
           -- ------------------------------------------------------------
             if (CPU_EXTENSION_RISCV_Zicsr = true) then
-              if (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_env_c) then -- system/environment
-                execute_engine.state_nxt <= SYS_ENV;
+              if (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_env_c) then -- environment
+                if (execute_engine.i_reg(instr_funct12_msb_c downto instr_funct12_lsb_c) = funct12_mret_c) then
+                  execute_engine.state_nxt <= TRAP_EXIT; -- mret
+                elsif (execute_engine.i_reg(instr_funct12_msb_c downto instr_funct12_lsb_c) = funct12_dret_c) and (CPU_EXTENSION_RISCV_DEBUG = true) then
+                  debug_ctrl.dret          <= '1';
+                  execute_engine.state_nxt <= TRAP_EXIT; -- dret
+                else
+                  execute_engine.state_nxt <= DISPATCH; -- default
+                end if;
+                if ((execute_engine.i_reg(instr_funct12_msb_c downto instr_funct12_lsb_c+1) = funct12_ecall_c(11 downto 1))) then
+                  trap_ctrl.env_call    <= not execute_engine.i_reg(instr_funct12_lsb_c); -- ecall
+                  trap_ctrl.break_point <=     execute_engine.i_reg(instr_funct12_lsb_c); -- ebreak
+                end if;
+                if (execute_engine.i_reg(instr_funct12_msb_c downto instr_funct12_lsb_c) = funct12_wfi_c) and
+                   ((CPU_EXTENSION_RISCV_DEBUG = false) or ((debug_ctrl.running = '0') and (csr.dcsr_step = '0'))) then
+                  execute_engine.sleep_nxt <= '1'; -- wfi not executed (=NOP) when in debug-mode or during single-stepping
+                end if;
               else -- CSR access
                 execute_engine.state_nxt <= CSR_ACCESS;
               end if;
@@ -1116,44 +1123,21 @@ begin
               execute_engine.state_nxt <= DISPATCH;
             end if;
 
-        end case;
 
+          when others => -- illegal opcode
+          -- ------------------------------------------------------------
+            execute_engine.state_nxt <= DISPATCH;
 
-      when SYS_ENV => -- system environment operation
-      -- ------------------------------------------------------------
-        -- mret / dret --
-        if (execute_engine.i_reg(instr_funct12_msb_c downto instr_funct12_lsb_c) = funct12_mret_c) then
-          execute_engine.state_nxt <= TRAP_EXIT; -- mret
-        elsif (execute_engine.i_reg(instr_funct12_msb_c downto instr_funct12_lsb_c) = funct12_dret_c) and (CPU_EXTENSION_RISCV_DEBUG = true) then
-          debug_ctrl.dret          <= '1';
-          execute_engine.state_nxt <= TRAP_EXIT; -- dret
-        else
-          execute_engine.state_nxt <= DISPATCH; -- default
-        end if;
-        -- ecall / ebreak --
-        if ((execute_engine.i_reg(instr_funct12_msb_c downto instr_funct12_lsb_c+1) = funct12_ecall_c(11 downto 1))) then
-          if (execute_engine.i_reg(instr_funct12_lsb_c) = funct12_ecall_c(0)) then
-            trap_ctrl.env_call <= '1'; -- ecall
-          else
-            trap_ctrl.break_point <= '1'; -- ebreak
-          end if;
-        end if;
-        -- wfi --
-        if (execute_engine.i_reg(instr_funct12_msb_c downto instr_funct12_lsb_c) = funct12_wfi_c) and
-           ((CPU_EXTENSION_RISCV_DEBUG = false) or ((debug_ctrl.running = '0') and (csr.dcsr_step = '0'))) then
-          execute_engine.sleep_nxt <= '1'; -- not executed (NOP) when in debug-mode or during single-stepping
-        end if;
+        end case; -- /EXECUTE
 
 
       when CSR_ACCESS => -- read & write status and control register (CSR) - no read/write if illegal instruction
       -- ------------------------------------------------------------
-        -- CSR write access (invalid CSR instructions are already checked by the illegal instruction logic) --
-        if (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_csrrw_c) or
-           (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_csrrwi_c) or -- CSRRW(I); always write CSR
-           (decode_aux.rs1_zero = '0') then -- CSRRS(I) / CSRRC(I): write CSR if rs1/imm5 is NOT zero
+        if (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_csrrw_c) or  -- CSRRW:  always write CSR
+           (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_csrrwi_c) or -- CSRRWI: always write CSR
+           (decode_aux.rs1_zero = '0') then -- CSRR(S/C)(I): write CSR if rs1/imm5 is NOT zero
           csr.we_nxt <= '1';
         end if;
-        -- register file write back --
         ctrl_nxt(ctrl_rf_mux1_c downto ctrl_rf_mux0_c) <= rf_mux_csr_c;
         ctrl_nxt(ctrl_rf_wb_en_c) <= '1'; -- valid RF write-back
         execute_engine.state_nxt  <= DISPATCH;
@@ -1169,20 +1153,26 @@ begin
         end if;
 
 
-      when BRANCH => -- update PC for taken branches and jumps
+      when BRANCH => -- update PC on taken branches and jumps
       -- ------------------------------------------------------------
         -- get and store return address (only relevant for jump-and-link operations) --
         ctrl_nxt(ctrl_rf_mux1_c downto ctrl_rf_mux0_c) <= rf_mux_npc_c; -- next PC
         ctrl_nxt(ctrl_rf_wb_en_c) <= execute_engine.i_reg(instr_opcode_lsb_c+2); -- valid RF write-back? (is jump-and-link?)
         -- destination address --
         execute_engine.pc_mux_sel <= '1'; -- PC <= alu.add = branch/jump destination
+        execute_engine.pc_we      <= '1'; -- update PC with destination; will be overridden again in DISPATCH if branch not taken
         if (execute_engine.i_reg(instr_opcode_lsb_c+2) = '1') or (execute_engine.branch_taken = '1') then -- JAL/JALR or taken branch
-          -- no need to check for illegal instructions here; the branch condition evaluation circuit will not set "branch_taken" if funct3 is invalid
-          execute_engine.pc_we        <= '1'; -- update PC
-          execute_engine.branched_nxt <= '1'; -- this is an actual branch
-          fetch_engine.reset          <= '1'; -- trigger new instruction fetch from modified PC
+          fetch_engine.reset       <= '1'; -- reset instruction fetch starting at modified PC
+          execute_engine.state_nxt <= BRANCHED;
+        else
+          execute_engine.state_nxt <= DISPATCH;
         end if;
-        execute_engine.state_nxt <= DISPATCH;
+
+
+      when BRANCHED => -- delay cycle to wait for reset of pipeline front-end
+      -- ------------------------------------------------------------
+        execute_engine.branched_nxt <= '1'; -- this is an actual branch
+        execute_engine.state_nxt    <= DISPATCH;
 
 
       when LOADSTORE_0 => -- trigger memory request
@@ -1342,29 +1332,13 @@ begin
   -- Illegal Instruction Check --------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   illegal_instruction_check: process(execute_engine, decode_aux, csr, csr_acc_valid, debug_ctrl)
-    variable opcode_v : std_ulogic_vector(6 downto 0);
   begin
     -- defaults --
     illegal_instruction <= '0';
     illegal_register    <= '0';
 
-    -- check opcode for rv32 --
-    if (execute_engine.i_reg(instr_opcode_lsb_c+1 downto instr_opcode_lsb_c) = "11") then
-      illegal_opcode_lsbs <= '0';
-    else
-      illegal_opcode_lsbs <= '1';
-    end if;
-
-    -- check for illegal compressed instruction --
-    if (CPU_EXTENSION_RISCV_C = true) then
-      illegal_compressed <= execute_engine.is_ici;
-    else
-      illegal_compressed <= '0';
-    end if;
-
-    -- check instructions --
-    opcode_v := execute_engine.i_reg(instr_opcode_msb_c downto instr_opcode_lsb_c+2) & "11"; -- save some bits here, LSBs are always 11 for rv32
-    case opcode_v is
+    -- check instruction --
+    case execute_engine.i_reg(instr_opcode_msb_c downto instr_opcode_lsb_c) is
 
       when opcode_lui_c | opcode_auipc_c | opcode_jal_c => -- check sufficient LUI, UIPC, JAL (only check actual OPCODE)
       -- ------------------------------------------------------------
@@ -1496,7 +1470,7 @@ begin
         end if;
         -- NOTE: ignore all remaining bit fields here
 
-      when opcode_syscsr_c => -- check system instructions
+      when opcode_system_c => -- check system instructions
       -- ------------------------------------------------------------
         -- CSR access --
         if ((execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_csrrw_c) or
@@ -1550,7 +1524,7 @@ begin
         -- illegal E-CPU register? --
         illegal_register <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zxcfu) and (execute_engine.i_reg(instr_rs2_msb_c) or execute_engine.i_reg(instr_rs1_msb_c) or execute_engine.i_reg(instr_rd_msb_c));
 
-      when others => -- undefined instruction -> illegal!
+      when others => -- illegal opcode
       -- ------------------------------------------------------------
         illegal_instruction <= '1';
 
@@ -1561,11 +1535,10 @@ begin
   -- Illegal Operation Check ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   -- check in EXECUTE state: any illegal condition? --
-  trap_ctrl.instr_il <= (illegal_opcode_lsbs or -- illegal opcode LSB bits - not rv32
-                         illegal_instruction or -- illegal instruction
+  trap_ctrl.instr_il <= (illegal_instruction or -- illegal instruction
                          (bool_to_ulogic_f(CPU_EXTENSION_RISCV_E) and illegal_register) or -- illegal register access in E extension
-                         illegal_compressed) -- illegal compressed instruction
-                        when (execute_engine.state = EXECUTE) else '0';
+                         (bool_to_ulogic_f(CPU_EXTENSION_RISCV_C) and execute_engine.is_ici)) -- illegal compressed instruction
+                        when (execute_engine.state = EXECUTE) else '0'; -- evaluate in EXECUTE stage only
 
 
 -- ****************************************************************************************************************************
@@ -2753,7 +2726,8 @@ begin
 
   -- trigger to enter debug-mode: instruction address match (fire AFTER execution) --
   hw_trigger_fire <= '1' when (CPU_EXTENSION_RISCV_DEBUG = true) and (csr.tdata1_exe = '1') and
-                              (csr.tdata2(data_width_c-1 downto 1) = execute_engine.pc(data_width_c-1 downto 1)) else '0';
+                              (csr.tdata2(data_width_c-1 downto 1) = execute_engine.pc(data_width_c-1 downto 1)) and
+                              (execute_engine.state = EXECUTE) else '0';
 
 
   -- Match Control CSR (mcontrol @ tdata1) - Read-Back --------------------------------------

--- a/rtl/core/neorv32_cpu_decompressor.vhd
+++ b/rtl/core/neorv32_cpu_decompressor.vhd
@@ -423,7 +423,7 @@ begin
             else -- C.EBREAK, C.JALR, C.ADD
               if (ci_instr16_i(6 downto 2) = "00000") then -- C.EBREAK, C.JALR
                 if (ci_instr16_i(11 downto 7) = "00000") then -- C.EBREAK
-                  ci_instr32_o(instr_opcode_msb_c downto instr_opcode_lsb_c)   <= opcode_syscsr_c;
+                  ci_instr32_o(instr_opcode_msb_c downto instr_opcode_lsb_c)   <= opcode_system_c;
                   ci_instr32_o(instr_funct12_msb_c downto instr_funct12_lsb_c) <= "000000000001";
                 else -- C.JALR
                   ci_instr32_o(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_jalr_c;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -65,7 +65,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060906"; -- no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060907"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -454,7 +454,7 @@ package neorv32_package is
   constant opcode_store_c  : std_ulogic_vector(6 downto 0) := "0100011"; -- store (data type via funct3)
   -- system/csr --
   constant opcode_fence_c  : std_ulogic_vector(6 downto 0) := "0001111"; -- fence / fence.i
-  constant opcode_syscsr_c : std_ulogic_vector(6 downto 0) := "1110011"; -- system/csr access (type via funct3)
+  constant opcode_system_c : std_ulogic_vector(6 downto 0) := "1110011"; -- system/csr access (type via funct3)
   -- atomic memory access (A) --
   constant opcode_atomic_c : std_ulogic_vector(6 downto 0) := "0101111"; -- atomic operations (A extension)
   -- floating point operations (Zfinx-only) (F/D/H/Q) --
@@ -507,8 +507,8 @@ package neorv32_package is
   -- system --
   constant funct12_ecall_c  : std_ulogic_vector(11 downto 0) := x"000"; -- ecall
   constant funct12_ebreak_c : std_ulogic_vector(11 downto 0) := x"001"; -- ebreak
-  constant funct12_mret_c   : std_ulogic_vector(11 downto 0) := x"302"; -- mret
   constant funct12_wfi_c    : std_ulogic_vector(11 downto 0) := x"105"; -- wfi
+  constant funct12_mret_c   : std_ulogic_vector(11 downto 0) := x"302"; -- mret
   constant funct12_dret_c   : std_ulogic_vector(11 downto 0) := x"7b2"; -- dret
 
   -- RISC-V Funct5 --------------------------------------------------------------------------
@@ -847,7 +847,7 @@ package neorv32_package is
 --constant trap_ipf_c   x  : std_ulogic_vector(6 downto 0) := "0" & "0" & "01100"; -- 0.12: instruction page fault
 --constant trap_lpf_c   x  : std_ulogic_vector(6 downto 0) := "0" & "0" & "01101"; -- 0.13: load page fault
 --constant trap_???_c   x  : std_ulogic_vector(6 downto 0) := "0" & "0" & "01110"; -- 0.14: reserved
---constant trap_lpf_c   x  : std_ulogic_vector(6 downto 0) := "0" & "0" & "01111"; -- 0.15: store page fault
+--constant trap_spf_c   x  : std_ulogic_vector(6 downto 0) := "0" & "0" & "01111"; -- 0.15: store page fault
   -- NEORV32-specific (custom) synchronous exceptions --
 -- none implemented yet
   -- RISC-V compliant asynchronous exceptions (interrupts) --

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -219,7 +219,7 @@ begin
     if ci_mode then
       -- No need to send the full expectation in one big chunk
       check_uart(net, uart1_rx_handle, nul & nul);
-      check_uart(net, uart1_rx_handle, "0/45" & cr & lf);
+      check_uart(net, uart1_rx_handle, "0/49" & cr & lf);
     end if;
 
     -- Apply some random data on each SLINK inputs and expect it to

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -234,6 +234,8 @@ int main() {
   // ----------------------------------------------------------
   asm volatile ("fence");
   asm volatile ("fence.i");
+  asm volatile ("fence");
+  asm volatile ("fence.i");
 
 
   // ----------------------------------------------------------

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -217,9 +217,6 @@ int main() {
   // test intro
   PRINT_STANDARD("\nStarting tests.\n\n");
 
-  // sync (test)
-  asm volatile ("fence.i");
-
   // enable global interrupts
   neorv32_cpu_eint();
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -573,9 +573,9 @@ int main() {
 
   cnt_test++;
 
-  // illegal 32-bit instruction (malformed SRA)
+  // illegal 32-bit instruction (MRET with incorrect opcode)
   asm volatile (".align 4 \n"
-                ".word 0xC0000033");
+                ".word 0x3020007f");
 
   // make sure this has cause an illegal exception
   if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_I_ILLEGAL) {


### PR DESCRIPTION
:chart_with_upwards_trend: This PR improves the overall efficiency of the CPU: the logic optimizations from this PR reduce the area costs of the CPU (~8% less) while also shortening the CPU's critical path (~12% higher f_max).

:lock: Furthermore, this PR closes further illegal instruction holes (illegal instruction words that where not correctly detected or that caused side effects even if identified as "illegal").

:bug: This PR also fixes a rare bug in the core of the NEORV32 runtime-environment (RTE): if the C-extensions is disabled, a malformed instruction word that uses an opcode from the RVC (compressed) instruction space would cause the computation of an incorrect return address.