### PR TITLE
add gate for CSR read address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,9 @@ The version number is globally defined by the `hw_version_c` constant in the mai
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 07.04.2022 | 1.6.9.9 | AND-gate CSR read address: reduces **CPU switching activity** (= dynamic power consumption) and even reduces area costs; [PR #295](https://github.com/stnolting/neorv32/pull/295) |
 | 06.04.2022 | 1.6.9.8 | :bug: fixed instruction decoding collision in CPU `B` extension; :lock: closed further illegal instruction encoding holes; optimized illegal instruction detection logic; [PR #294](https://github.com/stnolting/neorv32/pull/294) |
-| 04.04.2022 | 1.6.9.7 | **major CPU logic optimization**: reduced area costs and shortened critical path (higher f_max!); :bug: fixed rare bug in RTE (if C-extension is not implemented); :lock: closed further illegal instruction encoding holes; [PR #293](https://github.com/stnolting/neorv32/pull/293) |
+| 04.04.2022 | 1.6.9.7 | **major CPU logic optimization**: reduced area costs and shortened critical path (higher f_max!); :bug: fixed rare bug in RTE core (if C-extension is not implemented); :lock: closed further illegal instruction encoding holes; [PR #293](https://github.com/stnolting/neorv32/pull/293) |
 | 01.04.2022 | 1.6.9.6 | rework **CPU front-end**: instruction issue engine; much cleaner code, slightly less HW required; [PR #292](https://github.com/stnolting/neorv32/pull/292) |
 | 29.03.2022 | 1.6.9.5 | minor clock generator edits: reset **clock generator** explicitly if not being used by _any_ peripheral/IO device |
 | 19.03.2022 | 1.6.9.4 | :test_tube: change usage of VHDL `*_reduce_f` functions for signals that might effect gate-level simulations; [PR #290](https://github.com/stnolting/neorv32/pull/290) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -65,7 +65,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060908"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060909"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -367,7 +367,6 @@ package neorv32_package is
   constant ctrl_bus_de_lock_c   : natural := 40; -- remove atomic/exclusive access 
   constant ctrl_bus_ch_lock_c   : natural := 41; -- evaluate atomic/exclusive lock (SC operation)
   -- alu co-processors --
-  constant ctrl_cp_id_lsb_c     : natural := 42; -- cp select ID lsb [ALIAS]
   constant ctrl_cp_trig0_c      : natural := 42; -- trigger CP0
   constant ctrl_cp_trig1_c      : natural := 43; -- trigger CP1
   constant ctrl_cp_trig2_c      : natural := 44; -- trigger CP2
@@ -376,7 +375,6 @@ package neorv32_package is
   constant ctrl_cp_trig5_c      : natural := 47; -- trigger CP5
   constant ctrl_cp_trig6_c      : natural := 48; -- trigger CP6
   constant ctrl_cp_trig7_c      : natural := 49; -- trigger CP7
-  constant ctrl_cp_id_msb_c     : natural := 49; -- cp select ID msb [ALIAS]
   -- instruction word control blocks (used by cpu co-processors) --
   constant ctrl_ir_funct3_0_c   : natural := 50; -- funct3 bit 0
   constant ctrl_ir_funct3_1_c   : natural := 51; -- funct3 bit 1
@@ -554,6 +552,7 @@ package neorv32_package is
 
   -- RISC-V CSR Addresses -------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
+  constant csr_zero_c           : std_ulogic_vector(11 downto 0) := x"000"; -- always returns zero, only relevant for hardware access
   -- <<< standard read/write CSRs >>> --
   -- user floating-point CSRs --
   constant csr_class_float_c    : std_ulogic_vector(09 downto 0) := x"00" & "00"; -- floating point


### PR DESCRIPTION
This small PR adds an AND-gate to the CSR read address bus. This eliminates unnecessary switching activity in the (large) CSR block as the read address is only propagated (from the instruction word) if there is an actual CSR access. (Somehow,) this also reduces area costs of the CSR system :wink: