### PR TITLE
[rtl] add "cached access" infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 05.07.2022 | 1.7.3.4 | add "infrastructure" for cached (burst) bus accesses; [#359](https://github.com/stnolting/neorv32/pull/359) |
 | 01.07.2022 | 1.7.3.3 | minor rtl cleanups; [#357](https://github.com/stnolting/neorv32/pull/357) |
 | 29.06.2022 | 1.7.3.2 | :test_tube: add experimental core complex wrapper for integration into the [**LiteX**](https://github.com/enjoy-digital/litex) SoC builder framework; [#353](https://github.com/stnolting/neorv32/pull/353) |
 | 28.06.2022 | 1.7.3.1 | :bug: fix bug that caused permanent CPU stall if illegal load/store instruction; [#356](https://github.com/stnolting/neorv32/pull/356) |

--- a/rtl/core/neorv32_busswitch.vhd
+++ b/rtl/core/neorv32_busswitch.vhd
@@ -49,36 +49,39 @@ entity neorv32_busswitch is
   );
   port (
     -- global control --
-    clk_i          : in  std_ulogic; -- global clock, rising edge
-    rstn_i         : in  std_ulogic; -- global reset, low-active, async
+    clk_i           : in  std_ulogic; -- global clock, rising edge
+    rstn_i          : in  std_ulogic; -- global reset, low-active, async
     -- controller interface a --
-    ca_bus_addr_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-    ca_bus_rdata_o : out std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
-    ca_bus_wdata_i : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
-    ca_bus_ben_i   : in  std_ulogic_vector(03 downto 0); -- byte enable
-    ca_bus_we_i    : in  std_ulogic; -- write enable
-    ca_bus_re_i    : in  std_ulogic; -- read enable
-    ca_bus_ack_o   : out std_ulogic; -- bus transfer acknowledge
-    ca_bus_err_o   : out std_ulogic; -- bus transfer error
+    ca_bus_cached_i : in  std_ulogic; -- set if cached transfer
+    ca_bus_addr_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
+    ca_bus_rdata_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
+    ca_bus_wdata_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
+    ca_bus_ben_i    : in  std_ulogic_vector(03 downto 0); -- byte enable
+    ca_bus_we_i     : in  std_ulogic; -- write enable
+    ca_bus_re_i     : in  std_ulogic; -- read enable
+    ca_bus_ack_o    : out std_ulogic; -- bus transfer acknowledge
+    ca_bus_err_o    : out std_ulogic; -- bus transfer error
     -- controller interface b --
-    cb_bus_addr_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-    cb_bus_rdata_o : out std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
-    cb_bus_wdata_i : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
-    cb_bus_ben_i   : in  std_ulogic_vector(03 downto 0); -- byte enable
-    cb_bus_we_i    : in  std_ulogic; -- write enable
-    cb_bus_re_i    : in  std_ulogic; -- read enable
-    cb_bus_ack_o   : out std_ulogic; -- bus transfer acknowledge
-    cb_bus_err_o   : out std_ulogic; -- bus transfer error
+    cb_bus_cached_i : in  std_ulogic; -- set if cached transfer
+    cb_bus_addr_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
+    cb_bus_rdata_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
+    cb_bus_wdata_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
+    cb_bus_ben_i    : in  std_ulogic_vector(03 downto 0); -- byte enable
+    cb_bus_we_i     : in  std_ulogic; -- write enable
+    cb_bus_re_i     : in  std_ulogic; -- read enable
+    cb_bus_ack_o    : out std_ulogic; -- bus transfer acknowledge
+    cb_bus_err_o    : out std_ulogic; -- bus transfer error
     -- peripheral bus --
-    p_bus_src_o    : out std_ulogic; -- access source: 0 = A, 1 = B
-    p_bus_addr_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-    p_bus_rdata_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
-    p_bus_wdata_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
-    p_bus_ben_o    : out std_ulogic_vector(03 downto 0); -- byte enable
-    p_bus_we_o     : out std_ulogic; -- write enable
-    p_bus_re_o     : out std_ulogic; -- read enable
-    p_bus_ack_i    : in  std_ulogic; -- bus transfer acknowledge
-    p_bus_err_i    : in  std_ulogic  -- bus transfer error
+    p_bus_cached_o  : out std_ulogic; -- set if cached transfer
+    p_bus_src_o     : out std_ulogic; -- access source: 0 = A, 1 = B
+    p_bus_addr_o    : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
+    p_bus_rdata_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
+    p_bus_wdata_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
+    p_bus_ben_o     : out std_ulogic_vector(03 downto 0); -- byte enable
+    p_bus_we_o      : out std_ulogic; -- write enable
+    p_bus_re_o      : out std_ulogic; -- read enable
+    p_bus_ack_i     : in  std_ulogic; -- bus transfer acknowledge
+    p_bus_err_i     : in  std_ulogic  -- bus transfer error
   );
 end neorv32_busswitch;
 
@@ -216,6 +219,8 @@ begin
   p_bus_ben_o    <= cb_bus_ben_i when (PORT_CA_READ_ONLY = true) else
                     ca_bus_ben_i when (PORT_CB_READ_ONLY = true) else
                     ca_bus_ben_i when (arbiter.bus_sel = '0')    else cb_bus_ben_i;
+
+  p_bus_cached_o <= ca_bus_cached_i when (arbiter.bus_sel = '0') else cb_bus_cached_i;
 
   p_bus_we       <= ca_bus_we_i when (arbiter.bus_sel = '0') else cb_bus_we_i;
   p_bus_re       <= ca_bus_re_i when (arbiter.bus_sel = '0') else cb_bus_re_i;

--- a/rtl/core/neorv32_icache.vhd
+++ b/rtl/core/neorv32_icache.vhd
@@ -61,6 +61,7 @@ entity neorv32_icache is
     host_ack_o   : out std_ulogic; -- bus transfer acknowledge
     host_err_o   : out std_ulogic; -- bus transfer error
     -- peripheral bus interface --
+    bus_cached_o : out std_ulogic; -- set if cached (!) access in progress
     bus_addr_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
     bus_rdata_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
     bus_re_o     : out std_ulogic; -- read enable
@@ -279,6 +280,9 @@ begin
 
   -- signal cache miss to CPU --
   miss_o <= '1' when (ctrl.state = S_CACHE_MISS) else '0';
+
+  -- cache access in progress --
+  bus_cached_o <= '1' when (ctrl.state = S_BUS_DOWNLOAD_REQ) or (ctrl.state = S_BUS_DOWNLOAD_GET) else '0';
 
 
 	-- Cache Memory ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a minimal infrastructure to allow all internal devices to check if the current bus access is "cached". Right now, this feature is not used and does not impact area/critical path at all. I am planning to use this additional information to allow **burst accesses** for some peripherals:

* work-in-progress: XIP (reducing overhead - faster access)
* planned: Wishbone ("real" pipelined burst accesses)