### PR TITLE
:bug: fix SPI & XIP clock phase offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 03.06.2022 | 1.7.2.3 | :bug: fixed bug in **SPI** and **XIP** modules: noticeable phase offset between SPI clock and SPI data when using minimal SPI clock prescalers; [#336](https://github.com/stnolting/neorv32/pull/336) |
 | 03.06.2022 | 1.7.2.2 | :sparkles: (finally) added a **dedicated hardware reset** to all IO/peripheral devices; [#334](https://github.com/stnolting/neorv32/pull/334) |
 | 02.06.2022 | 1.7.2.1 | :sparkles: add **watchdog** pause flag to stop watchdog timeout counter when CPU is in sleep mode; [#331](https://github.com/stnolting/neorv32/pull/331) |
 | 02.06.2022 | [**:rocket:1.7.2**](https://github.com/stnolting/neorv32/releases/tag/v1.7.2) | **New release** |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
-| 03.06.2022 | 1.7.2.3 | :bug: fixed bug in **SPI** and **XIP** modules: noticeable phase offset between SPI clock and SPI data when using minimal SPI clock prescalers; [#336](https://github.com/stnolting/neorv32/pull/336) |
+| 04.06.2022 | 1.7.2.3 | :bug: fixed bug in **SPI** and **XIP** modules: phase offset between SPI clock and SPI data; [#336](https://github.com/stnolting/neorv32/pull/336) |
 | 03.06.2022 | 1.7.2.2 | :sparkles: (finally) added a **dedicated hardware reset** to all IO/peripheral devices; [#334](https://github.com/stnolting/neorv32/pull/334) |
 | 02.06.2022 | 1.7.2.1 | :sparkles: add **watchdog** pause flag to stop watchdog timeout counter when CPU is in sleep mode; [#331](https://github.com/stnolting/neorv32/pull/331) |
 | 02.06.2022 | [**:rocket:1.7.2**](https://github.com/stnolting/neorv32/releases/tag/v1.7.2) | **New release** |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -68,7 +68,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070202"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070203"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/rtl/core/neorv32_xip.vhd
+++ b/rtl/core/neorv32_xip.vhd
@@ -488,15 +488,14 @@ begin
         ctrl.di_sync <= '-';
       else
         -- defaults --
-        spi_clk_o    <= cf_cpol_i;
-        spi_csn_o    <= '1'; -- de-selected by default
-        ctrl.di_sync <= spi_data_i;
+        spi_csn_o <= '1'; -- de-selected by default
 
         -- fsm --
         case ctrl.state is
 
           when S_IDLE => -- wait for new transmission trigger
           -- ------------------------------------------------------------
+            spi_clk_o   <= cf_cpol_i;
             ctrl.bitcnt <= op_nbytes_i & "000"; -- number of bytes
             ctrl.csen   <= op_csen_i;
             if (op_start_i = '1') then
@@ -508,27 +507,32 @@ begin
           -- ------------------------------------------------------------
             spi_csn_o <= not ctrl.csen;
             if (spi_clk_en_i = '1') then
+              if (cf_cpha_i = '1') then -- clock phase shift
+                spi_clk_o <= not cf_cpol_i;
+              end if;
               ctrl.state <= S_RTX_A;
             end if;
 
           when S_RTX_A => -- first half of bit transmission
           -- ------------------------------------------------------------
             spi_csn_o <= not ctrl.csen;
-            spi_clk_o <= cf_cpha_i xor cf_cpol_i;
             if (spi_clk_en_i = '1') then
-              ctrl.bitcnt <= std_ulogic_vector(unsigned(ctrl.bitcnt) - 1);
-              ctrl.state  <= S_RTX_B;
+              spi_clk_o    <= not (cf_cpha_i xor cf_cpol_i);
+              ctrl.di_sync <= spi_data_i;
+              ctrl.bitcnt  <= std_ulogic_vector(unsigned(ctrl.bitcnt) - 1);
+              ctrl.state   <= S_RTX_B;
             end if;
 
           when S_RTX_B => -- second half of bit transmission
           -- ------------------------------------------------------------
             spi_csn_o <= not ctrl.csen;
-            spi_clk_o <= not (cf_cpha_i xor cf_cpol_i);
             if (spi_clk_en_i = '1') then
               ctrl.sreg <= ctrl.sreg(ctrl.sreg'left-1 downto 0) & ctrl.di_sync;
               if (or_reduce_f(ctrl.bitcnt) = '0') then -- all bits transferred?
+                spi_clk_o  <= cf_cpol_i;
                 ctrl.state <= S_DONE; -- transmission done
               else
+                spi_clk_o  <= cf_cpha_i xor cf_cpol_i;
                 ctrl.state <= S_RTX_A; -- next bit
               end if;
             end if;


### PR DESCRIPTION
This PR fixes the SPI phase offset problem (between SPI clock and SPI data_in/data_out) as described in #335 by @andkae. The XIP module is also affected by this bug and is also fixed by this PR.

ℹ️ This bug is only relevant only when using the SPI/XIP interface at very high clock speeds that are close to the processor's main clock (small clock prescaler or high-speed mode enabled).