### PR TITLE
Fix PMP locking

### DIFF
--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -64,23 +64,18 @@ has been moved to a separate repository: https://github.com/stnolting/neorv32-ve
 :sectnums:
 ==== RISC-V Incompatibility Issues and Limitations
 
-This list shows the currently identified issues regarding full RISC-V-compatibility. Note that most
-of the cases listed below are "special cases" that should not occur in "normal" programs. However,
-some of these incompatibilities can be circumvented using software emulation (for example for
-handling unaligned memory accesses).
+This list shows the currently identified issues regarding full RISC-V-compatibility.
 
 .Read-Only "Read-Write" CSRs
 [IMPORTANT]
-The NEORV32 <<_misa>> and <<_mtval>> CSRs are _read-only_ - the RISC-V specs. declare
-these registers as _read/write_. Any machine-mode write access to them is ignored and will _not_
+The NEORV32 <<_misa>> and <<_mtval>> CSRs are _read-only_ - the RISC-V specs. declares
+these registers to be _read/write_. Any machine-mode write access to them is ignored and will _not_
 cause any exceptions or side-effects to maintain RISC-V compatibility.
 
-.Physical Memory Protection
+.Physical Memory Protection (PMP)
 [IMPORTANT]
 The RISC-V-compatible NEORV32 <<_machine_physical_memory_protection_csrs>> only implements the **TOR**
-(top of region) mode and only up to 16 PMP regions. Furthermore, the <<_pmpcfg>>'s _lock bits_ only lock
-the according PMP entry and not the entries below. All region rules are checked in parallel **without**
-prioritization so for identical memory regions the most restrictive PMP rule will be enforced.
+(top of region) mode and only up to 16 PMP regions.
 
 .No Hardware Support of Misaligned Memory Accesses
 [WARNING]

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -539,7 +539,8 @@ as the MSB is hardwired to zero
 |=======================
 
 [WARNING]
-Setting the lock bit `L` **only locks the according PMP entry** and not the PMP entries below!
+Setting the lock bit `L` and setting TOR mode in `pmpcfg(i)` will also lock write access to `pmpaddr(i-1)`.
+See the RISC-V specs. for more information.
 
 
 :sectnums!:

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1890,12 +1890,17 @@ begin
             end loop; -- i (pmpcfg entry)
           end if;
           -- R/W: pmpaddr* - PMP address registers --
-          if (csr.addr(11 downto 4) = csr_class_pmpaddr_c) then 
-            for i in 0 to PMP_NUM_REGIONS-1 loop
-              if (csr.addr(3 downto 0) = std_ulogic_vector(to_unsigned(i, 4))) and (csr.pmpcfg(i)(7) = '0') then -- unlocked pmpaddr access
+          if (csr.addr(11 downto 4) = csr_class_pmpaddr_c) then
+            for i in 0 to PMP_NUM_REGIONS-2 loop
+              if (csr.addr(3 downto 0) = std_ulogic_vector(to_unsigned(i, 4))) and (csr.pmpcfg(i)(7) = '0') and -- unlocked pmpaddr access
+                ((csr.pmpcfg(i+1)(7) = '0') or (csr.pmpcfg(i+1)(3) = '0')) then -- pmpcfg(i+1) not "LOCKED TOR" [TOR-mode only!]
                 csr.pmpaddr(i) <= csr.wdata(data_width_c-3 downto index_size_f(PMP_MIN_GRANULARITY)-2);
               end if;
             end loop; -- i (PMP regions)
+            -- very last entry --
+            if (csr.addr(3 downto 0) = std_ulogic_vector(to_unsigned(PMP_NUM_REGIONS-1, 4))) and (csr.pmpcfg(PMP_NUM_REGIONS-1)(7) = '0') then -- unlocked pmpaddr access
+              csr.pmpaddr(PMP_NUM_REGIONS-1) <= csr.wdata(data_width_c-3 downto index_size_f(PMP_MIN_GRANULARITY)-2);
+            end if;
           end if;
 
           -- machine counter setup --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -68,7 +68,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070307"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070308"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------


### PR DESCRIPTION
Triggered by https://github.com/riscv/riscv-isa-manual/issues/866 this PR fixes the locking behavior of the physical memory protection (PMP) CPU extension:

If PMP entry `i` is locked, writes to `pmpcfg(i)` and `pmpaddr(i)` are ignored. Additionally, if PMP entry `i` is locked and `pmpcfg(i).A` is set to TOR, writes to `pmpaddr(i-1)` are ignored (**added by this PR**).