### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{vhd,vhdl}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,10 +8,19 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 
-[*.{vhd,vhdl}]
+# RTL files
+[*.{vhd,vhdl,v}]
 charset = utf-8
 indent_style = space
 indent_size = 2
 
+# C files
+[*.{c,h,cpp,hpp}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+# Makefiles
 [Makefile]
+charset = utf-8
 indent_style = tab

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,9 @@ to [open a new issue](https://github.com/stnolting/neorv32/issues) or start a ne
 Also look out for issues and pull requests labeled with
 [![help-wanted](https://img.shields.io/badge/-help%20wanted-brightgreen)](https://github.com/stnolting/neorv32/labels/help%20wanted).
 
-:information_source: Please note we have a [Code of Conduct](https://github.com/stnolting/neorv32/tree/master/CODE_OF_CONDUCT.md),
-please follow it in all your interactions with the project.
+:information_source: Please note we have a [**Code of Conduct**](https://github.com/stnolting/neorv32/tree/master/CODE_OF_CONDUCT.md),
+please follow it in all your interactions with the project. Also checkout out our
+[**File Formatting Standards**](https://github.com/stnolting/neorv32/tree/master/.editroconfig).
 
 ## Contributing Process
 


### PR DESCRIPTION
I just stumbled across this: https://editorconfig.org / https://github.com/editorconfig :+1:

I think it would be a good idea to add some guide lines regarding file formatting. What do you think about this?