### PR TITLE
✨ [rtl] add optional SPI data FIFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 01.08.2022 | 1.7.4.8 | :sparkles: add configurable data FIFO to **SPI** module; [#381](https://github.com/stnolting/neorv32/pull/381) |
 | 31.07.2022 | 1.7.4.7 | :warning: rework **SLINK** module; [#377](https://github.com/stnolting/neorv32/pull/377) |
 | 25.07.2022 | 1.7.4.6 | :warning: simplify memory configuration of **linker script**; :sparkles: add in-console configuration option; [#]375(https://github.com/stnolting/neorv32/pull/375) |
 | 22.07.2022 | 1.7.4.5 | add `CUSTOM_ID` generic; update bootloader; [#374](https://github.com/stnolting/neorv32/pull/374) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -909,6 +909,18 @@ implemented reducing access latency by one cycle but eventually increasing the c
 
 
 :sectnums!:
+===== _IO_SPI_FIFO_
+
+[cols="4,4,2"]
+[frame="all",grid="none"]
+|======
+| **IO_SPI_FIFO** | _natural_ | 0
+3+| Depth of the <<_serial_peripheral_interface_controller_spi>> FIFO. Has to be zero or a power of two.
+Maximum value is 32*1024.
+|======
+
+
+:sectnums!:
 ===== _IO_TWI_EN_
 
 [cols="4,4,2"]

--- a/docs/datasheet/soc_spi.adoc
+++ b/docs/datasheet/soc_spi.adoc
@@ -12,51 +12,57 @@
 |                          | `spi_sdo_o` | 1-bit serial data output
 |                          | `spi_sdi_i` | 1-bit serial data input
 |                          | `spi_csn_i` | 8-bit dedicated chip select (low-active)
-| Configuration generics:  | _IO_SPI_EN_ | implement SPI controller when _true_
+| Configuration generics:  | _IO_SPI_EN_   | implement SPI controller when _true_
+|                          | _IO_SPI_FIFO_ | data FIFO size, has to be zero or a power of two
 | CPU interrupts:          | fast IRQ channel 6 | transmission done interrupt (see <<_processor_interrupts>>)
 |=======================
 
 
-**Theory of Operation**
+**Overview**
 
 SPI is a synchronous serial transmission interface for fast on-board communications.
-The NEORV32 SPI transceiver supports 8-, 16-, 24- and 32-bit wide transmissions.
-The unit provides 8 dedicated chip select signals via the top entity's `spi_csn_o` signal, which are
+The NEORV32 SPI transceiver module supports 8-, 16-, 24- and 32-bit wide transmissions, all 4 standard clock mode
+and 8 dedicated chip select signals via the top entity's `spi_csn_o` signal, which are
 directly controlled by the SPI module (no additional GPIO required).
+An optional FIFO can be implemented via the _IO_SPI_FIFO_ generic to support block-based transmissions
+without CPU interaction.
 
 [NOTE]
 The NEORV32 SPI module only supports _host mode_. Transmission are initiated only by the processor's SPI module
-(and not by an external SPI module).
+and not by any external SPI module.
 
-The SPI unit is enabled by setting the _SPI_CTRL_EN_ bit in the `CTRL` control register. No transfer can be initiated
-and no interrupt request will be triggered if this bit is cleared. Furthermore, a transfer being in process
-can be terminated at any time by clearing this bit.
+The SPI module provides a single control register `CTRL` used to configure the module and to check its status
+and a data register `DATA` for receiving/transmitting data. If the data FIFO is implemented, this register
+is used to interface the FIFO.
 
-[IMPORTANT]
-Changes to the `CTRL` control register should be made only when the SPI module is idle as they directly effect
-transmissions being in-progress.
 
-[TIP]
-A transmission can be terminated at any time by disabling the SPI module
-by clearing the _SPI_CTRL_EN_ control register bit.
+**Theory of Operation**
 
-The data quantity to be transferred within a single transmission is defined via the _SPI_CTRL_SIZEx_ bits.
+The SPI module is enabled by setting the _SPI_CTRL_EN_ bit in the `CTRL` control register. No transfer can be initiated
+and no interrupt request will be triggered if this bit is cleared. Clearing this bit will reset the module (also clearing
+any FIFOs if implemented) and will also terminate any a transfer being in process.
+
+The data quantity to be transferred within a single data transmission is defined via the _SPI_CTRL_SIZEx_ bits.
 The SPI module supports 8-bit (`00`), 16-bit (`01`), 24-bit (`10`) and 32-bit (`11`) transfers.
 
 A transmission is started when writing data to the `DATA` register. The data must be LSB-aligned. So if
-the SPI transceiver is configured for less than 32-bit transfers data quantity, the transmit data must be placed
-into the lowest 8/16/24 bit of `DATA`. Vice versa, the received data is also always LSB-aligned. Application
-software should only actually process the amount of bits that were configured using _SPI_CTRL_SIZEx_ when
+the SPI transceiver is configured for less than 32-bit transfer data quantity, the transmit data must be placed
+into the lowest 8/16/24 bits of `DATA`. Vice versa, the received data is also always LSB-aligned. Application
+software should only process the amount of bits that was configured using _SPI_CTRL_SIZEx_ when
 reading `DATA`.
+
+The SPI operation is completed as soon as the _SPI_CTRL_BUSY_ flag clears. If a FIFO size greater than zero is configured,
+the busy flag clears when the current serial engine operation is completed and there is no data left in send buffer.
 
 [NOTE]
 The NEORV32 SPI module only support MSB-first mode. Data can be reversed before writing `DATA` (for TX) / after
-reading `DATA` (for RX) to implement LSB-first transmissions. Note that in both cases data in ` DATA` still
+reading `DATA` (for RX) to implement LSB-first transmissions. Note that in both cases data in `DATA` still
 needs to be LSB-aligned.
 
 [TIP]
-The actual transmission length is left to the user: after asserting chip-select an arbitrary amount of
-transmission with arbitrary data quantity (_SPI_CTRL_SIZEx_) can be made before de-asserting chip-select again.
+The total transmission length, which can be an arbitrary number of individual data transfers, is left to the user:
+after asserting chip-select an arbitrary amount of transmission with arbitrary data quantity (_SPI_CTRL_SIZEx_) can
+be made before de-asserting chip-select again.
 
 The SPI controller features 8 dedicated chip-select lines. These lines are controlled via the control register's
 _SPI_CTRL_CSx_ bits. When a specific _SPI_CTRL_CSx_ bit is **set**, the according chip-select line `spi_csn_o(x)`
@@ -70,7 +76,7 @@ the accessed device's chip-select signal but can also be use for controlling oth
 
 **SPI Clock Configuration**
 
-The SPI module supports all _standard SPI clock modes_ (0, 1, 2, 3), which is via the two control register bits
+The SPI module supports all _standard SPI clock modes_ (0, 1, 2, 3), which are configured via the two control register bits
 _SPI_CTRL_CPHA_ and _SPI_CTRL_CPOL_. The _SPI_CTRL_CPHA_ bit defines the _clock phase_ and the _SPI_CTRL_CPOL_
 bit defines the _clock polarity_.
 
@@ -87,7 +93,7 @@ image::SPI_timing_diagram2.wikimedia.png[]
 |=======================
 
 The SPI clock frequency (`spi_sck_o`) is programmed by the 3-bit _SPI_CTRL_PRSCx_ clock prescaler.
-The following prescalers are available:
+The following pre-scalers are available:
 
 .SPI prescaler configuration
 [cols="<4,^1,^1,^1,^1,^1,^1,^1,^1"]
@@ -107,15 +113,40 @@ Hence, the maximum SPI clock is f~main~ / 4.
 .High-Speed SPI mode
 [TIP]
 The module provides a "high-speed" SPI mode. In this mode the clock prescaler configuration (SPI_CTRL_PRSCx) is ignored
-and the SPI clock operates at f~main~ / 2 (half of the processor's main clock). High speed SPI mode is enabled by setting
+and the SPI clock operates at **f~main~ / 2** (half of the processor's main clock). High speed SPI mode is enabled by setting
 the control register's _SPI_CTRL_HIGHSPEED_ bit.
+
+
+**SPI FIFO**
+
+An optional FIFO buffer can be implemented by setting _IO_SPI_FIFO_ to a value greater than zero. Having a data FIFO
+allows (more) CPU-independent operation of the SPI module.
+
+Internally, two FIFOs are implemented: one for TX data and one for RX data. However, those two FIFOs are transparent for
+the software and operate as a single, unified "ring buffer". The status signals of the TX FIFO (empty, at least half full,
+full) are exposed as read-only signals via the SPI control register. In contrast, the RX FIFO only provides a "data available"
+flag (= RX FIFO not empty) via the SPI control register.
+
+[TIP]
+Application programs can implement "double buffering" when using the "FIFO less than half full" interrupt configuration
+option (see below).
 
 
 **SPI Interrupt**
 
-The SPI module provides a single interrupt to signal "transmission done" to the CPU. Whenever the SPI
-module completes the current transfer operation, the interrupt is triggered and has to be explicitly cleared again
-by writing zero to the according <<_mip>> CSR bit.
+The SPI module provides a single interrupt that can be used to signal certain transmission states to the CPU.
+The actual interrupt condition is configured by the two _SPI_CTRL_IRQx_ in the SPI module's control register:
+
+* `00`, `01` : trigger interrupt when SPI serial engine _completes_ current transmission
+* `10` : trigger interrupt when TX FIFO _becomes_ less than half full, not available if _IO_SPI_FIFO_ is zero
+* `11` : trigger interrupt when TX FIFO _becomes_ empty, not available if _IO_SPI_FIFO_ is zero
+
+Once the SPI CPU is triggered it has to be explicitly cleared again by writing zero to the according
+<<_mip>> CSR bit inside the SPI trap handler.
+
+[IMPORTANT]
+If not FIFO is implemented (_IO_SPI_FIFO_ = 0) the _SPI_CTRL_IRQx_ are hardwired to `00` statically configuring
+"SPI serial engine _completes_ current transmission" as interrupt condition.
 
 
 **Register Map**
@@ -125,24 +156,20 @@ by writing zero to the according <<_mip>> CSR bit.
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.19+<| `0xffffffa8` .19+<| `NEORV32_SPI.CTRL` <|`0` _SPI_CTRL_CS0_        ^| r/w .8+<| Direct chip-select 0..7; setting `spi_csn_o(x)` low when set
-                                              <|`1` _SPI_CTRL_CS1_        ^| r/w 
-                                              <|`2` _SPI_CTRL_CS2_        ^| r/w 
-                                              <|`3` _SPI_CTRL_CS3_        ^| r/w 
-                                              <|`4` _SPI_CTRL_CS4_        ^| r/w 
-                                              <|`5` _SPI_CTRL_CS5_        ^| r/w 
-                                              <|`6` _SPI_CTRL_CS6_        ^| r/w 
-                                              <|`7` _SPI_CTRL_CS7_        ^| r/w 
-                                              <|`8` _SPI_CTRL_EN_         ^| r/w <| SPI enable
-                                              <|`9` _SPI_CTRL_CPHA_       ^| r/w <| clock phase (`0`=sample RX on rising edge & update TX on falling edge; `1`=sample RX on falling edge & update TX on rising edge)
-                                              <|`10` _SPI_CTRL_PRSC0_     ^| r/w .3+| 3-bit clock prescaler select
-                                              <|`11` _SPI_CTRL_PRSC1_     ^| r/w
-                                              <|`12` _SPI_CTRL_PRSC2_     ^| r/w
-                                              <|`13` _SPI_CTRL_SIZE0_     ^| r/w .2+<| transfer size (`00`=8-bit, `01`=16-bit, `10`=24-bit, `11`=32-bit)
-                                              <|`14` _SPI_CTRL_SIZE1_     ^| r/w
-                                              <|`15` _SPI_CTRL_CPOL_      ^| r/w <| clock polarity
-                                              <|`16` _SPI_CTRL_HIGHSPEED_ ^| r/w <| enable SPI high-speed mode (ignoring _SPI_CTRL_PRSC_)
-                                              <|`17:30`                   ^| r/- <| _reserved, read as zero
-                                              <|`31` _SPI_CTRL_BUSY_      ^| r/- <| transmission in progress when set
-| `0xffffffac` | `NEORV32_SPI.DATA` |`31:0` | r/w | receive/transmit data, LSB-aligned
+.15+<| `0xffffffa8` .15+<| `NEORV32_SPI.CTRL` <|`7:0`   _SPI_CTRL_CS7_ : _SPI_CTRL_CS0_           ^| r/w <| Direct chip-select 0..7; setting `spi_csn_o(x)` low when set
+                                              <|`8`     _SPI_CTRL_EN_                             ^| r/w <| SPI module enable
+                                              <|`9`     _SPI_CTRL_CPHA_                           ^| r/w <| clock phase (`0`=sample RX on rising edge & update TX on falling edge; `1`=sample RX on falling edge & update TX on rising edge)
+                                              <|`12:10` _SPI_CTRL_PRSC2_ : _SPI_CTRL_PRSC0_       ^| r/w <| 3-bit clock prescaler select
+                                              <|`14:13` _SPI_CTRL_SIZE1_ : _SPI_CTRL_SIZE0_       ^| r/w <| transfer size (`00`=8-bit, `01`=16-bit, `10`=24-bit, `11`=32-bit)
+                                              <|`15`    _SPI_CTRL_CPOL_                           ^| r/w <| clock polarity
+                                              <|`16`    _SPI_CTRL_HIGHSPEED_                      ^| r/w <| enable SPI high-speed mode (ignoring _SPI_CTRL_PRSC_)
+                                              <|`18:17` _SPI_CTRL_IRQ1_ : _SPI_CTRL_IRQ0_         ^| r/w <| interrupt configuration (`0-` = SPI serial engine becomes idle, `10` = TX FIFO _become_ less than half full, `11` = TX FIFO _becomes_ empty)
+                                              <|`22:19` _SPI_CTRL_FIFO_MSB_ : _SPI_CTRL_FIFO_LSB_ ^| r/- <| FIFO depth; log2(_IO_SPI_FIFO_)
+                                              <|`23:26` _reserved_                                ^| r/- <| reserved, read as zero
+                                              <|`27`   _SPI_CTRL_RX_AVAIL_                        ^| r/- <| RX FIFO data available (RX FIFO not empty); zero if FIFO not implemented
+                                              <|`28`   _SPI_CTRL_TX_EMPTY_                        ^| r/- <| TX FIFO empty; zero if FIFO not implemented
+                                              <|`29`   _SPI_CTRL_TX_HALF_                         ^| r/- <| TX FIFO at least half full; zero if FIFO not implemented
+                                              <|`30`   _SPI_CTRL_TX_FULL_                         ^| r/- <| TX FIFO full; zero if FIFO not implemented
+                                              <|`31`   _SPI_CTRL_BUSY_                            ^| r/- <| SPI module busy when set (serial engine operation in progress and TX FIFO not empty yet)
+| `0xffffffac` | `NEORV32_SPI.DATA` |`31:0` | r/w | receive/transmit data (FIFO), LSB-aligned
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -63,7 +63,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070407"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070408"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -1025,6 +1025,7 @@ package neorv32_package is
       IO_UART1_RX_FIFO             : natural := 1;      -- RX fifo depth, has to be a power of two, min 1
       IO_UART1_TX_FIFO             : natural := 1;      -- TX fifo depth, has to be a power of two, min 1
       IO_SPI_EN                    : boolean := false;  -- implement serial peripheral interface (SPI)?
+      IO_SPI_FIFO                  : natural := 0;      -- SPI RTX fifo depth, has to be zero or a power of two
       IO_TWI_EN                    : boolean := false;  -- implement two-wire interface (TWI)?
       IO_PWM_NUM_CH                : natural := 0;      -- number of PWM channels to implement (0..60); 0 = disabled
       IO_WDT_EN                    : boolean := false;  -- implement watch dog timer (WDT)?
@@ -1751,6 +1752,9 @@ package neorv32_package is
   -- Component: Serial Peripheral Interface (SPI) -------------------------------------------
   -- -------------------------------------------------------------------------------------------
   component neorv32_spi
+    generic (
+      IO_SPI_FIFO : natural -- SPI RTX fifo depth, has to be zero or a power of two
+    );
     port (
       -- host access --
       clk_i       : in  std_ulogic; -- global clock line

--- a/rtl/core/neorv32_spi.vhd
+++ b/rtl/core/neorv32_spi.vhd
@@ -3,7 +3,6 @@
 -- # ********************************************************************************************* #
 -- # Frame format: 8/16/24/32-bit receive/transmit data, always MSB first, 2 clock modes,          #
 -- # 8 pre-scaled clocks (derived from system clock), 8 dedicated chip-select lines (low-active).  #
--- # Interrupt: "transfer done"                                                                    #
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
@@ -154,8 +153,10 @@ begin
 
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  assert not (is_power_of_two_f(IO_SPI_FIFO) = false)  report "NEORV32 PROCESSOR CONFIG ERROR: SPI <IO_SPI_FIFO> has to be a power of two." severity error;
-  assert not (IO_SPI_FIFO > 2**15) report "NEORV32 PROCESSOR CONFIG ERROR: SPI <IO_SPI_FIFO> has to be 1..32768." severity error;
+  assert not ((is_power_of_two_f(IO_SPI_FIFO) = false) and (IO_SPI_FIFO /= 0))
+  report "NEORV32 PROCESSOR CONFIG ERROR: SPI <IO_SPI_FIFO> has to be a power of two." severity error;
+  assert not (IO_SPI_FIFO > 2**15)
+  report "NEORV32 PROCESSOR CONFIG ERROR: SPI <IO_SPI_FIFO> has to be 1..32768." severity error;
 
 
   -- Access Control -------------------------------------------------------------------------
@@ -441,7 +442,7 @@ begin
   end process irq_generator;
 
   -- CPU interrupt --
-  irq_o <= '1' when (ctrl(ctrl_en_c) = '1') and (irq_gen = "01") else '0';
+  irq_o <= '1' when (ctrl(ctrl_en_c) = '1') and (irq_gen = "01") else '0'; -- rising edge detector
 
 
 end neorv32_spi_rtl;

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -1245,7 +1245,7 @@ begin
   if (IO_SPI_EN = true) generate
     neorv32_spi_inst: neorv32_spi
     generic map (
-      IO_SPI_FIFO => 4 -- SPI RTX fifo depth, has to be zero or a power of two
+      IO_SPI_FIFO => IO_SPI_FIFO -- SPI RTX fifo depth, has to be zero or a power of two
     )
     port map (
       -- host access --

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -126,6 +126,7 @@ entity neorv32_top is
     IO_UART1_RX_FIFO             : natural := 1;      -- RX fifo depth, has to be a power of two, min 1
     IO_UART1_TX_FIFO             : natural := 1;      -- TX fifo depth, has to be a power of two, min 1
     IO_SPI_EN                    : boolean := false;  -- implement serial peripheral interface (SPI)?
+    IO_SPI_FIFO                  : natural := 0;      -- SPI RTX fifo depth, has to be zero or a power of two
     IO_TWI_EN                    : boolean := false;  -- implement two-wire interface (TWI)?
     IO_PWM_NUM_CH                : natural := 0;      -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    : boolean := false;  -- implement watch dog timer (WDT)?
@@ -1243,6 +1244,9 @@ begin
   neorv32_spi_inst_true:
   if (IO_SPI_EN = true) generate
     neorv32_spi_inst: neorv32_spi
+    generic map (
+      IO_SPI_FIFO => 4 -- SPI RTX fifo depth, has to be zero or a power of two
+    )
     port map (
       -- host access --
       clk_i       => clk_i,                    -- global clock line

--- a/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
+++ b/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
@@ -108,6 +108,7 @@ entity neorv32_ProcessorTop_stdlogic is
     IO_UART1_RX_FIFO             : natural := 1;      -- RX fifo depth, has to be a power of two, min 1
     IO_UART1_TX_FIFO             : natural := 1;      -- TX fifo depth, has to be a power of two, min 1
     IO_SPI_EN                    : boolean := true;   -- implement serial peripheral interface (SPI)?
+    IO_SPI_FIFO                  : natural := 0;      -- SPI RTX fifo depth, has to be zero or a power of two
     IO_TWI_EN                    : boolean := true;   -- implement two-wire interface (TWI)?
     IO_PWM_NUM_CH                : natural := 4;      -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    : boolean := true;   -- implement watch dog timer (WDT)?
@@ -352,6 +353,7 @@ begin
     IO_UART1_RX_FIFO             => IO_UART1_RX_FIFO,   -- RX fifo depth, has to be a power of two, min 1
     IO_UART1_TX_FIFO             => IO_UART1_TX_FIFO,   -- TX fifo depth, has to be a power of two, min 1
     IO_SPI_EN                    => IO_SPI_EN,          -- implement serial peripheral interface (SPI)?
+    IO_SPI_FIFO                  => IO_SPI_FIFO,        -- SPI RTX fifo depth, has to be zero or a power of two
     IO_TWI_EN                    => IO_TWI_EN,          -- implement two-wire interface (TWI)?
     IO_PWM_NUM_CH                => IO_PWM_NUM_CH,      -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    => IO_WDT_EN,          -- implement watch dog timer (WDT)?

--- a/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
@@ -116,6 +116,7 @@ entity neorv32_top_avalonmm is
     IO_UART1_RX_FIFO             : natural := 1;      -- RX fifo depth, has to be a power of two, min 1
     IO_UART1_TX_FIFO             : natural := 1;      -- TX fifo depth, has to be a power of two, min 1
     IO_SPI_EN                    : boolean := false;  -- implement serial peripheral interface (SPI)?
+    IO_SPI_FIFO                  : natural := 0;      -- SPI RTX fifo depth, has to be zero or a power of two
     IO_TWI_EN                    : boolean := false;  -- implement two-wire interface (TWI)?
     IO_PWM_NUM_CH                : natural := 0;      -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    : boolean := false;  -- implement watch dog timer (WDT)?
@@ -321,6 +322,7 @@ begin
     IO_UART1_RX_FIFO => IO_UART1_RX_FIFO,
     IO_UART1_TX_FIFO => IO_UART1_TX_FIFO,
     IO_SPI_EN => IO_SPI_EN,
+    IO_SPI_FIFO => IO_SPI_FIFO,
     IO_TWI_EN => IO_TWI_EN,
     IO_PWM_NUM_CH => IO_PWM_NUM_CH,
     IO_WDT_EN => IO_WDT_EN,

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -102,8 +102,9 @@ entity neorv32_SystemTop_axi4lite is
     IO_UART1_RX_FIFO             : natural := 1;      -- RX fifo depth, has to be a power of two, min 1
     IO_UART1_TX_FIFO             : natural := 1;      -- TX fifo depth, has to be a power of two, min 1
     IO_SPI_EN                    : boolean := true;   -- implement serial peripheral interface (SPI)?
+    IO_SPI_FIFO                  : natural := 0;      -- SPI RTX fifo depth, has to be zero or a power of two
     IO_TWI_EN                    : boolean := true;   -- implement two-wire interface (TWI)?
-    IO_PWM_NUM_CH                : natural := 4;      -- number of PWM channels to implement (0..60); 0 = disabled
+    IO_PWM_NUM_CH                : natural := 0;      -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    : boolean := true;   -- implement watch dog timer (WDT)?
     IO_TRNG_EN                   : boolean := true;   -- implement true random number generator (TRNG)?
     IO_TRNG_FIFO                 : natural := 1;      -- TRNG fifo depth, has to be a power of two, min 1
@@ -345,6 +346,7 @@ begin
     IO_UART1_RX_FIFO             => IO_UART1_RX_FIFO,   -- RX fifo depth, has to be a power of two, min 1
     IO_UART1_TX_FIFO             => IO_UART1_TX_FIFO,   -- TX fifo depth, has to be a power of two, min 1
     IO_SPI_EN                    => IO_SPI_EN,          -- implement serial peripheral interface (SPI)?
+    IO_SPI_FIFO                  => IO_SPI_FIFO,        -- SPI RTX fifo depth, has to be zero or a power of two
     IO_TWI_EN                    => IO_TWI_EN,          -- implement two-wire interface (TWI)?
     IO_PWM_NUM_CH                => IO_PWM_NUM_CH,      -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    => IO_WDT_EN,          -- implement watch dog timer (WDT)?

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -346,7 +346,7 @@ begin
     IO_PWM_NUM_CH                => 30,            -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    => true,          -- implement watch dog timer (WDT)?
     IO_TRNG_EN                   => true,          -- implement true random number generator (TRNG)?
-    IO_TRNG_FIFO                 => 0,             -- TRNG fifo depth, has to be a power of two, min 1
+    IO_TRNG_FIFO                 => 4,             -- TRNG fifo depth, has to be a power of two, min 1
     IO_CFS_EN                    => true,          -- implement custom functions subsystem (CFS)?
     IO_CFS_CONFIG                => (others => '0'), -- custom CFS configuration generic
     IO_CFS_IN_SIZE               => 32,            -- size of CFS input conduit in bits

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -341,6 +341,7 @@ begin
     IO_UART1_RX_FIFO             => 1,             -- RX fifo depth, has to be a power of two, min 1
     IO_UART1_TX_FIFO             => 1,             -- TX fifo depth, has to be a power of two, min 1
     IO_SPI_EN                    => true,          -- implement serial peripheral interface (SPI)?
+    IO_SPI_FIFO                  => 4,             -- SPI RTX fifo depth, has to be zero or a power of two
     IO_TWI_EN                    => true,          -- implement two-wire interface (TWI)?
     IO_PWM_NUM_CH                => 30,            -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    => true,          -- implement watch dog timer (WDT)?

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -346,7 +346,7 @@ begin
     IO_PWM_NUM_CH                => 30,            -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    => true,          -- implement watch dog timer (WDT)?
     IO_TRNG_EN                   => true,          -- implement true random number generator (TRNG)?
-    IO_TRNG_FIFO                 => 4,             -- TRNG fifo depth, has to be a power of two, min 1
+    IO_TRNG_FIFO                 => 0,             -- TRNG fifo depth, has to be a power of two, min 1
     IO_CFS_EN                    => true,          -- implement custom functions subsystem (CFS)?
     IO_CFS_CONFIG                => (others => '0'), -- custom CFS configuration generic
     IO_CFS_IN_SIZE               => 32,            -- size of CFS input conduit in bits

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -232,6 +232,7 @@ begin
     IO_UART1_RX_FIFO             => 1,             -- RX fifo depth, has to be a power of two, min 1
     IO_UART1_TX_FIFO             => 1,             -- TX fifo depth, has to be a power of two, min 1
     IO_SPI_EN                    => true,          -- implement serial peripheral interface (SPI)?
+    IO_SPI_FIFO                  => 4,             -- SPI RTX fifo depth, has to be zero or a power of two
     IO_TWI_EN                    => true,          -- implement two-wire interface (TWI)?
     IO_PWM_NUM_CH                => 30,            -- number of PWM channels to implement (0..60); 0 = disabled
     IO_WDT_EN                    => true,          -- implement watch dog timer (WDT)?

--- a/sw/bootloader/bootloader.c
+++ b/sw/bootloader/bootloader.c
@@ -278,7 +278,7 @@ int main(void) {
 #if (SPI_EN != 0)
   // setup SPI for 8-bit, clock-mode 0
   if (neorv32_spi_available()) {
-    neorv32_spi_setup(SPI_FLASH_CLK_PRSC, 0, 0, 0);
+    neorv32_spi_setup(SPI_FLASH_CLK_PRSC, 0, 0, 0, 0);
   }
 #endif
 

--- a/sw/example/demo_spi/main.c
+++ b/sw/example/demo_spi/main.c
@@ -315,7 +315,7 @@ void spi_setup(void) {
   }
   neorv32_uart0_printf("\n+ New SPI data size = %u byte(s)\n\n", tmp);
 
-  neorv32_spi_setup(spi_prsc, clk_phase, clk_pol, data_size);
+  neorv32_spi_setup(spi_prsc, clk_phase, clk_pol, data_size, 0);
   spi_configured = 1; // SPI is configured now
   spi_size = tmp;
 }

--- a/sw/example/demo_spi_irq/drv/neorv32_spi_irq.c
+++ b/sw/example/demo_spi_irq/drv/neorv32_spi_irq.c
@@ -46,6 +46,22 @@
 
 
 /**********************************************************************//**
+ * Initializes SPI flow control handle. The data structure elements are listed in #t_neorv32_spi.
+ *
+ * @param[in,out] *self SPI driver common data handle. See #t_neorv32_spi.
+ **************************************************************************/
+void neorv32_spi_init(t_neorv32_spi *self) {
+
+  self->uint8IsBusy = 0;
+  self->uint32Fifo = (uint32_t) neorv32_spi_get_fifo_depth(); // acquire FIFO depth in elements
+  self->uint32Total = 0;
+  self->uint32Write = 0;  // write element count
+  self->uint32Read = 0; // read element count
+  return;
+}
+
+
+/**********************************************************************//**
  * SPI interrupt service routine. The data structure elements are listed in #t_neorv32_spi.
  *
  * @param[in,out] *self SPI driver common data handle. See #t_neorv32_spi.
@@ -53,46 +69,77 @@
 void neorv32_spi_isr(t_neorv32_spi *self) {
 
   uint32_t  uint32Buf;  // help variable
+  uint32_t  uint32Lim;  // loop limit
+
 
   neorv32_cpu_csr_write(CSR_MIP, ~(1<<SPI_FIRQ_PENDING)); // ack/clear FIRQ
 
-  if ( self->uint32CurrentElem == self->uint32TotalElem ) { // leave if accicently called ISR
+  if ( 0 == self->uint32Total ) { // leave if accidentally called ISR
     return;
   }
 
-  uint32Buf = 0;  // data type conversion
   switch (self->uint8SzElem) {
     case 1:   // uint8_t
-      ((uint8_t *) self->ptrSpiBuf)[self->uint32CurrentElem] = (uint8_t) (NEORV32_SPI.DATA & 0xff); // capture from last transfer
-      if ( self->uint32CurrentElem == self->uint32TotalElem-1 ) { // transfer done, no new data
-        neorv32_spi_cs_dis(self->uint8Csn); // deselect slave
-        break;  // +1, signals complete
+      // read data from SPI from last transfer
+      for ( ; self->uint32Read<self->uint32Write; (self->uint32Read)++ ) {
+        ((uint8_t *) self->ptrSpiBuf)[self->uint32Read] = (uint8_t) (NEORV32_SPI.DATA & 0xff);  // capture from last transfer
       }
-      uint32Buf |= ((uint8_t *) self->ptrSpiBuf)[self->uint32CurrentElem+1];
-      NEORV32_SPI.DATA = uint32Buf; // next transfer
+      if ( self->uint32Read == self->uint32Total ) {  // transfer done, no new data
+        neorv32_spi_cs_dis(self->uint8Csn); // deselect slave
+        self->uint32Total = 0;
+        self->uint8IsBusy = 0;
+        break;
+      }
+      // write next packet
+      uint32Lim = min(self->uint32Write+self->uint32Fifo, self->uint32Total);
+      for ( ; self->uint32Write<uint32Lim; (self->uint32Write)++ ) {
+        uint32Buf = 0;
+        uint32Buf |= ((uint8_t *) self->ptrSpiBuf)[self->uint32Write];
+        NEORV32_SPI.DATA = uint32Buf; // next transfer
+      }
       break;
     case 2:   // uint16_t
-      ((uint16_t *) self->ptrSpiBuf)[self->uint32CurrentElem] = (uint16_t) (NEORV32_SPI.DATA & 0xffff); // capture from last transfer
-      if ( self->uint32CurrentElem == self->uint32TotalElem-1 ) { // transfer done, no new data
-        neorv32_spi_cs_dis(self->uint8Csn); // deselect slave
-        break;  // +1, signals complete
+      // read data from SPI from last transfer
+      for ( ; self->uint32Read<self->uint32Write; (self->uint32Read)++ ) {
+        ((uint16_t *) self->ptrSpiBuf)[self->uint32Read] = (uint16_t) (NEORV32_SPI.DATA & 0xffff);  // capture from last transfer
       }
-      uint32Buf |= ((uint16_t *) self->ptrSpiBuf)[self->uint32CurrentElem+1];
-      NEORV32_SPI.DATA = uint32Buf; // next transfer
+      if ( self->uint32Read == self->uint32Total ) {  // transfer done, no new data
+        neorv32_spi_cs_dis(self->uint8Csn); // deselect slave
+        self->uint32Total = 0;
+        self->uint8IsBusy = 0;
+        break;
+      }
+      // write next packet
+      uint32Lim = min(self->uint32Write+self->uint32Fifo, self->uint32Total);
+      for ( ; self->uint32Write<uint32Lim; (self->uint32Write)++ ) {
+        uint32Buf = 0;
+        uint32Buf |= ((uint16_t *) self->ptrSpiBuf)[self->uint32Write];
+        NEORV32_SPI.DATA = uint32Buf; // next transfer
+      }
       break;
     case 4:   // uint32_t
-      ((uint32_t *) self->ptrSpiBuf)[self->uint32CurrentElem] = NEORV32_SPI.DATA; // capture from last transfer
-      if ( self->uint32CurrentElem == self->uint32TotalElem-1 ) { // transfer done, no new data
-        neorv32_spi_cs_dis(self->uint8Csn); // deselect slave
-        break;  // +1, signals complete
+      // read data from SPI from last transfer
+      for ( ; self->uint32Read<self->uint32Write; (self->uint32Read)++ ) {
+        ((uint32_t *) self->ptrSpiBuf)[self->uint32Read] = NEORV32_SPI.DATA;  // capture from last transfer
       }
-      uint32Buf = ((uint32_t *) self->ptrSpiBuf)[self->uint32CurrentElem+1];  // next transfer
-      NEORV32_SPI.DATA = uint32Buf; // next transfer
+      if ( self->uint32Read == self->uint32Total ) {  // transfer done, no new data
+        neorv32_spi_cs_dis(self->uint8Csn); // deselect slave
+        self->uint32Total = 0;
+        self->uint8IsBusy = 0;
+        break;
+      }
+      // write next packet
+      uint32Lim = min(self->uint32Write+self->uint32Fifo, self->uint32Total);
+      for ( ; self->uint32Write<uint32Lim; (self->uint32Write)++ ) {
+        uint32Buf = 0;
+        uint32Buf |= ((uint32_t *) self->ptrSpiBuf)[self->uint32Write];
+        NEORV32_SPI.DATA = uint32Buf; // next transfer
+      }
       break;
     default:  // unknown
       return;
   }
-  (self->uint32CurrentElem)++;  // next element
+  return;
 }
 
 
@@ -113,18 +160,22 @@ int neorv32_spi_rw(t_neorv32_spi *self, void *spi, uint8_t csn, uint32_t num_ele
 
   uint32_t  uint32Buf;  // help variable
 
-  if ( (self->uint32CurrentElem != self->uint32TotalElem) || (0 != neorv32_spi_busy()) ) {
+  if ( 0 != self->uint8IsBusy ) {
     return 1; // transfer active, no new request
   }
 
-  self->uint32CurrentElem = 0;
-  self->uint32TotalElem = num_elem;
+  self->uint32Total = num_elem;
+  self->uint32Write = 0;  // write element count
+  self->uint32Read = 0;   // read element count
   self->ptrSpiBuf = spi;
   self->uint8SzElem = data_byte;
   self->uint8Csn = csn;
+  self->uint8IsBusy = 1;  // mark as busy
+
+  neorv32_spi_cs_en(self->uint8Csn);  // select SPI channel
 
   uint32Buf = 0;
-  switch (self->uint8SzElem) {  // start first transfer, rest is handled by ISR
+  switch (self->uint8SzElem) {  // start first transfer, rest is handled by ISR; can only sent one element, otherwise clash with ISR
     case 1:   // uint8_t
       uint32Buf |= ((uint8_t *) self->ptrSpiBuf)[0];
       break;
@@ -136,10 +187,9 @@ int neorv32_spi_rw(t_neorv32_spi *self, void *spi, uint8_t csn, uint32_t num_ele
       break;
     default:
       return 2; // unsupported byte size
-  }
-
-  neorv32_spi_cs_en(self->uint8Csn);  // select SPI channel
-  NEORV32_SPI.DATA = uint32Buf;   // next transfer
+    }
+    (self->uint32Write)++;
+    NEORV32_SPI.DATA = uint32Buf; // next transfer
 
   return 0; // successful end
 }
@@ -155,7 +205,7 @@ int neorv32_spi_rw(t_neorv32_spi *self, void *spi, uint8_t csn, uint32_t num_ele
  **************************************************************************/
 int neorv32_spi_rw_busy(t_neorv32_spi *self) {
 
-  if ( self->uint32TotalElem != self->uint32CurrentElem ) {
+  if ( 0 != self->uint8IsBusy ) {
     return 1;
   }
   return 0;

--- a/sw/example/demo_spi_irq/drv/neorv32_spi_irq.h
+++ b/sw/example/demo_spi_irq/drv/neorv32_spi_irq.h
@@ -44,20 +44,31 @@
 #ifndef neorv32_spi_irq_h
 #define neorv32_spi_irq_h
 
+// MIN macro
+//   https://stackoverflow.com/questions/3437404/min-and-max-in-c
+#define min(a,b) \
+  ({ __typeof__ (a) _a = (a); \
+     __typeof__ (b) _b = (b); \
+    _a < _b ? _a : _b; })
+
 // data handle for ISR
 typedef struct t_neorv32_spi
 {
-  void*     ptrSpiBuf;          /**< SPI buffer data pointer */
-  uint8_t   uint8SzElem;        /**< Element Size in byte */
-  uint8_t   uint8Csn;           /**< SPI chip select channel */
-  uint32_t  uint32TotalElem;    /**< Number of elements in buffer */
-  uint32_t  uint32CurrentElem;  /**< Buffer element in transfer */
+  void*     ptrSpiBuf;    /**< SPI buffer data pointer */
+  uint8_t   uint8SzElem;  /**< Element Size in byte */
+  uint8_t   uint8Csn;     /**< SPI chip select channel */
+  uint16_t  uint32Fifo;   /**< Number of elements in Fifo */
+  uint32_t  uint32Total;  /**< Number of elements in buffer */
+  uint32_t  uint32Write;  /**< To SPI core write elements */
+  uint32_t  uint32Read;   /**< From SPI core read elements */
+  uint8_t uint8IsBusy;    /**< Spi Core is Busy*/
 } t_neorv32_spi;
 
 
 // prototypes
-void     neorv32_spi_isr(t_neorv32_spi *self);
-int      neorv32_spi_rw(t_neorv32_spi *self, void *spi, uint8_t csn, uint32_t num_elem, uint8_t data_byte);
-int      neorv32_spi_rw_busy(t_neorv32_spi *self);
+void  neorv32_spi_init(t_neorv32_spi *self);
+void  neorv32_spi_isr(t_neorv32_spi *self);
+int   neorv32_spi_rw(t_neorv32_spi *self, void *spi, uint8_t csn, uint32_t num_elem, uint8_t data_byte);
+int   neorv32_spi_rw_busy(t_neorv32_spi *self);
 
 #endif // neorv32_spi_irq_h

--- a/sw/example/demo_spi_irq/main.c
+++ b/sw/example/demo_spi_irq/main.c
@@ -110,7 +110,7 @@ int main()
 
   // configure SPI
   neorv32_spi_disable();
-  neorv32_spi_setup(0, 0, 0, 0);  // spi mode 0, 8bit
+  neorv32_spi_setup(0, 0, 0, 0, 0);  // spi mode 0, 8bit, IRQ when current PHY operation is done
   neorv32_spi_enable();
 
   // IRQ based data transfer

--- a/sw/example/demo_spi_irq/main.c
+++ b/sw/example/demo_spi_irq/main.c
@@ -108,9 +108,13 @@ int main()
   neorv32_cpu_irq_enable(SPI_FIRQ_ENABLE);    // FIRQ6: SPI Interrupt
   neorv32_cpu_eint();                         // enable global interrupts
 
-  // configure SPI
+  // SPI
+    // SPI Control
+  neorv32_spi_init(&g_neorv32_spi);
+    // Configure
   neorv32_spi_disable();
-  neorv32_spi_setup(0, 0, 0, 0, 0);  // spi mode 0, 8bit, IRQ when current PHY operation is done
+    // neorv32_spi_setup(int prsc, int clk_phase, int clk_polarity, int data_size, int irq_config)
+  neorv32_spi_setup(0, 0, 0, 0, 3);  // spi mode 0, 8bit, IRQ: 0-: PHY going idle, 10: TX fifo less than half full, 11: TX fifo empty
   neorv32_spi_enable();
 
   // IRQ based data transfer

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1217,7 +1217,7 @@ int main() {
     cnt_test++;
 
     // configure SPI
-    neorv32_spi_setup(CLK_PRSC_2, 0, 0, 0);
+    neorv32_spi_setup(CLK_PRSC_2, 0, 0, 0, 0); // IRQ when SPI PHY becomes idle
 
     // enable fast interrupt
     neorv32_cpu_irq_enable(CSR_MIE_FIRQ6E);

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -1119,7 +1119,17 @@ enum NEORV32_SPI_CTRL_enum {
   SPI_CTRL_SIZE1     = 14, /**< SPI control register(14) (r/w): Transfer data size msb (00: 8-bit, 01: 16-bit, 10: 24-bit, 11: 32-bit) */
   SPI_CTRL_CPOL      = 15, /**< SPI control register(15) (r/w): Clock polarity */
   SPI_CTRL_HIGHSPEED = 16, /**< SPI control register(16) (r/w): SPI high-speed mode enable (ignoring SPI_CTRL_PRSC) */
+  SPI_CTRL_IRQ0      = 17, /**< SPI control register(17) (r/w): Interrupt configuration lsb (0-: PHY going idle) */
+  SPI_CTRL_IRQ1      = 18, /**< SPI control register(18) (r/w): Interrupt configuration lsb (10: TX fifo less than half full, 11: TX fifo empty) */
+  SPI_CTRL_FIFO_LSB  = 19, /**< SPI control register(19) (r/-): log2(FIFO size), lsb */
+  SPI_CTRL_FIFO_MSB  = 22, /**< SPI control register(22) (r/-): log2(FIFO size), msb */
 
+  SPI_CTRL_TX_EMPTY  = 25, /**< SPI control register(25) (r/-): TX FIFO empty */
+  SPI_CTRL_TX_HALF   = 26, /**< SPI control register(26) (r/-): TX FIFO at least half full */
+  SPI_CTRL_TX_FULL   = 27, /**< SPI control register(27) (r/-): TX FIFO full */
+  SPI_CTRL_RX_EMPTY  = 28, /**< SPI control register(28) (r/-): RX FIFO empty */
+  SPI_CTRL_RX_HALF   = 29, /**< SPI control register(29) (r/-): RX FIFO at least half full */
+  SPI_CTRL_RX_FULL   = 30, /**< SPI control register(30) (r/-): RX FIFO full */
   SPI_CTRL_BUSY      = 31  /**< SPI control register(31) (r/-): SPI busy flag */
 };
 /**@}*/

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -1124,12 +1124,10 @@ enum NEORV32_SPI_CTRL_enum {
   SPI_CTRL_FIFO_LSB  = 19, /**< SPI control register(19) (r/-): log2(FIFO size), lsb */
   SPI_CTRL_FIFO_MSB  = 22, /**< SPI control register(22) (r/-): log2(FIFO size), msb */
 
-  SPI_CTRL_TX_EMPTY  = 25, /**< SPI control register(25) (r/-): TX FIFO empty */
-  SPI_CTRL_TX_HALF   = 26, /**< SPI control register(26) (r/-): TX FIFO at least half full */
-  SPI_CTRL_TX_FULL   = 27, /**< SPI control register(27) (r/-): TX FIFO full */
-  SPI_CTRL_RX_EMPTY  = 28, /**< SPI control register(28) (r/-): RX FIFO empty */
-  SPI_CTRL_RX_HALF   = 29, /**< SPI control register(29) (r/-): RX FIFO at least half full */
-  SPI_CTRL_RX_FULL   = 30, /**< SPI control register(30) (r/-): RX FIFO full */
+  SPI_CTRL_RX_AVAIL  = 27, /**< SPI control register(27) (r/-): RX FIFO data available (RX FIFO not empty) */
+  SPI_CTRL_TX_EMPTY  = 28, /**< SPI control register(28) (r/-): TX FIFO empty */
+  SPI_CTRL_TX_HALF   = 29, /**< SPI control register(29) (r/-): TX FIFO at least half full */
+  SPI_CTRL_TX_FULL   = 30, /**< SPI control register(30) (r/-): TX FIFO full */
   SPI_CTRL_BUSY      = 31  /**< SPI control register(31) (r/-): SPI busy flag */
 };
 /**@}*/

--- a/sw/lib/include/neorv32_spi.h
+++ b/sw/lib/include/neorv32_spi.h
@@ -45,13 +45,14 @@
 
 // prototypes
 int      neorv32_spi_available(void);
-void     neorv32_spi_setup(uint8_t prsc, uint8_t clk_phase, uint8_t clk_polarity, uint8_t data_size);
+void     neorv32_spi_setup(int prsc, int clk_phase, int clk_polarity, int data_size, int irq_config);
 void     neorv32_spi_disable(void);
 void     neorv32_spi_enable(void);
+int      neorv32_spi_get_fifo_depth(void);
 void     neorv32_spi_highspeed_enable(void);
 void     neorv32_spi_highspeed_disable(void);
-void     neorv32_spi_cs_en(uint8_t cs);
-void     neorv32_spi_cs_dis(uint8_t cs);
+void     neorv32_spi_cs_en(int cs);
+void     neorv32_spi_cs_dis(int cs);
 uint32_t neorv32_spi_trans(uint32_t tx_data);
 void     neorv32_spi_put_nonblocking(uint32_t tx_data);
 uint32_t neorv32_spi_get_nonblocking(void);

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -789,34 +789,22 @@
               <description>TX FIFO is empty</description>
             </field>
             <field>
+              <name>SPI_CTRL_RX_AVAIL</name>
+              <bitRange>[28:28]</bitRange>
+              <access>read-only</access>
+              <description>RX FIFO data available (RX FIFO not empty)</description>
+            </field>
+            <field>
               <name>SPI_CTRL_TX_HALF</name>
-              <bitRange>[26:26]</bitRange>
+              <bitRange>[29:29]</bitRange>
               <access>read-only</access>
               <description>TX FIFO is at least half full</description>
             </field>
             <field>
               <name>SPI_CTRL_TX_FULL</name>
-              <bitRange>[27:27]</bitRange>
-              <access>read-only</access>
-              <description>TX FIFO is full</description>
-            </field>
-            <field>
-              <name>SPI_CTRL_RX_EMPTY</name>
-              <bitRange>[28:28]</bitRange>
-              <access>read-only</access>
-              <description>RX FIFO is empty</description>
-            </field>
-            <field>
-              <name>SPI_CTRL_RX_HALF</name>
-              <bitRange>[29:29]</bitRange>
-              <access>read-only</access>
-              <description>RX FIFO is at least half full</description>
-            </field>
-            <field>
-              <name>SPI_CTRL_RX_FULL</name>
               <bitRange>[30:30]</bitRange>
               <access>read-only</access>
-              <description>RX FIFO is full</description>
+              <description>TX FIFO is full</description>
             </field>
             <field>
               <name>SPI_CTRL_BUSY</name>

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -772,6 +772,53 @@
               <description>SPI high-speed mode enable (ignoring SPI_CTRL_PRSC)</description>
             </field>
             <field>
+              <name>SPI_CTRL_IRQ</name>
+              <bitRange>[18:17]</bitRange>
+              <description>Interrupt configuration</description>
+            </field>
+            <field>
+              <name>SPI_CTRL_FIFO</name>
+              <bitRange>[22:19]</bitRange>
+              <access>read-only</access>
+              <description>log2(FIFO size)</description>
+            </field>
+            <field>
+              <name>SPI_CTRL_TX_EMPTY</name>
+              <bitRange>[25:25]</bitRange>
+              <access>read-only</access>
+              <description>TX FIFO is empty</description>
+            </field>
+            <field>
+              <name>SPI_CTRL_TX_HALF</name>
+              <bitRange>[26:26]</bitRange>
+              <access>read-only</access>
+              <description>TX FIFO is at least half full</description>
+            </field>
+            <field>
+              <name>SPI_CTRL_TX_FULL</name>
+              <bitRange>[27:27]</bitRange>
+              <access>read-only</access>
+              <description>TX FIFO is full</description>
+            </field>
+            <field>
+              <name>SPI_CTRL_RX_EMPTY</name>
+              <bitRange>[28:28]</bitRange>
+              <access>read-only</access>
+              <description>RX FIFO is empty</description>
+            </field>
+            <field>
+              <name>SPI_CTRL_RX_HALF</name>
+              <bitRange>[29:29]</bitRange>
+              <access>read-only</access>
+              <description>RX FIFO is at least half full</description>
+            </field>
+            <field>
+              <name>SPI_CTRL_RX_FULL</name>
+              <bitRange>[30:30]</bitRange>
+              <access>read-only</access>
+              <description>RX FIFO is full</description>
+            </field>
+            <field>
               <name>SPI_CTRL_BUSY</name>
               <bitRange>[31:31]</bitRange>
               <access>read-only</access>


### PR DESCRIPTION
This PR adds an optional data FIFO to the SPI module (idea by @akaeba from https://github.com/stnolting/neorv32/discussions/378). A new top generic is added to configure the SPI FIFO size: `IO_TRNG_FIFO`, default = 0; has to be zero or a power of two. Furthermore, all FIFO status signals are added to the SPI control register and a fine grained interrupt configuration is added:
* interrupt if SPI PHY completes the current transmission (default, behavior of pre-PR version)
* interrupt if SPI TX FIFO _becomes_ empty
* interrupt if SPI TX FIFO _becomes_ less than half full

✔️ The changes from this PR are fully backwards compatible.