### PR TITLE
[linker script, crt0] align all sections to 32-bit boundaries

### DIFF
--- a/docs/datasheet/software.adoc
+++ b/docs/datasheet/software.adoc
@@ -339,6 +339,12 @@ The `.text` and `.rodata` sections are mapped to processor's instruction memory 
 `.bss` and `heap` sections are mapped to the processor's data memory space. Finally, the `.text`, `.rodata` and `.data`
 sections are extracted and concatenated into a single file `main.bin`.
 
+.Section Alignment
+[NOTE]
+The default NEORV32 linker script aligns _all_ section so they start and end on a 32-bit (word) boundary. The default
+NEORV32 start-up code (crt0) makes use of this alignment by using word-level memory instruction to initialize the `.data`
+section and to clear the `.bss` section.
+
 
 :sectnums:
 ==== RAM Layout

--- a/sw/common/crt0.S
+++ b/sw/common/crt0.S
@@ -45,7 +45,7 @@ _start:
 
 
 // ************************************************************************************************
-// We need to ensure interrupts are globally disabled at start. This is is required if this code
+// We need to ensure interrupts are globally disabled at start. This is required if this code
 // is part of a program uploaded by the on-chip debugger (potentionally taking control from the
 // bootloader). We setup a new stack pointer here and WE DO NOT WANT TO trap to an outdated trap
 // handler with a modified stack pointer.
@@ -76,7 +76,7 @@ __crt0_cpu_csr_init:
   csrw mtvec, x10
   csrw mepc,  x10                       // just to init mepc
 
-  csrw mstatus, zero                    // clear all control flags, also disable global IRQ
+  csrw mstatus, zero                    // clear all control flags, also disable IRQs globally
   csrw mie,     zero                    // absolutely no interrupt sources, thanks
   csrw mip,     zero                    // clear all pending interrupts
 
@@ -157,26 +157,26 @@ __crt0_reset_io_loop:
 
 
 // ************************************************************************************************
-// Copy initialized .data section from ROM to RAM (byte-wise)
+// Copy initialized .data section from ROM to RAM (word-wise, section begins and ends on word boundary)
 // ************************************************************************************************
 __crt0_copy_data:
-  la   x11, __crt0_copy_data_src_begin        // start of data area (copy source)
-  la   x12, __crt0_copy_data_dst_begin        // start of data area (copy destination)
-  la   x13, __crt0_copy_data_dst_end          // last address of destination data area
+  la   x11, __crt0_copy_data_src_begin // start of data area (copy source)
+  la   x12, __crt0_copy_data_dst_begin // start of data area (copy destination)
+  la   x13, __crt0_copy_data_dst_end   // last address of destination data area
 
 __crt0_copy_data_loop:
   bge  x12, x13,  __crt0_copy_data_loop_end
-  lb   x14, 0(x11)
-  sb   x14, 0(x12)
-  addi x11, x11, 1
-  addi x12, x12, 1
+  lw   x14, 0(x11)
+  sw   x14, 0(x12)
+  addi x11, x11, 4
+  addi x12, x12, 4
   j    __crt0_copy_data_loop
 
 __crt0_copy_data_loop_end:
 
 
 // ************************************************************************************************
-// Clear .bss section (byte-wise)
+// Clear .bss section (word-wise, section begins and ends on word boundary)
 // ************************************************************************************************
 __crt0_clear_bss:
   la   x14,  __crt0_bss_start
@@ -184,8 +184,8 @@ __crt0_clear_bss:
 
 __crt0_clear_bss_loop:
   bge  x14,  x15, __crt0_clear_bss_loop_end
-  sb   zero, 0(x14)
-  addi x14,  x14, 1
+  sw   zero, 0(x14)
+  addi x14,  x14, 4
   j    __crt0_clear_bss_loop
 
 __crt0_clear_bss_loop_end:

--- a/sw/common/neorv32.ld
+++ b/sw/common/neorv32.ld
@@ -46,34 +46,34 @@ OUTPUT_ARCH(riscv)
 ENTRY(_start)
 SEARCH_DIR("/opt/riscv/riscv32-unknown-elf/lib"); SEARCH_DIR("=/opt/riscv/riscv64-unknown-linux-gnu/lib"); SEARCH_DIR("=/usr/local/lib"); SEARCH_DIR("=/lib"); SEARCH_DIR("=/usr/lib");
 
