### PR TITLE
[TRNG] add optional/configurable data FIFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 17.05.2022 | 1.7.1.7 | :sparkles: add optional/configurable data FIFO to **TRNG**; new top generic `IO_TRNG_FIFO`; [#316](https://github.com/stnolting/neorv32/pull/316) |
 | 13.05.2022 | 1.7.1.6 | :bug: fixed bug in **BUSKEEPER** timeout logic; [#315](https://github.com/stnolting/neorv32/pull/315) |
 | 10.05.2022 | 1.7.1.5 | code clean-up and minor optimization of `B` extension (bit-manipulation) CPU co-processor; [#312](https://github.com/stnolting/neorv32/pull/312) |
 | 06.05.2022 | 1.7.1.4 | :sparkles: upgrade TRNG module to new [neoTRNG v2](https://github.com/stnolting/neoTRNG); [#311](https://github.com/stnolting/neorv32/pull/311) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -969,6 +969,18 @@ information.
 
 
 :sectnums!:
+===== _IO_TRNG_FIFO_
+
+[cols="4,4,2"]
+[frame="all",grid="none"]
+|======
+| **IO_TRNG_FIFO** | _natural_ | 1
+3+| Defines the depth of the TRNG data FIFO. Minimal value is 1;, has to be a power of two.
+See section <<_true_random_number_generator_trng>> for more information.
+|======
+
+
+:sectnums!:
 ===== _IO_CFS_EN_
 
 [cols="4,4,2"]
@@ -1082,9 +1094,9 @@ specifications. However, bare-metal system can also repurpose these interrupts. 
 [options="header",grid="rows"]
 |=======================
 | Top signal | Width | Description
-| `mtime_irq_i` | 1 | Machine timer interrupt from _processor-external_ MTIME unit. This IRQ is only available if the processor-internal MTIME unit is not used (<<_io_mtime_en>> = false).
-| `msw_irq_i`   | 1 | Machine software interrupt. This interrupt is used for inter-processor interrupts in multi-core systems. However, it can also be used for any custom purpose.
-| `mext_irq_i`  | 1 | Machine external interrupt. This interrupt is used for any processor-external interrupt source (like a platform interrupt controller).
+| `mtime_irq_i` | 1 | Machine timer interrupt from _processor-external_ MTIME unit (_MTI_). This IRQ is only available if the processor-internal MTIME unit is not used (<<_io_mtime_en>> = false).
+| `msw_irq_i`   | 1 | Machine software interrupt (_MSI_). This interrupt is used for inter-processor interrupts in multi-core systems. However, it can also be used for any custom purpose.
+| `mext_irq_i`  | 1 | Machine external interrupt (_MEI_). This interrupt is used for any processor-external interrupt source (like a platform interrupt controller).
 |=======================
 
 .Trigger type

--- a/docs/datasheet/soc_trng.adoc
+++ b/docs/datasheet/soc_trng.adoc
@@ -9,7 +9,8 @@
 | Software driver file(s): | neorv32_trng.c |
 |                          | neorv32_trng.h |
 | Top entity port:         | none | 
-| Configuration generics:  | _IO_TRNG_EN_ | implement TRNG when _true_
+| Configuration generics:  | _IO_TRNG_EN_   | implement TRNG when _true_
+|                          | _IO_TRNG_FIFO_ | data FIFO depth, min 1, has to be a power of two
 | CPU interrupts:          | none | 
 |=======================
 
@@ -31,7 +32,7 @@ detailed evaluation of the random number quality can be found it it's repository
 .Inferring Latches
 [NOTE]
 The synthesis tool might emit a warning like _"inferring latches for ... neorv32_trng ..."_. This is no problem
-as this is what we actually want (the TRNG is based on latches).
+as this is what we actually want: the TRNG is based on latches, which implement the inverters of the ring oscillators.
 
 .Simulation
 [IMPORTANT]
@@ -43,10 +44,17 @@ The _TRNG_CTRL_SIM_MODE_ flag of the control register is set if simulation mode 
 **Using the TRNG**
 
 The TRNG features a single register for status and data access. When the _TRNG_CTRL_EN_ control register (`CTRL`)
-bit is set, the TRNG is enabled and starts operation. As soon as the _TRNG_CTRL_VALID_ bit is set, the currently
-sampled 8-bit random data byte can be obtained from the lowest 8 bits of the `CTRL` register
-(_TRNG_CTRL_DATA_MSB_ : _TRNG_CTRL_DATA_LSB_). These bits always keep the latest valid data obtained from the TRNG
-entropy source. The _TRNG_CTRL_VALID_ bit is automatically cleared when reading the control register.
+bit is set, the TRNG is enabled and starts operation. As soon as the _TRNG_CTRL_VALID_ bit is set a random data byte
+is available and can be obtained from the lowest 8 bits of the `CTRL` register
+(_TRNG_CTRL_DATA_MSB_ : _TRNG_CTRL_DATA_LSB_).
+
+An optional random data FIFO can be configured using the <<_io_trng_fifo>> generic. This FIFO automatically samples
+new random data from the TRNG to provide some kind of _random data pool_ for applications, which require a large number
+of RND data in a short time. The minimal and default value for <<_io_trng_fifo>> is 1 (implementing a register rather
+than a real FIFO); the generic has to be a power of two.
+
+The random data FIFO can be cleared at any time either by disabling the TRNG via the _TRNG_CTRL_EN_ flag or by
+setting the _TRNG_CTRL_FIFO_CLR_ flag. Note that this falg is write-only and auto clears after being set.
 
 .TRNG Reset
 [NOTE]
@@ -59,7 +67,8 @@ disabled (=reset) by clearing the _TRNG_CTRL_EN_ and waiting some 1000s clock cy
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.4+<| `0xffffffb8` .4+<| `NEORV32_TRNG.CTRL` <|`7:0` _TRNG_CTRL_DATA_MSB_ : _TRNG_CTRL_DATA_MSB_ ^| r/- <| 8-bit random data
+.5+<| `0xffffffb8` .5+<| `NEORV32_TRNG.CTRL` <|`7:0` _TRNG_CTRL_DATA_MSB_ : _TRNG_CTRL_DATA_MSB_ ^| r/- <| 8-bit random data
+                                             <|`28` _TRNG_CTRL_FIFO_CLR_                         ^| -/w <| clear data FIFO when set (auto clears)
                                              <|`29` _TRNG_CTRL_SIM_MODE_                         ^| r/- <| simulation mode (PRNG!)
                                              <|`30` _TRNG_CTRL_EN_                               ^| r/w <| TRNG enable
                                              <|`31` _TRNG_CTRL_VALID_                            ^| r/- <| random data is valid when set

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -68,7 +68,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070106"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070107"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -1010,6 +1010,7 @@ package neorv32_package is
       IO_PWM_NUM_CH                : natural := 0;      -- number of PWM channels to implement (0..60); 0 = disabled
       IO_WDT_EN                    : boolean := false;  -- implement watch dog timer (WDT)?
       IO_TRNG_EN                   : boolean := false;  -- implement true random number generator (TRNG)?
+      IO_TRNG_FIFO                 : natural := 1;      -- TRNG fifo depth, has to be a power of two, min 1
       IO_CFS_EN                    : boolean := false;  -- implement custom functions subsystem (CFS)?
       IO_CFS_CONFIG                : std_ulogic_vector(31 downto 0) := x"00000000"; -- custom CFS configuration generic
       IO_CFS_IN_SIZE               : positive := 32;    -- size of CFS input conduit in bits
@@ -1789,6 +1790,9 @@ package neorv32_package is
   -- Component: True Random Number Generator (TRNG) -----------------------------------------
   -- -------------------------------------------------------------------------------------------
   component neorv32_trng
+    generic (
+      IO_TRNG_FIFO : natural := 1 -- RND fifo depth, has to be a power of two, min 1
+    );
     port (
       -- host access --
       clk_i  : in  std_ulogic; -- global clock line

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -128,6 +128,7 @@ entity neorv32_top is
     IO_PWM_NUM_CH                : natural := 0;      -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    : boolean := false;  -- implement watch dog timer (WDT)?
     IO_TRNG_EN                   : boolean := false;  -- implement true random number generator (TRNG)?
+    IO_TRNG_FIFO                 : natural := 1;      -- TRNG fifo depth, has to be a power of two, min 1
     IO_CFS_EN                    : boolean := false;  -- implement custom functions subsystem (CFS)?
     IO_CFS_CONFIG                : std_ulogic_vector(31 downto 0) := x"00000000"; -- custom CFS configuration generic
     IO_CFS_IN_SIZE               : positive := 32;    -- size of CFS input conduit in bits
@@ -1308,6 +1309,9 @@ begin
   neorv32_trng_inst_true:
   if (IO_TRNG_EN = true) generate
     neorv32_trng_inst: neorv32_trng
+    generic map (
+      IO_TRNG_FIFO => IO_TRNG_FIFO -- RND fifo depth, has to be a power of two, min 1
+    )
     port map (
       -- host access --
       clk_i  => clk_i,                     -- global clock line

--- a/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
+++ b/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
@@ -110,6 +110,7 @@ entity neorv32_ProcessorTop_stdlogic is
     IO_PWM_NUM_CH                : natural := 4;      -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    : boolean := true;   -- implement watch dog timer (WDT)?
     IO_TRNG_EN                   : boolean := false;  -- implement true random number generator (TRNG)?
+    IO_TRNG_FIFO                 : natural := 1;      -- TRNG fifo depth, has to be a power of two, min 1
     IO_CFS_EN                    : boolean := false;  -- implement custom functions subsystem (CFS)?
     IO_CFS_CONFIG                : std_ulogic_vector(31 downto 0); -- custom CFS configuration generic
     IO_CFS_IN_SIZE               : positive := 32;    -- size of CFS input conduit in bits
@@ -346,6 +347,7 @@ begin
     IO_PWM_NUM_CH                => IO_PWM_NUM_CH,      -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    => IO_WDT_EN,          -- implement watch dog timer (WDT)?
     IO_TRNG_EN                   => IO_TRNG_EN,         -- implement true random number generator (TRNG)?
+    IO_TRNG_FIFO                 => IO_TRNG_FIFO,       -- TRNG fifo depth, has to be a power of two, min 1
     IO_CFS_EN                    => IO_CFS_EN,          -- implement custom functions subsystem (CFS)?
     IO_CFS_CONFIG                => IO_CFS_CONFIG_INT,  -- custom CFS configuration generic
     IO_CFS_IN_SIZE               => IO_CFS_IN_SIZE,     -- size of CFS input conduit in bits

--- a/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
@@ -119,6 +119,7 @@ entity neorv32_top_avalonmm is
     IO_PWM_NUM_CH                : natural := 0;      -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    : boolean := false;  -- implement watch dog timer (WDT)?
     IO_TRNG_EN                   : boolean := false;  -- implement true random number generator (TRNG)?
+    IO_TRNG_FIFO                 : natural := 1;      -- TRNG fifo depth, has to be a power of two, min 1
     IO_CFS_EN                    : boolean := false;  -- implement custom functions subsystem (CFS)?
     IO_CFS_CONFIG                : std_ulogic_vector(31 downto 0) := x"00000000"; -- custom CFS configuration generic
     IO_CFS_IN_SIZE               : positive := 32;    -- size of CFS input conduit in bits
@@ -319,6 +320,7 @@ begin
     IO_PWM_NUM_CH => IO_PWM_NUM_CH,
     IO_WDT_EN => IO_WDT_EN,
     IO_TRNG_EN => IO_TRNG_EN,
+    IO_TRNG_FIFO => IO_TRNG_FIFO,
     IO_CFS_EN => IO_CFS_EN,
     IO_CFS_CONFIG => IO_CFS_CONFIG,
     IO_CFS_IN_SIZE => IO_CFS_IN_SIZE,

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -105,6 +105,7 @@ entity neorv32_SystemTop_axi4lite is
     IO_PWM_NUM_CH                : natural := 4;      -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    : boolean := true;   -- implement watch dog timer (WDT)?
     IO_TRNG_EN                   : boolean := true;   -- implement true random number generator (TRNG)?
+    IO_TRNG_FIFO                 : natural := 1;      -- TRNG fifo depth, has to be a power of two, min 1
     IO_CFS_EN                    : boolean := false;  -- implement custom functions subsystem (CFS)?
     IO_CFS_CONFIG                : std_logic_vector(31 downto 0) := x"00000000"; -- custom CFS configuration generic
     IO_CFS_IN_SIZE               : positive := 32;    -- size of CFS input conduit in bits
@@ -344,6 +345,7 @@ begin
     IO_PWM_NUM_CH                => IO_PWM_NUM_CH,      -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    => IO_WDT_EN,          -- implement watch dog timer (WDT)?
     IO_TRNG_EN                   => IO_TRNG_EN,         -- implement true random number generator (TRNG)?
+    IO_TRNG_FIFO                 => IO_TRNG_FIFO,       -- TRNG fifo depth, has to be a power of two, min 1
     IO_CFS_EN                    => IO_CFS_EN,          -- implement custom functions subsystem (CFS)?
     IO_CFS_CONFIG                => IO_CFS_CONFIG_INT,  -- custom CFS configuration generic
     IO_CFS_IN_SIZE               => IO_CFS_IN_SIZE,     -- size of CFS input conduit in bits

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -339,6 +339,7 @@ begin
     IO_PWM_NUM_CH                => 30,            -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    => true,          -- implement watch dog timer (WDT)?
     IO_TRNG_EN                   => true,          -- implement true random number generator (TRNG)?
+    IO_TRNG_FIFO                 => 4,             -- TRNG fifo depth, has to be a power of two, min 1
     IO_CFS_EN                    => true,          -- implement custom functions subsystem (CFS)?
     IO_CFS_CONFIG                => (others => '0'), -- custom CFS configuration generic
     IO_CFS_IN_SIZE               => 32,            -- size of CFS input conduit in bits

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -230,6 +230,7 @@ begin
     IO_PWM_NUM_CH                => 30,            -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    => true,          -- implement watch dog timer (WDT)?
     IO_TRNG_EN                   => true,          -- implement true random number generator (TRNG)?
+    IO_TRNG_FIFO                 => 4,             -- TRNG fifo depth, has to be a power of two, min 1
     IO_CFS_EN                    => true,          -- implement custom functions subsystem (CFS)?
     IO_CFS_CONFIG                => (others => '0'), -- custom CFS configuration generic
     IO_CFS_IN_SIZE               => 32,            -- size of CFS input conduit in bits

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -1216,6 +1216,7 @@ enum NEORV32_TRNG_CTRL_enum {
   TRNG_CTRL_DATA_LSB =  0, /**< TRNG data/control register(0)  (r/-): Random data byte LSB */
   TRNG_CTRL_DATA_MSB =  7, /**< TRNG data/control register(7)  (r/-): Random data byte MSB */
 
+  TRNG_CTRL_FIFO_CLR = 28, /**< TRNG data/control register(28) (-/w): Clear data FIFO (auto clears) */
   TRNG_CTRL_SIM_MODE = 29, /**< TRNG data/control register(29) (r/-): PRNG mode (simulation mode) */
   TRNG_CTRL_EN       = 30, /**< TRNG data/control register(30) (r/w): TRNG enable */
   TRNG_CTRL_VALID    = 31  /**< TRNG data/control register(31) (r/-): Random data output valid */

--- a/sw/lib/include/neorv32_trng.h
+++ b/sw/lib/include/neorv32_trng.h
@@ -47,6 +47,7 @@
 int  neorv32_trng_available(void);
 void neorv32_trng_enable(void);
 void neorv32_trng_disable(void);
+void neorv32_trng_fifo_clear(void);
 int  neorv32_trng_get(uint8_t *data);
 int  neorv32_trng_check_sim_mode(void);
 

--- a/sw/lib/source/neorv32_trng.c
+++ b/sw/lib/source/neorv32_trng.c
@@ -78,6 +78,9 @@ void neorv32_trng_enable(void) {
   for (i=0; i<256; i++) {
     asm volatile ("nop");
   }
+
+  // clear random "pool"
+  neorv32_trng_fifo_clear();
 }
 
 
@@ -87,6 +90,15 @@ void neorv32_trng_enable(void) {
 void neorv32_trng_disable(void) {
 
   NEORV32_TRNG.CTRL = 0;
+}
+
+
+/**********************************************************************//**
+ * Clear TRNG random data "pool" (data FIFO).
+ **************************************************************************/
+void neorv32_trng_fifo_clear(void) {
+
+  NEORV32_TRNG.CTRL |= 1 << TRNG_CTRL_FIFO_CLR; // auto clears
 }
 
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -954,6 +954,11 @@
               <description>Random data</description>
             </field>
             <field>
+              <name>TRNG_CTRL_FIFO_CLR</name>
+              <bitRange>[28:28]</bitRange>
+              <description>Clear data FIFO when set (auto clears)</description>
+            </field>
+            <field>
               <name>TRNG_CTRL_SIM_MODE</name>
               <bitRange>[29:29]</bitRange>
               <access>read-only</access>


### PR DESCRIPTION
This PR adds an optional and configurable data FIFO to the processor's _true random number generator_ module (**TRNG**).

The TRNG requires at least 16x8=128 cycles to generate a new RND data bytes (see [stnolting/neoTRNG](https://github.com/stnolting/neoTRNG) for more information). The new optional FIFO provides something like a "random data pool" by constantly sampling data from the TRNG core.

* The TRNG FIFO is configured by the new top generic `IO_TRNG_FIFO`: default value is 1, minimal value is 1, has to be a power of two.
* The FIFO can be cleared at any time either by disabling and re-enabling the TRNG module or via the new control register bit _TRNG_CTRL_FIFO_CLR_ (`NEORV32_TRNG.CTRL` bit 28; write-only, auto clears).