### PR TITLE
[rtl] rework reset system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 11.06.2022 | 1.7.2.7 | reworked processor **reset system**; :warning: changed behavior of **watchdog's** "lock" bit; add watchdog "access password"; [#345](https://github.com/stnolting/neorv32/pull/345) |
 | 10.06.2022 | 1.7.2.6 | **Wishbone** interface now _gates_ all outgoing signals (= signals remain stable if there is no active Wishbone access); [#344](https://github.com/stnolting/neorv32/pull/344) |
 | 09.06.2022 | 1.7.2.5 | reworked **TWI** module fixing several interface timing issues; :warning: removed "START condition done interrupt" and "STOP condition done interrupt"; [#340](https://github.com/stnolting/neorv32/pull/340) |
 | 06.06.2022 | 1.7.2.4 | split executable images into package and body; [#338](https://github.com/stnolting/neorv32/pull/338) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -59,7 +59,7 @@ bits/channels are hardwired to zero.
 [options="header",grid="rows"]
 |=======================
 | Signal | Width | Dir. | Function
-4+^| **Global Control**
+4+^| **Global Control (<<_processor_clocking>> and <<_processor_reset>>)**
 | `clk_i` | 1 | in | global clock line, all registers triggering on rising edge
 | `rstn_i` | 1 | in | global reset, asynchronous, **low-active**
 4+^| **JTAG Access Port for <<_on_chip_debugger_ocd>>**
@@ -1075,6 +1075,94 @@ See section <<_execute_in_place_module_xip>> for more information.
 <<<
 // ####################################################################################################################
 :sectnums:
+=== Processor Clocking
+
+The processor is implemented as fully-synchronous logic design using a _single clock domain_ that is driven by the top's
+`clk_i` signal. This clock signal is used by all internal registers and memories, which trigger on the rising edge of
+this clock signal. External "clocks" like the OCD's JTAG clock or the TWI's serial clock are synchronized into the
+processor's clock domain before being further processed.
+
+[NOTE]
+The registers of the <<_processor_reset>> system trigger on a falling clock edge.
+
+Many processor modules like the UARTs or the timers require a programmable time base for operations. In order to simplify
+the hardware, the processor implements a global "clock generator" that provides _clock enables_ for certain frequencies.
+These clock enable signals are synchronous to the system's main clock and will be high for only a single cycle of this main
+clock. Hence, processor modules can use these signals for sub-main-clock operations while still having a single clock domain
+only. 
+
+In total, 8 sub-main-clock signals are available. All processor modules, which feature a time-based configuration, provide a
+programmable three-bit prescaler select in their according control register to select one of the 8 available clocks. The
+mapping of the prescaler select bits to the according clock source is shown in the table below. Here, _f_ represents the
+processor main clock from the top entity's `clk_i` signal.
+
+[cols="<3,^1,^1,^1,^1,^1,^1,^1,^1"]
+[grid="rows"]
+|=======================
+| Prescaler bits:  | `0b000` | `0b001` | `0b010` | `0b011` | `0b100` | `0b101` | `0b110` | `0b111`
+| Resulting clock: | _f/2_   | _f/4_   | _f/8_   | _f/64_  | _f/128_ | _f/1024_| _f/2048_| _f/4096_
+|=======================
+
+The software framework provides pre-defined aliases for the prescaler select bits:
+
+.Prescaler Aliases from `neorv32.h`
+[source]
+--------------------------
+enum NEORV32_CLOCK_PRSC_enum {
+  CLK_PRSC_2    = 0, /**< CPU_CLK (from clk_i top signal) / 2 */
+  CLK_PRSC_4    = 1, /**< CPU_CLK (from clk_i top signal) / 4 */
+  CLK_PRSC_8    = 2, /**< CPU_CLK (from clk_i top signal) / 8 */
+  CLK_PRSC_64   = 3, /**< CPU_CLK (from clk_i top signal) / 64 */
+  CLK_PRSC_128  = 4, /**< CPU_CLK (from clk_i top signal) / 128 */
+  CLK_PRSC_1024 = 5, /**< CPU_CLK (from clk_i top signal) / 1024 */
+  CLK_PRSC_2048 = 6, /**< CPU_CLK (from clk_i top signal) / 2048 */
+  CLK_PRSC_4096 = 7  /**< CPU_CLK (from clk_i top signal) / 4096 */
+};
+--------------------------
+
+[TIP]
+If no peripheral modules requires a clock signal from the internal generator (all available modules disabled by clearing the
+_enable_ bit in the according module's control register), it is automatically deactivated to reduce dynamic power consumption.
+
+
+
+<<<
+// ####################################################################################################################
+:sectnums:
+=== Processor Reset
+
+The processor provides two reset systems: an _external_ one and an _internal_ one. The external reset is triggered by
+the asynchronous, low-active `rstn_i` top entity signal. The internal reset is a synchronous, low-active reset that
+can be triggered by the external reset, the <<_on_chip_debugger_ocd>> and the <<_watchdog_timer_wdt>>.
+
+If the external hardware reset (`rstn_i`) is active it will be _asynchronously_ applied to all processor modules. An
+internal shift register ensures that the system wide reset will be active for at least 4 clock cycles. After that,
+the system wide reset is de-asserted _synchronously_ at a _falling_ edge of the main clock to ensure there are no
+meta-stable situation (like de-asserting reset at a rising edge).
+
+If one of the internal reset sources trigger a reset, this will be applied _synchronously_ to all processor modules
+at a rising edge. This signal is also extended to be active for at least 4 clock cycles. After that, the system wide
+reset is also de-asserted _synchronously_ at a _falling_ edge.
+
+[TIP]
+The EE Times provided a nice article about FPGA resets. The reset system of the NEORV32 is loosely based on this
+article: https://www.eetimes.com/how-do-i-reset-my-fpga/
+
+The system-wide reset will reset the CPU, the <<_processor_clocking>> system and the IO/peripheral devices.
+
+[NOTE]
+Note that the system reset will **NOT** reset _all_ PCU register by default. See section <<_cpu_hardware_reset>>
+for more information.
+
+[NOTE]
+The system reset will only reset the control registers of each implemented IO/peripheral module. This will also
+reset the according "module enable flag" to zero, which - in turn - will cause a _synchronous_ and
+module-internal reset of the remaining logic.
+
+
+<<<
+// ####################################################################################################################
+:sectnums:
 === Processor Interrupts
 
 The NEORV32 Processor provides several interrupt request signals (IRQs) for custom platform use.
@@ -1372,40 +1460,7 @@ exited as soon as the application logic has finished initializing the memory wit
 
 Basically, the NEORV32 processor is a SoC consisting of the NEORV32 CPU, peripheral/IO devices, embedded
 memories, an external memory interface and a bus infrastructure to interconnect all units. Additionally, the
-system implements an internal reset generator and a global clock generator/divider.
-
-
-**Internal Reset Generator**
-
-The internal reset generator is responsible for controlling the processor-global system reset.
-This system reset is either triggered via the external reset pin (`rstn_i`, low-active), by the internal
-watchdog timer (if implemented) or by the on-chip debugger (if implemented). If any of those sources issues
-an active reset the system reset is activated for at least 4 cycles.
-
-
-**Internal Clock Divider**
-
-An internal clock divider generates 8 clock signals derived from the processor's main clock input `clk_i`.
-These derived clock signals are not actual _clock signals_. Instead, they are derived from a simple counter and
-can be used as "clock enable" signal by the different processor modules. Thus, the whole processor operates using
-only the main clock signal (single clock domain). Some of the processor peripherals like the Watchdog or the
-UARTs can select one of the derived clock enabled signals for their internal operations.
-
-[TIP]
-If none of the peripheral modules require a clock signal from the internal divider, it is automatically deactivated
-to reduce dynamic power consumption.
-
-Peripheral devices, which feature a time-based configuration, provide a three-bit prescaler select in their
-according control register to select one of the eight available clocks. The mapping of the prescaler select
-bits to the according clock source is shown in the table below. Here, _f_ represents the processor main clock
-from the top entity's `clk_i` signal.
-
-[cols="<3,^1,^1,^1,^1,^1,^1,^1,^1"]
-[grid="rows"]
-|=======================
-| Prescaler bits:  | `0b000` | `0b001` | `0b010` | `0b011` | `0b100` | `0b101` | `0b110` | `0b111`
-| Resulting clock: | _f/2_   | _f/4_   | _f/8_   | _f/64_  | _f/128_ | _f/1024_| _f/2048_| _f/4096_
-|=======================
+system implements an internal reset generator (-> <<_processor_reset>>) and a global clock system (-> <<_processor_clocking>>).
 
 
 **Peripheral / IO Devices**
@@ -1415,7 +1470,7 @@ address _0xFFFFFE00_. A region of 512 bytes is reserved for this devices. Hence,
 accessed using a memory-mapped scheme. A special linker script as well as the NEORV32 core software
 library abstract the specific memory layout for the user.
 
-.Address Space Mapping
+.Module Address Space Mapping
 [IMPORTANT]
 The base address of each component/module has to be aligned to the
 total size of the module's occupied address space! The occupied address space
@@ -1428,19 +1483,18 @@ All peripheral/IO devices can only be written in full-word mode (i.e. 32-bit). B
 Processor-internal memories as well as modules connected to the external memory interface can still
 be written with a byte-wide granularity.
 
-.Unimplemented Modules
+.Unimplemented Modules / "Address Holes"
 [NOTE]
-When accessing an IO device that hast not been implemented (disabled via the according generic), a
-load or store access fault exception is triggered.
+When accessing an IO device that hast not been implemented (disabled via the according generic)
+or when accessing an address that is _unused_, a load or store access fault exception is raise.
 
 .Module Reset
 [NOTE]
-All processor-internal modules provide a dedicated hardware reset, which can be triggered by the external reset
-signal, the watchdog timer or the on-chip debugger. When active, the system-wide reset will ensure that all
-**module interface register** (like the control register) are reset to all-zero. Note that this hardware reset
-does not _directly_ reset the remaining module's logic - the internal logic is reset _synchronously_ when the
+All processor-internal modules provide a dedicated hardware reset, which is triggered by the <<_processor_reset>>
+system. When active, the system-wide reset will reset all module's _control registers_ to all-zero. Note that this
+hardware reset does not _directly_ reset the remaining module's logic - the internal logic is reset _synchronously_ when the
 enable bit in the according unit's control register is cleared. Software can trigger a module reset
-by clearing the enable bit of the module's control register.
+by clearing the enable bit of the module's control register. See section <<_processor_reset>> for more information.
 
 .Software Access
 [TIP]
@@ -1458,9 +1512,10 @@ A CMSIS-SVD-compatible **System View Description (SVD)** file including all peri
 Most peripheral/IO devices provide some kind of interrupt (for example to signal available incoming data). These
 interrupts are entirely mapped to the CPU's <<_custom_fast_interrupt_request_lines>>. Note that all these
 interrupt lines are high-active and are permanently triggered until the IRQ-causing condition is resolved.
+See section <<_processor_interrupts>> for more information.
 
 
-**Nomenclature for the Peripheral / IO Devices Listing**
+**Nomenclature for Peripheral / IO Devices Listing**
 
 Each peripheral device chapter features a register map showing accessible control and data registers of the
 according device including the implemented control and status bits. C-language code can directly interact with these

--- a/docs/datasheet/soc_wdt.adoc
+++ b/docs/datasheet/soc_wdt.adoc
@@ -25,7 +25,8 @@ a system reset or an interrupt is generated depending on the configured operatio
 
 Whenever the watchdog control register `NEORV32_WDT.CTRL` shall be written the upper-most (MSB-aligned) 16 bit of the
 write data have to contain the "watchdog access password". If the password is incorrect the write access is entirely ignored
-and will not cause any side effects.
+and the watchdog hardware module will **not acknowledge** the bus write access leading to a **store access fault exception**.
+Read accesses are not affected by the access password at all.
 
 * Watchdog access password (`write_data[31:16]`) = **`0xCA36`**
 
@@ -115,5 +116,5 @@ or the watchdog itself (if _WDT_CTRL_MODE_ is set).
                                               <|`10` _WDT_CTRL_HALF_    ^| r/- ^| `0` ^| -   <| set if at least half of the max. timeout counter value has been reached
                                               <|`11` _WDT_CTRL_PAUSE_   ^| r/w ^| `0` ^| no  <| pause WDT when CPU is in sleep mode
                                               <|`15:12` -               ^| r/- ^| -   ^| -   <| _reserved_, reads as zero
-                                              <|`31:16` _WDT_CTRL_PWD_  ^| -/w ^| -   ^| -   <| watchdog password, has to be `0xCA36` - otherwise any write access is ignored, reads as zero
+                                              <|`31:16` _WDT_CTRL_PWD_  ^| -/w ^| -   ^| -   <| watchdog write access password, has to be `0xCA36`, reads as zero
 |=======================

--- a/docs/datasheet/soc_wdt.adoc
+++ b/docs/datasheet/soc_wdt.adoc
@@ -16,9 +16,21 @@
 
 **Theory of Operation**
 
-The watchdog (WDT) provides a last resort for safety-critical applications. The WDT has an internal 20-bit
+The watchdog (WDT) provides a last resort for safety-critical applications. The WDT provides an internal 20-bit
 wide counter that needs to be reset every now and then by the user program. If the counter overflows, either
 a system reset or an interrupt is generated depending on the configured operation mode.
+
+
+**Access Password**
+
+Whenever the watchdog control register `NEORV32_WDT.CTRL` shall be written the upper-most (MSB-aligned) 16 bit of the
+write data have to contain the "watchdog access password". If the password is incorrect the write access is entirely ignored
+and will not cause any side effects.
+
+* Watchdog access password (`write_data[31:16]`) = **`0xCA36`**
+
+
+**Timeout Configuration**
 
 The watchdog is enabled by setting the control register's `WDT_CTRL_EN_ bit. The clock used to increment the
 internal counter is selected via the 3-bit _WDT_CTRL_CLK_SELx_ prescaler:
@@ -38,26 +50,26 @@ internal counter is selected via the 3-bit _WDT_CTRL_CLK_SELx_ prescaler:
 |=======================
 
 The _WDT_CTRL_HALF_ flag of the control register `CTRL` indicates that at least half of the maximum timeout
-value has already been reached. The watchdog is reset by setting the _WDT_CTRL_RESET_ bit.
+value has already been reached. The watchdog is "fed" by setting the _WDT_CTRL_RESET_ control register bit, which
+will reset the timeout counter.
+
+
+**Watchdog Action**
 
 Whenever the internal counter overflows the watchdog executes one of two possible actions: either a hard
 processor reset is triggered or an interrupt is requested via the CPU's fast interrupt channel #0. The
-_WDT_CTRL_MODE_ bit defines the action to be taken on an overflow: when cleared, the Watchdog will assert an
+_WDT_CTRL_MODE_ bit defines the action to be taken on an overflow: when cleared, the watchdog will assert an
 IRQ, when set the WDT will cause a system wide reset. The configured action can also be triggered manually at
 any time by setting the _WDT_CTRL_FORCE_ bit.
 
+The cause of the last system reset can be determined via the _WDT_CTRL_RCAUSE_ flag. If this flag is
+zero, the processor has been reset via the external reset signal (or the on-chip debugger). If this flag is set
+the last system reset was caused by the watchdog itself.
+
+.Watchdog Interrupt
 [NOTE]
 A watchdog interrupt can only occur if the watchdog is enabled and interrupt mode is enabled.
 A triggered interrupt has to be cleared again by writing zero to the according <<_mip>> CSR bit.
-
-The cause of the last system reset can be determined via the _WDT_CTRL_RCAUSE_ flag. If this flag is
-zero, the processor has been reset via the external reset signal. If this flag is set the last system reset was
-initiated by the watchdog.
-
-The Watchdog control register can be locked in order to protect the current configuration. The lock is
-activated by setting the _WDT_CTRL_LOCK_ bit. In the locked state any write access to the configuration flags is
-ignored (see table below, "writable if locked"). Read accesses to the control register are not effected. The
-lock can only be removed by a system reset (via external reset signal or via a watchdog reset action).
 
 .Watchdog Operation during Debugging
 [IMPORTANT]
@@ -72,6 +84,17 @@ By default the watchdog keeps operating when the CPU enters sleep mode. However,
 the CPU is sleeping by setting the _WDT_CTRL_PAUSE_ control register bit.
 
 
+**Configuration Lock**
+
+The watchdog control register can be locked to protect the current configuration from being modified. The lock is activated by
+setting the _WDT_CTRL_LOCK_ bit. In the locked state any write access to the control register's configuration flags is
+ignored (see table below, "writable if locked"). Read accesses to the control register as well as watchdog resets (_WDT_CTRL_RESET_)
+and forced watchdog actions (_WDT_CTRL_FORCE_) are not affected.
+
+The lock is removed by a system reset, which can be triggered via the external hardware reset signal, the on-chip debugger
+or the watchdog itself (if _WDT_CTRL_MODE_ is set).
+
+
 **Register Map**
 
 .WDT register map (`struct NEORV32_WDT`)
@@ -79,7 +102,7 @@ the CPU is sleeping by setting the _WDT_CTRL_PAUSE_ control register bit.
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Reset value | Writable if locked | Function
-.12+<| `0xffffffbc` .12+<| `NEORV32_WDT.CTRL` <|`0` _WDT_CTRL_EN_       ^| r/w ^| `0` ^| no  <| watchdog enable
+.14+<| `0xffffffbc` .14+<| `NEORV32_WDT.CTRL` <|`0` _WDT_CTRL_EN_       ^| r/w ^| `0` ^| no  <| watchdog enable
                                               <|`1` _WDT_CTRL_CLK_SEL0_ ^| r/w ^| `0` ^| no  .3+<| 3-bit clock prescaler select
                                               <|`2` _WDT_CTRL_CLK_SEL1_ ^| r/w ^| `0` ^| no 
                                               <|`3` _WDT_CTRL_CLK_SEL2_ ^| r/w ^| `0` ^| no 
@@ -91,4 +114,6 @@ the CPU is sleeping by setting the _WDT_CTRL_PAUSE_ control register bit.
                                               <|`9` _WDT_CTRL_DBEN_     ^| r/w ^| `0` ^| no  <| allow WDT to continue operation even when CPU is in debug mode
                                               <|`10` _WDT_CTRL_HALF_    ^| r/- ^| `0` ^| -   <| set if at least half of the max. timeout counter value has been reached
                                               <|`11` _WDT_CTRL_PAUSE_   ^| r/w ^| `0` ^| no  <| pause WDT when CPU is in sleep mode
+                                              <|`15:12` -               ^| r/- ^| -   ^| -   <| _reserved_, reads as zero
+                                              <|`31:16` _WDT_CTRL_PWD_  ^| -/w ^| -   ^| -   <| watchdog password, has to be `0xCA36` - otherwise any write access is ignored, reads as zero
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -1665,7 +1665,8 @@ package neorv32_package is
     port (
       -- host access --
       clk_i       : in  std_ulogic; -- global clock line
-      rstn_i      : in  std_ulogic; -- global reset line, low-active, async
+      rstn_ext_i  : in  std_ulogic; -- external reset line, low-active, async
+      rstn_int_i  : in  std_ulogic; -- internal reset line, low-active, async
       rden_i      : in  std_ulogic; -- read enable
       wren_i      : in  std_ulogic; -- write enable
       addr_i      : in  std_ulogic_vector(31 downto 0); -- address
@@ -1680,7 +1681,7 @@ package neorv32_package is
       clkgen_i    : in  std_ulogic_vector(07 downto 0);
       -- timeout event --
       irq_o       : out std_ulogic; -- timeout IRQ
-      rstn_o      : out std_ulogic  -- timeout reset, low_active
+      rstn_o      : out std_ulogic  -- timeout reset, low_active, sync
     );
   end component;
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -68,7 +68,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070206"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070207"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -1665,7 +1665,7 @@ package neorv32_package is
     port (
       -- host access --
       clk_i       : in  std_ulogic; -- global clock line
-      rstn_i      : in  std_ulogic; -- global reset line, low-active
+      rstn_i      : in  std_ulogic; -- global reset line, low-active, async
       rden_i      : in  std_ulogic; -- read enable
       wren_i      : in  std_ulogic; -- write enable
       addr_i      : in  std_ulogic_vector(31 downto 0); -- address
@@ -1680,7 +1680,7 @@ package neorv32_package is
       clkgen_i    : in  std_ulogic_vector(07 downto 0);
       -- timeout event --
       irq_o       : out std_ulogic; -- timeout IRQ
-      rstn_o      : out std_ulogic  -- timeout reset, low_active, use it as async!
+      rstn_o      : out std_ulogic  -- timeout reset, low_active
     );
   end component;
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -245,10 +245,11 @@ architecture neorv32_top_rtl of neorv32_top is
   constant io_slink_en_c : boolean := boolean(SLINK_NUM_RX > 0) or boolean(SLINK_NUM_TX > 0); -- implement slink at all?
 
   -- reset generator --
-  signal ext_rstn_sync : std_ulogic_vector(3 downto 0) := (others => '0'); -- initialize (=reset) via bitstream (for FPGAs only)
-  signal ext_rstn      : std_ulogic;
-  signal sys_rstn      : std_ulogic;
-  signal wdt_rstn      : std_ulogic;
+  signal rstn_ext_sreg : std_ulogic_vector(3 downto 0) := (others => '0'); -- initialize (reset) via bitstream
+  signal rstn_int_sreg : std_ulogic_vector(3 downto 0) := (others => '0'); -- initialize (reset) via bitstream
+  signal rstn_ext      : std_ulogic;
+  signal rstn_int      : std_ulogic;
+  signal rstn_wdt      : std_ulogic;
 
   -- clock generator --
   signal clk_div       : std_ulogic_vector(11 downto 0);
@@ -430,7 +431,7 @@ begin
 
 
 -- ****************************************************************************************************************************
--- Clock/Reset System
+-- Clock and Reset System
 -- ****************************************************************************************************************************
 
 
@@ -439,29 +440,31 @@ begin
   reset_generator: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      ext_rstn_sync <= (others => '0');
-      ext_rstn      <= '0';
-      sys_rstn      <= '0';
-    elsif rising_edge(clk_i) then
-      -- keep internal reset active for at least <ext_rstn_sync'size> clock cycles --
-      ext_rstn_sync <= ext_rstn_sync(ext_rstn_sync'left-1 downto 0) & '1';
-      -- beautified external reset signal --
-      if (and_reduce_f(ext_rstn_sync) = '1') then
-        ext_rstn <= '1';
+      rstn_ext_sreg <= (others => '0');
+      rstn_int_sreg <= (others => '0');
+      rstn_ext      <= '0';
+      rstn_int      <= '0';
+    elsif falling_edge(clk_i) then -- inverted clock to release reset _before_ all FFs trigger (rising edge)
+      -- external reset --
+      rstn_ext_sreg <= rstn_ext_sreg(rstn_ext_sreg'left-1 downto 0) & '1'; -- active for at least <rstn_ext_sreg'size> clock cycles
+      -- internal reset --
+      if (rstn_wdt = '0') or (dci_ndmrstn = '0') then -- sync reset sources
+        rstn_int_sreg <= (others => '0');
       else
-        ext_rstn <= '0';
+        rstn_int_sreg <= rstn_int_sreg(rstn_int_sreg'left-1 downto 0) & '1'; -- active for at least <rstn_int_sreg'size> clock cycles
       end if;
-      -- system reset: can also be triggered by watchdog and debug module --
-      sys_rstn <= ext_rstn and wdt_rstn and dci_ndmrstn;
+      -- reset nets --
+      rstn_ext <= and_reduce_f(rstn_ext_sreg); -- external reset (via reset pin)
+      rstn_int <= and_reduce_f(rstn_int_sreg); -- internal reset (via reset pin, WDT or OCD)
     end if;
   end process reset_generator;
 
 
   -- Clock Generator ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  clock_generator: process(sys_rstn, clk_i)
+  clock_generator: process(rstn_int, clk_i)
   begin
-    if (sys_rstn = '0') then
+    if (rstn_int = '0') then
       clk_gen_en_ff <= '0';
       clk_div       <= (others => '0');
       clk_div_ff    <= (others => '0');
@@ -469,7 +472,7 @@ begin
       clk_gen_en_ff <= or_reduce_f(clk_gen_en);
       if (clk_gen_en_ff = '1') then
         clk_div <= std_ulogic_vector(unsigned(clk_div) + 1);
-      else
+      else -- reset if disabled
         clk_div <= (others => '0');
       end if;
       clk_div_ff <= clk_div;
@@ -541,7 +544,7 @@ begin
   port map (
     -- global control --
     clk_i         => clk_i,       -- global clock, rising edge
-    rstn_i        => sys_rstn,    -- global reset, low-active, async
+    rstn_i        => rstn_int,    -- global reset, low-active, async
     sleep_o       => cpu_s.sleep, -- cpu is in sleep mode when set
     debug_o       => cpu_s.debug, -- cpu is in debug mode when set
     priv_o        => cpu_s.priv,  -- current effective privilege level
@@ -615,7 +618,7 @@ begin
     port map (
       -- global control --
       clk_i        => clk_i,         -- global clock, rising edge
-      rstn_i       => sys_rstn,      -- global reset, low-active, async
+      rstn_i       => rstn_int,      -- global reset, low-active, async
       clear_i      => cpu_i.fence,   -- cache clear
       miss_o       => open,          -- cache miss
       -- host controller interface --
@@ -653,7 +656,7 @@ begin
   port map (
     -- global control --
     clk_i          => clk_i,         -- global clock, rising edge
-    rstn_i         => sys_rstn,      -- global reset, low-active, async
+    rstn_i         => rstn_int,      -- global reset, low-active, async
     -- controller interface a --
     ca_bus_addr_i  => cpu_d.addr,    -- bus access address
     ca_bus_rdata_o => cpu_d.rdata,   -- bus read data
@@ -715,7 +718,7 @@ begin
   port map (
     -- host access --
     clk_i      => clk_i,                          -- global clock line
-    rstn_i     => sys_rstn,                       -- global reset line, low-active, use as async
+    rstn_i     => rstn_int,                       -- global reset line, low-active, use as async
     addr_i     => p_bus.addr,                     -- address
     rden_i     => io_rden,                        -- read enable
     wren_i     => io_wren,                        -- byte write enable
@@ -846,7 +849,7 @@ begin
     port map (
       -- global control --
       clk_i      => clk_i,                         -- global clock line
-      rstn_i     => sys_rstn,                      -- global reset line, low-active
+      rstn_i     => rstn_int,                      -- global reset line, low-active
       -- host access --
       src_i      => p_bus.src,                     -- access type (0: data, 1:instruction)
       addr_i     => p_bus.addr,                    -- address
@@ -901,7 +904,7 @@ begin
     port map (
       -- global control --
       clk_i       => clk_i,                        -- global clock line
-      rstn_i      => sys_rstn,                     -- global reset line, low-active
+      rstn_i      => rstn_int,                     -- global reset line, low-active
       -- host access: control register access port --
       ct_addr_i   => p_bus.addr,                   -- address
       ct_rden_i   => io_rden,                      -- read enable
@@ -971,7 +974,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                    -- global clock line
-      rstn_i      => sys_rstn,                 -- global reset line, low-active, use as async
+      rstn_i      => rstn_int,                 -- global reset line, low-active, use as async
       addr_i      => p_bus.addr,               -- address
       rden_i      => io_rden,                  -- read enable
       wren_i      => io_wren,                  -- word write enable
@@ -1008,7 +1011,7 @@ begin
     port map (
       -- host access --
       clk_i  => clk_i,                     -- global clock line
-      rstn_i => sys_rstn,                  -- global reset line, low-active
+      rstn_i => rstn_int,                  -- global reset line, low-active
       addr_i => p_bus.addr,                -- address
       rden_i => io_rden,                   -- read enable
       wren_i => io_wren,                   -- write enable
@@ -1038,7 +1041,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                    -- global clock line
-      rstn_i      => ext_rstn,                 -- global reset line, low-active
+      rstn_i      => rstn_ext,                 -- global reset line, low-active, async
       rden_i      => io_rden,                  -- read enable
       wren_i      => io_wren,                  -- write enable
       addr_i      => p_bus.addr,               -- address
@@ -1053,7 +1056,7 @@ begin
       clkgen_i    => clk_gen,
       -- timeout event --
       irq_o       => wdt_irq,                  -- timeout IRQ
-      rstn_o      => wdt_rstn                  -- timeout reset, low_active, use it as async!
+      rstn_o      => rstn_wdt                  -- timeout reset, low_active
     );
     resp_bus(RESP_WDT).err <= '0'; -- no access error possible
   end generate;
@@ -1063,7 +1066,7 @@ begin
     resp_bus(RESP_WDT) <= resp_bus_entry_terminate_c;
     --
     wdt_irq   <= '0';
-    wdt_rstn  <= '1';
+    rstn_wdt  <= '1';
     wdt_cg_en <= '0';
   end generate;
 
@@ -1076,7 +1079,7 @@ begin
     port map (
       -- host access --
       clk_i  => clk_i,                      -- global clock line
-      rstn_i => sys_rstn,                   -- global reset line, low-active
+      rstn_i => rstn_int,                   -- global reset line, low-active
       addr_i => p_bus.addr,                 -- address
       rden_i => io_rden,                    -- read enable
       wren_i => io_wren,                    -- write enable
@@ -1133,7 +1136,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                      -- global clock line
-      rstn_i      => sys_rstn,                   -- global reset line, low-active
+      rstn_i      => rstn_int,                   -- global reset line, low-active
       addr_i      => p_bus.addr,                 -- address
       rden_i      => io_rden,                    -- read enable
       wren_i      => io_wren,                    -- write enable
@@ -1181,7 +1184,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                      -- global clock line
-      rstn_i      => sys_rstn,                   -- global reset line, low-active
+      rstn_i      => rstn_int,                   -- global reset line, low-active
       addr_i      => p_bus.addr,                 -- address
       rden_i      => io_rden,                    -- read enable
       wren_i      => io_wren,                    -- write enable
@@ -1224,7 +1227,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                    -- global clock line
-      rstn_i      => sys_rstn,                 -- global reset line, low-active
+      rstn_i      => rstn_int,                 -- global reset line, low-active
       addr_i      => p_bus.addr,               -- address
       rden_i      => io_rden,                  -- read enable
       wren_i      => io_wren,                  -- write enable
@@ -1265,7 +1268,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                    -- global clock line
-      rstn_i      => sys_rstn,                 -- global reset line, low-active
+      rstn_i      => rstn_int,                 -- global reset line, low-active
       addr_i      => p_bus.addr,               -- address
       rden_i      => io_rden,                  -- read enable
       wren_i      => io_wren,                  -- write enable
@@ -1306,7 +1309,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                    -- global clock line
-      rstn_i      => sys_rstn,                 -- global reset line, low-active
+      rstn_i      => rstn_int,                 -- global reset line, low-active
       addr_i      => p_bus.addr,               -- address
       rden_i      => io_rden,                  -- read enable
       wren_i      => io_wren,                  -- write enable
@@ -1342,7 +1345,7 @@ begin
     port map (
       -- host access --
       clk_i  => clk_i,                     -- global clock line
-      rstn_i => sys_rstn,                  -- global reset line, low-active
+      rstn_i => rstn_int,                  -- global reset line, low-active
       addr_i => p_bus.addr,                -- address
       rden_i => io_rden,                   -- read enable
       wren_i => io_wren,                   -- write enable
@@ -1370,7 +1373,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                       -- global clock line
-      rstn_i      => sys_rstn,                    -- global reset line, low-active
+      rstn_i      => rstn_int,                    -- global reset line, low-active
       addr_i      => p_bus.addr,                  -- address
       rden_i      => io_rden,                     -- read enable
       wren_i      => io_wren,                     -- write enable
@@ -1412,7 +1415,7 @@ begin
     port map (
       -- host access --
       clk_i          => clk_i,                      -- global clock line
-      rstn_i         => sys_rstn,                   -- global reset line, low-active
+      rstn_i         => rstn_int,                   -- global reset line, low-active
       addr_i         => p_bus.addr,                 -- address
       rden_i         => io_rden,                    -- read enable
       wren_i         => io_wren,                    -- write enable
@@ -1459,7 +1462,7 @@ begin
     port map (
       -- host access --
       clk_i     => clk_i,                     -- global clock line
-      rstn_i    => sys_rstn,                  -- global reset line, low-active
+      rstn_i    => rstn_int,                  -- global reset line, low-active
       addr_i    => p_bus.addr,                -- address
       rden_i    => io_rden,                   -- read enable
       wren_i    => io_wren,                   -- write enable
@@ -1490,7 +1493,7 @@ begin
     port map (
       -- host access --
       clk_i     => clk_i,                      -- global clock line
-      rstn_i    => sys_rstn,                   -- global reset line, low-active
+      rstn_i    => rstn_int,                   -- global reset line, low-active
       addr_i    => p_bus.addr,                 -- address
       rden_i    => io_rden,                    -- read enable
       wren_i    => io_wren,                    -- write enable
@@ -1582,7 +1585,7 @@ begin
     port map (
       -- global control --
       clk_i            => clk_i,                    -- global clock line
-      rstn_i           => ext_rstn,                 -- external reset, low-active
+      rstn_i           => rstn_ext,                 -- external reset, low-active
       -- debug module interface (DMI) --
       dmi_rstn_i       => dmi.rstn,
       dmi_req_valid_i  => dmi.req_valid,
@@ -1636,7 +1639,7 @@ begin
     port map (
       -- global control --
       clk_i            => clk_i,          -- global clock line
-      rstn_i           => ext_rstn,       -- external reset, low-active
+      rstn_i           => rstn_ext,       -- external reset, low-active
       -- jtag connection --
       jtag_trst_i      => jtag_trst_i,
       jtag_tck_i       => jtag_tck_i,

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -1041,7 +1041,8 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                    -- global clock line
-      rstn_i      => rstn_ext,                 -- global reset line, low-active, async
+      rstn_ext_i  => rstn_ext,                 -- external reset line, low-active, async
+      rstn_int_i  => rstn_int,                 -- internal reset line, low-active, async
       rden_i      => io_rden,                  -- read enable
       wren_i      => io_wren,                  -- write enable
       addr_i      => p_bus.addr,               -- address
@@ -1056,7 +1057,7 @@ begin
       clkgen_i    => clk_gen,
       -- timeout event --
       irq_o       => wdt_irq,                  -- timeout IRQ
-      rstn_o      => rstn_wdt                  -- timeout reset, low_active
+      rstn_o      => rstn_wdt                  -- timeout reset, low_active, sync
     );
     resp_bus(RESP_WDT).err <= '0'; -- no access error possible
   end generate;

--- a/rtl/core/neorv32_wdt.vhd
+++ b/rtl/core/neorv32_wdt.vhd
@@ -145,7 +145,7 @@ begin
   write_access: process(rstn_int_i, clk_i)
   begin
     if (rstn_int_i = '0') then
-      ctrl.reset   <= '1'; -- reset counter on start-up
+      ctrl.reset   <= '0';
       ctrl.enforce <= '0';
       ctrl.enable  <= '0'; -- disable WDT
       ctrl.mode    <= '0';
@@ -206,7 +206,7 @@ begin
             ((not cpu_debug_i) or ctrl.dben) and -- CPU not in debug mode or allowed to also run when in debug mode
             ((not cpu_sleep_i) or (not ctrl.pause)); -- pause watchdog when CPU is in sleep mode
 
-  -- action trigger --
+  -- action triggers --
   irq_o  <= ctrl.enable and (wdt_cnt(wdt_cnt'left) or ctrl.enforce) and (not ctrl.mode); -- mode 0: IRQ
   hw_rst <= ctrl.enable and (wdt_cnt(wdt_cnt'left) or ctrl.enforce) and (    ctrl.mode); -- mode 1: RESET
 

--- a/rtl/core/neorv32_wdt.vhd
+++ b/rtl/core/neorv32_wdt.vhd
@@ -228,7 +228,7 @@ begin
   read_access: process(clk_i)
   begin
     if rising_edge(clk_i) then
-      ack_o  <= rden or wren;
+      ack_o  <= rden or (wren and pwd_ok); -- bus access (timeout) exception if write access with incorrect password
       data_o <= (others => '0');
       if (rden = '1') then
         data_o(ctrl_enable_c) <= ctrl.enable;

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -1254,7 +1254,10 @@ typedef struct __attribute__((packed,aligned(4))) {
 /** WDT module hardware access (#neorv32_wdt_t) */
 #define NEORV32_WDT (*((volatile neorv32_wdt_t*) (NEORV32_WDT_BASE)))
 
-/** WTD control register bits */
+/** WDT access password */
+#define NEORV32_WDT_PWD (0xCA36)
+
+/** WDT control register bits */
 enum NEORV32_WDT_CTRL_enum {
   WDT_CTRL_EN       =  0, /**< WDT control register(0) (r/w): Watchdog enable */
   WDT_CTRL_CLK_SEL0 =  1, /**< WDT control register(1) (r/w): Clock prescaler select bit 0 */
@@ -1267,7 +1270,10 @@ enum NEORV32_WDT_CTRL_enum {
   WDT_CTRL_LOCK     =  8, /**< WDT control register(8) (r/w): Lock write access to control register, clears on reset (HW or WDT) only */
   WDT_CTRL_DBEN     =  9, /**< WDT control register(9) (r/w): Allow WDT to continue operation even when in debug mode */
   WDT_CTRL_HALF     = 10, /**< WDT control register(10) (r/-): Set if at least half of the max. timeout counter value has been reached */
-  WDT_CTRL_PAUSE    = 11  /**< WDT control register(11) (r/w): Pause WDT when CPU is in sleep mode */
+  WDT_CTRL_PAUSE    = 11, /**< WDT control register(11) (r/w): Pause WDT when CPU is in sleep mode */
+
+  WDT_CTRL_PWD_LSB  = 16, /**< WDT control register(16) (-/w): Watchdog access password, LSB ("NEORV32_WDT_PWD") */
+  WDT_CTRL_PWD_MSB  = 31  /**< WDT control register(31) (-/w): Watchdog access password, MSB ("NEORV32_WDT_PWD") */
 };
 /**@}*/
 

--- a/sw/lib/source/neorv32_wdt.c
+++ b/sw/lib/source/neorv32_wdt.c
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -62,6 +62,8 @@ int neorv32_wdt_available(void) {
 
 /**********************************************************************//**
  * Configure and enable watchdog timer. The WDT control register bits are listed in #NEORV32_WDT_CTRL_enum.
+ *
+ * @warning Once set the watchdog lock can only be removed by an external hardware reset!
  *
  * @param[in] prsc Clock prescaler to select timeout interval. See #NEORV32_CLOCK_PRSC_enum.
  * @param[in] mode Trigger system reset on timeout when 1, trigger interrupt on timeout when 0.

--- a/sw/lib/source/neorv32_wdt.c
+++ b/sw/lib/source/neorv32_wdt.c
@@ -71,7 +71,7 @@ int neorv32_wdt_available(void) {
  **************************************************************************/
 void neorv32_wdt_setup(uint8_t prsc, uint8_t mode, uint8_t lock) {
 
-  NEORV32_WDT.CTRL = (NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB) | (1 << WDT_CTRL_RESET); // reset
+  NEORV32_WDT.CTRL = (NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB) | (1 << WDT_CTRL_RESET); // reset and disable
 
   uint32_t prsc_int = (uint32_t)(prsc & 0x07);
   prsc_int = prsc_int << WDT_CTRL_CLK_SEL0;
@@ -95,8 +95,8 @@ void neorv32_wdt_setup(uint8_t prsc, uint8_t mode, uint8_t lock) {
  * @return Returns 0 if WDT is really deactivated, -1 otherwise.
  **************************************************************************/
 int neorv32_wdt_disable(void) {
-  
-  NEORV32_WDT.CTRL = NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB;
+
+  NEORV32_WDT.CTRL = (NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB) | (1 << WDT_CTRL_RESET); // reset and disable
 
   // check if WDT is really off
   if (NEORV32_WDT.CTRL & (1 << WDT_CTRL_EN)) {
@@ -109,7 +109,7 @@ int neorv32_wdt_disable(void) {
 
 
 /**********************************************************************//**
- * Reset (running) watchdog.
+ * Feed watchdog (reset timeout counter).
  **************************************************************************/
 void neorv32_wdt_reset(void) {
 
@@ -120,14 +120,14 @@ void neorv32_wdt_reset(void) {
 /**********************************************************************//**
  * Get cause of last system reset.
  *
- * @return Cause of last reset/IRQ (0: external reset, 1: watchdog timeout).
+ * @return Cause of last reset (0: system reset - OCD or external, 1: watchdog timeout).
  **************************************************************************/
 int neorv32_wdt_get_cause(void) {
 
   if (NEORV32_WDT.CTRL & (1 << WDT_CTRL_RCAUSE)) { // reset caused by watchdog
     return 1;
   }
-  else { // external reset
+  else { // reset caused by system (external or OCD)
     return 0;
   }
 }

--- a/sw/lib/source/neorv32_wdt.c
+++ b/sw/lib/source/neorv32_wdt.c
@@ -71,7 +71,7 @@ int neorv32_wdt_available(void) {
  **************************************************************************/
 void neorv32_wdt_setup(uint8_t prsc, uint8_t mode, uint8_t lock) {
 
-  NEORV32_WDT.CTRL = (1 << WDT_CTRL_RESET); // reset WDT counter
+  NEORV32_WDT.CTRL = (NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB) | (1 << WDT_CTRL_RESET); // reset
 
   uint32_t prsc_int = (uint32_t)(prsc & 0x07);
   prsc_int = prsc_int << WDT_CTRL_CLK_SEL0;
@@ -85,7 +85,7 @@ void neorv32_wdt_setup(uint8_t prsc, uint8_t mode, uint8_t lock) {
   const uint32_t enable = (uint32_t)(1 << WDT_CTRL_EN);
 
   // update WDT control register
-  NEORV32_WDT.CTRL = enable | mode_int | prsc_int | lock_int;
+  NEORV32_WDT.CTRL = (NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB) | enable | mode_int | prsc_int | lock_int;
 }
 
 
@@ -96,11 +96,11 @@ void neorv32_wdt_setup(uint8_t prsc, uint8_t mode, uint8_t lock) {
  **************************************************************************/
 int neorv32_wdt_disable(void) {
   
-  NEORV32_WDT.CTRL = 0;
+  NEORV32_WDT.CTRL = NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB;
 
-  // check if wdt is really off
+  // check if WDT is really off
   if (NEORV32_WDT.CTRL & (1 << WDT_CTRL_EN)) {
-    return -1; // WDT still active
+    return -1; // still active
   }
   else {
     return 0;
@@ -113,7 +113,7 @@ int neorv32_wdt_disable(void) {
  **************************************************************************/
 void neorv32_wdt_reset(void) {
 
-  NEORV32_WDT.CTRL = NEORV32_WDT.CTRL | (1 << WDT_CTRL_RESET);
+  NEORV32_WDT.CTRL |= (NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB) | (1 << WDT_CTRL_RESET);
 }
 
 
@@ -138,5 +138,5 @@ int neorv32_wdt_get_cause(void) {
  **************************************************************************/
 void neorv32_wdt_force(void) {
 
-  NEORV32_WDT.CTRL = NEORV32_WDT.CTRL | (1 << WDT_CTRL_FORCE);
+  NEORV32_WDT.CTRL |= (NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB) | (1 << WDT_CTRL_FORCE);
 }

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -1059,6 +1059,11 @@
               <bitRange>[11:11]</bitRange>
               <description>Pause WDT when CPU is in sleep mode</description>
             </field>
+            <field>
+              <name>WDT_CTRL_PWD</name>
+              <bitRange>[31:16]</bitRange>
+              <description>Watchdog password, has to be `0xCA36` - otherwise any write access is ignored, reads as zero</description>
+            </field>
           </fields>
         </register>
       </registers>


### PR DESCRIPTION
This PR reworks the processor's internal reset generator system and also the behavior of the watchdog's "lock" feature.

### Reset System

The reset generator system has been split into an _external_ and an _internal_ system. The external reset is triggered by the processor's `rstn_i` signal while the internal reset is triggered by the processor's `rstn_i` signal, the watchdog or the on-chip debugger.

Whenever a valid reset request occurs (internal or external) the reset generator ensures that the reset applied to the system is active for at least 4 cycles. Furthermore, the reset applied to system will be release on _falling_ edge of the system clock to avoid metastable situation (= reset is de-asserted during a rising edge). More information can be found in this nice article: https://www.eetimes.com/how-do-i-reset-my-fpga/

### Watchdog

The watchdog is now reset by the _internal_ processor reset, which can be triggered via the external hardware reset signal `rstn_i`, the on-chip debugger or the watchdog itself (system reset on watchdog timeout).

* ⚠️ The watchdog now requires an "access password" in the upper most 16 bits (MSB-aligned) of the data to be written. If the password is incorrect no data will be written to the watchdog control register adn the according bus access will **not be acknowledged** resulting in a **store access fault** exception**. The password is hardwired to `0xCA36` and is used by the [WDT library functions](https://github.com/stnolting/neorv32/blob/main/sw/lib/include/neorv32_wdt.h).
