### PR TITLE
Rework `C` decompressor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The version number is globally defined by the `hw_version_c` constant in the mai
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
-| 07.04.2022 | 1.6.9.10 | rework compressed instructions (`C`) decompressor: closed further illegal compressed instruction holes; code clean-ups; `mtval` CSR now shows the decompressed 32-bit instruction when executing an illegal compressed instruction; [PR #296](https://github.com/stnolting/neorv32/pull/296) |
+| 08.04.2022 | 1.6.9.10 | rework compressed instruction (`C` ISA extension) de-compressor: :lock: closed further illegal compressed instruction holes; code clean-ups; `mtval` CSR now shows the decompressed 32-bit instruction when executing an illegal compressed instruction; minor RTL code cleanups (removing legacy stuff); [PR #296](https://github.com/stnolting/neorv32/pull/296) |
 | 07.04.2022 | 1.6.9.9 | AND-gate CSR read address: reduces **CPU switching activity** (= dynamic power consumption) and even reduces area costs; [PR #295](https://github.com/stnolting/neorv32/pull/295) |
 | 06.04.2022 | 1.6.9.8 | :bug: fixed instruction decoding collision in CPU `B` extension; :lock: closed further illegal instruction encoding holes; optimized illegal instruction detection logic; [PR #294](https://github.com/stnolting/neorv32/pull/294) |
 | 04.04.2022 | 1.6.9.7 | **major CPU logic optimization**: reduced area costs and shortened critical path (higher f_max!); :bug: fixed rare bug in RTE core (if C-extension is not implemented); :lock: closed further illegal instruction encoding holes; [PR #293](https://github.com/stnolting/neorv32/pull/293) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The version number is globally defined by the `hw_version_c` constant in the mai
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 07.04.2022 | 1.6.9.10 | rework compressed instructions (`C`) decompressor: closed further illegal compressed instruction holes; code clean-ups; `mtval` CSR now shows the decompressed 32-bit instruction when executing an illegal compressed instruction; [PR #296](https://github.com/stnolting/neorv32/pull/296) |
 | 07.04.2022 | 1.6.9.9 | AND-gate CSR read address: reduces **CPU switching activity** (= dynamic power consumption) and even reduces area costs; [PR #295](https://github.com/stnolting/neorv32/pull/295) |
 | 06.04.2022 | 1.6.9.8 | :bug: fixed instruction decoding collision in CPU `B` extension; :lock: closed further illegal instruction encoding holes; optimized illegal instruction detection logic; [PR #294](https://github.com/stnolting/neorv32/pull/294) |
 | 04.04.2022 | 1.6.9.7 | **major CPU logic optimization**: reduced area costs and shortened critical path (higher f_max!); :bug: fixed rare bug in RTE core (if C-extension is not implemented); :lock: closed further illegal instruction encoding holes; [PR #293](https://github.com/stnolting/neorv32/pull/293) |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -423,7 +423,7 @@ interrupt) this register provides the address of the next not-yet-executed instr
 | 0x343 | **Machine bad address or instruction** | `mtval`
 3+| Reset value: _UNDEFINED_
 3+| The `mtval` CSR is compatible to the RISC-V specifications. When a trap is triggered, the CSR shows either
-the faulting address (for misaligned/faulting load/store/fetch) or the faulting instruction word itself (for illegal
+the faulting address (for misaligned/faulting load/store/fetch) or the faulting (decompressed) instruction word itself (for illegal
 instructions). For all other exceptions (including interrupts) the CSR is set to zero.
 |=======================
 
@@ -440,6 +440,11 @@ instructions). For all other exceptions (including interrupts) the CSR is set to
 
 [IMPORTANT]
 The NEORV32 `mtval` CSR is read-only. However, a write access will _NOT_ raise an illegal instruction exception.
+
+[NOTE]
+In case an invalid compressed instruction raised an illegal instruction exception, `mtval` will show the
+according de-compressed instruction word. To get the "real" 16-bit instruction that caused the exception
+perform a memory load using the address stored in <<_mepc>>.
 
 :sectnums!:
 ===== **`mip`**

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -755,9 +755,6 @@ begin
     -- memory access size / sign --
     ctrl_o(ctrl_bus_unsigned_c) <= execute_engine.i_reg(instr_funct3_msb_c); -- unsigned LOAD (LBU, LHU)
     ctrl_o(ctrl_bus_size_msb_c downto ctrl_bus_size_lsb_c) <= execute_engine.i_reg(instr_funct3_lsb_c+1 downto instr_funct3_lsb_c); -- mem transfer size
-    -- alu.shifter --
-    ctrl_o(ctrl_alu_shift_dir_c) <= execute_engine.i_reg(instr_funct3_msb_c); -- shift direction (left/right)
-    ctrl_o(ctrl_alu_shift_ar_c)  <= execute_engine.i_reg(30); -- is arithmetic shift
     -- instruction's function blocks (for co-processors) --
     ctrl_o(ctrl_ir_opcode7_6_c  downto ctrl_ir_opcode7_0_c) <= execute_engine.i_reg(instr_opcode_msb_c  downto instr_opcode_lsb_c);
     ctrl_o(ctrl_ir_funct12_11_c downto ctrl_ir_funct12_0_c) <= execute_engine.i_reg(instr_funct12_msb_c downto instr_funct12_lsb_c);
@@ -881,7 +878,7 @@ begin
   end process decode_helper;
 
   -- CSR access address --
-  csr.addr <= execute_engine.i_reg(instr_csr_id_msb_c downto instr_csr_id_lsb_c);
+  csr.addr <= execute_engine.i_reg(instr_imm12_msb_c downto instr_imm12_lsb_c);
 
 
   -- Execute Engine FSM Comb ----------------------------------------------------------------

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -939,22 +939,19 @@ begin
 
       when DISPATCH => -- Get new command from instruction issue engine
       -- ------------------------------------------------------------
-        -- PC update --
+        -- PC & IR update --
         execute_engine.pc_mux_sel <= '0'; -- linear next PC
-        -- IR update --
-        execute_engine.is_ci_nxt <= issue_engine.data(32); -- flag to indicate a de-compressed instruction
-        execute_engine.i_reg_nxt <= issue_engine.data(31 downto 0);
+        execute_engine.i_reg_nxt  <= issue_engine.data(31 downto 0);
+        execute_engine.is_ci_nxt  <= issue_engine.data(32); -- this is a de-compressed instruction
+        execute_engine.is_ici_nxt <= issue_engine.data(35); -- illegal compressed instruction
         --
         if (issue_engine.valid(0) = '1') or (issue_engine.valid(1) = '1') then -- instruction available?
           -- PC update --
           execute_engine.branched_nxt <= '0';
           execute_engine.pc_we        <= not execute_engine.branched; -- update PC with linear next_pc if there was no actual branch
           -- IR update - exceptions --
-          if (CPU_EXTENSION_RISCV_C = false) then
-            trap_ctrl.instr_ma <= issue_engine.data(33); -- misaligned instruction fetch address, if C disabled
-          end if;
-          trap_ctrl.instr_be        <= issue_engine.data(34); -- bus access fault during instruction fetch
-          execute_engine.is_ici_nxt <= issue_engine.data(35); -- invalid decompressed instruction
+          trap_ctrl.instr_ma <= issue_engine.data(33) and (not bool_to_ulogic_f(CPU_EXTENSION_RISCV_C)); -- misaligned instruction fetch (if C disabled)
+          trap_ctrl.instr_be <= issue_engine.data(34); -- bus access fault during instruction fetch
           -- any reason to go to trap state? --
           if (execute_engine.sleep = '1') or -- enter sleep state
              (trap_ctrl.exc_fire = '1') or -- exception during LAST instruction (e.g. illegal instruction)

--- a/rtl/core/neorv32_cpu_cp_shifter.vhd
+++ b/rtl/core/neorv32_cpu_cp_shifter.vhd
@@ -106,10 +106,10 @@ begin
           shifter.cnt  <= shamt_i; -- shift amount
         elsif (or_reduce_f(shifter.cnt) = '1') then -- running shift (cnt != 0)
           shifter.cnt <= std_ulogic_vector(unsigned(shifter.cnt) - 1);
-          if (ctrl_i(ctrl_alu_shift_dir_c) = '0') then -- SLL: shift left logical
+          if (ctrl_i(ctrl_ir_funct3_2_c) = '0') then -- SLL: shift left logical
             shifter.sreg <= shifter.sreg(shifter.sreg'left-1 downto 0) & '0';
           else -- SRL: shift right logical / SRA: shift right arithmetical
-            shifter.sreg <= (shifter.sreg(shifter.sreg'left) and ctrl_i(ctrl_alu_shift_ar_c)) & shifter.sreg(shifter.sreg'left downto 1);
+            shifter.sreg <= (shifter.sreg(shifter.sreg'left) and ctrl_i(ctrl_ir_funct12_10_c)) & shifter.sreg(shifter.sreg'left downto 1);
           end if;
         end if;
       end if;
@@ -132,7 +132,7 @@ begin
     shifter_unit_async: process(rs1_i, shamt_i, ctrl_i, bs_level)
     begin
       -- input level: convert left shifts to right shifts --
-      if (ctrl_i(ctrl_alu_shift_dir_c) = '0') then -- is left shift?
+      if (ctrl_i(ctrl_ir_funct3_2_c) = '0') then -- is left shift?
         bs_level(index_size_f(data_width_c)) <= bit_rev_f(rs1_i); -- reverse bit order of input operand
       else
         bs_level(index_size_f(data_width_c)) <= rs1_i;
@@ -141,7 +141,7 @@ begin
       -- shifter array --
       for i in index_size_f(data_width_c)-1 downto 0 loop
         if (shamt_i(i) = '1') then
-          bs_level(i)(data_width_c-1 downto data_width_c-(2**i)) <= (others => (bs_level(i+1)(data_width_c-1) and ctrl_i(ctrl_alu_shift_ar_c)));
+          bs_level(i)(data_width_c-1 downto data_width_c-(2**i)) <= (others => (bs_level(i+1)(data_width_c-1) and ctrl_i(ctrl_ir_funct12_10_c)));
           bs_level(i)((data_width_c-(2**i))-1 downto 0) <= bs_level(i+1)(data_width_c-1 downto 2**i);
         else
           bs_level(i) <= bs_level(i+1);
@@ -149,7 +149,7 @@ begin
       end loop;
 
       -- re-convert original left shifts --
-      if (ctrl_i(ctrl_alu_shift_dir_c) = '0') then
+      if (ctrl_i(ctrl_ir_funct3_2_c) = '0') then
         bs_result <= bit_rev_f(bs_level(0));
       else
         bs_result <= bs_level(0);

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -65,7 +65,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060909"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01060910"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -347,64 +347,62 @@ package neorv32_package is
   constant ctrl_alu_opa_mux_c   : natural := 21; -- operand A select (0=rs1, 1=PC)
   constant ctrl_alu_opb_mux_c   : natural := 22; -- operand B select (0=rs2, 1=IMM)
   constant ctrl_alu_unsigned_c  : natural := 23; -- is unsigned ALU operation
-  constant ctrl_alu_shift_dir_c : natural := 24; -- shift direction (0=left, 1=right)
-  constant ctrl_alu_shift_ar_c  : natural := 25; -- is arithmetic shift
-  constant ctrl_alu_frm0_c      : natural := 26; -- FPU rounding mode bit 0
-  constant ctrl_alu_frm1_c      : natural := 27; -- FPU rounding mode bit 1
-  constant ctrl_alu_frm2_c      : natural := 28; -- FPU rounding mode bit 2
+  constant ctrl_alu_frm0_c      : natural := 24; -- FPU rounding mode bit 0
+  constant ctrl_alu_frm1_c      : natural := 25; -- FPU rounding mode bit 1
+  constant ctrl_alu_frm2_c      : natural := 26; -- FPU rounding mode bit 2
   -- bus interface --
-  constant ctrl_bus_size_lsb_c  : natural := 29; -- transfer size lsb (00=byte, 01=half-word)
-  constant ctrl_bus_size_msb_c  : natural := 30; -- transfer size msb (10=word, 11=?)
-  constant ctrl_bus_rd_c        : natural := 31; -- read data request
-  constant ctrl_bus_wr_c        : natural := 32; -- write data request
-  constant ctrl_bus_if_c        : natural := 33; -- instruction fetch request
-  constant ctrl_bus_mo_we_c     : natural := 34; -- memory address and data output register write enable
-  constant ctrl_bus_mi_we_c     : natural := 35; -- memory data input register write enable
-  constant ctrl_bus_unsigned_c  : natural := 36; -- is unsigned load
-  constant ctrl_bus_fence_c     : natural := 37; -- executed fence operation
-  constant ctrl_bus_fencei_c    : natural := 38; -- executed fencei operation
-  constant ctrl_bus_lock_c      : natural := 39; -- make atomic/exclusive access lock
-  constant ctrl_bus_de_lock_c   : natural := 40; -- remove atomic/exclusive access 
-  constant ctrl_bus_ch_lock_c   : natural := 41; -- evaluate atomic/exclusive lock (SC operation)
+  constant ctrl_bus_size_lsb_c  : natural := 27; -- transfer size lsb (00=byte, 01=half-word)
+  constant ctrl_bus_size_msb_c  : natural := 28; -- transfer size msb (10=word, 11=?)
+  constant ctrl_bus_rd_c        : natural := 29; -- read data request
+  constant ctrl_bus_wr_c        : natural := 30; -- write data request
+  constant ctrl_bus_if_c        : natural := 31; -- instruction fetch request
+  constant ctrl_bus_mo_we_c     : natural := 32; -- memory address and data output register write enable
+  constant ctrl_bus_mi_we_c     : natural := 33; -- memory data input register write enable
+  constant ctrl_bus_unsigned_c  : natural := 34; -- is unsigned load
+  constant ctrl_bus_fence_c     : natural := 35; -- executed fence operation
+  constant ctrl_bus_fencei_c    : natural := 36; -- executed fencei operation
+  constant ctrl_bus_lock_c      : natural := 37; -- make atomic/exclusive access lock
+  constant ctrl_bus_de_lock_c   : natural := 38; -- remove atomic/exclusive access 
+  constant ctrl_bus_ch_lock_c   : natural := 39; -- evaluate atomic/exclusive lock (SC operation)
   -- alu co-processors --
-  constant ctrl_cp_trig0_c      : natural := 42; -- trigger CP0
-  constant ctrl_cp_trig1_c      : natural := 43; -- trigger CP1
-  constant ctrl_cp_trig2_c      : natural := 44; -- trigger CP2
-  constant ctrl_cp_trig3_c      : natural := 45; -- trigger CP3
-  constant ctrl_cp_trig4_c      : natural := 46; -- trigger CP4
-  constant ctrl_cp_trig5_c      : natural := 47; -- trigger CP5
-  constant ctrl_cp_trig6_c      : natural := 48; -- trigger CP6
-  constant ctrl_cp_trig7_c      : natural := 49; -- trigger CP7
+  constant ctrl_cp_trig0_c      : natural := 40; -- trigger CP0
+  constant ctrl_cp_trig1_c      : natural := 41; -- trigger CP1
+  constant ctrl_cp_trig2_c      : natural := 42; -- trigger CP2
+  constant ctrl_cp_trig3_c      : natural := 43; -- trigger CP3
+  constant ctrl_cp_trig4_c      : natural := 44; -- trigger CP4
+  constant ctrl_cp_trig5_c      : natural := 45; -- trigger CP5
+  constant ctrl_cp_trig6_c      : natural := 46; -- trigger CP6
+  constant ctrl_cp_trig7_c      : natural := 47; -- trigger CP7
   -- instruction word control blocks (used by cpu co-processors) --
-  constant ctrl_ir_funct3_0_c   : natural := 50; -- funct3 bit 0
-  constant ctrl_ir_funct3_1_c   : natural := 51; -- funct3 bit 1
-  constant ctrl_ir_funct3_2_c   : natural := 52; -- funct3 bit 2
-  constant ctrl_ir_funct12_0_c  : natural := 53; -- funct12 bit 0
-  constant ctrl_ir_funct12_1_c  : natural := 54; -- funct12 bit 1
-  constant ctrl_ir_funct12_2_c  : natural := 55; -- funct12 bit 2
-  constant ctrl_ir_funct12_3_c  : natural := 56; -- funct12 bit 3
-  constant ctrl_ir_funct12_4_c  : natural := 57; -- funct12 bit 4
-  constant ctrl_ir_funct12_5_c  : natural := 58; -- funct12 bit 5
-  constant ctrl_ir_funct12_6_c  : natural := 59; -- funct12 bit 6
-  constant ctrl_ir_funct12_7_c  : natural := 60; -- funct12 bit 7
-  constant ctrl_ir_funct12_8_c  : natural := 61; -- funct12 bit 8
-  constant ctrl_ir_funct12_9_c  : natural := 62; -- funct12 bit 9
-  constant ctrl_ir_funct12_10_c : natural := 63; -- funct12 bit 10
-  constant ctrl_ir_funct12_11_c : natural := 64; -- funct12 bit 11
-  constant ctrl_ir_opcode7_0_c  : natural := 65; -- opcode7 bit 0
-  constant ctrl_ir_opcode7_1_c  : natural := 66; -- opcode7 bit 1
-  constant ctrl_ir_opcode7_2_c  : natural := 67; -- opcode7 bit 2
-  constant ctrl_ir_opcode7_3_c  : natural := 68; -- opcode7 bit 3
-  constant ctrl_ir_opcode7_4_c  : natural := 69; -- opcode7 bit 4
-  constant ctrl_ir_opcode7_5_c  : natural := 70; -- opcode7 bit 5
-  constant ctrl_ir_opcode7_6_c  : natural := 71; -- opcode7 bit 6
+  constant ctrl_ir_funct3_0_c   : natural := 48; -- funct3 bit 0
+  constant ctrl_ir_funct3_1_c   : natural := 49; -- funct3 bit 1
+  constant ctrl_ir_funct3_2_c   : natural := 50; -- funct3 bit 2
+  constant ctrl_ir_funct12_0_c  : natural := 51; -- funct12 bit 0
+  constant ctrl_ir_funct12_1_c  : natural := 52; -- funct12 bit 1
+  constant ctrl_ir_funct12_2_c  : natural := 53; -- funct12 bit 2
+  constant ctrl_ir_funct12_3_c  : natural := 54; -- funct12 bit 3
+  constant ctrl_ir_funct12_4_c  : natural := 55; -- funct12 bit 4
+  constant ctrl_ir_funct12_5_c  : natural := 56; -- funct12 bit 5
+  constant ctrl_ir_funct12_6_c  : natural := 57; -- funct12 bit 6
+  constant ctrl_ir_funct12_7_c  : natural := 58; -- funct12 bit 7
+  constant ctrl_ir_funct12_8_c  : natural := 59; -- funct12 bit 8
+  constant ctrl_ir_funct12_9_c  : natural := 60; -- funct12 bit 9
+  constant ctrl_ir_funct12_10_c : natural := 61; -- funct12 bit 10
+  constant ctrl_ir_funct12_11_c : natural := 62; -- funct12 bit 11
+  constant ctrl_ir_opcode7_0_c  : natural := 63; -- opcode7 bit 0
+  constant ctrl_ir_opcode7_1_c  : natural := 64; -- opcode7 bit 1
+  constant ctrl_ir_opcode7_2_c  : natural := 65; -- opcode7 bit 2
+  constant ctrl_ir_opcode7_3_c  : natural := 66; -- opcode7 bit 3
+  constant ctrl_ir_opcode7_4_c  : natural := 67; -- opcode7 bit 4
+  constant ctrl_ir_opcode7_5_c  : natural := 68; -- opcode7 bit 5
+  constant ctrl_ir_opcode7_6_c  : natural := 69; -- opcode7 bit 6
   -- cpu status --
-  constant ctrl_priv_mode_c     : natural := 72; -- effective privilege mode
-  constant ctrl_sleep_c         : natural := 73; -- set when CPU is in sleep mode
-  constant ctrl_trap_c          : natural := 74; -- set when CPU is entering trap execution
-  constant ctrl_debug_running_c : natural := 75; -- set when CPU is in debug mode
+  constant ctrl_priv_mode_c     : natural := 70; -- effective privilege mode
+  constant ctrl_sleep_c         : natural := 71; -- set when CPU is in sleep mode
+  constant ctrl_trap_c          : natural := 72; -- set when CPU is entering trap execution
+  constant ctrl_debug_running_c : natural := 73; -- set when CPU is in debug mode
   -- control bus size --
-  constant ctrl_width_c         : natural := 76; -- control bus size
+  constant ctrl_width_c         : natural := 74; -- control bus size
 
   -- Comparator Bus -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -431,8 +429,6 @@ package neorv32_package is
   constant instr_imm12_msb_c   : natural := 31; -- immediate12 bit 11
   constant instr_imm20_lsb_c   : natural := 12; -- immediate20 bit 0
   constant instr_imm20_msb_c   : natural := 31; -- immediate20 bit 21
-  constant instr_csr_id_lsb_c  : natural := 20; -- csr select bit 0
-  constant instr_csr_id_msb_c  : natural := 31; -- csr select bit 11
   constant instr_funct5_lsb_c  : natural := 27; -- funct5 select bit 0
   constant instr_funct5_msb_c  : natural := 31; -- funct5 select bit 4
 


### PR DESCRIPTION
This is another logic optimization PR: rework logic of the `C`-extension's compressed instruction de-compressor.

* closed further illegal `C` instruction encoding holes
* `mtval` CSR now provides the de-compressed 32-bit instruction word when an illegal instruction has been raised by executing an invalid compressed instruction (instead of just showing all-zero)
* code cleanups (removing legacy stuff)