### PR TITLE
[rtl] relocate TWI tri-state drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 16.08.2022 | 1.7.5.2 | relocate TWI tri-state drivers; [#]386()https://github.com/stnolting/neorv32/pull/386 |
 | 15.08.2022 | 1.7.5.1 | change base address of **BUSKEEPER**; [#385](https://github.com/stnolting/neorv32/pull/385) |
 | 15.08.2022 | [**:rocket:1.7.5**](https://github.com/stnolting/neorv32/releases/tag/v1.7.5) | **New release** |
 | 14.08.2022 | 1.7.4.10 | cleanup of FIFO rtl component [#384](https://github.com/stnolting/neorv32/pull/384) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -63,7 +63,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070501"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070502"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -1789,9 +1789,11 @@ package neorv32_package is
       -- clock generator --
       clkgen_en_o : out std_ulogic; -- enable clock generator
       clkgen_i    : in  std_ulogic_vector(07 downto 0);
-      -- com lines --
-      twi_sda_io  : inout std_logic; -- serial data line
-      twi_scl_io  : inout std_logic; -- serial clock line
+      -- com lines (require external tri-state drivers) --
+      twi_sda_i   : in  std_ulogic; -- serial data line input
+      twi_sda_o   : out std_ulogic; -- serial data line output
+      twi_scl_i   : in  std_ulogic; -- serial clock line input
+      twi_scl_o   : out std_ulogic; -- serial clock line output
       -- interrupt --
       irq_o       : out std_ulogic -- transfer done IRQ
     );

--- a/rtl/core/neorv32_twi.vhd
+++ b/rtl/core/neorv32_twi.vhd
@@ -57,9 +57,11 @@ entity neorv32_twi is
     -- clock generator --
     clkgen_en_o : out std_ulogic; -- enable clock generator
     clkgen_i    : in  std_ulogic_vector(07 downto 0);
-    -- com lines --
-    twi_sda_io  : inout std_logic; -- serial data line
-    twi_scl_io  : inout std_logic; -- serial clock line
+    -- com lines (require external tri-state drivers) --
+    twi_sda_i   : in  std_ulogic; -- serial data line input
+    twi_sda_o   : out std_ulogic; -- serial data line output
+    twi_scl_i   : in  std_ulogic; -- serial clock line input
+    twi_scl_o   : out std_ulogic; -- serial clock line output
     -- interrupt --
     irq_o       : out std_ulogic -- transfer done IRQ
   );
@@ -341,15 +343,12 @@ begin
   arbiter.claimed <= '1' when (arbiter.busy = '1') or ((io_con.sda_in_ff(1) = '0') and (io_con.scl_in_ff(1) = '0')) else '0';
 
 
-  -- Tri-State Driver -----------------------------------------------------------------------
+  -- Tri-State Driver Interface -------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  -- SDA and SCL need to be of type std_logic to be correctly resolved in simulation
-  twi_sda_io <= '0' when (io_con.sda_out = '0') else 'Z';
-  twi_scl_io <= '0' when (io_con.scl_out = '0') else 'Z';
-
-  -- read-back - "to_bit" to avoid hardware-vs-simulation mismatch --
-  io_con.sda_in <= to_stdulogic(to_bit(twi_sda_io));
-  io_con.scl_in <= to_stdulogic(to_bit(twi_scl_io));
+  twi_sda_o <= io_con.sda_out; -- NOTE: signal lines can only be actively driven low
+  twi_scl_o <= io_con.scl_out;
+  io_con.sda_in <= twi_sda_i;
+  io_con.scl_in <= twi_scl_i;
 
 
 end neorv32_twi_rtl;


### PR DESCRIPTION
This PR relocates the TWI tri-state drivers from the TWI module to the NEORV32 top entity (one level to the top).

Maybe the tri-state drivers should be excluded from the processor so that they have to be implemented in the **design's** top entity... 🤔 Some synthesis tools seem to have problems if tri-state drivers are "buried" somewhere _inside_ the design (looking at you Vivado)...