### PR TITLE
🚀 [docs] add neorv32-verilog repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 
 ![neorv32 Overview](https://raw.githubusercontent.com/stnolting/neorv32/main/docs/figures/neorv32_processor.png)
 
-The NEORV32 Processor is a **customizable microcontroller-like system on chip (SoC)** written in platform-independent
-**VHDL** that is based on the NEORV32 [RISC-V](https://riscv.org/) CPU. The project is intended as auxiliary processor in larger SoC designs
+The NEORV32 Processor is a **customizable microcontroller-like system on chip (SoC)** built around the NEORV32
+[RISC-V](https://riscv.org/) CPU. The project is intended as auxiliary processor in larger SoC designs
 or as *ready-to-go* stand-alone custom microcontroller that even fits into a Lattice iCE40 UltraPlus 5k
 low-power & low-density FPGA running at 24+ MHz.
 
@@ -34,6 +34,8 @@ Therefore, the CPU ensures that all memory access are acknowledged and no invali
 are executed. Whenever an unexpected situation occurs the application code is informed via precise and resumable hardware exceptions.
 
 :interrobang: Want to know more? Check out the [project's rationale](https://stnolting.github.io/neorv32/#_rationale).
+
+:recycle: Looking for an **all-Verilog** version? Have a look at [neorv32-verilog](https://github.com/stnolting/neorv32-verilog).
 
 :books: For detailed information take a look at the [NEORV32 online documentation](https://stnolting.github.io/neorv32/).
 The latest _PDF_ versions can be found [here](https://github.com/stnolting/neorv32/releases/tag/nightly).
@@ -51,20 +53,21 @@ various FPGA boards and toolchains to get you started. Also check out the list o
 [FreeRTOS](https://github.com/stnolting/neorv32/tree/main/sw/example/demo_freeRTOS) operating systems and
 [LiteX](https://github.com/enjoy-digital/litex/wiki/CPUs#risc-v---neorv32) SoC Builder Framework.
 
-:bulb: Feel free to open a [new issue](https://github.com/stnolting/neorv32/issues) or start a
-[new discussion](https://github.com/stnolting/neorv32/discussions) if you have questions, comments, ideas or if something is
+:bulb: Feel free to open a new [issue](https://github.com/stnolting/neorv32/issues) or start a new
+[discussion](https://github.com/stnolting/neorv32/discussions) if you have questions, comments, ideas or if something is
 not working as expected. Or have a chat on our [gitter channel](https://gitter.im/neorv32/community).
 See how to [contribute](https://github.com/stnolting/neorv32/blob/main/CONTRIBUTING.md).
 
-:rocket: Check out the [quick links below](#6-Getting-Started) or directly jump to the
+:rocket: Check out the [quick links below](#6-Getting-Started) or jump directly to the
 [*User Guide*](https://stnolting.github.io/neorv32/ug/) to get started
-setting up your NEORV32 setup!
+setting up _your_ NEORV32 Processor!
 
 
 ### Key Features
 
 - [x] all-in-one package: **CPU** + **SoC** + **Software Framework & Tooling**
 - [x] completely described in behavioral, platform-independent VHDL - **no** platform-specific primitives, macros, attributes, etc.
+- [x] all-Verilog "version" [available](https://github.com/stnolting/neorv32-verilog)
 - [x] extensive configuration options for adapting the processor to the requirements of the application
 - [x] highly [extensible hardware](https://stnolting.github.io/neorv32/ug/#_comparative_summary) - on CPU, processor and system level
 - [x] aims to be as small as possible while being as RISC-V-compliant as possible - with a reasonable area-vs-performance trade-off
@@ -79,17 +82,21 @@ setting up your NEORV32 setup!
 [![release](https://img.shields.io/github/v/release/stnolting/neorv32?longCache=true&style=flat-square&logo=GitHub)](https://github.com/stnolting/neorv32/releases)
 [![GitHub Pages](https://img.shields.io/website.svg?label=stnolting.github.io%2Fneorv32&longCache=true&style=flat-square&url=http%3A%2F%2Fstnolting.github.io%2Fneorv32%2Findex.html&logo=GitHub)](https://stnolting.github.io/neorv32)
 \
+[![Processor](https://img.shields.io/github/workflow/status/stnolting/neorv32/Processor/main?longCache=true&style=flat-square&label=Processor%20Check&logo=Github%20Actions&logoColor=fff)](https://github.com/stnolting/neorv32/actions?query=workflow%3AProcessor)
 [![Documentation](https://img.shields.io/github/workflow/status/stnolting/neorv32/Documentation/main?longCache=true&style=flat-square&label=Documentation&logo=Github%20Actions&logoColor=fff)](https://github.com/stnolting/neorv32/actions?query=workflow%3ADocumentation)
-[![Processor](https://img.shields.io/github/workflow/status/stnolting/neorv32/Processor/main?longCache=true&style=flat-square&label=Processor&logo=Github%20Actions&logoColor=fff)](https://github.com/stnolting/neorv32/actions?query=workflow%3AProcessor)
+\
 [![riscv-arch-test](https://img.shields.io/github/workflow/status/stnolting/neorv32-verif/riscv-arch-test/main?longCache=true&style=flat-square&label=riscv-arch-test&logo=Github%20Actions&logoColor=fff)](https://github.com/stnolting/neorv32-verif/actions?query=workflow%3Ariscv-arch-test)
 [![Prebuilt_Toolchains](https://img.shields.io/github/workflow/status/stnolting/riscv-gcc-prebuilt/Test%20Toolchains/main?longCache=true&style=flat-square&label=Prebuilt%20Toolchains&logo=Github%20Actions&logoColor=fff)](https://github.com/stnolting/riscv-gcc-prebuilt/actions/workflows/main.yml)
 [![Implementation](https://img.shields.io/github/workflow/status/stnolting/neorv32-setups/Implementation/main?longCache=true&style=flat-square&label=Implementation&logo=Github%20Actions&logoColor=fff)](https://github.com/stnolting/neorv32-setups/actions?query=workflow%3AImplementation)
+[![neorv32-verilog](https://img.shields.io/github/workflow/status/stnolting/neorv32-verilog/Verification/main?longCache=true&style=flat-square&label=neorv32-verilog&logo=Github%20Actions&logoColor=fff)](https://github.com/stnolting/neorv32-verilog/actions/workflows/main.yml)
 
 The NEORV32 is fully operational.
 The processor passes the official RISC-V architecture tests, which is checked by the
 [neorv32-verif](https://github.com/stnolting/neorv32-verif) repository. It can successfully run _any_ C program
 (for example from the [`sw/example`](https://github.com/stnolting/neorv32/tree/main/sw/example) folder) including CoreMark
 and FreeRTOS and can be synthesized for _any_ target technology - tested on Intel, Xilinx and Lattice FPGAs.
+The conversion into a plain Verilog netlist module is automatically checked by the
+[neorv32-verilog](https://github.com/stnolting/neorv32-verilog) repository.
 
 [[back to top](#The-NEORV32-RISC-V-Processor)]
 
@@ -305,6 +312,7 @@ This overview provides some *quick links* to the most important sections of the
 * [Debugging via the On-Chip Debugger](https://stnolting.github.io/neorv32/ug/#_debugging_using_the_on_chip_debugger) - step through code *online* and *in-system*
 * [Simulation](https://stnolting.github.io/neorv32/ug/#_simulating_the_processor) - simulate the whole SoC
 * [LiteX Integration](https://stnolting.github.io/neorv32/ug/#_litex_soc_builder_support) - build a SoC using NEORV32 + [LiteX](https://github.com/enjoy-digital/litex)
+* [Convert to Verilog](https://stnolting.github.io/neorv32/ug/#_neorv32_in_verilog) - turn the NEORV32 into an all-Verilog design
 
 ### :copyright: Legal
 

--- a/docs/datasheet/overview.adoc
+++ b/docs/datasheet/overview.adoc
@@ -61,6 +61,7 @@ include::rationale.adoc[]
 
 * all-in-one package: **CPU** + **SoC** + **Software Framework & Tooling**
 * completely described in behavioral, platform-independent VHDL - no vendor- or technology-specific primitives, attributes, macros, libraries, etc. are used at all
+* all-Verilog "version" https://github.com/stnolting/neorv32-verilog[available] (auto-generated netlist)
 * extensive configuration options for adapting the processor to the requirements of the application
 * highly https://stnolting.github.io/neorv32/ug/#_comparative_summary[extensible hardware] - on CPU, SoC and system level
 * aims to be as small as possible while being as RISC-V-compliant as possible - with a reasonable area-vs-performance trade-off

--- a/docs/userguide/content.adoc
+++ b/docs/userguide/content.adoc
@@ -27,7 +27,7 @@ which provides **SoC setups** for various FPGAs, boards and toolchains.
 * RTOS support for <<_zephyr_rtos_support, Zephyr>> and <<_freertos_support, FreeRTOS>>
 * build SoCs using <<_litex_soc_builder_support, LiteX>>
 * in-system <<_debugging_using_the_on_chip_debugger, debugging>> of the whole processor
-
+* <<_neorv32_in_verilog>> - an all-Verilog "version" of the processor
 
 
 include::sw_toolchain_setup.adoc[]
@@ -67,6 +67,8 @@ include::free_rtos_support.adoc[]
 include::litex_support.adoc[]
 
 include::debugging_with_ocd.adoc[]
+
+include::neorv32_in_verilog.adoc[]
 
 
 

--- a/docs/userguide/neorv32_in_verilog.adoc
+++ b/docs/userguide/neorv32_in_verilog.adoc
@@ -1,0 +1,35 @@
+<<<
+:sectnums:
+== NEORV32 in Verilog
+
+If you are more of a Verilog fan or if your EDA toolchain does not support VHDL or mixed-language designs
+you can use an **all-Verilog** version of the processor provided by the https://github.com/stnolting/neorv32-verilog[`neorv32-verilog`] repository.
+Note that this is **not a manual re-implementation of the core in Verilog** but rather an automated conversion.
+GHDL's synthesis feature is used to convert a pre-configured NEORV32 setup - including all peripherals, memories
+and memory images - into an unoptimized plain-Verilog netlist module file without any (technology-specific) primitives
+
+.GHDL Synthesis
+[TIP]
+More information regarding GHDL's synthesis option can be found at https://ghdl.github.io/ghdl/using/Synthesis.html.
+
+An intermediate VHDL wrapper is provided that can be used to configure the processor (using VHDL generics) and to customize
+the interface ports. After conversion, a single Verilog file is generated that contains the whole NEORV32 processor.
+The original processor module hierarchy is preserved as well as most (all?) signal names, which allows easy inspection and debugging
+of simulation waveforms and synthesis results.
+
+.Example: interface of the resulting NEORV32 Verilog module (for a minimal SoC configuration)
+[source,verilog]
+----
+module neorv32_verilog_wrapper
+  (input  clk_i,
+   input  rstn_i,
+   input  uart0_rxd_i,
+   output uart0_txd_o);
+----
+
+The generated Verilog netlist has been tested with
+https://github.com/steveicarus/iverilog[Icarus Verilog]
+(simulation) and Xilinx Vivado (simulation and synthesis).
+
+[TIP]
+For detailed information check out the `neorv32-verilog` repository at https://github.com/stnolting/neorv32-verilog.

--- a/docs/userguide/neorv32_in_verilog.adoc
+++ b/docs/userguide/neorv32_in_verilog.adoc
@@ -4,7 +4,11 @@
 
 If you are more of a Verilog fan or if your EDA toolchain does not support VHDL or mixed-language designs
 you can use an **all-Verilog** version of the processor provided by the https://github.com/stnolting/neorv32-verilog[`neorv32-verilog`] repository.
+
+[IMPORTANT]
 Note that this is **not a manual re-implementation of the core in Verilog** but rather an automated conversion.
+
+
 GHDL's synthesis feature is used to convert a pre-configured NEORV32 setup - including all peripherals, memories
 and memory images - into an unoptimized plain-Verilog netlist module file without any (technology-specific) primitives
 

--- a/docs/userguide/neorv32_in_verilog.adoc
+++ b/docs/userguide/neorv32_in_verilog.adoc
@@ -8,9 +8,8 @@ you can use an **all-Verilog** version of the processor provided by the https://
 [IMPORTANT]
 Note that this is **not a manual re-implementation of the core in Verilog** but rather an automated conversion.
 
-
 GHDL's synthesis feature is used to convert a pre-configured NEORV32 setup - including all peripherals, memories
-and memory images - into an unoptimized plain-Verilog netlist module file without any (technology-specific) primitives
+and memory images - into an unoptimized plain-Verilog netlist module file without any (technology-specific) primitives.
 
 .GHDL Synthesis
 [TIP]


### PR DESCRIPTION
[![neorv32-verilog](https://img.shields.io/github/workflow/status/stnolting/neorv32-verilog/Verification/main?longCache=true&style=flat&label=neorv32-verilog%20check&logo=Github%20Actions&logoColor=fff)](https://github.com/stnolting/neorv32-verilog/actions/workflows/main.yml)

This PR adds some documentation and links for the [neorv32-verilog](https://github.com/stnolting/neorv32-verilog) repository, which provides an automated GHDL-based flow to convert a custom NEORV32 configuration into an all-Verilog netlist module file (triggered by #266).