### PR TITLE
🧪 [XIP] add experimental burst mode; fix endianness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:----------:|:-------:|:--------|
+| 08.07.2022 | 1.7.3.6 | :test_tube: added burst mode option to **XIP module** to accelerate consecutive flash read accesses; :warning: fixed XIP endianness: was BIG-endian and is now LITTLE-endian; [#361](https://github.com/stnolting/neorv32/pull/361) |
 | 08.07.2022 | 1.7.3.5 | Update "raw" executable generation options of makefile and image generator; [#360](https://github.com/stnolting/neorv32/pull/360) |
 | 05.07.2022 | 1.7.3.4 | add "infrastructure" for cached (burst) bus accesses; [#359](https://github.com/stnolting/neorv32/pull/359) |
 | 01.07.2022 | 1.7.3.3 | minor rtl cleanups; [#357](https://github.com/stnolting/neorv32/pull/357) |

--- a/docs/datasheet/soc_xip.adoc
+++ b/docs/datasheet/soc_xip.adoc
@@ -185,7 +185,14 @@ of the SPI access latency.
 
 **XIP Burst Mode**
 
-TODO
+By default, every XIP access to the flash transmits the read command and the word-aligned address before reading four consecutive
+data bytes. Obviously, this introduces a certain transmission overhead. To reduces this overhead, the XIP mode allows to utilize
+the flash's _incrmental read_ function, which will return consecutive bytes when continuing to send clock cycles after a read command.
+Hence, the XIP module provides an optional "burst mode" to accelerate consecutive read accesses.
+
+The XIP burst mode is enabled by setting the _XIP_CTRL_BURST_EN_ bit in the module's control register. The burst mode only affects
+the actual XIP mode and _not_ the direct SPI mode. Hence, it should be enabled right before enabling XIP mode only.
+By using the XIP burst mode flash read accesses can be accelerated by up to 50%.
 
 
 **Register Map**

--- a/docs/datasheet/soc_xip.adoc
+++ b/docs/datasheet/soc_xip.adoc
@@ -154,15 +154,15 @@ control register bits. Note that the 72-bit transmission size is only available 
 size of the direct SPI accesses is limited to 64-bit.
 
 [NOTE]
-There is no _continuous read_ feature (i.e. a burst SPI transmission fetching several data words at once) implemented yet.
-
-[NOTE]
 When using four SPI flash address bytes, the most significant 4 bits of the address are always hardwired
 to zero allowing a maximum **accessible** flash size of 256MB.
 
 [NOTE]
 The XIP module always fetches a full naturally aligned 32-bit word from the SPI flash. Any sub-word data masking
-or alignment will be performed by the CPU logic.
+or alignment will be performed by the CPU core logic.
+
+[IMPORTANT]
+The XIP mode requires the 4-byte data words in the flash to be ordered in **little-endian** byte order.
 
 After the SPI properties (including the amount of address bytes **and** the total amount of SPI transfer bytes)
 and XIP address mapping are configured, the actual XIP mode can be enabled by setting
@@ -183,14 +183,19 @@ It is highly recommended to enable the <<_processor_internal_instruction_cache_i
 of the SPI access latency.
 
 
+**XIP Burst Mode**
+
+TODO
+
+
 **Register Map**
 
-.XIP register map (`struct NEORV32_XIP`)
+.XIP Register Map (`struct NEORV32_XIP`)
 [cols="<2,<2,<4,^1,<7"]
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.16+<| `0xffffff40` .16+<| `NEORV32_XIP.CTRL` <|`0`  _XIP_CTRL_EN_    ^| r/w <| XIP module enable
+.17+<| `0xffffff40` .17+<| `NEORV32_XIP.CTRL` <|`0`  _XIP_CTRL_EN_    ^| r/w <| XIP module enable
                                               <|`1`  _XIP_CTRL_PRSC0_ ^| r/w .3+| 3-bit SPI clock prescaler select
                                               <|`2`  _XIP_CTRL_PRSC1_ ^| r/w
                                               <|`3`  _XIP_CTRL_PRSC2_ ^| r/w
@@ -203,7 +208,8 @@ of the SPI access latency.
                                               <|`24:21` _XIP_CTRL_XIP_PAGE_MSB_ : _XIP_CTRL_XIP_PAGE_LSB_ ^| r/w <| XIP memory page
                                               <|`25` _XIP_CTRL_SPI_CSEN_  ^| r/w <| Allow SPI chip-select to be actually asserted when set
                                               <|`26` _XIP_CTRL_HIGHSPEED_ ^| r/w <| enable SPI high-speed mode (ignoring _XIP_CTRL_PRSC_)
-                                              <|`29:27`                   ^| r/- <| _reserved_, read as zero
+                                              <|`27` _XIP_CTRL_BURST_EN_  ^| r/w <| Enable XIP burst mode
+                                              <|`29:28`                   ^| r/- <| _reserved_, read as zero
                                               <|`30` _XIP_CTRL_PHY_BUSY_  ^| r/- <| SPI PHY busy when set
                                               <|`31` _XIP_CTRL_XIP_BUSY_  ^| r/- <| XIP access in progress when set
 | `0xffffff44` | _reserved_            |`31:0` | r/- | _reserved_, read as zero

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -68,7 +68,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070305"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070306"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/rtl/core/neorv32_xip.vhd
+++ b/rtl/core/neorv32_xip.vhd
@@ -362,7 +362,7 @@ begin
       when S_BUSY => -- wait for PHY to complete operation
       -- ------------------------------------------------------------
         if (phy_if.busy = '0') then
-          acc_data_o        <= phy_if.rdata;
+          acc_data_o        <= bswap32_f(phy_if.rdata); -- convert to little-endian
           acc_ack_o         <= '1';
           arbiter.state_nxt <= S_IDLE;
         end if;

--- a/rtl/core/neorv32_xip.vhd
+++ b/rtl/core/neorv32_xip.vhd
@@ -107,11 +107,12 @@ architecture neorv32_xip_rtl of neorv32_xip is
   constant ctrl_page3_c       : natural := 24; -- r/w: XIP memory page - bit 3
   constant ctrl_spi_csen_c    : natural := 25; -- r/w: SPI chip-select enabled
   constant ctrl_highspeed_c   : natural := 26; -- r/w: SPI high-speed mode enable (ignoring ctrl_spi_prsc)
+  constant ctrl_burst_en_c    : natural := 27; -- r/w: XIP burst mode enable
   --
   constant ctrl_phy_busy_c    : natural := 30; -- r/-: SPI PHY is busy when set
   constant ctrl_xip_busy_c    : natural := 31; -- r/-: XIP access in progress
   --
-  signal ctrl : std_ulogic_vector(26 downto 0);
+  signal ctrl : std_ulogic_vector(27 downto 0);
 
   -- Direct SPI access registers --
   signal spi_data_lo : std_ulogic_vector(31 downto 0);
@@ -122,12 +123,14 @@ architecture neorv32_xip_rtl of neorv32_xip is
   signal xip_addr : std_ulogic_vector(31 downto 0);
 
   -- SPI access fetch arbiter --
-  type arbiter_state_t is (S_DIRECT, S_IDLE, S_TRIG, S_BUSY);
+  type arbiter_state_t is (S_DIRECT, S_IDLE, S_CHECK, S_TRIG, S_BUSY);
   type arbiter_t is record
-    state     : arbiter_state_t;
-    state_nxt : arbiter_state_t;
-    addr      : std_ulogic_vector(31 downto 0);
-    busy      : std_ulogic;
+    state          : arbiter_state_t;
+    state_nxt      : arbiter_state_t;
+    addr           : std_ulogic_vector(31 downto 0);
+    addr_lookahead : std_ulogic_vector(31 downto 0);
+    busy           : std_ulogic;
+    tmo_cnt        : std_ulogic_vector(04 downto 0);
   end record;
   signal arbiter : arbiter_t;
 
@@ -146,6 +149,7 @@ architecture neorv32_xip_rtl of neorv32_xip is
     cf_cpol_i    : in  std_ulogic; -- clock idle polarity
     -- operation control --
     op_start_i   : in  std_ulogic; -- trigger new transmission
+    op_final_i   : in  std_ulogic; -- end current transmission
     op_csen_i    : in  std_ulogic; -- actually enabled device for transmission
     op_busy_o    : out std_ulogic; -- transmission in progress when set
     op_nbytes_i  : in  std_ulogic_vector(03 downto 0); -- actual number of bytes to transmit (1..9)
@@ -162,6 +166,7 @@ architecture neorv32_xip_rtl of neorv32_xip is
   -- PHY interface --
   type phy_if_t is record
     start : std_ulogic; -- trigger new transmission
+    final : std_ulogic; -- stop current transmission
     busy  : std_ulogic; -- transmission in progress when set
     wdata : std_ulogic_vector(71 downto 0); -- write data
     rdata : std_ulogic_vector(31 downto 0); -- read data
@@ -213,6 +218,7 @@ begin
           ctrl(ctrl_page3_c downto ctrl_page0_c)             <= ct_data_i(ctrl_page3_c downto ctrl_page0_c);
           ctrl(ctrl_spi_csen_c)                              <= ct_data_i(ctrl_spi_csen_c);
           ctrl(ctrl_highspeed_c)                             <= ct_data_i(ctrl_highspeed_c);
+          ctrl(ctrl_burst_en_c)                              <= ct_data_i(ctrl_burst_en_c);
         end if;
 
         -- SPI direct data access register lo --
@@ -243,6 +249,7 @@ begin
             ct_data_o(ctrl_page3_c downto ctrl_page0_c)             <= ctrl(ctrl_page3_c downto ctrl_page0_c);
             ct_data_o(ctrl_spi_csen_c)                              <= ctrl(ctrl_spi_csen_c);
             ct_data_o(ctrl_highspeed_c)                             <= ctrl(ctrl_highspeed_c);
+            ct_data_o(ctrl_burst_en_c)                              <= ctrl(ctrl_burst_en_c);
             --
             ct_data_o(ctrl_phy_busy_c) <= phy_if.busy;
             ct_data_o(ctrl_xip_busy_c) <= arbiter.busy;
@@ -284,12 +291,23 @@ begin
   arbiter_sync: process(clk_i)
   begin
     if rising_edge(clk_i) then
+      -- state control --
       if (ctrl(ctrl_enable_c) = '0') or (ctrl(ctrl_xip_enable_c) = '0') then -- sync reset
         arbiter.state <= S_DIRECT;
       else
         arbiter.state <= arbiter.state_nxt;
       end if;
-      arbiter.addr <= acc_addr_i; -- buffer address (reducing fan-out on CPU's address net)
+      -- address look-ahead --
+      if (acc_rden_i = '1') and (acc_addr_i(31 downto 28) = ctrl(ctrl_page3_c downto ctrl_page0_c)) then
+        arbiter.addr <= acc_addr_i; -- buffer address (reducing fan-out on CPU's address net)
+      end if;
+      arbiter.addr_lookahead <= std_ulogic_vector(unsigned(arbiter.addr) + 4); -- prefetch address of *next* linear access
+      -- pending flash access timeout --
+      if (ctrl(ctrl_enable_c) = '0') or (ctrl(ctrl_xip_enable_c) = '0') or (arbiter.state = S_BUSY) then -- sync reset
+        arbiter.tmo_cnt <= (others => '0');
+      elsif (arbiter.tmo_cnt(arbiter.tmo_cnt'left) = '0') then -- stop if maximum reached
+        arbiter.tmo_cnt <= std_ulogic_vector(unsigned(arbiter.tmo_cnt) + 1);
+      end if;
     end if;
   end process arbiter_sync;
 
@@ -306,29 +324,42 @@ begin
 
     -- SPI PHY interface defaults --
     phy_if.start <= '0';
+    phy_if.final <= arbiter.tmo_cnt(arbiter.tmo_cnt'left) or (not ctrl(ctrl_burst_en_c)); -- terminate if timeout or if burst mode not enabled
     phy_if.wdata <= ctrl(ctrl_rd_cmd7_c downto ctrl_rd_cmd0_c) & xip_addr & x"00000000"; -- MSB-aligned: CMD + address + 32-bit zero data
 
     -- fsm --
     case arbiter.state is
 
-      when S_DIRECT => -- XIP access disabled: allow direct SPI access
+      when S_DIRECT => -- XIP access disabled; direct SPI access
       -- ------------------------------------------------------------
         phy_if.wdata      <= spi_data_hi & spi_data_lo & x"00"; -- MSB-aligned data
         phy_if.start      <= spi_trigger;
+        phy_if.final      <= '1'; -- do not keep CS active after transmission is done
         arbiter.state_nxt <= S_IDLE;
 
-      when S_IDLE => -- XIP: wait for new bus request
+      when S_IDLE => -- wait for new bus request
       -- ------------------------------------------------------------
         if (acc_rden_i = '1') and (acc_addr_i(31 downto 28) = ctrl(ctrl_page3_c downto ctrl_page0_c)) then
+          arbiter.state_nxt <= S_CHECK;
+        end if;
+
+      when S_CHECK => -- check if we can resume flash access
+      -- ------------------------------------------------------------
+        if (arbiter.addr(27 downto 2) = arbiter.addr_lookahead(27 downto 2)) and (ctrl(ctrl_burst_en_c) = '1') and -- access to _next_ address
+           (arbiter.tmo_cnt(arbiter.tmo_cnt'left) = '0') then -- no "pending access" timeout yet
+          phy_if.start      <= '1'; -- resume flash access
+          arbiter.state_nxt <= S_BUSY;
+        else
+          phy_if.final      <= '1'; -- reset flash access
           arbiter.state_nxt <= S_TRIG;
         end if;
 
-      when S_TRIG => -- XIP: trigger flash read
+      when S_TRIG => -- trigger NEW flash read
       -- ------------------------------------------------------------
         phy_if.start      <= '1';
         arbiter.state_nxt <= S_BUSY;
 
-      when S_BUSY => -- XIP: wait for PHY to complete operation
+      when S_BUSY => -- wait for PHY to complete operation
       -- ------------------------------------------------------------
         if (phy_if.busy = '0') then
           acc_data_o        <= phy_if.rdata;
@@ -372,6 +403,7 @@ begin
     cf_cpol_i    => ctrl(ctrl_spi_cpol_c), -- clock idle polarity
     -- operation control --
     op_start_i   => phy_if.start,          -- trigger new transmission
+    op_final_i   => phy_if.final,          -- end current transmission
     op_csen_i    => ctrl(ctrl_spi_csen_c), -- actually enabled device for transmission
     op_busy_o    => phy_if.busy,           -- transmission in progress when set
     op_nbytes_i  => ctrl(ctrl_spi_nbytes3_c downto ctrl_spi_nbytes0_c), -- actual number of bytes to transmit
@@ -444,6 +476,7 @@ entity neorv32_xip_phy is
     cf_cpol_i    : in  std_ulogic; -- clock idle polarity
     -- operation control --
     op_start_i   : in  std_ulogic; -- trigger new transmission
+    op_final_i   : in  std_ulogic; -- end current transmission
     op_csen_i    : in  std_ulogic; -- actually enabled device for transmission
     op_busy_o    : out std_ulogic; -- transmission in progress when set
     op_nbytes_i  : in  std_ulogic_vector(03 downto 0); -- actual number of bytes to transmit (1..9)
@@ -459,8 +492,8 @@ end neorv32_xip_phy;
 
 architecture neorv32_xip_phy_rtl of neorv32_xip_phy is
 
-  -- controller --
-  type ctrl_state_t is (S_IDLE, S_START, S_RTX_A, S_RTX_B, S_DONE);
+  -- serial engine --
+  type ctrl_state_t is (S_IDLE, S_WAIT, S_START, S_SYNC, S_RTX_A, S_RTX_B, S_DONE);
   type ctrl_t is record
     state   : ctrl_state_t;
     sreg    : std_ulogic_vector(71 downto 0); -- only the lowest 32-bit are used as RX data
@@ -472,9 +505,9 @@ architecture neorv32_xip_phy_rtl of neorv32_xip_phy is
 
 begin
 
-  -- Serial Interface Control Unit ----------------------------------------------------------
+  -- Serial Interface Engine ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  control_unit: process(clk_i)
+  serial_engine: process(clk_i)
   begin
     if rising_edge(clk_i) then
       if (cf_enable_i = '0') then
@@ -486,26 +519,41 @@ begin
         ctrl.sreg(ctrl.sreg'left) <= '0'; -- this drives SDO
         ctrl.bitcnt  <= (others => '-');
         ctrl.di_sync <= '-';
-      else
-        -- defaults --
-        spi_csn_o <= '1'; -- de-selected by default
-
-        -- fsm --
+      else -- fsm
         case ctrl.state is
 
           when S_IDLE => -- wait for new transmission trigger
           -- ------------------------------------------------------------
+            spi_csn_o   <= '1'; -- flash disabled
             spi_clk_o   <= cf_cpol_i;
             ctrl.bitcnt <= op_nbytes_i & "000"; -- number of bytes
             ctrl.csen   <= op_csen_i;
             if (op_start_i = '1') then
-              ctrl.sreg  <= op_wdata_i;
               ctrl.state <= S_START;
             end if;
 
-          when S_START => -- sync start of transmission
+          when S_START => -- start of transmission
           -- ------------------------------------------------------------
-            spi_csn_o <= not ctrl.csen;
+            -- keep current spi_csn_o state
+            ctrl.sreg <= op_wdata_i;
+            if (spi_clk_en_i = '1') then
+              ctrl.state <= S_SYNC;
+            end if;
+
+          when S_WAIT => -- wait for resume transmission trigger
+          -- ------------------------------------------------------------
+            spi_csn_o   <= not ctrl.csen; -- keep CS active
+            ctrl.bitcnt <= "0100" & "000"; -- 4 bytes: 32-bit read data only
+--          ctrl.sreg   <= (others => '0');
+            if (op_final_i = '1') then -- terminate pending flash access
+              ctrl.state  <= S_IDLE;
+            elsif (op_start_i = '1') then -- resume flash access
+              ctrl.state  <= S_SYNC;
+            end if;
+
+          when S_SYNC => -- synchronize SPI clock
+          -- ------------------------------------------------------------
+            spi_csn_o <= not ctrl.csen; -- enable flash
             if (spi_clk_en_i = '1') then
               if (cf_cpha_i = '1') then -- clock phase shift
                 spi_clk_o <= not cf_cpol_i;
@@ -515,7 +563,6 @@ begin
 
           when S_RTX_A => -- first half of bit transmission
           -- ------------------------------------------------------------
-            spi_csn_o <= not ctrl.csen;
             if (spi_clk_en_i = '1') then
               spi_clk_o    <= not (cf_cpha_i xor cf_cpol_i);
               ctrl.di_sync <= spi_data_i;
@@ -525,7 +572,6 @@ begin
 
           when S_RTX_B => -- second half of bit transmission
           -- ------------------------------------------------------------
-            spi_csn_o <= not ctrl.csen;
             if (spi_clk_en_i = '1') then
               ctrl.sreg <= ctrl.sreg(ctrl.sreg'left-1 downto 0) & ctrl.di_sync;
               if (or_reduce_f(ctrl.bitcnt) = '0') then -- all bits transferred?
@@ -539,9 +585,8 @@ begin
 
           when S_DONE => -- transmission done
           -- ------------------------------------------------------------
-            spi_csn_o <= not ctrl.csen;
             if (spi_clk_en_i = '1') then
-              ctrl.state <= S_IDLE;
+              ctrl.state <= S_WAIT;
             end if;
 
           when others => -- undefined
@@ -551,10 +596,10 @@ begin
         end case;
       end if;
     end if;
-  end process control_unit;
+  end process serial_engine;
 
   -- serial unit busy --
-  op_busy_o <= '0' when (ctrl.state = S_IDLE) else '1';
+  op_busy_o <= '0' when (ctrl.state = S_IDLE) or (ctrl.state = S_WAIT) else '1';
 
   -- serial data output --
   spi_data_o <= ctrl.sreg(ctrl.sreg'left);

--- a/sw/example/demo_xip/main.c
+++ b/sw/example/demo_xip/main.c
@@ -80,7 +80,7 @@ uint32_t byte_swap32(uint32_t data);
 
 /**********************************************************************//**
  * @name Simple demo program to be stored to the XIP flash.
- * @note This is a the "raw HEX version" from the rv32i-only "sw/example/blink_led" demo program.
+ * @note This is a the "raw HEX version" from the rv32i-only "sw/example/blink_led" demo program (using "make clean_all hex").
  * This program has been compiled using a modified linker script:
  * rom ORIGIN = XIP base page + flash base address (= 0x20000000 + FLASH_BASE)
  **************************************************************************/

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -879,6 +879,7 @@ enum NEORV32_XIP_CTRL_enum {
   XIP_CTRL_PAGE_MSB       = 24, /**< XIP control register(24) (r/w): XIP memory page, MSB */
   XIP_CTRL_SPI_CSEN       = 25, /**< XIP control register(25) (r/w): SPI chip-select enable */
   XIP_CTRL_HIGHSPEED      = 26, /**< XIP control register(26) (r/w): SPI high-speed mode enable (ignoring XIP_CTRL_PRSC) */
+  XIP_CTRL_BURST_EN       = 27, /**< XIP control register(27) (r/w): Enable XIP burst mode */
 
   XIP_CTRL_PHY_BUSY       = 30, /**< XIP control register(20) (r/-): SPI PHY is busy */
   XIP_CTRL_XIP_BUSY       = 31  /**< XIP control register(31) (r/-): XIP access in progress */

--- a/sw/lib/include/neorv32_xip.h
+++ b/sw/lib/include/neorv32_xip.h
@@ -49,6 +49,8 @@ int  neorv32_xip_setup(uint8_t prsc, uint8_t cpol, uint8_t cpha, uint8_t rd_cmd)
 int  neorv32_xip_start(uint8_t abytes, uint32_t page_base);
 void neorv32_xip_highspeed_enable(void);
 void neorv32_xip_highspeed_disable(void);
+void neorv32_xip_burst_mode_enable(void);
+void neorv32_xip_burst_mode_disable(void);
 int  neorv32_xip_spi_trans(uint8_t nbytes, uint64_t *rtx_data);
 
 #endif // neorv32_xip_h

--- a/sw/lib/source/neorv32_xip.c
+++ b/sw/lib/source/neorv32_xip.c
@@ -82,8 +82,11 @@ int neorv32_xip_setup(uint8_t prsc, uint8_t cpol, uint8_t cpha, uint8_t rd_cmd) 
   // reset module
   NEORV32_XIP.CTRL = 0;
 
-  uint32_t ctrl = 0;
+  // clear data registers
+  NEORV32_XIP.DATA_LO = 0;
+  NEORV32_XIP.DATA_HI = 0; // will not trigger SPI transfer as module is disabled
 
+  uint32_t ctrl = 0;
   ctrl |= ((uint32_t)(1            )) << XIP_CTRL_EN; // enable module
   ctrl |= ((uint32_t)(prsc   & 0x07)) << XIP_CTRL_PRSC0;
   ctrl |= ((uint32_t)(cpol   & 0x01)) << XIP_CTRL_CPOL;
@@ -164,6 +167,26 @@ void neorv32_xip_highspeed_enable(void) {
 void neorv32_xip_highspeed_disable(void) {
 
   NEORV32_XIP.CTRL &= ~(1 << XIP_CTRL_HIGHSPEED);
+}
+
+
+/**********************************************************************//**
+ * Enable XIP burst mode (incremental reads).
+ *
+ * @note Make sure your flash supports this feature (most flash chips do so).
+ **************************************************************************/
+void neorv32_xip_burst_mode_enable(void) {
+
+  NEORV32_XIP.CTRL |= 1 << XIP_CTRL_BURST_EN;
+}
+
+
+/**********************************************************************//**
+ * Disable XIP burst mode.
+ **************************************************************************/
+void neorv32_xip_burst_mode_disable(void) {
+
+  NEORV32_XIP.CTRL &= ~(1 << XIP_CTRL_BURST_EN);
 }
 
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -419,6 +419,11 @@
               <description>SPI high-speed mode enable (ignoring XIP_CTRL_PRSC)</description>
             </field>
             <field>
+              <name>XIP_CTRL_BURST_EN</name>
+              <bitRange>[27:27]</bitRange>
+              <description>Enable burst mode (for XIP accesses)</description>
+            </field>
+            <field>
               <name>XIP_CTRL_PHY_BUSY</name>
               <bitRange>[30:30]</bitRange>
               <access>read-only</access>


### PR DESCRIPTION
This PR adds an optional (experimental) **burst mode** for the XIP mode. The burst mode makes use of the flash's "incremental read" functionality to speed up sequential flash read accesses. XIP burst mode is enabled by setting bit 27 of the XIP's control register (calling new function `neorv32_xip_burst_mode_enable()`).

:bug: This PR also fixes the endiannes of the XIP mode. Now the XIP mode expects the data words to be stored in **little-endian** byte order to the flash. Thanks to @betocool-prog for finding this bug!

:warning: Programs stored to a flash for being used with the XIP module need to be updated due to the changed byte order.