### PR TITLE
🚀 [sw] Update software framework to GCC 12.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 20.08.2022 | 1.7.5.6 | :sparkles: update software framework to GCC 12.1.0 (new prebuilt toolchains available!) [#391](https://github.com/stnolting/neorv32/pull/391) |
 | 18.08.2022 | 1.7.5.5 | :lock: add **TRNG** read data protection; [#389](https://github.com/stnolting/neorv32/pull/389) |
 | 18.08.2022 | 1.7.5.4 | minor rtl cleanup in **PWM** module; [#388](https://github.com/stnolting/neorv32/pull/388) |
 | 17.08.2022 | 1.7.5.3 | optimized **CPU front-end** - faster instruction fetch; [#387](https://github.com/stnolting/neorv32/pull/387) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -63,7 +63,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070505"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070506"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/common/common.mk
+++ b/sw/common/common.mk
@@ -125,7 +125,7 @@ IMAGE_GEN = $(NEORV32_EXG_PATH)/image_gen
 
 # Compiler & linker flags
 CC_OPTS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -Wall -ffunction-sections -fdata-sections -nostartfiles -mno-fdiv
-CC_OPTS += -Wl,--gc-sections -lm -lc -lgcc -lc
+CC_OPTS += -Wl,--gc-sections -lm -lc -lgcc -lc -Wl,--no-warn-rwx-segments
 CC_OPTS += $(USER_FLAGS)
 
 

--- a/sw/common/common.mk
+++ b/sw/common/common.mk
@@ -125,7 +125,7 @@ IMAGE_GEN = $(NEORV32_EXG_PATH)/image_gen
 
 # Compiler & linker flags
 CC_OPTS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -Wall -ffunction-sections -fdata-sections -nostartfiles -mno-fdiv
-CC_OPTS += -Wl,--gc-sections -lm -lc -lgcc -lc -Wl,--no-warn-rwx-segments
+CC_OPTS += -Wl,--gc-sections -lm -lc -lgcc -lc
 CC_OPTS += $(USER_FLAGS)
 
 

--- a/sw/common/neorv32.ld
+++ b/sw/common/neorv32.ld
@@ -40,11 +40,10 @@
  * Modified for the NEORV32 processor by Stephan Nolting. */
 
 
-OUTPUT_FORMAT("elf32-littleriscv", "elf32-littleriscv", "elf32-littleriscv")
+OUTPUT_FORMAT("elf32-littleriscv")
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
 SEARCH_DIR("/opt/riscv/riscv32-unknown-elf/lib")
-SEARCH_DIR("=/opt/riscv/riscv64-unknown-linux-gnu/lib")
 SEARCH_DIR("=/usr/local/lib")
 SEARCH_DIR("=/lib")
 SEARCH_DIR("=/usr/lib")
@@ -53,7 +52,7 @@ SEARCH_DIR("=/usr/lib")
 /* ************************************************************************************************* */
 /* +++ NEORV32 memory configuration +++                                                              */
 /* If the symbols are not explicitly defined the default configurations are used. If required, only  */
-/* the edit the very last entry in each row.                                                         */
+/* edit the very last entry in each row.                                                             */
 /* NOTE: section sizes have to be a multiple of 4 bytes; base addresses have to be 32-bit-aligned.   */
 /* ************************************************************************************************* */
 

--- a/sw/example/demo_freeRTOS/makefile
+++ b/sw/example/demo_freeRTOS/makefile
@@ -49,9 +49,6 @@ ASM_INC ?= -I .
 # Optimization
 EFFORT ?= -Os
 
-# Compiler toolchain
-RISCV_PREFIX ?= riscv32-unknown-elf-
-
 # CPU architecture and ABI
 MARCH ?= rv32i
 MABI  ?= ilp32
@@ -59,7 +56,6 @@ MABI  ?= ilp32
 # User flags for additional configuration (will be added to compiler flags)
 USER_FLAGS ?=
 # *****************************************************************************
-
 
 
 # -----------------------------------------------------------------------------

--- a/sw/lib/source/syscalls.c
+++ b/sw/lib/source/syscalls.c
@@ -271,7 +271,7 @@ ssize_t _write(int file, const void *ptr, size_t len)
 
 extern char __heap_start[];
 extern char __heap_end[];
-static char *brk = __heap_start;
+static char *brk = &__heap_start[0];
 
 int _brk(void *addr)
 {
@@ -283,14 +283,14 @@ void *_sbrk(ptrdiff_t incr)
 {
     char *old_brk = brk;
 
-    if (__heap_start == __heap_end) {
+    if (&__heap_start[0] == &__heap_end[0]) {
         return NULL;
     }
 
-    if ((brk += incr) < __heap_end) {
+    if ((brk += incr) < &__heap_end[0]) {
         brk += incr;
     } else {
-        brk = __heap_end;
+        brk = &__heap_end[0];
     }
     return old_brk;
 }

--- a/sw/ocd-firmware/debug_rom.ld
+++ b/sw/ocd-firmware/debug_rom.ld
@@ -5,7 +5,7 @@
 /* # ********************************************************************************************* # */
 /* # BSD 3-Clause License                                                                          # */
 /* #                                                                                               # */
-/* # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     # */
+/* # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     # */
 /* #                                                                                               # */
 /* # Redistribution and use in source and binary forms, with or without modification, are          # */
 /* # permitted provided that the following conditions are met:                                     # */
@@ -43,10 +43,13 @@
 /* modified for the NEORV32 processor by Stephan Nolting */
 
 
-OUTPUT_FORMAT("elf32-littleriscv", "elf32-littleriscv", "elf32-littleriscv")
+OUTPUT_FORMAT("elf32-littleriscv")
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
-SEARCH_DIR("/opt/riscv/riscv32-unknown-elf/lib"); SEARCH_DIR("=/opt/riscv/riscv64-unknown-linux-gnu/lib"); SEARCH_DIR("=/usr/local/lib"); SEARCH_DIR("=/lib"); SEARCH_DIR("=/usr/lib");
+SEARCH_DIR("/opt/riscv/riscv32-unknown-elf/lib")
+SEARCH_DIR("=/usr/local/lib")
+SEARCH_DIR("=/lib")
+SEARCH_DIR("=/usr/lib")
 
 MEMORY
 {

--- a/sw/ocd-firmware/makefile
+++ b/sw/ocd-firmware/makefile
@@ -7,7 +7,7 @@
 # ********************************************************************************************* #
 # BSD 3-Clause License                                                                          #
 #                                                                                               #
-# Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+# Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
 #                                                                                               #
 # Redistribution and use in source and binary forms, with or without modification, are          #
 # permitted provided that the following conditions are met:                                     #
@@ -111,16 +111,14 @@ OBJCOPY = $(RISCV_PREFIX)objcopy
 SIZE    = $(RISCV_PREFIX)size
 
 # Host native compiler
-CC_X86 = g++ -Wall -O -g
+CC_X86 = gcc -Wall -O -g
 
 # NEORV32 executable image generator
 IMAGE_GEN = $(NEORV32_EXG_PATH)/image_gen
 
 # Compiler & linker flags
 CC_OPTS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -Wall -ffunction-sections -fdata-sections -nostartfiles -mno-fdiv
-CC_OPTS += -Wl,--gc-sections -lm -lc -lgcc -lc
-# This accelerates instruction fetch after branches when C extension is enabled (irrelevant when C extension is disabled)
-CC_OPTS += -falign-functions=4 -falign-labels=4 -falign-loops=4 -falign-jumps=4
+CC_OPTS += -Wl,--gc-sections -lm -lc -lgcc -lc -Wl,--no-warn-rwx-segments
 CC_OPTS += $(USER_FLAGS)
 
 

--- a/sw/ocd-firmware/makefile
+++ b/sw/ocd-firmware/makefile
@@ -118,7 +118,7 @@ IMAGE_GEN = $(NEORV32_EXG_PATH)/image_gen
 
 # Compiler & linker flags
 CC_OPTS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -Wall -ffunction-sections -fdata-sections -nostartfiles -mno-fdiv
-CC_OPTS += -Wl,--gc-sections -lm -lc -lgcc -lc -Wl,--no-warn-rwx-segments
+CC_OPTS += -Wl,--gc-sections -lm -lc -lgcc -lc
 CC_OPTS += $(USER_FLAGS)
 
 


### PR DESCRIPTION
Minor edits to adapt to the most recent toolchain from https://github.com/stnolting/riscv-gcc-prebuilt -> GCC 12.1.0 🚀