### PR TITLE
[rtl] add "async TX" Wishbone option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 21.06.2022 | 1.7.2.10 | :sparkles: add option to implement an asynchronous **Wishbone** TX path; add new top generic `MEM_EXT_ASYNC_TX`; [#352](https://github.com/stnolting/neorv32/pull/352) |
 | 17.06.2022 | 1.7.2.9 | minor rtl code clean-ups/optimization of **CPU core** and **Neoled** module; [#351](https://github.com/stnolting/neorv32/pull/351) |
 | 16.06.2022 | 1.7.2.8 | :warning: rework **SLINK** module, add support for T_LAST signals; [#349](https://github.com/stnolting/neorv32/pull/349) |
 | 11.06.2022 | 1.7.2.7 | reworked processor **reset system**; :warning: changed behavior of **watchdog's** "lock" bit; add watchdog "access password"; [#345](https://github.com/stnolting/neorv32/pull/345) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -707,6 +707,20 @@ implemented reducing access latency by one cycle but eventually increasing the c
 |======
 
 
+:sectnums!:
+===== _MEM_EXT_ASYNC_TX_
+
+[cols="4,4,2"]
+[frame="all",grid="none"]
+|======
+| **MEM_EXT_ASYNC_TX** | _boolen_ | false
+3+| By default, _MEM_EXT_ASYNC_TX_ = _false_ implements register for all outgoing (TX) signals
+in order to shorten the critical path. By setting _MEM_EXT_ASYNC_TX_ = _true_ an _asynchronous_ ("direct") path is
+implemented reducing access latency by one cycle but eventually increasing the critical path.
+|======
+
+
+
 // ####################################################################################################################
 :sectnums:
 ==== Stream Link Interface

--- a/docs/datasheet/soc_wishbone.adoc
+++ b/docs/datasheet/soc_wishbone.adoc
@@ -24,6 +24,7 @@
 |                          | _MEM_EXT_PIPE_MODE_  | when _false_ (default): classic/standard Wishbone protocol; when _true_: pipelined Wishbone protocol
 |                          | _MEM_EXT_BIG_ENDIAN_ | byte-order (Endianness) of external memory interface; true=BIG, false=little (default)
 |                          | _MEM_EXT_ASYNC_RX_   | use registered RX path when _false_ (default); use async/direct RX path when _true_
+|                          | _MEM_EXT_ASYNC_TX_   | use registered TX path when _false_ (default); use async/direct TX path when _true_
 | CPU interrupts:          | none |
 |=======================
 
@@ -124,19 +125,23 @@ Application software can check the Endianness configuration of the external bus 
 SYSINFO module (see section <<_system_configuration_information_memory_sysinfo>> for more information).
 
 
-**Latency and Gating**
+**Access Latency**
 
 By default, the Wishbone gateway introduces two additional latency cycles: processor-outgoing (`*_o`) and
 processor-incoming (`*_i`) signals are fully registered. Thus, any access from the CPU to a processor-external devices
-via Wishbone requires 2 additional clock cycles (at least; depending on device's latency).
+via Wishbone requires 2 additional clock cycles. This can ease timing closure when using large (combinatorial) Wishbone
+interconnection networks.
 
-If the attached Wishbone network / peripheral already provides output registers or if the Wishbone network is not relevant
-for timing closure, the default buffering of incoming signals can be disabled by implementing an
-"asynchronous" RX path. The configuration is done via the _MEM_EXT_ASYNC_RX_ generic.
+Optionally, the latency of the Wishbone gateway can be reduced by removing the input and output register stages.
+Enabling the _MEM_EXT_ASYNC_RX_ option will remove the input register stage; enabling _MEM_EXT_ASYNC_TX_ option will
+remove the output register stages. Each enabled option reduces access latency by 1 cycle.
 
-All outgoing signals use a "gating mechanism" so they only change if there is a actual Wishbone transaction being in
+.Output Gating
+[NOTE]
+All outgoing Wishbone signals use a "gating mechanism" so they only change if there is a actual Wishbone transaction being in
 progress. This can reduce dynamic switching activity in the external bus system and also simplifies simulation-based
-inspection of the Wishbone transactions.
+inspection of the Wishbone transactions. Note that this output gating is only available if the output register buffer is not
+disabled (_MEM_EXT_ASYNC_TX_ = _false_).
 
 
 **AXI4-Lite Connectivity**
@@ -153,5 +158,5 @@ image::neorv32_axi_soc.png[]
 
 [WARNING]
 Using the auto-termination timeout feature (_MEM_EXT_TIMEOUT_ greater than zero) is **not AXI4 compliant** as
-the AXI protocol does not support canceling of bus transactions. Therefore, the NEORV32 top wrapper with AXI4-Lite interface
+the AXI protocol does not support "aborting" bus transactions. Therefore, the NEORV32 top wrapper with AXI4-Lite interface
 (`rtl/system_integration/neorv32_SystemTop_axi4lite`) configures _MEM_EXT_TIMEOUT_ = 0 by default.

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -68,7 +68,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070209"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070210"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -987,6 +987,7 @@ package neorv32_package is
       MEM_EXT_PIPE_MODE            : boolean := false;  -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
       MEM_EXT_BIG_ENDIAN           : boolean := false;  -- byte order: true=big-endian, false=little-endian
       MEM_EXT_ASYNC_RX             : boolean := false;  -- use register buffer for RX data when false
+      MEM_EXT_ASYNC_TX             : boolean := false;  -- use register buffer for TX data when false
       -- Stream link interface (SLINK) --
       SLINK_NUM_TX                 : natural := 0;      -- number of TX links (0..8)
       SLINK_NUM_RX                 : natural := 0;      -- number of TX links (0..8)
@@ -1827,7 +1828,8 @@ package neorv32_package is
       BUS_TIMEOUT       : natural; -- cycles after an UNACKNOWLEDGED bus access triggers a bus fault exception
       PIPE_MODE         : boolean; -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
       BIG_ENDIAN        : boolean; -- byte order: true=big-endian, false=little-endian
-      ASYNC_RX          : boolean  -- use register buffer for RX data when false
+      ASYNC_RX          : boolean; -- use register buffer for RX data when false
+      ASYNC_TX          : boolean  -- use register buffer for TX data when false
     );
     port (
       -- global control --

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -102,6 +102,7 @@ entity neorv32_top is
     MEM_EXT_PIPE_MODE            : boolean := false;  -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
     MEM_EXT_BIG_ENDIAN           : boolean := false;  -- byte order: true=big-endian, false=little-endian
     MEM_EXT_ASYNC_RX             : boolean := false;  -- use register buffer for RX data when false
+    MEM_EXT_ASYNC_TX             : boolean := false;  -- use register buffer for TX data when false
 
     -- Stream link interface (SLINK) --
     SLINK_NUM_TX                 : natural := 0;      -- number of TX links (0..8)
@@ -846,7 +847,8 @@ begin
       BUS_TIMEOUT       => MEM_EXT_TIMEOUT,    -- cycles after an UNACKNOWLEDGED bus access triggers a bus fault exception
       PIPE_MODE         => MEM_EXT_PIPE_MODE,  -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
       BIG_ENDIAN        => MEM_EXT_BIG_ENDIAN, -- byte order: true=big-endian, false=little-endian
-      ASYNC_RX          => MEM_EXT_ASYNC_RX    -- use register buffer for RX data when false
+      ASYNC_RX          => MEM_EXT_ASYNC_RX,   -- use register buffer for RX data when false
+      ASYNC_TX          => MEM_EXT_ASYNC_TX    -- use register buffer for TX data when false
     )
     port map (
       -- global control --

--- a/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
+++ b/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
@@ -87,6 +87,7 @@ entity neorv32_ProcessorTop_stdlogic is
     MEM_EXT_PIPE_MODE            : boolean := false;  -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
     MEM_EXT_BIG_ENDIAN           : boolean := false;  -- byte order: true=big-endian, false=little-endian
     MEM_EXT_ASYNC_RX             : boolean := false;  -- use register buffer for RX data when false
+    MEM_EXT_ASYNC_TX             : boolean := false;  -- use register buffer for TX data when false
     -- Stream link interface --
     SLINK_NUM_TX                 : natural := 0;      -- number of TX links (0..8)
     SLINK_NUM_RX                 : natural := 0;      -- number of TX links (0..8)
@@ -328,6 +329,7 @@ begin
     MEM_EXT_PIPE_MODE            => MEM_EXT_PIPE_MODE,  -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
     MEM_EXT_BIG_ENDIAN           => MEM_EXT_BIG_ENDIAN, -- byte order: true=big-endian, false=little-endian
     MEM_EXT_ASYNC_RX             => MEM_EXT_ASYNC_RX,   -- use register buffer for RX data when false
+    MEM_EXT_ASYNC_TX             => MEM_EXT_ASYNC_TX,   -- use register buffer for TX data when false
     -- Stream link interface --
     SLINK_NUM_TX                 => SLINK_NUM_TX,       -- number of TX links (0..8)
     SLINK_NUM_RX                 => SLINK_NUM_RX,       -- number of TX links (0..8)

--- a/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
@@ -296,6 +296,7 @@ begin
     MEM_EXT_PIPE_MODE => false,
     MEM_EXT_BIG_ENDIAN => false,
     MEM_EXT_ASYNC_RX => false,
+    MEM_EXT_ASYNC_TX => false,
 
     -- Stream link interface (SLINK) --
     SLINK_NUM_TX => SLINK_NUM_TX,

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -327,6 +327,7 @@ begin
     MEM_EXT_PIPE_MODE            => false,              -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
     MEM_EXT_BIG_ENDIAN           => false,              -- byte order: true=big-endian, false=little-endian
     MEM_EXT_ASYNC_RX             => false,              -- use register buffer for RX data when false
+    MEM_EXT_ASYNC_TX             => false,              -- use register buffer for TX data when false
     -- External Interrupts Controller (XIRQ) --
     XIRQ_NUM_CH                  => XIRQ_NUM_CH, -- number of external IRQ channels (0..32)
     XIRQ_TRIGGER_TYPE            => XIRQ_TRIGGER_TYPE_INT, -- trigger type: 0=level, 1=edge

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -317,6 +317,10 @@ begin
     -- External memory interface --
     MEM_EXT_EN                   => true,          -- implement external memory bus interface?
     MEM_EXT_TIMEOUT              => 256,           -- cycles after a pending bus access auto-terminates (0 = disabled)
+    MEM_EXT_PIPE_MODE            => false,         -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
+    MEM_EXT_BIG_ENDIAN           => false,         -- byte order: true=big-endian, false=little-endian
+    MEM_EXT_ASYNC_RX             => false,         -- use register buffer for RX data when false
+    MEM_EXT_ASYNC_TX             => false,         -- use register buffer for TX data when false
     -- Stream link interface --
     SLINK_NUM_TX                 => 8,             -- number of TX links (0..8)
     SLINK_NUM_RX                 => 8,             -- number of TX links (0..8)

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -208,6 +208,10 @@ begin
     -- External memory interface --
     MEM_EXT_EN                   => true,          -- implement external memory bus interface?
     MEM_EXT_TIMEOUT              => 256,           -- cycles after a pending bus access auto-terminates (0 = disabled)
+    MEM_EXT_PIPE_MODE            => false,         -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
+    MEM_EXT_BIG_ENDIAN           => false,         -- byte order: true=big-endian, false=little-endian
+    MEM_EXT_ASYNC_RX             => false,         -- use register buffer for RX data when false
+    MEM_EXT_ASYNC_TX             => false,         -- use register buffer for TX data when false
     -- Stream link interface --
     SLINK_NUM_TX                 => 8,             -- number of TX links (0..8)
     SLINK_NUM_RX                 => 8,             -- number of TX links (0..8)


### PR DESCRIPTION
This PR adds another configuration option for the external memory interface (**Wishbone**). By default, all incoming and outgoing Wishbone signals are registered to allow easy timing closure even when using complex (combinatorial) Wishbone interconnection networks.

The processor already provides the `MEM_EXT_ASYNC_RX` option to omit the register stage for incoming signals (seen from the processor). The new `MEM_EXT_ASYNC_TX` option now allows to also omit the register stage for outgoing signals.

Each enabled option will reduce the external memory interface latency by 1 cycle. If both options are enabled an external memory can be accessed with the same latency as any processor-internal memory.