-/* **************************************************************************
+/* ********************************************************************************************
  * NEORV32 memory section configuration.                                     
- * **************************************************************************
+ * ********************************************************************************************
  * "ram"   : data memory (int/ext DMEM) - make sure this is sync with the HW!
  * "rom"   : instruction memory (int/ext IMEM or bootloader ROM)             
- * "iodev" : peripheral/IO devices                                           
- * ************************************************************************** */
+ * "iodev" : peripheral/IO devices               
+ * NOTE: All sections defined in this script start and end on a 32-bit (word) aligned boundary. 
+ * ******************************************************************************************** */
 MEMORY
 {
-/* section base addresses and sizes have to be a multiple of 4 bytes
- * ram section: first value of LENGTH => data memory used by bootloader (fixed!); second value of LENGTH => *physical* size of data memory
- * adapt the right-most value to match the *total physical data memory size* of your setup */
+
+  /* section base addresses and sizes have to be a multiple of 4 bytes
+   * ram section: first value of LENGTH => data memory used by bootloader (fixed!); second value of LENGTH => *physical* size of data memory
+   * adapt the right-most value to match the *total physical data memory size* of your setup */
 
   ram  (rwx) : ORIGIN = 0x80000000, LENGTH = DEFINED(make_bootloader) ? 512 : 8*1024
 
-/* rom and iodev sections should NOT be modified by the user at all! 
- * rom section: first value of ORIGIN/LENGTH => bootloader ROM; second value of ORIGIN/LENGTH => maximum *logical* size of instruction memory */
+  /* rom and iodev sections should NOT be modified by the user at all! 
+   * rom section: first value of ORIGIN/LENGTH => bootloader ROM; second value of ORIGIN/LENGTH => maximum *logical* size of instruction memory */
 
   rom   (rx) : ORIGIN = DEFINED(make_bootloader) ? 0xFFFF0000 : 0x00000000, LENGTH = DEFINED(make_bootloader) ? 32K : 2048M
-  iodev (rw) : ORIGIN = 0xFFFFFE00, LENGTH = 512
+  iodev (rw) : ORIGIN = 0xFFFFFE00, LENGTH = 512 /* this is hardware-defined and must not be altered! */
 
 }
 /* ************************************************************************* */
 
 SECTIONS
 {
-  /* start section on WORD boundary */
-  . = ALIGN(4);
 
   /* default heap size: we can use up to 1/4 of available data memory (RAM) by default
    * WARNING! the heap will collide with the stack if allocating too much memory! */
@@ -81,7 +81,7 @@ SECTIONS
 
 
   /* First part of the actual executable file: actual instructions */
-  .text :
+  .text : ALIGN(4)
   {
     PROVIDE(__text_start = .);
     PROVIDE(__textstart = .);
@@ -99,7 +99,6 @@ SECTIONS
 
     /* finish section on WORD boundary */
     . = ALIGN(4);
-
     PROVIDE (__etext = .);
     PROVIDE (_etext = .);
     PROVIDE (etext = .);
@@ -107,48 +106,20 @@ SECTIONS
 
 
   /* Second part of the actual executable: read-only data, placed right next to .text */
-  .rodata :
+  .rodata : ALIGN(4)
   {
-    /* these are a list of 32-bit pointers that point to functions
-     * that are called before/after executing "main". */
-
-
-    /* constructors are not supported by default. */
-
-    /* __init_array_start = .;
-     * KEEP (*(.preinit_array))
-     * KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-     * KEEP (*(.rodata EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
-     * __init_array_end = .;
-     */
-
-
-    /* main should never return, hence there is no default support for deconstructors!
-     * however, if main return, the "after_main_handler" will be called by crt0, which can be used to implement
-     * _minimal_ deconstructor support or to call __libc_fini_array is really really required. */
-
-    /*
-     * __fini_array_start = .;
-     * KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
-     * KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
-     * __fini_array_end = .;
-     */
-
-
     /* constant data like strings */
-
     *(.rodata .rodata.* .gnu.linkonce.r.*)
     *(.rodata1)
 
-
     /* finish section on WORD boundary */
     . = ALIGN(4);
+    __RODATA_END__ = .;
   } > rom
 
 
-  /* initialized read/write data, accessed in RAM, placed in ROM, copied during boot
-   * not part of the final executable */
-  .data :
+  /* initialized read/write data, accessed in RAM, placed in ROM, copied during boot - not part of the final executable */
+  .data : ALIGN(4)
   {
     __DATA_BEGIN__ = .;
     __SDATA_BEGIN__ = .;
@@ -170,22 +141,18 @@ SECTIONS
     PROVIDE_HIDDEN (__tdata_start = .);
     *(.tdata .tdata.* .gnu.linkonce.td.*)
 
-
     /* finish section on WORD boundary */
     . = ALIGN(4);
-
-    _edata = .; PROVIDE (edata = .);
-    . = .;
+    _edata = .;
+    PROVIDE (edata = .);
     __DATA_END__ = .;
     __global_pointer$ = __DATA_END__ + 0x800;
-
   } > ram AT > rom
 
 
   /* zero/non-initialized read/write data placed in RAM - not part of the final executable */
-  .bss (NOLOAD):
+  .bss (NOLOAD): ALIGN(4)
   {
-    . = ALIGN(4);
     __BSS_START__ = .;
     *(.dynsbss)
     *(.sbss .sbss.* .gnu.linkonce.sb.*)
@@ -207,17 +174,20 @@ SECTIONS
        pad the .data section.  */
     . = ALIGN(. != 0 ? 32 / 8 : 1);
 
+    /* finish section on WORD boundary */
     . = ALIGN(4);
     __BSS_END__ = .;
     _end = .; PROVIDE (end = .);
   } > ram
 
 
-  /* heap for dynamic memory allocation (use carefully!) -  not part of the final executable */
-  .heap :
+  /* heap for dynamic memory allocation (use carefully!) - not part of the final executable */
+  .heap : ALIGN(4)
   {
     PROVIDE(__heap_start = .);
     . = __heap_size;
+    /* finish section on WORD boundary */
+    . = ALIGN(4);
     PROVIDE(__heap_end = .);
   } > ram
 


### PR DESCRIPTION
This PR modifies the default NEORV32 linker script and start-up code (crt0):

* all relevant sections start and end on a 32-bit (word) aligned boundary
* crt0 can use word-level memory operations instead of byte-level memory operations to initialize `.data` and clear `.bss` sections (faster booting / start-up!)