### PR TITLE
Rework register file's "zero" register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,14 @@ can be found [online at GitHub-pages](https://stnolting.github.io/neorv32).
 The _hardware version identifier_ uses an additional custom version element (i.e. `MAJOR.MINOR.PATCH.individual`) to track _individual_ changes.
 The identifier number is incremented with every core RTL modification and also by major framework modifications.
 
-:information_source: The processor can determine its version from the `mimpid` CSR.
+:information_source: The version number is globally defined by the `hw_version_c` constant in the main VHDL
+[package file](https://github.com/stnolting/neorv32/blob/master/rtl/core/neorv32_package.vhd).
+The processor can determine its version by reading the `mimpid` CSR (at CSR address 0xf13).
 A 8x4-bit BCD representation is used. Leading zeros are optional. Example:
 
 ```
-mimpid (@0xf13) = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
+mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 ```
-
-The version number is globally defined by the `hw_version_c` constant in the main VHDL package file
-[`rtl/core/neorv32_package.vhd`](https://github.com/stnolting/neorv32/blob/master/rtl/core/neorv32_package.vhd).
 
 
 ### Version History
@@ -33,6 +32,7 @@ The version number is globally defined by the `hw_version_c` constant in the mai
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 10.04.2022 | 1.7.0.1 | rework handling of `x0` register (`zero`): shortens critical path and reduces area costs;  [#298](https://github.com/stnolting/neorv32/pull/298) |
 | 08.04.2022 | [**:rocket:1.7.0**](https://github.com/stnolting/neorv32/releases/tag/v1.7.0) | **New release** |
 | 08.04.2022 | 1.6.9.11 | :bug: fixed bug in interrupt setup of **`crt0` start-up code** [#297](https://github.com/stnolting/neorv32/pull/297) |
 | 08.04.2022 | 1.6.9.10 | rework compressed instruction (`C` ISA extension) de-compressor: :lock: closed further illegal compressed instruction holes; code clean-ups; `mtval` CSR now shows the decompressed 32-bit instruction when executing an illegal compressed instruction; minor RTL code cleanups (removing legacy stuff); [PR #296](https://github.com/stnolting/neorv32/pull/296) |

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -2093,11 +2093,15 @@ begin
   csr.privilege_eff <= priv_mode_m_c when (CPU_EXTENSION_RISCV_DEBUG = true) and (debug_ctrl.running = '1') else csr.privilege;
 
   -- PMP output to bus unit --
-  pmp_output:
-  for i in 0 to PMP_NUM_REGIONS-1 generate
-    pmp_addr_o(i)(data_width_c-1 downto index_size_f(PMP_MIN_GRANULARITY)) <= csr.pmpaddr(i); -- physical address
-    pmp_ctrl_o(i) <= csr.pmpcfg(i);
-  end generate;
+  pmp_output: process(csr)
+  begin
+    pmp_addr_o <= (others => (others => '0'));
+    pmp_ctrl_o <= (others => (others => '0'));
+    for i in 0 to PMP_NUM_REGIONS-1 loop
+      pmp_addr_o(i)(data_width_c-1 downto index_size_f(PMP_MIN_GRANULARITY)) <= csr.pmpaddr(i); -- physical address
+      pmp_ctrl_o(i) <= csr.pmpcfg(i);
+    end loop;
+  end process pmp_output;
 
 
   -- Control and Status Registers - Read Access ---------------------------------------------

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -351,8 +351,7 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
   type debug_ctrl_t is record
     state        : debug_ctrl_state_t;
     -- decoded state --
-    running      : std_ulogic; -- debug mode active
-    pending      : std_ulogic; -- waiting to start debug mode
+    running      : std_ulogic; -- CPU is in debug mode
     -- entering triggers --
     trig_hw      : std_ulogic; -- hardware trigger
     trig_break   : std_ulogic; -- ebreak instruction
@@ -746,10 +745,9 @@ begin
     ctrl_o(ctrl_bus_wr_c)   <= ctrl(ctrl_bus_wr_c)   and (not trap_ctrl.exc_buf(exc_iillegal_c));
     -- current effective privilege level --
     ctrl_o(ctrl_priv_mode_c) <= csr.privilege_eff;
-    -- register addresses --
+    -- register sources --
     ctrl_o(ctrl_rf_rs1_adr4_c downto ctrl_rf_rs1_adr0_c) <= execute_engine.i_reg(instr_rs1_msb_c downto instr_rs1_lsb_c);
     ctrl_o(ctrl_rf_rs2_adr4_c downto ctrl_rf_rs2_adr0_c) <= execute_engine.i_reg(instr_rs2_msb_c downto instr_rs2_lsb_c);
-    ctrl_o(ctrl_rf_rd_adr4_c  downto ctrl_rf_rd_adr0_c)  <= execute_engine.i_reg(instr_rd_msb_c  downto instr_rd_lsb_c);
     -- instruction fetch request --
     ctrl_o(ctrl_bus_if_c) <= fetch_engine.bus_if;
     -- memory access size / sign --
@@ -919,8 +917,9 @@ begin
 
     -- CONTROL DEFAULTS --
     ctrl_nxt <= (others => '0'); -- default: all off
-    ctrl_nxt(ctrl_alu_op2_c downto ctrl_alu_op0_c) <= alu_op_add_c; -- default ALU operation: ADD
-    ctrl_nxt(ctrl_rf_mux1_c downto ctrl_rf_mux0_c) <= rf_mux_alu_c; -- default RF input: ALU
+    ctrl_nxt(ctrl_alu_op2_c downto ctrl_alu_op0_c)       <= alu_op_add_c; -- default ALU operation: ADD
+    ctrl_nxt(ctrl_rf_mux1_c downto ctrl_rf_mux0_c)       <= rf_mux_alu_c; -- default RF input: ALU
+    ctrl_nxt(ctrl_rf_rd_adr4_c downto ctrl_rf_rd_adr0_c) <= execute_engine.i_reg(instr_rd_msb_c downto instr_rd_lsb_c); -- rd
     -- ALU sign control --
     if (execute_engine.i_reg(instr_opcode_lsb_c+4) = '1') then -- ALU ops
       ctrl_nxt(ctrl_alu_unsigned_c) <= execute_engine.i_reg(instr_funct3_lsb_c+0); -- unsigned ALU operation? (SLTIU, SLTU)
@@ -1164,6 +1163,12 @@ begin
       -- ------------------------------------------------------------
         execute_engine.branched_nxt <= '1'; -- this is an actual branch
         execute_engine.state_nxt    <= DISPATCH;
+        -- use this state also to clear register file's x0 register --
+        if (reset_x0_c = true) then -- if x0 is a "real" register that has to be initialized to zero
+          ctrl_nxt(ctrl_rf_mux1_c downto ctrl_rf_mux0_c)       <= rf_mux_csr_c; -- this will return 0 since csr.re_nxt is cleared
+          ctrl_nxt(ctrl_rf_rd_adr4_c downto ctrl_rf_rd_adr0_c) <= (others => '0'); -- rd = x0 (zero)
+          ctrl_nxt(ctrl_rf_zero_we_c)                          <= '1'; -- allow write access to x0
+        end if;
 
 
       when LOADSTORE_0 => -- trigger memory request
@@ -2639,8 +2644,7 @@ begin
     end process debug_control;
   end generate;
 
-  -- state decoding --
-  debug_ctrl.pending <= '1' when (debug_ctrl.state = DEBUG_PENDING) and (CPU_EXTENSION_RISCV_DEBUG = true) else '0';
+  -- CPU is *in* debug mode --
   debug_ctrl.running <= '1' when ((debug_ctrl.state = DEBUG_ONLINE) or (debug_ctrl.state = DEBUG_EXIT)) and (CPU_EXTENSION_RISCV_DEBUG = true) else '0';
 
   -- entry debug mode triggers --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -44,6 +44,9 @@ package neorv32_package is
   constant ispace_base_c : std_ulogic_vector(31 downto 0) := x"00000000"; -- default instruction memory address space base address
   constant dspace_base_c : std_ulogic_vector(31 downto 0) := x"80000000"; -- default data memory address space base address
 
+  -- if register x0 is implemented as actual physical register is has to be set to zero by the CPU hardware --
+  constant reset_x0_c : boolean := true; -- has to be 'true' for the default register file rtl description (BRAM-based)
+
   -- use dedicated hardware reset value for UNCRITICAL CPU registers --
   -- FALSE=reset value is irrelevant (might simplify HW), default; TRUE=defined LOW reset value
   constant dedicated_reset_c : boolean := false;
@@ -65,7 +68,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070000"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070001"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -340,69 +343,70 @@ package neorv32_package is
   constant ctrl_rf_rd_adr4_c    : natural := 15; -- destination register address bit 4
   constant ctrl_rf_mux0_c       : natural := 16; -- input source select lsb
   constant ctrl_rf_mux1_c       : natural := 17; -- input source select msb
+  constant ctrl_rf_zero_we_c    : natural := 18; -- allow write access to x0
   -- alu --
-  constant ctrl_alu_op0_c       : natural := 18; -- ALU operation select bit 0
-  constant ctrl_alu_op1_c       : natural := 19; -- ALU operation select bit 1
-  constant ctrl_alu_op2_c       : natural := 20; -- ALU operation select bit 2
-  constant ctrl_alu_opa_mux_c   : natural := 21; -- operand A select (0=rs1, 1=PC)
-  constant ctrl_alu_opb_mux_c   : natural := 22; -- operand B select (0=rs2, 1=IMM)
-  constant ctrl_alu_unsigned_c  : natural := 23; -- is unsigned ALU operation
-  constant ctrl_alu_frm0_c      : natural := 24; -- FPU rounding mode bit 0
-  constant ctrl_alu_frm1_c      : natural := 25; -- FPU rounding mode bit 1
-  constant ctrl_alu_frm2_c      : natural := 26; -- FPU rounding mode bit 2
+  constant ctrl_alu_op0_c       : natural := 19; -- ALU operation select bit 0
+  constant ctrl_alu_op1_c       : natural := 20; -- ALU operation select bit 1
+  constant ctrl_alu_op2_c       : natural := 21; -- ALU operation select bit 2
+  constant ctrl_alu_opa_mux_c   : natural := 22; -- operand A select (0=rs1, 1=PC)
+  constant ctrl_alu_opb_mux_c   : natural := 23; -- operand B select (0=rs2, 1=IMM)
+  constant ctrl_alu_unsigned_c  : natural := 24; -- is unsigned ALU operation
+  constant ctrl_alu_frm0_c      : natural := 25; -- FPU rounding mode bit 0
+  constant ctrl_alu_frm1_c      : natural := 26; -- FPU rounding mode bit 1
+  constant ctrl_alu_frm2_c      : natural := 27; -- FPU rounding mode bit 2
   -- bus interface --
-  constant ctrl_bus_size_lsb_c  : natural := 27; -- transfer size lsb (00=byte, 01=half-word)
-  constant ctrl_bus_size_msb_c  : natural := 28; -- transfer size msb (10=word, 11=?)
-  constant ctrl_bus_rd_c        : natural := 29; -- read data request
-  constant ctrl_bus_wr_c        : natural := 30; -- write data request
-  constant ctrl_bus_if_c        : natural := 31; -- instruction fetch request
-  constant ctrl_bus_mo_we_c     : natural := 32; -- memory address and data output register write enable
-  constant ctrl_bus_mi_we_c     : natural := 33; -- memory data input register write enable
-  constant ctrl_bus_unsigned_c  : natural := 34; -- is unsigned load
-  constant ctrl_bus_fence_c     : natural := 35; -- executed fence operation
-  constant ctrl_bus_fencei_c    : natural := 36; -- executed fencei operation
-  constant ctrl_bus_lock_c      : natural := 37; -- make atomic/exclusive access lock
-  constant ctrl_bus_de_lock_c   : natural := 38; -- remove atomic/exclusive access 
-  constant ctrl_bus_ch_lock_c   : natural := 39; -- evaluate atomic/exclusive lock (SC operation)
+  constant ctrl_bus_size_lsb_c  : natural := 28; -- transfer size lsb (00=byte, 01=half-word)
+  constant ctrl_bus_size_msb_c  : natural := 29; -- transfer size msb (10=word, 11=?)
+  constant ctrl_bus_rd_c        : natural := 30; -- read data request
+  constant ctrl_bus_wr_c        : natural := 31; -- write data request
+  constant ctrl_bus_if_c        : natural := 32; -- instruction fetch request
+  constant ctrl_bus_mo_we_c     : natural := 33; -- memory address and data output register write enable
+  constant ctrl_bus_mi_we_c     : natural := 34; -- memory data input register write enable
+  constant ctrl_bus_unsigned_c  : natural := 35; -- is unsigned load
+  constant ctrl_bus_fence_c     : natural := 36; -- executed fence operation
+  constant ctrl_bus_fencei_c    : natural := 37; -- executed fencei operation
+  constant ctrl_bus_lock_c      : natural := 38; -- make atomic/exclusive access lock
+  constant ctrl_bus_de_lock_c   : natural := 39; -- remove atomic/exclusive access 
+  constant ctrl_bus_ch_lock_c   : natural := 40; -- evaluate atomic/exclusive lock (SC operation)
   -- alu co-processors --
-  constant ctrl_cp_trig0_c      : natural := 40; -- trigger CP0
-  constant ctrl_cp_trig1_c      : natural := 41; -- trigger CP1
-  constant ctrl_cp_trig2_c      : natural := 42; -- trigger CP2
-  constant ctrl_cp_trig3_c      : natural := 43; -- trigger CP3
-  constant ctrl_cp_trig4_c      : natural := 44; -- trigger CP4
-  constant ctrl_cp_trig5_c      : natural := 45; -- trigger CP5
-  constant ctrl_cp_trig6_c      : natural := 46; -- trigger CP6
-  constant ctrl_cp_trig7_c      : natural := 47; -- trigger CP7
+  constant ctrl_cp_trig0_c      : natural := 41; -- trigger CP0
+  constant ctrl_cp_trig1_c      : natural := 42; -- trigger CP1
+  constant ctrl_cp_trig2_c      : natural := 43; -- trigger CP2
+  constant ctrl_cp_trig3_c      : natural := 44; -- trigger CP3
+  constant ctrl_cp_trig4_c      : natural := 45; -- trigger CP4
+  constant ctrl_cp_trig5_c      : natural := 46; -- trigger CP5
+  constant ctrl_cp_trig6_c      : natural := 47; -- trigger CP6
+  constant ctrl_cp_trig7_c      : natural := 48; -- trigger CP7
   -- instruction word control blocks (used by cpu co-processors) --
-  constant ctrl_ir_funct3_0_c   : natural := 48; -- funct3 bit 0
-  constant ctrl_ir_funct3_1_c   : natural := 49; -- funct3 bit 1
-  constant ctrl_ir_funct3_2_c   : natural := 50; -- funct3 bit 2
-  constant ctrl_ir_funct12_0_c  : natural := 51; -- funct12 bit 0
-  constant ctrl_ir_funct12_1_c  : natural := 52; -- funct12 bit 1
-  constant ctrl_ir_funct12_2_c  : natural := 53; -- funct12 bit 2
-  constant ctrl_ir_funct12_3_c  : natural := 54; -- funct12 bit 3
-  constant ctrl_ir_funct12_4_c  : natural := 55; -- funct12 bit 4
-  constant ctrl_ir_funct12_5_c  : natural := 56; -- funct12 bit 5
-  constant ctrl_ir_funct12_6_c  : natural := 57; -- funct12 bit 6
-  constant ctrl_ir_funct12_7_c  : natural := 58; -- funct12 bit 7
-  constant ctrl_ir_funct12_8_c  : natural := 59; -- funct12 bit 8
-  constant ctrl_ir_funct12_9_c  : natural := 60; -- funct12 bit 9
-  constant ctrl_ir_funct12_10_c : natural := 61; -- funct12 bit 10
-  constant ctrl_ir_funct12_11_c : natural := 62; -- funct12 bit 11
-  constant ctrl_ir_opcode7_0_c  : natural := 63; -- opcode7 bit 0
-  constant ctrl_ir_opcode7_1_c  : natural := 64; -- opcode7 bit 1
-  constant ctrl_ir_opcode7_2_c  : natural := 65; -- opcode7 bit 2
-  constant ctrl_ir_opcode7_3_c  : natural := 66; -- opcode7 bit 3
-  constant ctrl_ir_opcode7_4_c  : natural := 67; -- opcode7 bit 4
-  constant ctrl_ir_opcode7_5_c  : natural := 68; -- opcode7 bit 5
-  constant ctrl_ir_opcode7_6_c  : natural := 69; -- opcode7 bit 6
+  constant ctrl_ir_funct3_0_c   : natural := 49; -- funct3 bit 0
+  constant ctrl_ir_funct3_1_c   : natural := 50; -- funct3 bit 1
+  constant ctrl_ir_funct3_2_c   : natural := 51; -- funct3 bit 2
+  constant ctrl_ir_funct12_0_c  : natural := 52; -- funct12 bit 0
+  constant ctrl_ir_funct12_1_c  : natural := 53; -- funct12 bit 1
+  constant ctrl_ir_funct12_2_c  : natural := 54; -- funct12 bit 2
+  constant ctrl_ir_funct12_3_c  : natural := 55; -- funct12 bit 3
+  constant ctrl_ir_funct12_4_c  : natural := 56; -- funct12 bit 4
+  constant ctrl_ir_funct12_5_c  : natural := 57; -- funct12 bit 5
+  constant ctrl_ir_funct12_6_c  : natural := 58; -- funct12 bit 6
+  constant ctrl_ir_funct12_7_c  : natural := 59; -- funct12 bit 7
+  constant ctrl_ir_funct12_8_c  : natural := 60; -- funct12 bit 8
+  constant ctrl_ir_funct12_9_c  : natural := 61; -- funct12 bit 9
+  constant ctrl_ir_funct12_10_c : natural := 62; -- funct12 bit 10
+  constant ctrl_ir_funct12_11_c : natural := 63; -- funct12 bit 11
+  constant ctrl_ir_opcode7_0_c  : natural := 64; -- opcode7 bit 0
+  constant ctrl_ir_opcode7_1_c  : natural := 65; -- opcode7 bit 1
+  constant ctrl_ir_opcode7_2_c  : natural := 66; -- opcode7 bit 2
+  constant ctrl_ir_opcode7_3_c  : natural := 67; -- opcode7 bit 3
+  constant ctrl_ir_opcode7_4_c  : natural := 68; -- opcode7 bit 4
+  constant ctrl_ir_opcode7_5_c  : natural := 69; -- opcode7 bit 5
+  constant ctrl_ir_opcode7_6_c  : natural := 70; -- opcode7 bit 6
   -- cpu status --
-  constant ctrl_priv_mode_c     : natural := 70; -- effective privilege mode
-  constant ctrl_sleep_c         : natural := 71; -- set when CPU is in sleep mode
-  constant ctrl_trap_c          : natural := 72; -- set when CPU is entering trap execution
-  constant ctrl_debug_running_c : natural := 73; -- set when CPU is in debug mode
+  constant ctrl_priv_mode_c     : natural := 71; -- effective privilege mode
+  constant ctrl_sleep_c         : natural := 72; -- set when CPU is in sleep mode
+  constant ctrl_trap_c          : natural := 73; -- set when CPU is entering trap execution
+  constant ctrl_debug_running_c : natural := 74; -- set when CPU is in debug mode
   -- control bus size --
-  constant ctrl_width_c         : natural := 74; -- control bus size
+  constant ctrl_width_c         : natural := 75; -- control bus size
 
   -- Comparator Bus -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/sw/common/crt0.S
+++ b/sw/common/crt0.S
@@ -45,15 +45,12 @@ _start:
 
 
 // ************************************************************************************************
-// This is the very first instruction that is executed after hardware reset. It ensures that x0 is
-// written at least once - the CPU HW will ensure it is always set to zero on any write access.
-//
-// Furthermore, we have to disable ALL interrupts, which is required if this code is part of a
-// program uploaded by the on-chip debugger (potentionally taking control from the bootloader).
-// We setup a new stack pointer here and WE DO NOT WANT TO trap to an outdated trap handler with
-// a modified stack pointer.
+// We need to ensure interrupts are globally disabled at start. This is is required if this code
+// is part of a program uploaded by the on-chip debugger (potentionally taking control from the
+// bootloader). We setup a new stack pointer here and WE DO NOT WANT TO trap to an outdated trap
+// handler with a modified stack pointer.
 // ************************************************************************************************
-  csrrci zero, mstatus, (1<<3) // disable global interrupt flag and write "anything" to x0
+  csrrci zero, mstatus, (1<<3) // disable global interrupt flag
 
 
 // ************************************************************************************************


### PR DESCRIPTION
This PR reworks the handling of register `x0` (= "zero"), which is always returns zero.

We do not want to implement AND-gates to set the register source operands (`rs1` & `rs2`) to zero when reading from register `x0` since this would cost ~64 LUTs and would also increase the critical path. Hence, register zero is part of the register file and will also be mapped to the register file-absorbing block RAM - so register `x0` is a _physical register_. We do not want to rely on BRAM initialization to ensure that `x0` is always zero. Thus, a special logic is required.


### Pre-PR

The current register file checks all write accesses if they target register zero. For any write access to this register, the actual read data is set to zero. This increases the critical path (register file -> ALU -> register file) as an additional logic level is required. Furthermore, the very first instruction of a program has to write to `x0` to make sure it is cleared. Currently, this is ensured by the CPU start-up code `crt0.S`. However, this is not portable as users might use custom start-up codes.

### Post-Pr

The CPU control ensures that register `x0` is set to zero by forcing a zero-write to this register. The additional logic to flush the register file write data to zero is removed. This shortens the critical path and also reduces area costs.

ℹ️ For implementations using a custom register file architecture (where `x0` is actually _hardwired_ to zero) the hardware-based initialization can be disabled by setting `reset_x0_c := false` (VHDL constant in `neorv32_package.vhd`).

--------------------

This PR also fixes a synthesis/simulation warning regarding unconnected `pmp_*` signals.