### PR TITLE
⚠️ [rtl] cleanup CPU standard counters, remove CPU_CNT_WIDTH generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 08.09.2022 | 1.7.6.4 | :warning: cleanup CPU standard counters and remove _CPU_CNT_WIDTH_ generic; [#407](https://github.com/stnolting/neorv32/pull/407) |
 | 07.09.2022 | 1.7.6.3 | minor rtl edits and cleanups; [#406](https://github.com/stnolting/neorv32/pull/406) |
 | 03.09.2022 | 1.7.6.2 | cleanup hardware reset logic; [#405](https://github.com/stnolting/neorv32/pull/405) |
 | 02.09.2022 | 1.7.6.1 | :sparkles: add new processor module: **1-Wire Interface Controller** (ONEWIRE); [#402](https://github.com/stnolting/neorv32/pull/402) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -598,7 +598,7 @@ will raise an illegal instruction exception if <<_mstatus>>`.TW` is set.
 ==== **`Zicntr`** CPU Base Counters
 
 The `Zicntr` ISA extension adds the basic cycle `[m]cycle[h]`), instruction-retired (`[m]instret[h]`) and time (`time[h]`)
-counters. This extensions is stated as _mandatory_ by the RISC-V spec. However, size-constrained setups may remove support for
+counters. This extensions is stated as _mandatory_ by the RISC-V spec. However, area-constrained setups may remove support for
 these counters. Section <<_machine_counter_and_timer_csrs>> shows a list of all `Zicntr`-related CSRs.
 These are available if the `Zicntr` ISA extensions is enabled via the <<_cpu_extension_riscv_zicntr>> generic.
 
@@ -606,10 +606,10 @@ Additional CSRs:
 
 * <<_cycleh>>, <<_mcycleh>> - cycle counter
 * <<_instreth>>, <<_minstreth>> - instructions-retired counter
-* <<_timeh>> - system _wall-clock_ time
+* <<_timeh>> - system _wall-clock_ time (driven by the <<_machine_system_timer_mtime>>)
 
 [NOTE]
-Disabling the `Zicntr` extension does not remove the `time[h]`-driving MTIME unit.
+Disabling the `Zicntr` extension does not remove the `time[h]`-driving <<_machine_system_timer_mtime>>.
 
 If the `Zicntr` ISA extension is disabled, all accesses to the according counter CSRs will raise an illegal instruction exception.
 

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -526,30 +526,14 @@ The two MSBs of each `pmpaddr` are hardwired to zero (= bits 33:32 of the physic
 :sectnums:
 ==== (Machine) Counter and Timer CSRs
 
-[NOTE]
-The <<_cpu_cnt_width>> generic defines the total size of the CPU's <<_cycleh>> and <<_instreth>>
-/ <<_mcycleh>> and <<_minstreth>>
-counter CSRs (low and high words combined); the time CSRs are not affected by this generic. Note that any
-configuration with <<_cpu_cnt_width>> less than 64 is not RISC-V compliant.
-
-.Effective CPU counter width (`[m]cycle` & `[m]instret`)
-[IMPORTANT]
-If _CPU_CNT_WIDTH_ is less than 64 (the default value) and greater than or equal 32, the according
-MSBs of `[m]cycleh` and `[m]instreth` are read-only and always read as zero. This configuration
-will also set the _CSR_MXISA_ZXSCNT_ flag ("small counters") in the <<_mxisa>> CSR. +
- +
-If _CPU_CNT_WIDTH_ is less than 32 and greater than 0, the `[m]cycleh` and `[m]instreth` CSRs are hardwired to zero
-and any write access to them is ignored. Furthermore, the according MSBs of `[m]cycle` and `[m]instret` are read-only
-and always read as zero. This configuration will also set the _CSR_MXISA_ZXSCNT_ flag ("small counters") in
-the <<_mxisa>> CSR. +
- +
-If _CPU_CNT_WIDTH_ is 0, the <<_cycleh>> and <<_instreth>> / <<_mcycleh>> and <<_minstreth>> CSRs are hardwired to zero
-and any write access to them is ignored.
-
 .Counter Reset
 [IMPORTANT]
 The counter CSRs do **not** provide a hardware reset. Hence, the CSRs have to be explicitly initialized by software
 before being used.
+
+.Counter Size
+[NOTE]
+When implemented (by enabling the `Zicntr` ISA extension) the standard CPU counters are always 64-bit wide (low-word + high-word).
 
 
 :sectnums!:
@@ -826,7 +810,7 @@ NEORV32-specific read-only CSR that helps machine-mode software to discover `Z*`
 |  9    | _CSR_MXISA_ZIHPM_     | r/- | `Zihpm` (hardware performance monitors) extension available when set (via top's <<_cpu_extension_riscv_zihpm>> generic)
 |  8    | _CSR_MXISA_PMP_       | r/- | PMP` (physical memory protection) extension available when set (via top's <<_pmp_num_regions>> generic)
 |  7    | _CSR_MXISA_ZICNTR_    | r/- | `Zicntr` extension (`I` sub-extension) available when set - `[m]cycle`, `[m]instret` and `[m]time` CSRs available when set (via top's <<_cpu_extension_riscv_zicntr>> generic)
-|  6    | _CSR_MXISA_ZXSCNT_    | r/- | Custom extension - _Small_ CPU counters: `[m]cycle` & `[m]instret` CSRs have less than 64-bit when set (via top's <<_cpu_cnt_width>> generic)
+|  6    | -                     | r/- | _reserved_, read as zero
 |  5    | _CSR_MXISA_ZFINX_     | r/- | `Zfinx` extension (`F` sub-/alternative-extension: FPU using `x` registers) available when set (via top's <<_cpu_extension_riscv_zfinx>> generic)
 |  4    | -                     | r/- | _reserved_, read as zero
 |  3    | _CSR_MXISA_ZXCFU_     | r/- | `Zxcfu` extension (custom functions unit for custom RISC-V instructions) available when set (via top's <<_cpu_extension_riscv_zxcfu>> generic)

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -449,20 +449,6 @@ The state of this generic can be retrieved by software via the <<_mxisa>> CSR.
 
 
 :sectnums!:
-===== _CPU_CNT_WIDTH_
-
-[cols="4,4,2"]
-[frame="all",grid="none"]
-|======
-| **CPU_CNT_WIDTH** | _natural_ | 64
-3+| This generic configures the total size of the CPU's <<_mcycleh>> and <<_minstreth>> CSRs (low word + high word).
-The maximum value is 64, the minimum value is 0. See section <<_machine_counter_and_timer_csrs>> for more information.
-This generic is only relevant if the `Zicntr` ISa extension is enabled (<<_cpu_extension_riscv_zicntr>>).
-Note: configurations with a counter width of less than 64 bits do not comply to the RISC-V specs.
-|======
-
-
-:sectnums!:
 ===== _CPU_IPB_ENTRIES_
 
 [cols="4,4,2"]

--- a/docs/userguide/application_specific_configuration.adoc
+++ b/docs/userguide/application_specific_configuration.adoc
@@ -52,9 +52,9 @@ and DMEM memories.
 * Use the _embedded_ RISC-V CPU architecture extension (`CPU_EXTENSION_RISCV_E`) to reduce block RAM utilization.
 * The compressed instructions extension (`CPU_EXTENSION_RISCV_C`) requires additional logic for the decoder but
 also reduces program code size by approximately 30%.
-* If not explicitly used/required, constrain the CPU's counter sizes: `CPU_CNT_WIDTH` for `[m]instret[h]`
-(number of instruction) and `[m]cycle[h]` (number of cycles) counters. You can even remove these counters
-by setting `CPU_CNT_WIDTH => 0` if they are not used at all (note, this is not RISC-V compliant).
+* If not explicitly used/required, exclude the CPU standart counters `[m]instret[h]`
+(number of instruction) and `[m]cycle[h]` (number of cycles) from synthesis by disabling the `Zicntr` ISA extension
+(note, this is not RISC-V compliant).
 * Reduce the CPU's prefetch buffer size (`CPU_IPB_ENTRIES`).
 * Map CPU shift operations to a small and iterative shifter unit (`FAST_SHIFT_EN => false`).
 * If you have unused DSP block available, you can map multiplication operations to those slices instead of
@@ -75,7 +75,7 @@ adds additional register stages to maintain critical path length. Obviously, thi
 In order to optimize for a minimal critical path (= maximum clock speed) the following points should be considered:
 
 * Complex CPU extensions (in terms of hardware requirements) should be avoided (examples: floating-point unit, physical memory protection).
-* Large carry chains (>32-bit) should be avoided (constrain CPU counter sizes: e.g. `CPU_CNT_WIDTH => 32` and `HPM_NUM_CNTS => 32`).
+* Large carry chains (>32-bit) should be avoided (i.e. constrain the HPM counter sizes via `HPM_CNT_WIDTH`).
 * If the target FPGA provides sufficient DSP resources, CPU multiplication operations can be mapped to DSP slices (`FAST_MUL_EN => true`)
 reducing LUT usage and critical path impact while also increasing overall performance.
 * Use the synchronous (registered) RX path configuration of the external memory interface (`MEM_EXT_ASYNC_RX => false`).

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -67,7 +67,6 @@ entity neorv32_cpu is
     -- Extension Options --
     FAST_MUL_EN                  : boolean; -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean; -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                : natural; -- total width of CPU cycle and instret counters (0..64)
     CPU_IPB_ENTRIES              : natural; -- entries in instruction prefetch buffer, has to be a power of 2, min 2
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              : natural; -- number of regions (0..16)
@@ -181,10 +180,6 @@ begin
   -- CSR system --
   assert not (CPU_EXTENSION_RISCV_Zicsr = false) report "NEORV32 CPU CONFIG WARNING! No exception/interrupt/trap/privileged features available when <CPU_EXTENSION_RISCV_Zicsr> = false." severity warning;
 
-  -- CPU counters (cycle and instret) --
-  assert not ((CPU_EXTENSION_RISCV_Zicntr = true) and ((CPU_CNT_WIDTH < 0) or (CPU_CNT_WIDTH > 64))) report "NEORV32 CPU CONFIG ERROR! Invalid <CPU_CNT_WIDTH> configuration. Has to be 0..64." severity error;
-  assert not ((CPU_EXTENSION_RISCV_Zicntr = true) and (CPU_CNT_WIDTH < 64)) report "NEORV32 CPU CONFIG WARNING! Implementing CPU <cycle> and <instret> CSRs with reduced size (" & integer'image(CPU_CNT_WIDTH) & "-bit instead of 64-bit). This is not RISC-V compliant and might have unintended SW side effects." severity warning;
-
   -- U-extension requires Zicsr extension --
   assert not ((CPU_EXTENSION_RISCV_Zicsr = false) and (CPU_EXTENSION_RISCV_U = true)) report "NEORV32 CPU CONFIG ERROR! User mode requires <CPU_EXTENSION_RISCV_Zicsr> extension to be enabled." severity error;
 
@@ -244,7 +239,6 @@ begin
     -- Tuning Options --
     FAST_MUL_EN                  => FAST_MUL_EN,                  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => FAST_SHIFT_EN,                -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                => CPU_CNT_WIDTH,                -- total width of CPU cycle and instret counters (0..64)
     CPU_IPB_ENTRIES              => CPU_IPB_ENTRIES,              -- entries is instruction prefetch buffer, has to be a power of 2, min 2
     -- Physical memory protection (PMP) --
     PMP_NUM_REGIONS              => PMP_NUM_REGIONS,              -- number of regions (0..16)

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -72,7 +72,6 @@ entity neorv32_cpu_control is
     -- Tuning Options --
     FAST_MUL_EN                  : boolean; -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean; -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                : natural; -- total width of CPU cycle and instret counters (0..64)
     CPU_IPB_ENTRIES              : natural; -- entries in instruction prefetch buffer, has to be a power of 2, min 2
     -- Physical memory protection (PMP) --
     PMP_NUM_REGIONS              : natural; -- number of regions (0..16)
@@ -130,10 +129,6 @@ entity neorv32_cpu_control is
 end neorv32_cpu_control;
 
 architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
-
-  -- CPU core counter ([m]cycle, [m]instret) width - high/low parts --
-  constant cpu_cnt_lo_width_c : natural := natural(cond_sel_int_f(boolean(CPU_CNT_WIDTH < 32), CPU_CNT_WIDTH, 32));
-  constant cpu_cnt_hi_width_c : natural := natural(cond_sel_int_f(boolean(CPU_CNT_WIDTH > 32), CPU_CNT_WIDTH-32, 0));
 
   -- HPM counter width - high/low parts --
   constant hpm_cnt_lo_width_c : natural := natural(cond_sel_int_f(boolean(HPM_CNT_WIDTH < 32), HPM_CNT_WIDTH, 32));
@@ -340,6 +335,18 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
     tdata2            : std_ulogic_vector(data_width_c-1 downto 0); -- tdata2 (R/W): address-match register
   end record;
   signal csr : csr_t;
+
+  -- counter CSRs write access decoder --
+  type cnt_csr_we_t is record
+    wdata    : std_ulogic_vector(data_width_c-1 downto 0);
+    cycle    : std_ulogic;
+    cycleh   : std_ulogic;
+    instret  : std_ulogic;
+    instreth : std_ulogic;
+    hpm      : std_ulogic_vector(28 downto 0);
+    hpmh     : std_ulogic_vector(28 downto 0);
+  end record;
+  signal cnt_csr_we : cnt_csr_we_t;
 
   -- debug mode controller --
   type debug_ctrl_state_t is (DEBUG_OFFLINE, DEBUG_PENDING, DEBUG_ONLINE, DEBUG_LEAVING);
@@ -2232,14 +2239,14 @@ begin
           -- counters and timers --
           -- --------------------------------------------------------------------
           when csr_cycle_c | csr_mcycle_c => -- [m]cycle (r/w): Cycle counter LOW
-            if (cpu_cnt_lo_width_c > 0) and (CPU_EXTENSION_RISCV_Zicntr) then csr.rdata(cpu_cnt_lo_width_c-1 downto 0) <= csr.mcycle(cpu_cnt_lo_width_c-1 downto 0); else NULL; end if;
+            if (CPU_EXTENSION_RISCV_Zicntr) then csr.rdata <= csr.mcycle; else NULL; end if;
           when csr_cycleh_c | csr_mcycleh_c => -- [m]cycleh (r/w): Cycle counter HIGH
-            if (cpu_cnt_hi_width_c > 0) and (CPU_EXTENSION_RISCV_Zicntr) then csr.rdata(cpu_cnt_hi_width_c-1 downto 0) <= csr.mcycleh(cpu_cnt_hi_width_c-1 downto 0); else NULL; end if;
+            if (CPU_EXTENSION_RISCV_Zicntr) then csr.rdata <= csr.mcycleh; else NULL; end if;
 
           when csr_instret_c | csr_minstret_c => -- [m]instret (r/w): Instructions-retired counter LOW
-            if (cpu_cnt_lo_width_c > 0) and (CPU_EXTENSION_RISCV_Zicntr) then csr.rdata(cpu_cnt_lo_width_c-1 downto 0) <= csr.minstret(cpu_cnt_lo_width_c-1 downto 0); else NULL; end if;
+            if (CPU_EXTENSION_RISCV_Zicntr) then csr.rdata <= csr.minstret; else NULL; end if;
           when csr_instreth_c | csr_minstreth_c => -- [m]instreth (r/w): Instructions-retired counter HIGH
-            if (cpu_cnt_hi_width_c > 0) and (CPU_EXTENSION_RISCV_Zicntr) then csr.rdata(cpu_cnt_hi_width_c-1 downto 0) <= csr.minstreth(cpu_cnt_hi_width_c-1 downto 0); else NULL; end if;
+            if (CPU_EXTENSION_RISCV_Zicntr) then csr.rdata <= csr.minstreth; else NULL; end if;
 
           when csr_time_c => -- time (r/-): System time LOW (from MTIME unit)
             if (CPU_EXTENSION_RISCV_Zicntr) then csr.rdata <= time_i(31 downto 00); else NULL; end if; 
@@ -2345,8 +2352,7 @@ begin
             csr.rdata(03) <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zxcfu);    -- Zxcfu: custom RISC-V instructions
 --          csr.rdata(04) <= '0'; -- reserved
             csr.rdata(05) <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zfinx);    -- Zfinx: FPU using x registers, "F-alternative"
-            csr.rdata(06) <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zicntr) and
-                             bool_to_ulogic_f(boolean(CPU_CNT_WIDTH /= 64)); -- Zxscnt: reduced-size CPU counters (from Zicntr)
+--          csr.rdata(06) <= '0'; -- reserved
             csr.rdata(07) <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zicntr);   -- Zicntr: base instructions, cycle and time CSRs
             csr.rdata(08) <= bool_to_ulogic_f(boolean(PMP_NUM_REGIONS > 0)); -- PMP: physical memory protection (Zspmp)
             csr.rdata(09) <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zihpm);    -- Zihpm: hardware performance monitors
@@ -2375,6 +2381,45 @@ begin
 -- CPU Counters / HPMs
 -- ****************************************************************************************************************************
 
+  -- Control and Status Registers - Counters - Write Access Decoder -------------------------
+  -- -------------------------------------------------------------------------------------------
+  csr_counters_we_decoder: process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      -- defaults --
+      cnt_csr_we.cycle    <= '0';
+      cnt_csr_we.cycleh   <= '0';
+      cnt_csr_we.instret  <= '0';
+      cnt_csr_we.instreth <= '0';
+      cnt_csr_we.hpm      <= (others => '0');
+      cnt_csr_we.hpmh     <= (others => '0');
+      cnt_csr_we.wdata    <= csr.wdata; -- buffer write data
+
+      -- write access --
+      if (csr.we = '1') then
+        if (csr.addr(11 downto 8) = csr_class_mcnt_c) then -- machine-mode counter access only
+          -- NOTE: no need to check bits 6:5 of the CSR address here as they're always zero - an
+          -- exception is raised if they're not all-zero
+          if (csr.addr(4 downto 0) = csr_mcycle_c(4 downto 0)) then -- / csr_mcycleh_c
+            cnt_csr_we.cycle  <= not csr.addr(7); -- low
+            cnt_csr_we.cycleh <=     csr.addr(7); -- high
+          end if;
+          if (csr.addr(4 downto 0) = csr_minstret_c(4 downto 0)) then -- / csr_minstreth_c
+            cnt_csr_we.instret  <= not csr.addr(7); -- low
+            cnt_csr_we.instreth <=     csr.addr(7); -- high
+          end if;
+          for i in 0 to 28 loop
+            if (csr.addr(4 downto 0) = std_ulogic_vector(unsigned(csr_mhpmcounter3_c(4 downto 0)) + i)) then -- / csr_mhpmcounter3h_c
+              cnt_csr_we.hpm(i)  <= not csr.addr(7); -- low
+              cnt_csr_we.hpmh(i) <=     csr.addr(7); -- high
+            end if;
+          end loop;
+        end if;
+      end if;
+    end if;
+  end process csr_counters_we_decoder;
+
+
   -- Control and Status Registers - Counters ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   csr_counters: process(clk_i)
@@ -2382,53 +2427,46 @@ begin
     -- NOTE: the counter CSRs do NOT have a dedicated reset and need to be initialized by software before being used!
     if rising_edge(clk_i) then
 
-      -- [m]cycle --
-      if (cpu_cnt_lo_width_c > 0) and (CPU_EXTENSION_RISCV_Zicntr = true) then
+      -- [machine] standard CPU counters --
+      if (CPU_EXTENSION_RISCV_Zicntr = true) then -- implemented at all?
+
+        -- mcycle --
         csr.mcycle_ovfl(0) <= csr.mcycle_nxt(csr.mcycle_nxt'left) and (not csr.mcountinhibit_cy) and cnt_event(hpmcnt_event_cy_c) and (not debug_ctrl.running);
-        if (csr.we = '1') and (csr.addr = csr_mcycle_c) then -- write access
-          csr.mcycle(cpu_cnt_lo_width_c-1 downto 0) <= csr.wdata(cpu_cnt_lo_width_c-1 downto 0);
+        if (cnt_csr_we.cycle = '1') then -- write access
+          csr.mcycle <= cnt_csr_we.wdata;
         elsif (csr.mcountinhibit_cy = '0') and (cnt_event(hpmcnt_event_cy_c) = '1') and (debug_ctrl.running = '0') then -- non-inhibited automatic update and not in debug mode
-          csr.mcycle(cpu_cnt_lo_width_c-1 downto 0) <= csr.mcycle_nxt(cpu_cnt_lo_width_c-1 downto 0);
+          csr.mcycle <= csr.mcycle_nxt(csr.mcycle_nxt'left-1 downto 0);
         end if;
-      else
-        csr.mcycle_ovfl <= (others => '0');
-        csr.mcycle      <= (others => '0');
-      end if;
 
-      -- [m]cycleh --
-      if (cpu_cnt_hi_width_c > 0) and (CPU_EXTENSION_RISCV_Zicntr = true) then
-        if (csr.we = '1') and (csr.addr = csr_mcycleh_c) then -- write access
-          csr.mcycleh(cpu_cnt_hi_width_c-1 downto 0) <= csr.wdata(cpu_cnt_hi_width_c-1 downto 0);
+        -- mcycleh --
+        if (cnt_csr_we.cycleh = '1') then -- write access
+          csr.mcycleh <= cnt_csr_we.wdata;
         else -- automatic update
-          csr.mcycleh(cpu_cnt_hi_width_c-1 downto 0) <= std_ulogic_vector(unsigned(csr.mcycleh(cpu_cnt_hi_width_c-1 downto 0)) + unsigned(csr.mcycle_ovfl));
+          csr.mcycleh <= std_ulogic_vector(unsigned(csr.mcycleh) + unsigned(csr.mcycle_ovfl));
         end if;
-      else
-        csr.mcycleh <= (others => '0');
-      end if;
 
-
-      -- [m]instret --
-      if (cpu_cnt_lo_width_c > 0) and (CPU_EXTENSION_RISCV_Zicntr = true) then
+        -- minstret --
         csr.minstret_ovfl(0) <= csr.minstret_nxt(csr.minstret_nxt'left) and (not csr.mcountinhibit_ir) and cnt_event(hpmcnt_event_ir_c) and (not debug_ctrl.running);
-        if (csr.we = '1') and (csr.addr = csr_minstret_c) then -- write access
-          csr.minstret(cpu_cnt_lo_width_c-1 downto 0) <= csr.wdata(cpu_cnt_lo_width_c-1 downto 0);
+        if (cnt_csr_we.instret = '1') then -- write access
+          csr.minstret <= cnt_csr_we.wdata;
         elsif (csr.mcountinhibit_ir = '0') and (cnt_event(hpmcnt_event_ir_c) = '1') and (debug_ctrl.running = '0') then -- non-inhibited automatic update and not in debug mode
-          csr.minstret(cpu_cnt_lo_width_c-1 downto 0) <= csr.minstret_nxt(cpu_cnt_lo_width_c-1 downto 0);
+          csr.minstret <= csr.minstret_nxt(csr.minstret_nxt'left-1 downto 0);
         end if;
+
+        -- minstreth --
+        if (cnt_csr_we.instreth = '1') then -- write access
+          csr.minstreth <= cnt_csr_we.wdata;
+        else -- automatic update
+          csr.minstreth <= std_ulogic_vector(unsigned(csr.minstreth) + unsigned(csr.minstret_ovfl));
+        end if;
+
       else
+        csr.mcycle_ovfl   <= (others => '0');
+        csr.mcycle        <= (others => '0');
+        csr.mcycleh       <= (others => '0');
         csr.minstret_ovfl <= (others => '0');
         csr.minstret      <= (others => '0');
-      end if;
-
-      -- [m]instreth --
-      if (cpu_cnt_hi_width_c > 0) and (CPU_EXTENSION_RISCV_Zicntr = true) then
-        if (csr.we = '1') and (csr.addr = csr_minstreth_c) then -- write access
-          csr.minstreth(cpu_cnt_hi_width_c-1 downto 0) <= csr.wdata(cpu_cnt_hi_width_c-1 downto 0);
-        else -- automatic update
-          csr.minstreth(cpu_cnt_hi_width_c-1 downto 0) <= std_ulogic_vector(unsigned(csr.minstreth(cpu_cnt_hi_width_c-1 downto 0)) + unsigned(csr.minstret_ovfl));
-        end if;
-      else
-        csr.minstreth <= (others => '0');
+        csr.minstreth     <= (others => '0');
       end if;
 
 
@@ -2438,8 +2476,8 @@ begin
         -- [m]hpmcounter* --
         if (hpm_cnt_lo_width_c > 0) and (CPU_EXTENSION_RISCV_Zihpm = true) then
           csr.mhpmcounter_ovfl(i)(0) <= csr.mhpmcounter_nxt(i)(csr.mhpmcounter_nxt(i)'left) and (not csr.mcountinhibit_hpm(i)) and hpmcnt_trigger(i);
-          if (csr.we = '1') and (csr.addr = std_ulogic_vector(unsigned(csr_mhpmcounter3_c) + i)) then -- write access
-            csr.mhpmcounter(i)(hpm_cnt_lo_width_c-1 downto 0) <= csr.wdata(hpm_cnt_lo_width_c-1 downto 0);
+          if (cnt_csr_we.hpm(i) = '1') then -- write access
+            csr.mhpmcounter(i)(hpm_cnt_lo_width_c-1 downto 0) <= cnt_csr_we.wdata(hpm_cnt_lo_width_c-1 downto 0);
           elsif (csr.mcountinhibit_hpm(i) = '0') and (hpmcnt_trigger(i) = '1') then -- non-inhibited automatic update
             csr.mhpmcounter(i)(hpm_cnt_lo_width_c-1 downto 0) <= csr.mhpmcounter_nxt(i)(hpm_cnt_lo_width_c-1 downto 0);
           end if;
@@ -2450,8 +2488,8 @@ begin
 
         -- [m]hpmcounter*h --
         if (hpm_cnt_hi_width_c > 0) and (CPU_EXTENSION_RISCV_Zihpm = true) then
-          if (csr.we = '1') and (csr.addr = std_ulogic_vector(unsigned(csr_mhpmcounter3h_c) + i)) then -- write access
-            csr.mhpmcounterh(i)(hpm_cnt_hi_width_c-1 downto 0) <= csr.wdata(hpm_cnt_hi_width_c-1 downto 0);
+          if (cnt_csr_we.hpmh(i) = '1') then -- write access
+            csr.mhpmcounterh(i)(hpm_cnt_hi_width_c-1 downto 0) <= cnt_csr_we.wdata(hpm_cnt_hi_width_c-1 downto 0);
           else -- automatic update
             csr.mhpmcounterh(i)(hpm_cnt_hi_width_c-1 downto 0) <= std_ulogic_vector(unsigned(csr.mhpmcounterh(i)(hpm_cnt_hi_width_c-1 downto 0)) + unsigned(csr.mhpmcounter_ovfl(i)));
           end if;
@@ -2483,6 +2521,7 @@ begin
     if (HPM_NUM_CNTS /= 0) and (CPU_EXTENSION_RISCV_Zihpm = true) then
       for i in 0 to HPM_NUM_CNTS-1 loop
         csr.mhpmevent_rd(i)(hpmcnt_event_size_c-1 downto 0) <= csr.mhpmevent(i);
+        csr.mhpmevent_rd(i)(hpmcnt_event_never_c) <= '0'; -- "TIME" is always zero
         if (hpm_cnt_lo_width_c > 0) then
           csr.mhpmcounter_rd(i)(hpm_cnt_lo_width_c-1 downto 0) <= csr.mhpmcounter(i)(hpm_cnt_lo_width_c-1 downto 0);
         end if;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -59,7 +59,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070603"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070604"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -633,6 +633,7 @@ package neorv32_package is
   constant csr_dpc_c            : std_ulogic_vector(11 downto 0) := x"7b1";
   constant csr_dscratch0_c      : std_ulogic_vector(11 downto 0) := x"7b2";
   -- machine counters/timers --
+  constant csr_class_mcnt_c     : std_ulogic_vector(03 downto 0) := x"b"; -- machine-mode counters
   constant csr_mcycle_c         : std_ulogic_vector(11 downto 0) := x"b00";
   constant csr_minstret_c       : std_ulogic_vector(11 downto 0) := x"b02";
   --
@@ -701,6 +702,7 @@ package neorv32_package is
 
   -- <<< standard read-only CSRs >>> --
   -- user counters/timers --
+  constant csr_class_ucnt_c     : std_ulogic_vector(03 downto 0) := x"c"; -- user-mode counters
   constant csr_cycle_c          : std_ulogic_vector(11 downto 0) := x"c00";
   constant csr_time_c           : std_ulogic_vector(11 downto 0) := x"c01";
   constant csr_instret_c        : std_ulogic_vector(11 downto 0) := x"c02";
@@ -970,7 +972,6 @@ package neorv32_package is
       -- Tuning Options --
       FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
       FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
-      CPU_CNT_WIDTH                : natural := 64;     -- total width of CPU cycle and instret counters (0..64)
       CPU_IPB_ENTRIES              : natural := 2;      -- entries in instruction prefetch buffer, has to be a power of 2, min 2
       -- Physical Memory Protection (PMP) --
       PMP_NUM_REGIONS              : natural := 0;      -- number of regions (0..16)
@@ -1137,7 +1138,6 @@ package neorv32_package is
       -- Tuning Options --
       FAST_MUL_EN                  : boolean; -- use DSPs for M extension's multiplier
       FAST_SHIFT_EN                : boolean; -- use barrel shifter for shift operations
-      CPU_CNT_WIDTH                : natural; -- total width of CPU cycle and instret counters (0..64)
       CPU_IPB_ENTRIES              : natural; -- entries in instruction prefetch buffer, has to be a power of 2, min 2
       -- Physical Memory Protection (PMP) --
       PMP_NUM_REGIONS              : natural; -- number of regions (0..16)
@@ -1209,7 +1209,6 @@ package neorv32_package is
       -- Extension Options --
       FAST_MUL_EN                  : boolean; -- use DSPs for M extension's multiplier
       FAST_SHIFT_EN                : boolean; -- use barrel shifter for shift operations
-      CPU_CNT_WIDTH                : natural; -- total width of CPU cycle and instret counters (0..64)
       CPU_IPB_ENTRIES              : natural; -- entries is instruction prefetch buffer, has to be a power of 2, min 2
       -- Physical memory protection (PMP) --
       PMP_NUM_REGIONS              : natural; -- number of regions (0..16)

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -72,7 +72,6 @@ entity neorv32_top is
     -- Tuning Options --
     FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                : natural := 64;     -- total width of CPU cycle and instret counters (0..64)
     CPU_IPB_ENTRIES              : natural := 2;      -- entries in instruction prefetch buffer, has to be a power of 2, min 2
 
     -- Physical Memory Protection (PMP) --
@@ -549,7 +548,6 @@ begin
     -- Extension Options --
     FAST_MUL_EN                  => FAST_MUL_EN,                  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => FAST_SHIFT_EN,                -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                => CPU_CNT_WIDTH,                -- total width of CPU cycle and instret counters (0..64)
     CPU_IPB_ENTRIES              => CPU_IPB_ENTRIES,              -- entries is instruction prefetch buffer, has to be a power of 2
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              => PMP_NUM_REGIONS,              -- number of regions (0..16)

--- a/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
@@ -55,7 +55,6 @@ entity neorv32_ProcessorTop_Minimal is
     -- Extension Options --
     FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                : natural := 34;     -- total width of CPU cycle and instret counters (0..64)
 
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              : natural := 0;       -- number of regions (0..16)
@@ -132,7 +131,6 @@ begin
     -- Extension Options --
     FAST_MUL_EN                  => FAST_MUL_EN,    -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => FAST_SHIFT_EN,  -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                => CPU_CNT_WIDTH,  -- total width of CPU cycle and instret counters (0..64)
 
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              => PMP_NUM_REGIONS,       -- number of regions (0..16)

--- a/rtl/processor_templates/neorv32_ProcessorTop_MinimalBoot.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_MinimalBoot.vhd
@@ -56,7 +56,6 @@ entity neorv32_ProcessorTop_MinimalBoot is
     -- Extension Options --
     FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                : natural := 34;     -- total width of CPU cycle and instret counters (0..64)
 
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              : natural := 0;       -- number of regions (0..16)
@@ -148,7 +147,6 @@ begin
     -- Extension Options --
     FAST_MUL_EN                  => FAST_MUL_EN,    -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => FAST_SHIFT_EN,  -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                => CPU_CNT_WIDTH,  -- total width of CPU cycle and instret counters (0..64)
 
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              => PMP_NUM_REGIONS,       -- number of regions (0..16)

--- a/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
@@ -58,7 +58,6 @@ entity neorv32_ProcessorTop_UP5KDemo is
     -- Extension Options --
     FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                : natural := 34;     -- total width of CPU cycle and instret counters (0..64)
 
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              : natural := 0;       -- number of regions (0..16)
@@ -188,7 +187,6 @@ begin
     -- Extension Options --
     FAST_MUL_EN                  => FAST_MUL_EN,    -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => FAST_SHIFT_EN,  -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                => CPU_CNT_WIDTH,  -- total width of CPU cycle and instret counters (0..64)
 
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              => PMP_NUM_REGIONS,       -- number of regions (0..16)

--- a/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
+++ b/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
@@ -64,7 +64,6 @@ entity neorv32_ProcessorTop_stdlogic is
     -- Extension Options --
     FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                : natural := 64;     -- total width of CPU cycle and instret counters (0..64)
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              : natural := 0;      -- number of regions (0..16)
     PMP_MIN_GRANULARITY          : natural := 4;      -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
@@ -312,7 +311,6 @@ begin
     -- Extension Options --
     FAST_MUL_EN                  => FAST_MUL_EN,        -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => FAST_SHIFT_EN,      -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                => CPU_CNT_WIDTH,      -- total width of CPU cycle and instret counters (0..64)
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              => PMP_NUM_REGIONS,    -- number of regions (0..16)
     PMP_MIN_GRANULARITY          => PMP_MIN_GRANULARITY, -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes

--- a/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
@@ -70,7 +70,6 @@ entity neorv32_top_avalonmm is
     -- Extension Options --
     FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                : natural := 64;     -- total width of CPU cycle and instret counters (0..64)
     CPU_IPB_ENTRIES              : natural := 2;      -- entries is instruction prefetch buffer, has to be a power of 2
 
     -- Physical Memory Protection (PMP) --
@@ -272,7 +271,6 @@ begin
     -- Extension Options --
     FAST_MUL_EN => FAST_MUL_EN,
     FAST_SHIFT_EN => FAST_SHIFT_EN,
-    CPU_CNT_WIDTH => CPU_CNT_WIDTH,
     CPU_IPB_ENTRIES => CPU_IPB_ENTRIES,
 
     -- Physical Memory Protection (PMP) --

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -70,7 +70,6 @@ entity neorv32_SystemTop_axi4lite is
     -- Extension Options --
     FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                : natural := 64;     -- total width of CPU cycle and instret counters (0..64)
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              : natural := 0;      -- number of regions (0..16)
     PMP_MIN_GRANULARITY          : natural := 4;      -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
@@ -310,7 +309,6 @@ begin
     -- Extension Options --
     FAST_MUL_EN                  => FAST_MUL_EN,        -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => FAST_SHIFT_EN,      -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                => CPU_CNT_WIDTH,      -- total width of CPU cycle and instret counters (0..64)
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              => PMP_NUM_REGIONS,    -- number of regions (0..16)
     PMP_MIN_GRANULARITY          => PMP_MIN_GRANULARITY, -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes

--- a/rtl/system_integration/neorv32_litex_core_complex.vhd
+++ b/rtl/system_integration/neorv32_litex_core_complex.vhd
@@ -174,7 +174,6 @@ begin
     -- Tuning Options --
     FAST_MUL_EN                  => configs_c.fast_ops(CONFIG),     -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => configs_c.fast_ops(CONFIG),     -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                => 64,                             -- total width of CPU cycle and instret counters (0..64)
     CPU_IPB_ENTRIES              => configs_c.ipb(CONFIG),          -- entries in instruction prefetch buffer, has to be a power of 2, min 2
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              => configs_c.pmp_nr(CONFIG),       -- number of regions (0..16)

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -299,7 +299,6 @@ begin
     -- Extension Options --
     FAST_MUL_EN                  => false,         -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => false,         -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                => 64,            -- total width of CPU cycle and instret counters (0..64)
     CPU_IPB_ENTRIES              => 2,             -- entries is instruction prefetch buffer, has to be a power of 2, min 2
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              => 5,             -- number of regions (0..16)

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -190,7 +190,6 @@ begin
     -- Extension Options --
     FAST_MUL_EN                  => true,          -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => true,          -- use barrel shifter for shift operations
-    CPU_CNT_WIDTH                => 64,            -- total width of CPU cycle and instret counters (0..64)
     CPU_IPB_ENTRIES              => 2,             -- entries is instruction prefetch buffer, has to be a power of 2, min 2
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              => 5,             -- number of regions (0..16)

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -456,8 +456,8 @@ enum NEORV32_CSR_XISA_enum {
   CSR_MXISA_ZXCFU     =  3, /**< CPU mxisa CSR  (3): custom RISC-V instructions (r/-)*/
 
   CSR_MXISA_ZFINX     =  5, /**< CPU mxisa CSR  (5): FPU using x registers, "F-alternative" (r/-)*/
-  CSR_MXISA_ZXSCNT    =  6, /**< CPU mxisa CSR  (6): reduced-size CPU counters (from Zicntr) (r/-)*/ 
-  CSR_MXISA_ZICNTR    =  7, /**< CPU mxisa CSR  (7): base instructions, cycle and time CSRs (r/-)*/
+
+  CSR_MXISA_ZICNTR    =  7, /**< CPU mxisa CSR  (7): standard instruction, cycle and time counter CSRs (r/-)*/
   CSR_MXISA_PMP       =  8, /**< CPU mxisa CSR  (8): physical memory protection (also "Smpmp") (r/-)*/
   CSR_MXISA_ZIHPM     =  9, /**< CPU mxisa CSR  (9): hardware performance monitors (r/-)*/
   CSR_MXISA_DEBUGMODE = 10, /**< CPU mxisa CSR (10): RISC-V debug mode (r/-)*/

--- a/sw/lib/include/neorv32_cpu.h
+++ b/sw/lib/include/neorv32_cpu.h
@@ -56,7 +56,6 @@ uint32_t neorv32_cpu_pmp_get_granularity(void);
 int      neorv32_cpu_pmp_configure_region(uint32_t index, uint32_t base, uint8_t config);
 uint32_t neorv32_cpu_hpm_get_num_counters(void);
 uint32_t neorv32_cpu_hpm_get_size(void);
-uint32_t neorv32_cpu_cnt_get_size(void);
 void     neorv32_cpu_goto_user_mode(void);
 
 

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -364,9 +364,6 @@ void neorv32_rte_print_hw_config(void) {
   if (tmp & (1<<CSR_MXISA_ZXCFU)) {
     neorv32_uart0_printf("Zxcfu ");
   }
-  if (tmp & (1<<CSR_MXISA_ZXSCNT)) {
-    neorv32_uart0_printf("Zxscnt(!) ");
-  }
   if (tmp & (1<<CSR_MXISA_DEBUGMODE)) {
     neorv32_uart0_printf("DebugMode ");
   }
@@ -395,16 +392,6 @@ void neorv32_rte_print_hw_config(void) {
   uint32_t hpm_num = neorv32_cpu_hpm_get_num_counters();
   if (hpm_num != 0) {
     neorv32_uart0_printf("%u counter(s), %u bit", hpm_num, neorv32_cpu_hpm_get_size());
-  }
-  else {
-    neorv32_uart0_printf("not implemented");
-  }
-
-  // check RISC-V CPU counters
-  neorv32_uart0_printf("\nBase counters:     ");
-  uint32_t cnt_size = neorv32_cpu_cnt_get_size();
-  if (hpm_num != 0) {
-    neorv32_uart0_printf("%u bit", cnt_size);
   }
   else {
     neorv32_uart0_printf("not implemented");


### PR DESCRIPTION
This PR is another cleanup of the CPU's standard counters.

:warning: The `CPU_CNT_WIDTH` generic is removed. Hence, the width of the standard CPU counters (`[m]cycle` and `[m]instret`) is always 64-bit (low-word + high-word).

For area-constrained setups the standard CPU counters can be excluded from synthesis by disabling the `Zicntr` ISA extension (via the `CPU_EXTENSION_RISCV_Zicntr` generic).