### PR TITLE
[rtl] minor cleanups and typo fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 01.07.2022 | 1.7.3.3 | minor rtl cleanups; [#357](https://github.com/stnolting/neorv32/pull/357) |
 | 29.06.2022 | 1.7.3.2 | :test_tube: add experimental core complex wrapper for integration into the [**LiteX**](https://github.com/enjoy-digital/litex) SoC builder framework; [#353](https://github.com/stnolting/neorv32/pull/353) |
 | 28.06.2022 | 1.7.3.1 | :bug: fix bug that caused permanent CPU stall if illegal load/store instruction; [#356](https://github.com/stnolting/neorv32/pull/356) |
 | 23.06.2022 | [**:rocket:1.7.3**](https://github.com/stnolting/neorv32/releases/tag/v1.7.3) | **New release** _two years NEORV32!_ :tada: |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -136,7 +136,7 @@ Otherwise any access to the floating-point CSRs will raise an illegal instructio
 [frame="topbot",grid="none"]
 |=======================
 | 0x001 | **Floating-point accrued exceptions** | `fflags`
-3+| Reset value: _UNDEFINED_
+3+| Reset value: _0x00000000_
 3+| The `fflags` CSR is compatible to the RISC-V specifications. It shows the accrued ("accumulated")
 exception flags in the lowest 5 bits. This CSR is only available if a floating-point CPU extension is enabled.
 See the RISC-V ISA spec for more information.
@@ -150,7 +150,7 @@ See the RISC-V ISA spec for more information.
 [frame="topbot",grid="none"]
 |=======================
 | 0x002 | **Floating-point dynamic rounding mode** | `frm`
-3+| Reset value: _UNDEFINED_
+3+| Reset value: _0x00000000_
 3+| The `frm` CSR is compatible to the RISC-V specifications and is used to configure the rounding modes using
 the lowest 3 bits. This CSR is only available if a floating-point CPU extension is enabled. See the RISC-V
 ISA spec for more information.
@@ -164,7 +164,7 @@ ISA spec for more information.
 [frame="topbot",grid="none"]
 |=======================
 | 0x003 | **Floating-point control and status register** | `fcsr`
-3+| Reset value: _UNDEFINED_
+3+| Reset value: _0x00000000_
 3+| The `fcsr` CSR is compatible to the RISC-V specifications. It provides combined read/write access to the
 `fflags` and `frm` CSRs. This CSR is only available if a floating-point CPU extension is enabled. See the
 RISC-V ISA spec for more information.
@@ -327,7 +327,7 @@ Hence, the trap handler's base address has to be aligned to a 4-byte boundary.
 [frame="topbot",grid="none"]
 |=======================
 | 0x306 | **Machine counter enable** | `mcounteren`
-3+| Reset value: _UNDEFINED_
+3+| Reset value: _0x00000000_
 3+| The `mcounteren` CSR is compatible to the RISC-V specifications. The bits of this CSR define which
 counter/timer CSR can be accessed (read) from code running in a less-privileged modes. For example,
 if user-level code tries to read from a counter/timer CSR without enabled access, an illegal instruction
@@ -714,7 +714,7 @@ information) or when the CPU is in sleep-mode.
 [frame="topbot",grid="none"]
 |=======================
 | 0x232 -0x33f | **Machine hardware performance monitor event selector** | `mhpmevent3` - `mhpmevent31`
-3+| Reset value: _UNDEFINED_
+3+| Reset value: _0x00000000_
 3+| The `mhpmevent*` CSRs are compatible to the RISC-V specifications. The value in these CSRs define
 the architectural events that cause an increment of the according `mhpmcounter*[h]` counter(s). All available events are
 listed in the table below. If more than one event is selected, the according counter will increment if _any_ of
@@ -780,7 +780,7 @@ bit of arbitrary event counters. The event(s) that trigger an increment of these
 [frame="topbot",grid="none"]
 |=======================
 | 0x320 | **Machine counter-inhibit register** | `mcountinhibit`
-3+| Reset value: _UNDEFINED_
+3+| Reset value: _0x00000000_
 3+| The `mcountinhibit` CSR is compatible to the RISC-V specifications. The bits in this register define which
 counter/timer CSR are allowed to perform an automatic increment. Automatic update is enabled if the
 according bit in `mcountinhibit` is cleared. The following bits are implemented (all remaining bits are

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -118,6 +118,10 @@ CSRs with the following notes ...
 | 0xfc0   | <<_mxisa>>       | _CSR_MXISA_     | r/- | NEORV32-specific "extended" machine CPU ISA and extensions | `X`
 |=======================
 
+.Debug-Mode CSRs
+[NOTE]
+The CSRs related to the CPU's debug mode (used by the on-chip debugger) are not listed here as they are not accessible by
+normal software. See sections <<_cpu_debug_mode_csrs>> and <<_trigger_module_csrs>> for more information about those CSRs.
 
 
 <<<

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -277,7 +277,7 @@ Machine-mode software can discover available `Z*` _sub-extensions_ (like `Zicsr`
 [frame="topbot",grid="none"]
 |=======================
 | 0x304 | **Machine interrupt-enable register** | `mie`
-3+| Reset value: _UNDEFINED_
+3+| Reset value: _0x00000000_
 3+| The `mie` CSR is compatible to the RISC-V specifications and features custom extensions for the fast
 interrupt channels. It is used to enabled specific interrupts sources. Please note that interrupts also have to be
 globally enabled via the `CSR_MSTATUS_MIE` flag of the `mstatus` CSR. The following bits are implemented

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -161,7 +161,7 @@ begin
   -- CPU ISA Configuration ---------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   assert false report
-  "NEORV32 CPU ISA Configuration (MARCH): " &
+  "NEORV32 CPU CONFIG NOTE: ISA (MARCH) = " &
   cond_sel_string_f(CPU_EXTENSION_RISCV_E, "RV32E", "RV32I") &
   cond_sel_string_f(CPU_EXTENSION_RISCV_M, "M", "") &
   cond_sel_string_f(CPU_EXTENSION_RISCV_C, "C", "") &
@@ -181,6 +181,9 @@ begin
 
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
+  -- say hello --
+  assert false report "The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32" severity note;
+
   -- simulation notifier --
   assert not (is_simulation_c = true)  report "NEORV32 CPU WARNING! Assuming this is a simulation." severity warning;
   assert not (is_simulation_c = false) report "NEORV32 CPU NOTE: Assuming this is real hardware." severity note;
@@ -192,6 +195,7 @@ begin
 
   -- CPU boot address --
   assert not (CPU_BOOT_ADDR(1 downto 0) /= "00") report "NEORV32 CPU CONFIG ERROR! <CPU_BOOT_ADDR> has to be 32-bit aligned." severity error;
+  assert false report "NEORV32 CPU CONFIG NOTE: Boot from address 0x" & to_hstring32_f(CPU_BOOT_ADDR) & "." severity note;
 
   -- CSR system --
   assert not (CPU_EXTENSION_RISCV_Zicsr = false) report "NEORV32 CPU CONFIG WARNING! No exception/interrupt/trap/privileged features available when <CPU_EXTENSION_RISCV_Zicsr> = false." severity warning;
@@ -208,14 +212,14 @@ begin
   assert not (CPU_IPB_ENTRIES < 2) report "NEORV32 CPU CONFIG ERROR! Number of entries in instruction prefetch buffer <CPU_IPB_ENTRIES> has to be >= 2." severity error;
 
   -- PMP --
-  assert not (PMP_NUM_REGIONS > 0) report "NEORV32 CPU NOTE: Implementing " & positive'image(PMP_NUM_REGIONS) & " PMP regions." severity note;
+  assert not (PMP_NUM_REGIONS > 0) report "NEORV32 CPU CONFIG NOTE: Implementing " & positive'image(PMP_NUM_REGIONS) & " PMP regions." severity note;
   assert not (PMP_NUM_REGIONS > 16) report "NEORV32 CPU CONFIG ERROR! Number of PMP regions <PMP_NUM_REGIONS> out of valid range (0..16)." severity error;
   assert not ((is_power_of_two_f(PMP_MIN_GRANULARITY) = false) and (PMP_NUM_REGIONS > 0)) report "NEORV32 CPU CONFIG ERROR! <PMP_MIN_GRANULARITY> has to be a power of two." severity error;
   assert not (PMP_MIN_GRANULARITY < 4) report "NEORV32 CPU CONFIG ERROR! <PMP_MIN_GRANULARITY> has to be >= 4 bytes." severity error;
   assert not ((CPU_EXTENSION_RISCV_Zicsr = false) and (PMP_NUM_REGIONS > 0)) report "NEORV32 CPU CONFIG ERROR! Physical memory protection (PMP) requires <CPU_EXTENSION_RISCV_Zicsr> extension to be enabled." severity error;
 
   -- HPM counters --
-  assert not ((CPU_EXTENSION_RISCV_Zihpm = true) and (HPM_NUM_CNTS > 0)) report "NEORV32 CPU NOTE: Implementing " & positive'image(HPM_NUM_CNTS) & " HPM counters." severity note;
+  assert not ((CPU_EXTENSION_RISCV_Zihpm = true) and (HPM_NUM_CNTS > 0)) report "NEORV32 CPU CONFIG NOTE: Implementing " & positive'image(HPM_NUM_CNTS) & " HPM counters." severity note;
   assert not ((CPU_EXTENSION_RISCV_Zihpm = true) and (HPM_NUM_CNTS > 29)) report "NEORV32 CPU CONFIG ERROR! Number of HPM counters <HPM_NUM_CNTS> out of valid range (0..29)." severity error;
   assert not ((CPU_EXTENSION_RISCV_Zihpm = true) and ((HPM_CNT_WIDTH < 0) or (HPM_CNT_WIDTH > 64))) report "NEORV32 CPU CONFIG ERROR! HPM counter width <HPM_CNT_WIDTH> has to be 0..64 bit." severity error; 
   assert not ((CPU_EXTENSION_RISCV_Zicsr = false) and (CPU_EXTENSION_RISCV_Zihpm = true)) report "NEORV32 CPU CONFIG ERROR! Hardware performance monitors extension <CPU_EXTENSION_RISCV_Zihpm> requires <CPU_EXTENSION_RISCV_Zicsr> extension to be enabled." severity error;
@@ -228,7 +232,7 @@ begin
   assert not ((CPU_EXTENSION_RISCV_DEBUG = true) and (CPU_EXTENSION_RISCV_Zifencei = false)) report "NEORV32 CPU CONFIG ERROR! Debug mode requires <CPU_EXTENSION_RISCV_Zifencei> extension to be enabled." severity error;
 
   -- fast multiplication option --
-  assert not (FAST_MUL_EN = true) report "NEORV32 CPU CONFIG NOTE: <FAST_MUL_EN> enabled. Trying to use DSP blocks for base ISA multiplications." severity note;
+  assert not (FAST_MUL_EN = true) report "NEORV32 CPU CONFIG NOTE: <FAST_MUL_EN> enabled. Inferring DSP blocks for multiplications." severity note;
 
   -- fast shift option --
   assert not (FAST_SHIFT_EN = true) report "NEORV32 CPU CONFIG NOTE: <FAST_SHIFT_EN> enabled. Implementing full-parallel logic / barrel shifters." severity note;

--- a/rtl/core/neorv32_cpu_bus.vhd
+++ b/rtl/core/neorv32_cpu_bus.vhd
@@ -168,7 +168,7 @@ begin
   misaligned_d_check: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      misaligned <= def_rst_val_c;
+      misaligned <= '0';
     elsif rising_edge(clk_i) then
       if (ctrl_i(ctrl_bus_mo_we_c) = '1') then
         case data_size is -- data size
@@ -265,8 +265,8 @@ begin
   begin
     if (rstn_i = '0') then
       arbiter.pend <= '0';
-      arbiter.rw   <= def_rst_val_c;
-      arbiter.err  <= def_rst_val_c;
+      arbiter.rw   <= '0';
+      arbiter.err  <= '0';
     elsif rising_edge(clk_i) then
       if (arbiter.pend = '0') then -- idle
         arbiter.pend <= ctrl_i(ctrl_bus_wr_c) or ctrl_i(ctrl_bus_rd_c); -- start bus access

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1777,18 +1777,18 @@ begin
       csr.pmpcfg            <= (others => (others => '0'));
       csr.pmpaddr           <= (others => (others => def_rst_val_c));
       --
-      csr.mhpmevent         <= (others => (others => def_rst_val_c));
+      csr.mhpmevent         <= (others => (others => '0'));
       --
-      csr.mcounteren_cy     <= def_rst_val_c;
-      csr.mcounteren_tm     <= def_rst_val_c;
-      csr.mcounteren_ir     <= def_rst_val_c;
+      csr.mcounteren_cy     <= '0';
+      csr.mcounteren_tm     <= '0';
+      csr.mcounteren_ir     <= '0';
       --
-      csr.mcountinhibit_cy  <= def_rst_val_c;
-      csr.mcountinhibit_ir  <= def_rst_val_c;
-      csr.mcountinhibit_hpm <= (others => def_rst_val_c);
+      csr.mcountinhibit_cy  <= '0';
+      csr.mcountinhibit_ir  <= '0';
+      csr.mcountinhibit_hpm <= (others => '0');
       --
-      csr.fflags            <= (others => def_rst_val_c);
-      csr.frm               <= (others => def_rst_val_c);
+      csr.fflags            <= (others => '0');
+      csr.frm               <= (others => '0');
       --
       csr.dcsr_ebreakm      <= '0';
       csr.dcsr_ebreaku      <= '0';

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1764,16 +1764,16 @@ begin
       csr.mstatus_mpp       <= '0';
       csr.mstatus_tw        <= '0';
       csr.privilege         <= priv_mode_m_c; -- start in MACHINE mode
-      csr.mie_msie          <= def_rst_val_c;
-      csr.mie_meie          <= def_rst_val_c;
-      csr.mie_mtie          <= def_rst_val_c;
-      csr.mie_firqe         <= (others => def_rst_val_c);
+      csr.mie_msie          <= '0';
+      csr.mie_meie          <= '0';
+      csr.mie_mtie          <= '0';
+      csr.mie_firqe         <= (others => '0');
       csr.mtvec             <= (others => def_rst_val_c);
       csr.mscratch          <= x"19880704";
       csr.mepc              <= (others => def_rst_val_c);
       csr.mcause            <= (others => def_rst_val_c);
       csr.mtval             <= (others => def_rst_val_c);
-      csr.mip_firq_nclr     <= (others => def_rst_val_c);
+      csr.mip_firq_nclr     <= (others => '-');
       --
       csr.pmpcfg            <= (others => (others => '0'));
       csr.pmpaddr           <= (others => (others => def_rst_val_c));

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1757,7 +1757,6 @@ begin
   begin
     if (rstn_i = '0') then
       csr.we                <= '0';
-      csr.re                <= def_rst_val_c;
       --
       csr.mstatus_mie       <= '0';
       csr.mstatus_mpie      <= '0';
@@ -1805,7 +1804,6 @@ begin
     elsif rising_edge(clk_i) then
       -- write access? --
       csr.we <= csr.we_nxt and (not trap_ctrl.exc_buf(exc_iillegal_c)); -- write if not illegal instruction
-      csr.re <= csr.re_nxt;
 
       -- defaults --
       csr.mip_firq_nclr <= (others => '1'); -- active low
@@ -2106,6 +2104,7 @@ begin
     variable csr_addr_v : std_ulogic_vector(11 downto 0);
   begin
     if rising_edge(clk_i) then
+      csr.re    <= csr.re_nxt; -- read access?
       csr.rdata <= (others => '0'); -- default output, unimplemented CSRs read as zero
       if (CPU_EXTENSION_RISCV_Zicsr = true) then
 
@@ -2117,6 +2116,7 @@ begin
         else -- reduce switching activity if not accessed
           csr_addr_v := (others => '0'); -- = csr_zero_c
         end if;
+
         case csr_addr_v is
 
           -- hardware-only CSRs --

--- a/rtl/core/neorv32_cpu_cp_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_cp_bitmanip.vhd
@@ -556,12 +556,10 @@ begin
 
   -- Output Gate ----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  output_gate: process(rstn_i, clk_i)
+  output_gate: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      res_o <= (others => def_rst_val_c);
-    elsif rising_edge(clk_i) then
-      res_o <= (others => '0');
+    if rising_edge(clk_i) then
+      res_o <= (others => '0'); -- default
       if (valid = '1') then
         res_o <= res_out(op_andn_c)   or res_out(op_orn_c)    or res_out(op_xnor_c)  or
                  res_out(op_clz_c)    or res_out(op_cpop_c)   or -- res_out(op_ctz_c) is unused here

--- a/rtl/core/neorv32_cpu_cp_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_cp_muldiv.vhd
@@ -126,7 +126,7 @@ begin
       ctrl.cnt      <= (others => def_rst_val_c);
       ctrl.cp_op_ff <= (others => def_rst_val_c);
       ctrl.out_en   <= '0';
-      div.sign_mod <= def_rst_val_c;
+      div.sign_mod  <= def_rst_val_c;
     elsif rising_edge(clk_i) then
       -- defaults --
       ctrl.out_en <= '0';

--- a/rtl/core/neorv32_cpu_cp_shifter.vhd
+++ b/rtl/core/neorv32_cpu_cp_shifter.vhd
@@ -91,7 +91,7 @@ begin
     serial_shifter_core: process(rstn_i, clk_i)
     begin
       if (rstn_i = '0') then
-        shifter.busy_ff <= def_rst_val_c;
+        shifter.busy_ff <= '-';
         shifter.busy    <= '0';
         shifter.cnt     <= (others => def_rst_val_c);
         shifter.sreg    <= (others => def_rst_val_c);

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -68,8 +68,8 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070302"; -- NEORV32 version - no touchy!
-  constant archid_c     : natural := 19; -- official NEORV32 architecture ID - hands off!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070303"; -- NEORV32 version - no touchy!
+  constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -116,6 +116,7 @@ package neorv32_package is
   function xor_reduce_f(a : std_ulogic_vector) return std_ulogic;
   function to_hexchar_f(input : std_ulogic_vector(3 downto 0)) return character;
   function hexchar_to_stdulogicvector_f(input : character) return std_ulogic_vector;
+  function to_hstring32_f(input : std_ulogic_vector(31 downto 0)) return string;
   function bit_rev_f(input : std_ulogic_vector) return std_ulogic_vector;
   function is_power_of_two_f(input : natural) return boolean;
   function bswap32_f(input : std_ulogic_vector) return std_ulogic_vector;
@@ -2376,6 +2377,21 @@ package body neorv32_package is
     end case;
     return hex_value_v;
   end function hexchar_to_stdulogicvector_f;
+
+  -- Function: Convert 32-bit std_ulogic_vector to hex string -------------------------------
+  -- -------------------------------------------------------------------------------------------
+  function to_hstring32_f(input : std_ulogic_vector(31 downto 0)) return string is
+    variable res_v : string(1 to 8);
+    variable tmp_v : std_ulogic_vector(31 downto 0);
+    variable hex_v : std_ulogic_vector(3 downto 0);
+  begin
+    tmp_v := bit_rev_f(input);
+    for i in 0 to 7 loop
+      hex_v := tmp_v(i*4+3 downto i*4+0);
+      res_v(i+1) := to_hexchar_f(bit_rev_f(hex_v));
+    end loop; -- i
+    return res_v;
+  end function to_hstring32_f;
 
   -- Function: Bit reversal -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -382,7 +382,7 @@ begin
   -- Processor IO/Peripherals Configuration -------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   assert false report
-  "NEORV32 PROCESSOR IO Configuration: " &
+  "NEORV32 PROCESSOR CONFIG NOTE: Peripherals = " &
   cond_sel_string_f(IO_GPIO_EN, "GPIO ", "") &
   cond_sel_string_f(IO_MTIME_EN, "MTIME ", "") &
   cond_sel_string_f(IO_UART0_EN, "UART0 ", "") &
@@ -406,8 +406,8 @@ begin
   -- -------------------------------------------------------------------------------------------
   -- boot configuration --
   assert not (INT_BOOTLOADER_EN = true) report "NEORV32 PROCESSOR CONFIG NOTE: Boot configuration: Indirect boot via bootloader (processor-internal BOOTROM)." severity note;
-  assert not ((INT_BOOTLOADER_EN = false) and (MEM_INT_IMEM_EN = true)) report "NEORV32 PROCESSOR CONFIG NOTE: Boot configuration: Direct boot from memory (processor-internal IMEM)." severity note;
-  assert not ((INT_BOOTLOADER_EN = false) and (MEM_INT_IMEM_EN = false)) report "NEORV32 PROCESSOR CONFIG NOTE: Boot configuration: Direct boot from memory (processor-external (I)MEM)." severity note;
+  assert not ((INT_BOOTLOADER_EN = false) and (MEM_INT_IMEM_EN = true)) report "NEORV32 PROCESSOR CONFIG NOTE: Boot configuration = direct boot from memory (processor-internal IMEM)." severity note;
+  assert not ((INT_BOOTLOADER_EN = false) and (MEM_INT_IMEM_EN = false)) report "NEORV32 PROCESSOR CONFIG NOTE: Boot configuration = direct boot from memory (processor-external (I)MEM)." severity note;
   --
   assert not ((MEM_EXT_EN = false) and (MEM_INT_DMEM_EN = false)) report "NEORV32 PROCESSOR CONFIG ERROR! Core cannot fetch data without external memory interface and internal IMEM." severity error;
   assert not ((MEM_EXT_EN = false) and (MEM_INT_IMEM_EN = false) and (INT_BOOTLOADER_EN = false)) report "NEORV32 PROCESSOR CONFIG ERROR! Core cannot fetch instructions without external memory interface, internal IMEM and bootloader." severity error;

--- a/rtl/core/neorv32_wishbone.vhd
+++ b/rtl/core/neorv32_wishbone.vhd
@@ -144,23 +144,19 @@ architecture neorv32_wishbone_rtl of neorv32_wishbone is
 
 begin
 
-  -- Sanity Checks --------------------------------------------------------------------------
+  -- Configuration Info ---------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  -- protocol --
-  assert not (PIPE_MODE = false) report "NEORV32 PROCESSOR CONFIG NOTE: Ext. Bus Interface - STANDARD Wishbone protocol." severity note;
-  assert not (PIPE_MODE = true) report "NEORV32 PROCESSOR CONFIG NOTE: Ext. Bus Interface - PIPELINED Wishbone protocol." severity note;
+  assert false report
+  "NEORV32 PROCESSOR CONFIG NOTE: Ext. Bus Interface - " &
+  cond_sel_string_f(PIPE_MODE, "PIPELINED", "CASSIC/STANDARD") & "Wishbone protocol, " &
+  cond_sel_string_f(boolean(BUS_TIMEOUT /= 0), "auto-timeout (" & integer'image(BUS_TIMEOUT) & " cycles), ", "NO auto-timeout, ") &
+  cond_sel_string_f(BIG_ENDIAN, "BIG", "LITTLE") & "-endian byte order, " &
+  cond_sel_string_f(ASYNC_RX, "ASYNC ", "buffered ") & "RX path, " &
+  cond_sel_string_f(ASYNC_TX, "ASYNC ", "buffered ") & "TX path"
+  severity note;
 
-  -- bus timeout --
-  assert not (BUS_TIMEOUT /= 0) report "NEORV32 PROCESSOR CONFIG NOTE: Ext. Bus Interface - auto-timeout (" & integer'image(BUS_TIMEOUT) & " cycles)." severity note;
-  assert not (BUS_TIMEOUT  = 0) report "NEORV32 PROCESSOR CONFIG WARNING: Ext. Bus Interface - NO auto-timeout (can cause permanent CPU stall!)." severity warning;
-
-  -- endianness --
-  assert not (BIG_ENDIAN = false) report "NEORV32 PROCESSOR CONFIG NOTE: Ext. Bus Interface - LITTLE-endian byte order." severity note;
-  assert not (BIG_ENDIAN = true)  report "NEORV32 PROCESSOR CONFIG NOTE: Ext. Bus Interface - BIG-endian byte." severity note;
-
-  -- "async" (combinatorial) RX/TX --
-  assert not (ASYNC_RX = true)  report "NEORV32 PROCESSOR CONFIG NOTE: Ext. Bus Interface - ASYNC RX path." severity note;
-  assert not (ASYNC_TX = true)  report "NEORV32 PROCESSOR CONFIG NOTE: Ext. Bus Interface - ASYNC TX path." severity note;
+  -- no timeout warning --
+  assert not (BUS_TIMEOUT  = 0) report "NEORV32 PROCESSOR CONFIG WARNING! Ext. Bus Interface - NO auto-timeout (can cause permanent CPU stall!)." severity warning;
 
 
   -- Access Control -------------------------------------------------------------------------

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -669,9 +669,9 @@ enum NEORV32_CLOCK_PRSC_enum {
  **************************************************************************/
 /**@{*/
 /** instruction memory base address (r/w/x) */
-// -> configured via ispace_base_c constant in neorv32_package.vhd and available to SW via SYSCONFIG entry
+// -> configured via 'ispace_base_c' constant in neorv32_package.vhd and available to software via SYSINFO entry
 /** data memory base address (r/w/x) */
-// -> configured via dspace_base_c constant in neorv32_package.vhd and available to SW via SYSCONFIG entry
+// -> configured via 'dspace_base_c' constant in neorv32_package.vhd and available to software via SYSINFO entry
 /** bootloader memory base address (r/-/x) */
 #define BOOTLOADER_BASE_ADDRESS (0xFFFF0000UL)
 /** on-chip debugger complex base address (r/w/x) */


### PR DESCRIPTION
This is just another rtl clean-up PR (focusing mainly on cleaning up the assertions). The CPU assertions now also show the actual boot address:
```
neorv32_cpu.vhd:198:3:@0ms:(assertion note): NEORV32 CPU CONFIG NOTE: Boot from address 0x00000000.
```