### PR TITLE
:bug: fix buskeeper timeout error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 13.05.2022 | 1.7.1.6 | :bug: fixed bug in **BUSKEEPER** timeout logic; [#315](https://github.com/stnolting/neorv32/pull/315) |
 | 10.05.2022 | 1.7.1.5 | code clean-up and minor optimization of `B` extension (bit-manipulation) CPU co-processor; [#312](https://github.com/stnolting/neorv32/pull/312) |
 | 06.05.2022 | 1.7.1.4 | :sparkles: upgrade TRNG module to new [neoTRNG v2](https://github.com/stnolting/neoTRNG); [#311](https://github.com/stnolting/neorv32/pull/311) |
 | 05.05.2022 | 1.7.1.3 | :bug: bug fix in CPU counter overflow logic (`cycle` and `instret` counters); minor optimization of CPU execution unit; [#310](https://github.com/stnolting/neorv32/pull/310) |

--- a/rtl/core/neorv32_bus_keeper.vhd
+++ b/rtl/core/neorv32_bus_keeper.vhd
@@ -90,13 +90,17 @@ architecture neorv32_bus_keeper_rtl of neorv32_bus_keeper is
   signal wren   : std_ulogic; -- word write enable
   signal rden   : std_ulogic; -- read enable
 
+  -- timeout counter size --
+  constant cnt_width_c : natural := index_size_f(max_proc_int_response_time_c);
+
   -- controller --
   type control_t is record
     pending  : std_ulogic;
-    timeout  : std_ulogic_vector(index_size_f(max_proc_int_response_time_c) downto 0);
+    timeout  : std_ulogic_vector(cnt_width_c-1 downto 0);
     err_type : std_ulogic;
     bus_err  : std_ulogic;
     ignore   : std_ulogic;
+    expired  : std_ulogic;
   end record;
   signal control : control_t;
 
@@ -162,21 +166,26 @@ begin
 
       -- access monitor: IDLE --
       if (control.pending = '0') then
-        control.timeout <= std_ulogic_vector(to_unsigned(max_proc_int_response_time_c, index_size_f(max_proc_int_response_time_c)+1));
+        control.timeout <= std_ulogic_vector(to_unsigned(max_proc_int_response_time_c-1, cnt_width_c));
         control.ignore  <= '0';
         if (bus_rden_i = '1') or (bus_wren_i = '1') then
           control.pending <= '1';
         end if;
       -- access monitor: PENDING --
       else
-        control.ignore  <= control.ignore or (bus_ext_i or bus_xip_i); -- bus keeper shall ignore internal timeout of this access (because it's "external")
-        control.timeout <= std_ulogic_vector(unsigned(control.timeout) - 1); -- countdown timer
+        -- countdown timer --
+        if (control.expired = '0') then
+          control.timeout <= std_ulogic_vector(unsigned(control.timeout) - 1);
+        end if;
+        -- bus keeper shall ignore internal timeout during this access (because it's "external") --
+        control.ignore <= control.ignore or (bus_ext_i or bus_xip_i);
+        -- response handling --
         if (bus_err_i = '1') then -- error termination by bus system
           control.err_type <= err_device_c; -- device error
           control.bus_err  <= '1';
           control.pending  <= '0';
-        elsif ((or_reduce_f(control.timeout) = '0') and (control.ignore = '0')) or -- valid INTERNAL access timeout
-              (bus_tmo_i = '1') then -- external access timeout
+        elsif ((control.expired = '1') and (control.ignore = '0')) or -- valid INTERNAL access timeout
+              (bus_tmo_i = '1') then -- EXTERNAL access timeout
           control.err_type <= err_timeout_c; -- timeout error
           control.bus_err  <= '1';
           control.pending  <= '0';
@@ -188,6 +197,9 @@ begin
       end if;
     end if;
   end process keeper_control;
+
+  -- timeout counter expired? --
+  control.expired <= '1' when (or_reduce_f(control.timeout) = '0') else '0';
 
   -- signal bus error to CPU --
   err_o <= control.bus_err;

--- a/rtl/core/neorv32_bus_keeper.vhd
+++ b/rtl/core/neorv32_bus_keeper.vhd
@@ -96,6 +96,7 @@ architecture neorv32_bus_keeper_rtl of neorv32_bus_keeper is
     timeout  : std_ulogic_vector(index_size_f(max_proc_int_response_time_c) downto 0);
     err_type : std_ulogic;
     bus_err  : std_ulogic;
+    ignore   : std_ulogic;
   end record;
   signal control : control_t;
 
@@ -154,6 +155,7 @@ begin
       control.bus_err  <= '0'; -- required
       control.err_type <= '-';
       control.timeout  <= (others => '-');
+      control.ignore   <= '-';
     elsif rising_edge(clk_i) then
       -- defaults --
       control.bus_err <= '0';
@@ -161,17 +163,19 @@ begin
       -- access monitor: IDLE --
       if (control.pending = '0') then
         control.timeout <= std_ulogic_vector(to_unsigned(max_proc_int_response_time_c, index_size_f(max_proc_int_response_time_c)+1));
+        control.ignore  <= '0';
         if (bus_rden_i = '1') or (bus_wren_i = '1') then
           control.pending <= '1';
         end if;
       -- access monitor: PENDING --
       else
+        control.ignore  <= control.ignore or (bus_ext_i or bus_xip_i); -- bus keeper shall ignore internal timeout of this access (because it's "external")
         control.timeout <= std_ulogic_vector(unsigned(control.timeout) - 1); -- countdown timer
         if (bus_err_i = '1') then -- error termination by bus system
           control.err_type <= err_device_c; -- device error
           control.bus_err  <= '1';
           control.pending  <= '0';
-        elsif ((or_reduce_f(control.timeout) = '0') and (bus_ext_i = '0') and (bus_xip_i = '0')) or -- valid INTERNAL access timeout
+        elsif ((or_reduce_f(control.timeout) = '0') and (control.ignore = '0')) or -- valid INTERNAL access timeout
               (bus_tmo_i = '1') then -- external access timeout
           control.err_type <= err_timeout_c; -- timeout error
           control.bus_err  <= '1';

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -68,7 +68,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070105"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070106"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------


### PR DESCRIPTION
Fixes #314. @GideonZ

The BUSKEEPER raises an _internal timeout error_ if an external access (via Wishbone) has the same access latency as there are maximum _internal_ timeout cycles (`max_proc_int_response_time_c`).