### PR TITLE
🐛 [rtl] cycle & instret bug fix, wishbone.we bug fix; minor rtl updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
-| 15.07.2022 | 1.7.4.1 | :bug: fix permanent stall of `[m]cycle[h]` and `[m]instret[h]` counter if _HPM_NUM_CNTS_ = 0; hardwire `dcsr.mprven` to 1; [#367](https://github.com/stnolting/neorv32/pull/367) |
+| 15.07.2022 | 1.7.4.1 | :bug: fix permanent stall of `[m]cycle[h]` and `[m]instret[h]` counter if _HPM_NUM_CNTS_ = 0; :bug: fixed bug in Wishbone `we` signal when _ASYNC_TX_ mode enabled; hardwire `dcsr.mprven` to 1; [#367](https://github.com/stnolting/neorv32/pull/367) |
 | 14.07.2022 | [**:rocket:1.7.4**](https://github.com/stnolting/neorv32/releases/tag/v1.7.4) | **New release** |
 | 14.07.2022 | 1.7.3.11 | reset all "core" CSRs to all-zero; [#366](https://github.com/stnolting/neorv32/pull/366) |
 | 13.07.2022 | 1.7.3.10 | :bug: reworked/fixed **physical memory protection**; :sparkles: added `mstatus.MPRV` flag; [#365](https://github.com/stnolting/neorv32/pull/365) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 15.07.2022 | 1.7.4.1 | :bug: fix permanent stall of `[m]cycle[h]` and `[m]instret[h]` counter if _HPM_NUM_CNTS_ = 0; hardwire `dcsr.mprven` to 1; [#367](https://github.com/stnolting/neorv32/pull/367) |
 | 14.07.2022 | [**:rocket:1.7.4**](https://github.com/stnolting/neorv32/releases/tag/v1.7.4) | **New release** |
 | 14.07.2022 | 1.7.3.11 | reset all "core" CSRs to all-zero; [#366](https://github.com/stnolting/neorv32/pull/366) |
 | 13.07.2022 | 1.7.3.10 | :bug: reworked/fixed **physical memory protection**; :sparkles: added `mstatus.MPRV` flag; [#365](https://github.com/stnolting/neorv32/pull/365) |

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -578,7 +578,7 @@ is raised.
 [frame="topbot",grid="none"]
 |======
 | 0x7b0 | **Debug control and status register** | `dcsr`
-3+| Reset value: `0x40000403`
+3+| Reset value: `0x40000413`
 3+| The `dcsr` CSR is compatible to the RISC-V debug spec. It is used to configure debug mode and provides additional status information.
 The following bits are implemented. The reaming bits are read-only and always read as zero.
 |======
@@ -599,7 +599,7 @@ The following bits are implemented. The reaming bits are read-only and always re
 | 9     | `stoptime`    | r/- | `0` - timers increment as usual
 | 8:6   | `cause`       | r/- | cause identifier - why debug mode was entered (see below)
 | 5     | -             | r/- | `0` - _reserved_
-| 4     | `mprven`      | r/- | `0` - `mstatus.mprv` is ignored when in debug mode
+| 4     | `mprven`      | r/- | `1` - <<_mstatus>>`.mprv` is also evaluated when in debug mode
 | 3     | `nmip`        | r/- | `0` - non-maskable interrupt is pending
 | 2     | `step`        | r/w | enable single-stepping when set
 | 1:0   | `prv`         | r/w | CPU privilege level before/after debug mode
@@ -608,7 +608,7 @@ The following bits are implemented. The reaming bits are read-only and always re
 Cause codes in `dcsr.cause` (highest priority first):
 
 * `010` - trigger by hardware <<_trigger_module>>
-* `001` - executed EBREAK instruction
+* `001` - executed `EBREAK` instruction
 * `011` - external halt request (from DM)
 * `100` - return from single-stepping
 

--- a/rtl/core/neorv32_debug_dtm.vhd
+++ b/rtl/core/neorv32_debug_dtm.vhd
@@ -251,9 +251,9 @@ begin
       dmi_ctrl.dmihardreset <= '1';
       dmi_ctrl.dmireset     <= '1';
       dmi_ctrl.err          <= '0';
-      dmi_ctrl.rdata        <= (others => '-');
-      dmi_ctrl.wdata        <= (others => '-');
-      dmi_ctrl.addr         <= (others => '-');
+      dmi_ctrl.rdata        <= (others => '0');
+      dmi_ctrl.wdata        <= (others => '0');
+      dmi_ctrl.addr         <= (others => '0');
     elsif rising_edge(clk_i) then
 
       -- DMI status and control --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -63,7 +63,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070400"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070401"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -1887,6 +1887,7 @@ package neorv32_package is
       -- host access --
       clk_i       : in  std_ulogic; -- global clock line
       rstn_i      : in  std_ulogic; -- global reset line, low-active, use as async
+      priv_i      : in  std_ulogic; -- current CPU privilege mode
       addr_i      : in  std_ulogic_vector(31 downto 0); -- address
       rden_i      : in  std_ulogic; -- read enable
       wren_i      : in  std_ulogic; -- word write enable

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -995,6 +995,7 @@ begin
       -- host access --
       clk_i       => clk_i,                    -- global clock line
       rstn_i      => rstn_int,                 -- global reset line, low-active, use as async
+      priv_i      => p_bus.priv,               -- current CPU privilege mode
       addr_i      => p_bus.addr,               -- address
       rden_i      => io_rden,                  -- read enable
       wren_i      => io_wren,                  -- word write enable

--- a/rtl/core/neorv32_wishbone.vhd
+++ b/rtl/core/neorv32_wishbone.vhd
@@ -263,7 +263,7 @@ begin
 
   wb_adr_o <= addr_i when (ASYNC_TX = true) else ctrl.adr;
   wb_dat_o <= data_i when (ASYNC_TX = true) else ctrl.wdat;
-  wb_we_o  <= (wren_i or ctrl.we)  when (ASYNC_TX = true) else ctrl.we;
+  wb_we_o  <= (wren_i or (ctrl.we and ctrl.state)) when (ASYNC_TX = true) else ctrl.we;
   wb_sel_o <= end_byteen when (ASYNC_TX = true) else ctrl.sel;
   wb_stb_o <= stb_int when (PIPE_MODE = true) else cyc_int;
   wb_cyc_o <= cyc_int;

--- a/rtl/core/neorv32_wishbone.vhd
+++ b/rtl/core/neorv32_wishbone.vhd
@@ -148,7 +148,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   assert false report
   "NEORV32 PROCESSOR CONFIG NOTE: Ext. Bus Interface - " &
-  cond_sel_string_f(PIPE_MODE, "PIPELINED", "CASSIC/STANDARD") & "Wishbone protocol, " &
+  cond_sel_string_f(PIPE_MODE, "PIPELINED", "CLASSIC/STANDARD") & " Wishbone protocol, " &
   cond_sel_string_f(boolean(BUS_TIMEOUT /= 0), "auto-timeout (" & integer'image(BUS_TIMEOUT) & " cycles), ", "NO auto-timeout, ") &
   cond_sel_string_f(BIG_ENDIAN, "BIG", "LITTLE") & "-endian byte order, " &
   cond_sel_string_f(ASYNC_RX, "ASYNC ", "buffered ") & "RX path, " &

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -559,7 +559,7 @@ begin
 
         -- bus output register --
         wb_mem_a.err <= '0';
-        if (ext_mem_a.ack(ext_mem_a_latency_c-1) = '1') and (wb_mem_a.cyc = '1') and (wb_mem_a.ack = '0') then
+        if (ext_mem_a.ack(ext_mem_a_latency_c-1) = '1') and (wb_mem_a.cyc = '1') then
           wb_mem_a.rdata <= ext_mem_a.rdata(ext_mem_a_latency_c-1);
           wb_mem_a.ack   <= '1';
         else
@@ -608,7 +608,7 @@ begin
 
       -- bus output register --
       wb_mem_b.err <= '0';
-      if (ext_mem_b.ack(ext_mem_b_latency_c-1) = '1') and (wb_mem_b.cyc = '1') and (wb_mem_b.ack = '0') then
+      if (ext_mem_b.ack(ext_mem_b_latency_c-1) = '1') and (wb_mem_b.cyc = '1') then
         wb_mem_b.rdata <= ext_mem_b.rdata(ext_mem_b_latency_c-1);
         wb_mem_b.ack   <= '1';
       else
@@ -647,7 +647,7 @@ begin
       end if;
 
       -- bus output register --
-      if (ext_mem_c.ack(ext_mem_c_latency_c-1) = '1') and (wb_mem_c.cyc = '1') and (wb_mem_c.ack = '0') then
+      if (ext_mem_c.ack(ext_mem_c_latency_c-1) = '1') and (wb_mem_c.cyc = '1') then
         wb_mem_c.rdata <= ext_mem_c.rdata(ext_mem_c_latency_c-1);
         wb_mem_c.ack   <= '1';
         wb_mem_c.err   <= '0';

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -426,7 +426,7 @@ begin
 
         -- bus output register --
         wb_mem_a.err <= '0';
-        if (ext_mem_a.ack(ext_mem_a_latency_c-1) = '1') and (wb_mem_a.cyc = '1') and (wb_mem_a.ack = '0') then
+        if (ext_mem_a.ack(ext_mem_a_latency_c-1) = '1') and (wb_mem_a.cyc = '1') then
           wb_mem_a.rdata <= ext_mem_a.rdata(ext_mem_a_latency_c-1);
           wb_mem_a.ack   <= '1';
         else
@@ -475,7 +475,7 @@ begin
 
       -- bus output register --
       wb_mem_b.err <= '0';
-      if (ext_mem_b.ack(ext_mem_b_latency_c-1) = '1') and (wb_mem_b.cyc = '1') and (wb_mem_b.ack = '0') then
+      if (ext_mem_b.ack(ext_mem_b_latency_c-1) = '1') and (wb_mem_b.cyc = '1') then
         wb_mem_b.rdata <= ext_mem_b.rdata(ext_mem_b_latency_c-1);
         wb_mem_b.ack   <= '1';
       else
@@ -514,7 +514,7 @@ begin
       end if;
 
       -- bus output register --
-      if (ext_mem_c.ack(ext_mem_c_latency_c-1) = '1') and (wb_mem_c.cyc = '1') and (wb_mem_c.ack = '0') then
+      if (ext_mem_c.ack(ext_mem_c_latency_c-1) = '1') and (wb_mem_c.cyc = '1') then
         wb_mem_c.rdata <= ext_mem_c.rdata(ext_mem_c_latency_c-1);
         wb_mem_c.ack   <= '1';
         wb_mem_c.err   <= '0';

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -268,7 +268,7 @@ int main() {
 
 
   // ----------------------------------------------------------
-  // Test performance counter: setup as many events and counter as feasible
+  // Test performance counter: setup as many events and counters as possible
   // ----------------------------------------------------------
   neorv32_cpu_csr_write(CSR_MCAUSE, 0);
   PRINT_STANDARD("[%i] Setup HPM events ", cnt_test);
@@ -320,6 +320,8 @@ int main() {
   // prepare overflow
   neorv32_cpu_set_mcycle(0x00000000FFFFFFFFULL);
 
+  asm volatile ("nop"); // counter LOW should overflow here
+
   // get current cycle counter HIGH
   tmp_a = neorv32_cpu_csr_read(CSR_MCYCLEH);
 
@@ -345,6 +347,8 @@ int main() {
 
   // prepare overflow
   neorv32_cpu_set_minstret(0x00000000FFFFFFFFULL);
+
+  asm volatile ("nop"); // counter LOW should overflow here
 
   // get instruction counter HIGH
   tmp_a = neorv32_cpu_csr_read(CSR_INSTRETH);


### PR DESCRIPTION
* :bug: fixes a bug that permanently stops `[m]cycle[h]` and `[m]instret[h]` counter if no HPM counters are implemented (_HPM_NUM_CNTS_ = 0)
* :bug: fix bug in WISHBONE.WE signal (when _ASYNC_TX_ mode enabled): signal was high for 1 cycle even if a read transfers (we = low) was triggered (@ #350)
* hardwired `dcsr.mprven` to 1: `mstatus.mprv` is also evaluated when in debug mode
* CFS can now check the current CPU privilege mode (to optionally constrain access/features to privileged software only)
* minor rtl clean-ups