### PR TITLE
crt0.S: Do not clear XIP control registers except in bootloader mode

### DIFF
--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -1383,7 +1383,8 @@ system implements an internal reset generator and a global clock generator/divid
 Most processor-internal modules - except for the CPU and the watchdog timer - do not have a dedicated
 reset signal. However, all devices can be reset by software by clearing the corresponding unit's control
 register. The automatically included application start-up code (`crt0.S`) will perform a software-reset of all
-modules to ensure a clean system reset state.
+modules to ensure a clean system reset state. This feature can be manually deactivated if required. See section
+<<_start_up_code_crt0>> for more information.
 
 The hardware reset signal of the processor can either be triggered via the external reset pin (`rstn_i`, low-active),
 by the internal watchdog timer (if implemented) or by the on-chip debugger. The external reset signal `rstn_i`
@@ -1438,11 +1439,12 @@ be written with a byte-wide granularity.
 When accessing an IO device that hast not been implemented (via the according generic), a
 load/store access fault exception is triggered.
 
-.Hardware Reset
+.Module Reset
 [NOTE]
-Most of the IO devices do not have a hardware reset. Instead, the devices are reset via software by
-writing zero to the unit's control register. A general software-based reset of all devices is done by the
-application start-up code `crt0.S`.
+Most of the IO devices do not have a dedicated hardware reset at all. Instead, the devices are reset via software by
+writing zero to the unit's control register. A general software-based reset of **all** IO/peripheral devices is done by the
+application start-up code `crt0.S`. This feature can be manually deactivated if required. See section
+<<_start_up_code_crt0>> for more information.
 
 [TIP]
 You should use the provided core software library to interact with the peripheral devices. This

--- a/docs/datasheet/software.adoc
+++ b/docs/datasheet/software.adoc
@@ -447,20 +447,30 @@ The `crt0.S` start-up performs the following operations:
 [start=1]
 . Disable interrupts globally by clearing <<_mstatus>>`.mie`.
 . Initialize all integer registers `x1 - x31` (or just `x1 - x15` when using the `E` CPU extension) to a defined value.
-. Initialize all CPU core CSRs and also install a default "dummy" trap handler for _all_ traps. This handler catches all traps
+. Initialize all CPU core CSRs and also install a default "dummy" trap handler for _all_ exceptions.
 ** All interrupt sources are disabled and all pending interrupts are cleared.
 . Initialize the global pointer `gp` and the stack pointer `sp` according to the <<_ram_layout>> provided by the linker script.
 during the early boot phase.
 . Clear all counter CSRs and stop auto-increment.
-. Clear IO area: Write zero to all memory-mapped registers within the IO region (`iodev` section). If certain devices have not
-been implemented, a bus access fault exception will occur. This exception is captured by the dummy trap handler.
+. **Clear IO area**: Write zero to all memory-mapped registers within the IO region (`iodev` section) resetting all IO/peripheral modules.
+This step can be disabled by the user; see note below.
+If certain devices have not been implemented, a bus access fault exception will occur, which is captured by the dummy trap handler.
 . Clear the `.bss` section defined by the linker script.
 . Copy read-only data from the `.text` section to the `.data` section to set initialized variables.
 . Call the application's `main` function (with _no_ arguments: `argc` = `argv` = 0).
 . If the main function returns...
 ** the return value is copied to the <<_mscratch>> CSR to allow inspection by the on-chip debugger.
 ** an optional <<_after_main_handler>> is called (if defined at all).
-** the last step the CPU does is entering endless sleep mode (using the `wfi` instruction).
+** the CPU enters sleep mode (using the `wfi` instruction) or halts in an endless loop (if `wfi` "returns").
+
+.Disabling automatic software reset of all IO/peripheral devices during executable boot
+[IMPORTANT]
+The automatic "software reset" performed by the crt0 start-up code can be manually disabled. This can be handy for certain executables,
+which are booted by a (custom) bootloader and rely on certain IO initializations performed by the bootloader. To disable the automatic
+reset of all IO/peripheral modules the `NO_IO_RESET` symbol needs to be _defined_ before compilation using the makefile's `USER_FLAGS`
+variable. Furthermore, all object files need to be recompiled using the `clean_all` target.
+Example: `$ make USER_FLAGS+=-DNO_IO_RESET clean_all exe`
+
 
 :sectnums:
 ===== After-Main Handler

--- a/sw/common/crt0.S
+++ b/sw/common/crt0.S
@@ -146,10 +146,13 @@ __crt0_reset_io:
   la   x8,   __crt0_io_space_begin         // start of processor-internal IO region
   la   x9,   __crt0_io_space_end           // end of processor-internal IO region
 
+// Make this opt-out so that e.g. the XIP module can keep running
+#ifndef NO_IO_RESET
 __crt0_reset_io_loop:
   sw   zero, 0(x8)
   addi x8,   x8, 4
   bne  x8,   x9, __crt0_reset_io_loop
+#endif
 
 
 // ************************************************************************************************


### PR DESCRIPTION
When the bootloader executes an application from XIP, the startup code should not disable the XIP unit, otherwise the application will crash.