### PR TITLE
🐛 Fix sync. vs. async. exception collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 29.05.2022 | 1.7.1.9 | :bug: fixed bug in **CPU trap logic**: collision of synchronous and asynchronous exceptions; [#327](https://github.com/stnolting/neorv32/pull/327) |
 | 19.05.2022 | 1.7.1.8 | :bug: fixed bug in **XIP** address conversion logic: sub-word read accesses (half-word, byte) returned wrong data; [#320](https://github.com/stnolting/neorv32/pull/320) |
 | 17.05.2022 | 1.7.1.7 | :sparkles: add optional/configurable data FIFO to **TRNG**; new top generic `IO_TRNG_FIFO`; [#316](https://github.com/stnolting/neorv32/pull/316) |
 | 13.05.2022 | 1.7.1.6 | :bug: fixed bug in **BUSKEEPER** timeout logic; [#315](https://github.com/stnolting/neorv32/pull/315) |

--- a/docs/userguide/debugging_with_ocd.adoc
+++ b/docs/userguide/debugging_with_ocd.adoc
@@ -249,11 +249,12 @@ Breakpoint 1, 0x00000690 in neorv32_cpu_delay_ms ()
 Continuing.
 --------------------------
 
-.BREAK instructions in your program code
+.Hardcoded EBREAK Instructions In The Program Code
 [TIP]
 If your original application code uses the BREAK instruction (for example for some OS calls/signaling) this
 instruction will cause an enter to debug mode when executed. These situation cannot be continued using gdb's
-`c` command and have to be "stepped-over" using the single-step command `s`.
+`c` nor can they be "stepped-over" using the single-step command `s`. You need to declare the `ebreak` instruction
+as breakpoint to be able to resume operation after executing it. See https://sourceware.org/pipermail/gdb/2021-January/049125.html
 
 
 :sectnums:

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -967,8 +967,10 @@ begin
         end if;
 
 
-      when TRAP_ENTER => -- begin trap environment; stay here for sleep mode
+      when TRAP_ENTER => -- Begin trap environment; stay here for sleep mode
       -- ------------------------------------------------------------
+        -- this also serves as additional "delay" cycle to wait for (other) potential sync. exceptions
+        -- to reach the trap controller logic (issue #325)
         if (trap_ctrl.env_start = '1') then -- trap triggered?
           execute_engine.state_nxt <= TRAP_START;
         end if;
@@ -1541,8 +1543,7 @@ begin
 
         -- trap environment control --
         if (trap_ctrl.env_start = '0') then -- no started trap handler yet
-          if ((trap_ctrl.exc_fire = '1')) or
-             ((trap_ctrl.irq_fire = '1') and (trap_ctrl.irq_pend = '1')) then
+          if ((trap_ctrl.exc_fire = '1')) or ((trap_ctrl.irq_fire = '1') and (trap_ctrl.irq_pend = '1')) then
             trap_ctrl.env_start <= '1'; -- now execute engine can start trap handler
           end if;
         else -- trap environment ready to start
@@ -1620,8 +1621,8 @@ begin
 
     -- ----------------------------------------------------------------------------------------
     -- (re-)enter debug mode requests: basically, these are standard traps that have some
-    -- special handling - they have the highest INTERRUPT priority in order to go to debug when requested
-    -- even if other IRQs are pending right now
+    -- special handling - they have the highest INTERRUPT priority in order to go to debug
+    -- when requested even if other IRQs are pending right now
     -- ----------------------------------------------------------------------------------------
 
     -- evaluate ASYNC entry exceptions first!

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1625,7 +1625,14 @@ begin
     -- when requested even if other IRQs are pending right now
     -- ----------------------------------------------------------------------------------------
 
-    -- evaluate ASYNC entry exceptions first!
+    -- hardware trigger (sync) --
+    elsif (CPU_EXTENSION_RISCV_DEBUG = true) and (trap_ctrl.exc_buf(exc_db_hw_c) = '1') then
+      trap_ctrl.cause_nxt <= trap_db_hw_c;
+
+    -- break instruction (sync) --
+    elsif (CPU_EXTENSION_RISCV_DEBUG = true) and (trap_ctrl.exc_buf(exc_db_break_c) = '1') then
+      trap_ctrl.cause_nxt <= trap_db_break_c;
+
 
     -- external halt request (async) --
     elsif (CPU_EXTENSION_RISCV_DEBUG = true) and (trap_ctrl.irq_buf(irq_db_halt_c) = '1') then
@@ -1634,15 +1641,6 @@ begin
     -- single stepping (async) --
     elsif (CPU_EXTENSION_RISCV_DEBUG = true) and (trap_ctrl.irq_buf(irq_db_step_c) = '1') then
       trap_ctrl.cause_nxt <= trap_db_step_c;
-
-
-    -- hardware trigger (sync) --
-    elsif (CPU_EXTENSION_RISCV_DEBUG = true) and (trap_ctrl.exc_buf(exc_db_hw_c) = '1') then
-      trap_ctrl.cause_nxt <= trap_db_hw_c;
-
-    -- break instruction (sync) --
-    elsif (CPU_EXTENSION_RISCV_DEBUG = true) and (trap_ctrl.exc_buf(exc_db_break_c) = '1') then
-      trap_ctrl.cause_nxt <= trap_db_break_c;
 
     -- ----------------------------------------------------------------------------------------
     -- custom FAST interrupts (*asynchronous* exceptions)

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1202,8 +1202,9 @@ begin
       -- ------------------------------------------------------------
         ctrl_nxt(ctrl_rf_mux1_c downto ctrl_rf_mux0_c) <= rf_mux_mem_c; -- memory read data
         -- wait for memory response --
-        if (trap_ctrl.env_start = '1') and (trap_ctrl.cause(6 downto 5) = "00") then -- abort if SYNC non-debug EXCEPTION (bus or illegal)
-          execute_engine.state_nxt <= DISPATCH;
+        if (trap_ctrl.exc_buf(exc_laccess_c) = '1') or (trap_ctrl.exc_buf(exc_saccess_c) = '1') or -- bus error exception
+           (trap_ctrl.exc_buf(exc_lalign_c) = '1') or (trap_ctrl.exc_buf(exc_salign_c) = '1') then -- alignment error exception
+          execute_engine.state_nxt <= DISPATCH; -- abort!
         elsif (bus_d_wait_i = '0') then -- wait for bus to finish transaction
           if (execute_engine.i_reg(instr_opcode_msb_c-1) = '0') then -- load
             ctrl_nxt(ctrl_rf_wb_en_c) <= '1'; -- data write-back

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -68,7 +68,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070108"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070109"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -638,15 +638,22 @@ int main() {
   // ----------------------------------------------------------
   neorv32_cpu_csr_write(CSR_MCAUSE, 0);
   PRINT_STANDARD("[%i] BREAK EXC ", cnt_test);
-  cnt_test++;
 
-  asm volatile("EBREAK");
+  // skip on real hardware since ebreak will make problems when running this test program via gdb
+  if ((NEORV32_SYSINFO.SOC & (1<<SYSINFO_SOC_IS_SIM)) == 0) {
+    cnt_test++;
 
-  if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_BREAKPOINT) {
-    test_ok();
+    asm volatile("EBREAK");
+
+    if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_BREAKPOINT) {
+      test_ok();
+    }
+    else {
+      test_fail();
+    }
   }
   else {
-    test_fail();
+    PRINT_STANDARD("<skipped>\n");
   }
 
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -640,7 +640,7 @@ int main() {
   PRINT_STANDARD("[%i] BREAK EXC ", cnt_test);
 
   // skip on real hardware since ebreak will make problems when running this test program via gdb
-  if ((NEORV32_SYSINFO.SOC & (1<<SYSINFO_SOC_IS_SIM)) == 0) {
+  if (NEORV32_SYSINFO.SOC & (1<<SYSINFO_SOC_IS_SIM)) {
     cnt_test++;
 
     asm volatile("EBREAK");

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -840,6 +840,7 @@ int main() {
 
   // disable interrupt
   neorv32_cpu_irq_disable(CSR_MIE_MSIE);
+  sim_irq_trigger(0);
 
   if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_MSI) {
     test_ok();
@@ -869,6 +870,7 @@ int main() {
 
   // enable interrupt
   neorv32_cpu_irq_disable(CSR_MIE_MEIE);
+  sim_irq_trigger(0);
 
   if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_MEI) {
     test_ok();
@@ -1743,15 +1745,13 @@ void __attribute__((naked)) goto_user_mode(void) {
 
 
 /**********************************************************************//**
- * Simulation-based function to trigger CPU interrupts (MSI, MEI).
+ * Simulation-based function to set/clear CPU interrupts (MSI, MEI).
  *
  * @param[in] sel IRQ select mask (bit positions according to #NEORV32_CSR_MIE_enum).
  **************************************************************************/
 void sim_irq_trigger(uint32_t sel) {
 
   *(IO_REG32 (0xFF000000)) = sel;
-  asm volatile("nop"); // interrupt should kick in here (latest)
-  *(IO_REG32 (0xFF000000)) = 0;
 }
 
 


### PR DESCRIPTION
This PR aims to fix the collision of synchronous exceptions and asynchronous exceptions (interrupt) as described in #325 by @GideonZ. PR #326 might also fix that issue.