### PR TITLE
🐛 fix XIP sub-word accesses

### DIFF
--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -68,7 +68,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070107"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070108"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/rtl/core/neorv32_xip.vhd
+++ b/rtl/core/neorv32_xip.vhd
@@ -270,7 +270,8 @@ begin
     variable tmp_v : std_ulogic_vector(31 downto 0);
   begin
     tmp_v(31 downto 28) := "0000";
-    tmp_v(27 downto 00) := arbiter.addr(27 downto 00);
+    tmp_v(27 downto 02) := arbiter.addr(27 downto 02);
+    tmp_v(01 downto 00) := "00"; -- always align to 32-bit boundary; sub-word read accesses are handled by the CPU logic
     case ctrl(ctrl_xip_abytes1_c downto ctrl_xip_abytes0_c) is -- shift address bits to be MSB-aligned
       when "00"   => xip_addr <= tmp_v(07 downto 0) & x"000000"; -- 1 address byte
       when "01"   => xip_addr <= tmp_v(15 downto 0) & x"0000";   -- 2 address bytes


### PR DESCRIPTION
This PR fixes the sub-word read access via the XIp module (#317).

## Tests ✔️

Direct test:
```
XIP data access test...
XIP.word[0x20000000] = 0xfc800513
XIP.word[0x20000004] = 0x00052023

XIP.half[0x20000000] = 0x00000513
XIP.half[0x20000002] = 0x0000fc80
XIP.half[0x20000004] = 0x00002023
XIP.half[0x20000006] = 0x00000005

XIP.byte[0x20000000] = 0x00000013
XIP.byte[0x20000001] = 0x00000005
XIP.byte[0x20000002] = 0x00000080
XIP.byte[0x20000003] = 0x000000fc
XIP.byte[0x20000004] = 0x00000023
XIP.byte[0x20000005] = 0x00000020
XIP.byte[0x20000006] = 0x00000005
XIP.byte[0x20000007] = 0x00000000
```

Test via GDB:
```
(gdb) x/wx 0x20000000
0x20000000:     0xfc800513
(gdb) x/wx 0x20000004
0x20000004:     0x00052023

(gdb) x/wx 0x20000001
0x20000001:     0x23fc8005

(gdb) x/bx 0x20000000
0x20000000:     0x13
(gdb) x/bx 0x20000001
0x20000001:     0x05
(gdb) x/bx 0x20000002
0x20000002:     0x80
(gdb) x/bx 0x20000003
0x20000003:     0xfc
(gdb) x/bx 0x20000004
0x20000004:     0x23
```