### PR TITLE
:warning: [rtl] rework SLINK module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 31.07.2022 | 1.7.4.7 | :warning: rework **SLINK** module; [#377](https://github.com/stnolting/neorv32/pull/377) |
 | 25.07.2022 | 1.7.4.6 | :warning: simplify memory configuration of **linker script**; :sparkles: add in-console configuration option; [#]375(https://github.com/stnolting/neorv32/pull/375) |
 | 22.07.2022 | 1.7.4.5 | add `CUSTOM_ID` generic; update bootloader; [#374](https://github.com/stnolting/neorv32/pull/374) |
 | 21.07.2022 | 1.7.4.4 | :lock: specify **physical memory attributes (PMA)** ;[#372](https://github.com/stnolting/neorv32/pull/372) |

--- a/docs/datasheet/soc_slink.adoc
+++ b/docs/datasheet/soc_slink.adoc
@@ -24,67 +24,72 @@
 |                          | fast IRQ channel 11 | SLINK TX IRQ (see <<_processor_interrupts>>)
 |=======================
 
+
+**Overview**
+
 The SLINK component provides up to 8 independent RX (receiving) and TX (sending) links for moving
 stream data. The interface provides higher bandwidth and less latency than the external memory bus
-interface, which makes it ideally suited to couple custom stream processing units (like CORDICs, FFTs or
-cryptographic accelerators).
+interface, which makes it ideally suited to couple custom stream processing units.
 
-Each individual link provides an internal FIFO for data buffering. The FIFO depth is globally defined
+Each link provides an individual internal FIFO for data buffering. The FIFO depth is globally defined
 for all TX links via the _SLINK_TX_FIFO_ generic and for all RX links via the _SLINK_RX_FIFO_ generic.
 The FIFO depth has to be at least 1, which will implement a simple input/output register. The maximum
-value is limited to 32768 entries. Note that the FIFO depth has to be a power of two (for optimal
-logic mapping).
+value is limited to 32768 entries. Note that the FIFO depth has to be a power of two.
 
 The actual number of implemented RX/TX links is configured by the _SLINK_NUM_RX_ and _SLINK_NUM_TX_
-generics. The SLINK module will be synthesized only if at least one of these generics is greater than
+generics, respectively. The SLINK module will be synthesized only if at least one of these generics is greater than
 zero. All unimplemented links are internally terminated and their according output signals are set to zero.
 
 [NOTE]
 The NEORV32 stream link interfaces are compatible to the _AXI Stream_ specs.
 
+.Example Program
+[TIP]
+An example program for the SLINK module is available in `sw/example/demo_slink`.
+
 
 **Theory of Operation**
 
-The SLINK provides eight data registers (`DATA[i]`) to access the links (read accesses will access the RX links,
-write accesses will access the TX links), one control register (`CTRL`) and one status register (`STATUS`).
+The SLINK provides eight data registers (`DATA[i]`) to access the links (read accesses will access the RX link FIFOs,
+write accesses will access the TX link FIFOs), one control register (`CTRL`), one interrupt configuration register (`IRQ`)
+and two status registers - one for the RX links (`RX_STATUS`) and one for the TX links (`TX_STATUS`).
 
 The SLINK is globally activated by setting the control register's enable bit _SLINK_CTRL_EN_. Clearing this
-bit will reset all internal logic and will also clear all data FIFOs. The actual data links are accessed by
-reading or writing the according link data registers `DATA[0]` to `DATA[7]`. For example, writing the `DATA[0]`
+bit will reset all internal logic and will also clear all FIFOs. The actual data links are accessed by
+reading or writing the according link data registers `DATA[0]` to `DATA[7]`. For example, writing to `DATA[0]`
 will put the according data into the FIFO of TX link 0. Accordingly, reading from `DATA[0]` will return one data
 word from the FIFO of RX link 0.
 
-The current link status of each RX and TX channel is accessible via the `STATUS` register. Each link provides a
-read-only FIFO status flag in this register: the _SLINK_CTRL_RX_AVAIL_ flags indicate that there is _at least_
-one data word available in the according RX link's FIFO. The _SLINK_CTRL_TX_FREE_ flags indicate
-there is _at least_ one free entry in the according TX link's FIFO.
+The current link status of each RX and TX channel is accessible via the `*X_STATUS` registers. The FIFO's status
+signals that represent the fill level (empty, at least half full, full) are exposed as read-only flags via those two
+registers.
 
 [NOTE]
 Writing to a TX link's FIFO that is _full_ will have no effect. Reading data from a RX link's FIFO that is
 _empty_ will have no effect and will return the last valid data word.
 
-The "end of packet" signal `lst` is controlled by the status register's _SLINK_STATUS_RX_LAST_ and
-_SLINK_STATUS_TX_LAST_ bits. Note that the RX/TX `lst` signal is also buffered by the internal FIFOs.
-Setting a bit in _SLINK_STATUS_TX_LAST_ before writing data to `DATA` will set the `lst` signal when the
-written data word is actually send from the FIFO. Vice versa, a bit in _SLINK_STATUS_RX_LAST_ will be set
-if the according data word read from `DATA` was marked as "end of packet". 
+The TX link's "end of packet" signal `slink_tx_lst_o` is controlled by the `TX_STATUS` register's _SLINK_TX_STATUS_LAST_
+bits. Note that these bits are also buffered by the internal TX FIFOs, so setting one of these bits before writing data to
+`DATA` will set the `slink_tx_lst_o` signal when the written data word is actually send from the FIFO. Vice versa, the
+_SLINK_RX_STATUS_LAST_ bits in `RX_STATUS` represent the level of the according `slink_rx_lst_i` input when a new data word
+was samples. These bits are also buffered in the internal RX FIFOs.
 
 
 **Data Transmission**
 
 To send (TX) data the program should ensure there is at least one left in the according link's FIFO by checking
-_SLINK_CTRL_TX_FREE_. To mark the current data word to-be-send as "end of packet" the according _SLINK_STATUS_TX_LAST_
+_SLINK_CTRL_TX_FREE_. To mark the current data word to-be-send as "end of packet" the according _SLINK_TX_STATUS_LAST_
 bit has to be set _before_ writing `DATA`.
 
-Receive (RX) is available when the according link's _SLINK_CTRL_RX_AVAIL_ bit is set. To check if the received data
-is marked as "end of packet" the according _SLINK_STATUS_RX_LAST_ has to be checked _before_ reading `DATA`.
+Received data (RX) is available when the according link's _SLINK_RX_STATUS_EMPTY_ bit is cleared. To check if the received
+data is marked as "end of packet" the according _SLINK_RX_STATUS_LAST_ bit has to be examined _before_ reading `DATA`.
 
 
 **Interface & Protocol**
 
 The SLINK interface consists of four signals `dat`, `val`, `rdy` and `lst` for each RX and TX link.
-Each signal is an "array" with eight entires (one for each link). Note that an entry in `slink_*x_dat` is 32-bit
-wide while entries in `slink_*x_val` and `slink_*x_rdy` are are just 1-bit wide.
+Each signal is constructed as an "array" with eight entries - one for each link. Note that an entry in `slink_*x_dat` is 32-bit
+wide while entries in `slink_*x_val`, `slink_*x_rdy` and `slink_*x_lst` are are just 1-bit wide.
 
 * `dat` contains the actual data word
 * `val` marks the current transmission cycle as valid
@@ -97,16 +102,27 @@ image::stream_link_interface.png[width=560,align=center]
 
 **SLINK Interrupts**
 
-The stream interface provides two independent CPU interrupts - one for RX conditions (data received) and one
-for TX conditions (ready to send). The RX interrupt is controlled per-link by the _SLINK_CTRL_RX_IRQ_EN_
-control register bits while the TX interrupt is controlled per-link by the _SLINK_CTRL_TX_IRQ_EN_ control
-register bits. If any enabled link fulfills the RX/TX interrupt condition a RX/TX interrupt request is
-sent to the CPU. Note that all RX and TX interrupt conditions are logically OR-ed.
+The stream interface provides two independent CPU interrupt channels - one for RX conditions and one
+for TX conditions. These IRQs can be used to signal specific FIFO conditions (e.g. "data available") to the
+CPU. The specific interrupt conditions are programmed per-link via the `IRQ` register.
+A 2-bit-coded value is used to enable the according link's interrupt and to specify the actual condition.
 
-* RX interrupt: if the FIFO of link _i_ changes from status "empty" to "not empty" (data available) and the
-according _SLINK_CTRL_RX_IRQ_EN_ bit is set the SLINK RX interrupt is triggered
-* TX interrupt: if the FIFO of link _i_ changes from status "full" to "not full" (ready to send) and the
-according _SLINK_CTRL_TX_IRQ_EN_ bit is set the SLINK TX interrupt is triggered
+[NOTE]
+Note that all enabled interrupt configurations are logically OR-ed for the CPU RX and TX interrupts, respectively.
+Hence, if **any** link fulfills the according interrupt configuration the according RX/TX interrupt request is
+sent to the CPU.
+
+For the TX links (in `IRQ` _SLINK_IRQ_TX_) the following interrupt conditions are supported:
+
+* `0-`: off, no interrupt from link
+* `10`: interrupt fires if FIFO _becomes_ not empty
+* `11`: interrupt fires if FIFO _becomes_ at least half full
+
+For the RX links (in `IRQ` _SLINK_IRQ_RX_) the following interrupt conditions are supported:
+
+* `0-`: off, no interrupt from link
+* `10`: interrupt fires if FIFO _becomes_ empty
+* `11`: interrupt fires if FIFO _becomes_ less than half full
 
 Once the SLINK's RX or TX CPU interrupt has become pending, it has to be explicitly cleared again by writing
 zero to the according <<_mip>> CSR bit(s).
@@ -119,18 +135,23 @@ zero to the according <<_mip>> CSR bit(s).
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s) | R/W | Function
-.6+<| `0xfffffec0` .6+<| `NEORV32_SLINK.CTRL` <| `0`   _SLINK_CTRL_EN_ ^| r/w | SLINK global enable
-                                              <| `7:1` _reserved_      ^| r/- <| reserved, read as zero
-                                              <| `11:8`  _SLINK_CTRL_TX_FIFO_S3_ : _SLINK_CTRL_TX_FIFO_S0_ ^| r/- <| TX FIFO depth, log2(_SLINK_TX_FIFO_)
-                                              <| `15:12` _SLINK_CTRL_RX_FIFO_S3_ : _SLINK_CTRL_RX_FIFO_S0_ ^| r/- <| RX FIFO depth, log2(_SLINK_RX_FIFO_)
-                                              <| `23:13` _SLINK_CTRL_RX_IRQ_EN_MSB_ : _SLINK_CTRL_RX_IRQ_EN_LSB_ ^| r/- <| RX interrupt enable for link _i_
-                                              <| `23:13` _SLINK_CTRL_TX_IRQ_EN_MSB_ : _SLINK_CTRL_TX_IRQ_EN_LSB_ ^| r/- <| TX interrupt enable for link _i_
-| `0xfffffec4` : `0xfffffecf` | - |`31:0` | r/- | _reserved_
-.4+<| `0xfffffed0` .4+<| `NEORV32_SLINK.STATUS` <|`7:0`   _SLINK_STATUS_RX_AVAIL_MSB_ : _SLINK_STATUS_RX_AVAIL_LSB_ ^| r/- <| RX link _i_ FIFO is NOT empty (data available)
-                                                <|`15:8`  _SLINK_STATUS_TX_FREE_MSB_ : _SLINK_STATUS_TX_FREE_LSB_   ^| r/- <| TX link _i_ FIFO is NOT full (ready to send)
-                                                <|`23:16` _SLINK_STATUS_RX_LAST_MSB_ : _SLINK_STATUS_RX_LAST_LSB_   ^| r/- <| Indicates end of packet for RX link _i_
-                                                <|`31:24` _SLINK_STATUS_TX_LAST_MSB_ : _SLINK_STATUS_TX_LAST_LSB_   ^| r/w <| Set to indicate end of packet for TX link _i_
-| `0xfffffed4` : `0xfffffedf` | - |`31:0` | r/- | _reserved_
+.6+<| `0xfffffec0` .6+<| `NEORV32_SLINK.CTRL` <| `0`     _SLINK_CTRL_EN_                                     ^| r/w  | SLINK global enable/reset
+                                              <| `7:1`   _reserved_                                          ^| r/- <| _reserved_, returns zero
+                                              <| `19:16` _SLINK_CTRL_RX_NUM_MSB_  : _SLINK_CTRL_RX_NUM_LSB_  ^| r/- <| Number of RX links (_SLINK_NUM_RX_)
+                                              <| `23:20` _SLINK_CTRL_TX_NUM_MSB_  : _SLINK_CTRL_TX_NUM_LSB_  ^| r/- <| Number of TX links (_SLINK_NUM_TX_)
+                                              <| `27:24` _SLINK_CTRL_RX_FIFO_MSB_ : _SLINK_CTRL_RX_FIFO_LSB_ ^| r/- <| RX FIFO depth, log2(_SLINK_RX_FIFO_)
+                                              <| `31:28` _SLINK_CTRL_TX_FIFO_MSB_ : _SLINK_CTRL_TX_FIFO_MSB_ ^| r/- <| TX FIFO depth, log2(_SLINK_TX_FIFO_)
+.2+<| `0xfffffec4` .2+<| `NEORV32_SLINK.IRQ` <|`15:0`  _SLINK_IRQ_RX_MSB_ : _SLINK_IRQ_RX_LSB_ ^| r/w <| RX link _i_ interrupt configuration (2 bits per link)
+                                             <|`31:16` _SLINK_IRQ_TX_MSB_ : _SLINK_IRQ_TX_LSB_ ^| r/w <| TX link _i_ interrupt configuration (2 bits per link)
+.4+<| `0xfffffec8` .4+<| `NEORV32_SLINK.RX_STATUS` <|`7:0`   _SLINK_RX_STATUS_EMPTY_MSB_ : _SLINK_RX_STATUS_EMPTY_LSB_ ^| r/- <| RX link _i_ FIFO empty
+                                                   <|`15:8`  _SLINK_RX_STATUS_HALF_MSB_  : _SLINK_RX_STATUS_HALF_LSB_  ^| r/- <| RX link _i_ FIFO at least half full
+                                                   <|`23:16` _SLINK_RX_STATUS_FULL_MSB_  : _SLINK_RX_STATUS_FULL_LSB_  ^| r/- <| RX link _i_ FIFO full
+                                                   <|`31:24` _SLINK_RX_STATUS_LAST_MSB_  : _SLINK_RX_STATUS_LAST_LSB_  ^| r/- <| Current data word of RX link _i_ is marked as "end of packet"
+.4+<| `0xfffffecc` .4+<| `NEORV32_SLINK.TX_STATUS` <|`7:0`   _SLINK_TX_STATUS_EMPTY_MSB_ : _SLINK_TX_STATUS_EMPTY_LSB_ ^| r/- <| TX link _i_ FIFO empty
+                                                   <|`15:8`  _SLINK_TX_STATUS_HALF_MSB_  : _SLINK_TX_STATUS_HALF_LSB_  ^| r/- <| TX link _i_ FIFO at least half full
+                                                   <|`23:16` _SLINK_TX_STATUS_FULL_MSB_  : _SLINK_TX_STATUS_FULL_LSB_  ^| r/- <| TX link _i_ FIFO full
+                                                   <|`31:24` _SLINK_TX_STATUS_LAST_MSB_  : _SLINK_TX_STATUS_LAST_LSB_  ^| r/w <| Set to mark next data word of TX link _i_ is "end of packet"
+| `0xfffffed0` : `0xfffffedf` | - |`31:0` | r/- | _reserved_, returns zero
 | `0xfffffee0` | `NEORV32_SLINK.DATA[0]` | `31:0` | r/w | Link 0 RX/TX data
 | `0xfffffee4` | `NEORV32_SLINK.DATA[1]` | `31:0` | r/w | Link 1 RX/TX data
 | `0xfffffee8` | `NEORV32_SLINK.DATA[2]` | `31:0` | r/w | Link 2 RX/TX data

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -63,7 +63,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070406"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070407"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -210,6 +210,22 @@ package neorv32_package is
   -- Stream Link Interface (SLINK) --
   constant slink_base_c         : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffec0"; -- base address
   constant slink_size_c         : natural := 16*4; -- module's address space size in bytes
+  constant slink_ctrl_c         : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffec0";
+  constant slink_irq_c          : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffec4";
+  constant slink_rx_status_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffec8";
+  constant slink_tx_status_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffecc";
+--constant slink_reserved_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffed0";
+--constant slink_reserved_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffed4";
+--constant slink_reserved_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffed8";
+--constant slink_reserved_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffedc";
+  constant slink_link0_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffee0";
+  constant slink_link1_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffee4";
+  constant slink_link2_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffee8";
+  constant slink_link3_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffeec";
+  constant slink_link4_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffef0";
+  constant slink_link5_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffef4";
+  constant slink_link6_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffef7";
+  constant slink_link7_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffefc";
 
   -- reserved --
 --constant reserved_base_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff00"; -- base address

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -792,11 +792,12 @@ enum NEORV32_PWM_CTRL_enum {
 /**@{*/
 /** SLINK module prototype */
 typedef struct __attribute__((packed,aligned(4))) {
-  uint32_t       CTRL;          /**< offset 0: control register (#NEORV32_SLINK_CTRL_enum) */
-  const uint32_t reserved0[3];  /**< offset 4..12: reserved */
-  uint32_t       STATUS;        /**< offset 16: status register (#NEORV32_SLINK_STATUS_enum) */
-  const uint32_t reserved1[3];  /**< offset 20..28: reserved */
-  uint32_t       DATA[8];       /**< offset 32..60: stream link RX/TX data channels 0..7 */
+  uint32_t       CTRL;        /**< offset 0: control register (#NEORV32_SLINK_CTRL_enum) */
+  uint32_t       IRQ;         /**< offset 4: interrupt configuration register (#NEORV32_SLINK_IRQ_enum) */
+  const uint32_t RX_STATUS;   /**< offset 8: RX links status (#NEORV32_SLINK_RX_STATUS_enum) */
+  uint32_t       TX_STATUS;   /**< offset 12: interrupt configuration register (#NEORV32_SLINK_TX_STATUS_enum) */
+  const uint32_t reserved[4]; /**< offset 16..28: reserved */
+  uint32_t       DATA[8];     /**< offset 32..60: stream link RX/TX data channels 0..7 */
 } neorv32_slink_t;
 
 /** SLINK module base address */
@@ -807,38 +808,49 @@ typedef struct __attribute__((packed,aligned(4))) {
 
 /** SLINK control register bits */
 enum NEORV32_SLINK_CTRL_enum {
-  SLINK_CTRL_EN            =  0, /**< SLINK control register(0) (r/w): SLINK controller enable */
+  SLINK_CTRL_EN          =  0, /**< SLINK control register(0) (r/w): SLINK controller enable */
 
-  SLINK_CTRL_RX_FIFO_S0    =  8, /**< SLINK control register( 8) (r/-): log2(RX FIFO size) bit 0 */
-  SLINK_CTRL_RX_FIFO_S1    =  9, /**< SLINK control register( 9) (r/-): log2(RX FIFO size) bit 1 */
-  SLINK_CTRL_RX_FIFO_S2    = 10, /**< SLINK control register(10) (r/-): log2(RX FIFO size) bit 2 */
-  SLINK_CTRL_RX_FIFO_S3    = 11, /**< SLINK control register(11) (r/-): log2(RX FIFO size) bit 3 */
+  SLINK_CTRL_RX_NUM_LSB  = 16, /**< SLINK control register(16) (r/-): number of available RX links bit 0 */
+  SLINK_CTRL_RX_NUM_MSB  = 19, /**< SLINK control register(19) (r/-): number of available RX links bit 3 */
+  SLINK_CTRL_TX_NUM_LSB  = 20, /**< SLINK control register(20) (r/-): number of available TX links bit 0 */
+  SLINK_CTRL_TX_NUM_MSB  = 23, /**< SLINK control register(23) (r/-): number of available TX links bit 3 */
 
-  SLINK_CTRL_TX_FIFO_S0    = 12, /**< SLINK control register(12) (r/-): log2(TX FIFO size) bit 0 */
-  SLINK_CTRL_TX_FIFO_S1    = 13, /**< SLINK control register(13) (r/-): log2(TX FIFO size) bit 1 */
-  SLINK_CTRL_TX_FIFO_S2    = 14, /**< SLINK control register(14) (r/-): log2(TX FIFO size) bit 2 */
-  SLINK_CTRL_TX_FIFO_S3    = 15, /**< SLINK control register(15) (r/-): log2(TX FIFO size) bit 3 */
-
-  SLINK_CTRL_RX_IRQ_EN_LSB = 16, /**< SLINK control register(23:16) (r/w): Enable interrupt for RX link i, LSB */
-  SLINK_CTRL_RX_IRQ_EN_MSB = 23, /**< SLINK control register(23:16) (r/w): Enable interrupt for RX link i, MSB */
-
-  SLINK_CTRL_TX_IRQ_EN_LSB = 24, /**< SLINK control register(31:24) (r/w): Enable interrupt for TX link i, LSB */
-  SLINK_CTRL_TX_IRQ_EN_MSB = 31  /**< SLINK control register(31:24) (r/w): Enable interrupt for TX link i, MSB */
+  SLINK_CTRL_RX_FIFO_LSB = 24, /**< SLINK control register(24) (r/-): log2(RX FIFO size) bit 0 */
+  SLINK_CTRL_RX_FIFO_MSB = 27, /**< SLINK control register(27) (r/-): log2(RX FIFO size) bit 3 */
+  SLINK_CTRL_TX_FIFO_LSB = 28, /**< SLINK control register(28) (r/-): log2(TX FIFO size) bit 0 */
+  SLINK_CTRL_TX_FIFO_MSB = 31  /**< SLINK control register(31) (r/-): log2(TX FIFO size) bit 3 */
 };
 
-/** SLINK status register bits */
-enum NEORV32_SLINK_STATUS_enum {
-  SLINK_STATUS_RX_AVAIL_LSB =  0, /**< SLINK status register(7:0) (r/-): RX link i FIFO is NOT empty (data available), LSB */
-  SLINK_STATUS_RX_AVAIL_MSB =  7, /**< SLINK status register(7:0) (r/-): RX link i FIFO is NOT empty (data available), MSB */
+/** SLINK interrupt configuration register bits */
+enum NEORV32_SLINK_IRQ_enum {
+  SLINK_IRQ_RX_LSB =  0, /**< SLINK IRQ configuration register(15:00) (r/w): RX link IRQ configuration, LSB */
+  SLINK_IRQ_RX_MSB = 15, /**< SLINK IRQ configuration register(15:00) (r/w): RX link IRQ configuration, MSB */
+  SLINK_IRQ_TX_LSB = 16, /**< SLINK IRQ configuration register(31:16) (r/w): TX link IRQ configuration, LSB */
+  SLINK_IRQ_TX_MSB = 31  /**< SLINK IRQ configuration register(31:16) (r/w): TX link IRQ configuration, MSB */
+};
 
-  SLINK_STATUS_TX_FREE_LSB  =  8, /**< SLINK status register(15:8) (r/-): TX link i FIFO is NOT full (ready to send), LSB */
-  SLINK_STATUS_TX_FREE_MSB  = 15, /**< SLINK status register(15:8) (r/-): TX link i FIFO is NOT full (ready to send), MSB */
+/** SLINK RX status register bits */
+enum NEORV32_SLINK_RX_STATUS_enum {
+  SLINK_RX_STATUS_EMPTY_LSB =  0, /**< SLINK RX status register(07:00) (r/-): RX link i FIFO empty, LSB */
+  SLINK_RX_STATUS_EMPTY_MSB =  7, /**< SLINK RX status register(07:00) (r/-): RX link i FIFO empty, MSB */
+  SLINK_RX_STATUS_HALF_LSB  =  8, /**< SLINK RX status register(15:08) (r/-): RX link i FIFO at least half full, LSB */
+  SLINK_RX_STATUS_HALF_MSB  = 15, /**< SLINK RX status register(15:08) (r/-): RX link i FIFO at least half full, MSB */
+  SLINK_RX_STATUS_FULL_LSB  = 16, /**< SLINK RX status register(23:16) (r/-): RX link i FIFO full, LSB */
+  SLINK_RX_STATUS_FULL_MSB  = 23, /**< SLINK RX status register(23:16) (r/-): RX link i FIFO full, MSB */
+  SLINK_RX_STATUS_LAST_LSB  = 24, /**< SLINK RX status register(31:24) (r/-): Set to indicate end of packet for RX link i, LSB */
+  SLINK_RX_STATUS_LAST_MSB  = 31  /**< SLINK RX status register(31:24) (r/-): Set to indicate end of packet for RX link i, MSB */
+};
 
-  SLINK_STATUS_RX_LAST_LSB  = 16, /**< SLINK status register(23:16) (r/-): Indicates end of packet for RX link i, LSB */
-  SLINK_STATUS_RX_LAST_MSB  = 23, /**< SLINK status register(23:16) (r/-): Indicates end of packet for RX link i, MSB */
-
-  SLINK_STATUS_TX_LAST_LSB  = 24, /**< SLINK status register(31:24) (r/w): Set to indicate end of packet for TX link i, LSB */
-  SLINK_STATUS_TX_LAST_MSB  = 31, /**< SLINK status register(31:24) (r/w): Set to indicate end of packet for TX link i, MSB */
+/** SLINK TX status register bits */
+enum NEORV32_SLINK_TX_STATUS_enum {
+  SLINK_TX_STATUS_EMPTY_LSB =  0, /**< SLINK TX status register(07:00) (r/-): TX link i FIFO empty, LSB */
+  SLINK_TX_STATUS_EMPTY_MSB =  7, /**< SLINK TX status register(07:00) (r/-): TX link i FIFO empty, MSB */
+  SLINK_TX_STATUS_HALF_LSB  =  8, /**< SLINK TX status register(15:08) (r/-): TX link i FIFO at least half full, LSB */
+  SLINK_TX_STATUS_HALF_MSB  = 15, /**< SLINK TX status register(15:08) (r/-): TX link i FIFO at least half full, MSB */
+  SLINK_TX_STATUS_FULL_LSB  = 16, /**< SLINK TX status register(23:16) (r/-): TX link i FIFO full, LSB */
+  SLINK_TX_STATUS_FULL_MSB  = 23, /**< SLINK TX status register(23:16) (r/-): TX link i FIFO full, MSB */
+  SLINK_TX_STATUS_LAST_LSB  = 24, /**< SLINK TX status register(31:24) (r/w): Set to mark end of packet for TX link i, LSB */
+  SLINK_TX_STATUS_LAST_MSB  = 31  /**< SLINK TX status register(31:24) (r/w): Set to mark end of packet for TX link i, MSB */
 };
 /**@}*/
 

--- a/sw/lib/include/neorv32_slink.h
+++ b/sw/lib/include/neorv32_slink.h
@@ -43,7 +43,7 @@
 
 // prototypes
 int  neorv32_slink_available(void);
-void neorv32_slink_setup(uint32_t rx_irq_en, uint32_t tx_irq_en);
+void neorv32_slink_setup(uint32_t irq_config);
 void neorv32_slink_enable(void);
 void neorv32_slink_disable(void);
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -214,92 +214,21 @@
           <name>CTRL</name>
           <description>Control register</description>
           <addressOffset>0x00</addressOffset>
-          <fields>
-            <field>
-              <name>SLINK_CTRL_RX_NUMx</name>
-              <access>read-only</access>
-              <bitRange>[3:0]</bitRange>
-              <description>Number of implemented RX links</description>
-            </field>
-            <field>
-              <name>SLINK_CTRL_TX_NUMx</name>
-              <access>read-only</access>
-              <bitRange>[7:4]</bitRange>
-              <description>Number of implemented TX links</description>
-            </field>
-            <field>
-              <name>SLINK_CTRL_RX_FIFO_Sx</name>
-              <access>read-only</access>
-              <bitRange>[11:8]</bitRange>
-              <description>log2(RX FIFO size)</description>
-            </field>
-            <field>
-              <name>SLINK_CTRL_TX_FIFO_Sx</name>
-              <access>read-only</access>
-              <bitRange>[15:12]</bitRange>
-              <description>log2(TX FIFO size)</description>
-            </field>
-            <field>
-              <name>SLINK_CTRL_EN</name>
-              <access>read-write</access>
-              <bitRange>[31:31]</bitRange>
-              <description>SLINK enable flag</description>
-            </field>
-          </fields>
         </register>
         <register>
           <name>IRQ</name>
           <description>Link interrupt configuration register</description>
-          <addressOffset>0x08</addressOffset>
-          <fields>
-            <field>
-              <name>SLINK_IRQ_RX_EN</name>
-              <bitRange>[7:0]</bitRange>
-              <description>RX link interrupt enable</description>
-            </field>
-            <field>
-              <name>SLINK_IRQ_RX_MODE</name>
-              <bitRange>[15:8]</bitRange>
-              <description>RX link interrupt mode</description>
-            </field>
-            <field>
-              <name>SLINK_IRQ_TX_EN</name>
-              <bitRange>[23:16]</bitRange>
-              <description>TX link interrupt enable</description>
-            </field>
-            <field>
-              <name>SLINK_IRQ_TX_MODE</name>
-              <bitRange>[31:24]</bitRange>
-              <description>TX link interrupt mode</description>
-            </field>
-          </fields>
+          <addressOffset>0x04</addressOffset>
         </register>
         <register>
-          <name>STATUS</name>
-          <description>Link status register</description>
-          <addressOffset>0x10</addressOffset>
-          <fields>
-            <field>
-              <name>SLINK_STATUS_RX_AVAIL</name>
-              <bitRange>[7:0]</bitRange>
-              <description>RX link n FIFO is NOT empty (data available)</description>
-            </field>
-            <field>
-              <name>SLINK_STATUS_TX_FREE</name>
-              <bitRange>[15:8]</bitRange>
-              <description>TX link n FIFO is NOT full (ready to send)</description>
-            </field>
-            <field>
-              <name>SLINK_STATUS_RX_HALF</name>
-              <bitRange>[23:16]</bitRange>
-              <description>RX link n FIFO fill level is >= half-full</description>
-            </field>
-            <field>
-              <name>SLINK_STATUS_TX_HALF</name>
-              <bitRange>[31:24]</bitRange>
-              <description>TX link 0 FIFO fill level is > half-full</description>
-            </field>
-          </fields>
+          <name>RX_STATUS</name>
+          <description>Status of RX link FIFOs</description>
+          <addressOffset>0x08</addressOffset>
+        </register>
+        <register>
+          <name>TX_STATUS</name>
+          <description>Status of TX link FIFOs</description>
+          <addressOffset>0x0C</addressOffset>
         </register>
         <register>
           <name>DATA0</name>


### PR DESCRIPTION
This PR is another rework of the the processor's **Stream Link (SLINK)** module, triggered by  @betocool-prog (#376).

**⚠️ The module's register addresses and register contents are modified and are not backwards compatible!**

* add dedicated `RX_STATUS` and `TX_STATUS` registers that expose all FIFO's status signals (empty, at least half full, full) and "last element" signals
* add `IRQ` register to configure interrupt conditions per-link
* RX interrupt options:
  * FIFO of link `i` _becomes_ empty
  * FIFO of link `i` _becomes_ at least half full
* TX interrupt options:
  * FIFO of link `i` _becomes_ empty
  * FIFO of link `i` _becomes_ less than half full