### PR TITLE
[rtl] set 'mtval' CSR to zero if illegal instruction exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 10.09.2022 | 1.7.6.6 | :warning: set `mtval` to _zero_ on any illegal instruction exception - removes redundancies, simplifies hardware; [#409](https://github.com/stnolting/neorv32/pull/409) |
 | 09.09.2022 | 1.7.6.5 | minor rtl edits; add "output gate" to FIFO component; [#408](https://github.com/stnolting/neorv32/pull/408) |
 | 08.09.2022 | 1.7.6.4 | :warning: cleanup CPU standard counters and remove _CPU_CNT_WIDTH_ generic; [#407](https://github.com/stnolting/neorv32/pull/407) |
 | 07.09.2022 | 1.7.6.3 | minor rtl edits and cleanups; [#406](https://github.com/stnolting/neorv32/pull/406) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -83,11 +83,6 @@ The CPU does not support the resolution of unaligned memory access by the hardwa
 RISC-V-compatibility issue but an important thing to know. Any kind of unaligned memory access
 will raise an exception to allow a software-based emulation provided by the application.
 
-.`mtval` after Executing an Illegal Compressed Instruction
-[WARNING]
-If an illegal-instruction exception is caused by a **compressed** instruction (16-bit, `C` ISA extension)
-the according **de-compressed** instruction word (32-bit ) is written to `mtval`.
-
 
 <<<
 // ####################################################################################################################
@@ -866,13 +861,7 @@ be used in plain C code. The "`mepc`" and "`mtval`" columns show the value writt
 * **IPC** - address of interrupted instruction (instruction has not been executed yet)
 * **PC** - address of instruction that caused the trap
 * **ADR** - bad memory access address that caused the trap
-* **INST** - the faulting 32-bit instruction word itself (see warning below!)
 * **0** - zero
-
-.**INST** Value
-[WARNING]
-If an illegal-instruction exception is caused by a **compressed** instruction (16-bit, `C` ISA extension)
-the according **de-compressed** instruction word (32-bit ) is written to `mtval`.
 
 .NEORV32 Trap Listing
 [cols="3,6,5,14,11,4,4"]
@@ -882,7 +871,7 @@ the according **de-compressed** instruction word (32-bit ) is written to `mtval`
 7+^| **Synchronous Exceptions**
 | 1     | `0x00000000` | 0.0      | _TRAP_CODE_I_MISALIGNED_ | instruction address misaligned         | **PC**  | **ADR**
 | 2     | `0x00000001` | 0.1      | _TRAP_CODE_I_ACCESS_     | instruction access bus fault           | **PC**  | **ADR**
-| 3     | `0x00000002` | 0.2      | _TRAP_CODE_I_ILLEGAL_    | illegal instruction                    | **PC**  | **INST**
+| 3     | `0x00000002` | 0.2      | _TRAP_CODE_I_ILLEGAL_    | illegal instruction                    | **PC**  | **0**
 | 4     | `0x0000000B` | 0.11     | _TRAP_CODE_MENV_CALL_    | environment call from M-mode (`ecall`) | **PC**  | **0**
 | 5     | `0x00000008` | 0.8      | _TRAP_CODE_UENV_CALL_    | environment call from U-mode (`ecall`) | **PC**  | **0**
 | 6     | `0x00000003` | 0.3      | _TRAP_CODE_BREAKPOINT_   | software breakpoint (`ebreak`)         | **PC**  | **0**

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -392,16 +392,12 @@ See section <<_neorv32_trap_listing>> for more information.
 [cols="1,8,>3"]
 [frame="topbot",grid="none"]
 |=======================
-| 0x343 | `mtval` - **Machine bad address or instruction** | `Zicsr`
+| 0x343 | `mtval` - **Machine trap value register** | `Zicsr`
 3+<| Reset value: `0x00000000`
 |=======================
 
-[NOTE]
-The NEORV32 `mtval` CSR is read-only. However, a write access will _not_ raise an illegal instruction exception.
-
-[WARNING]
-If an illegal-instruction exception is caused by a **compressed** instruction (16-bit, `C` ISA extension)
-the according **de-compressed** instruction word (32-bit ) is written to `mtval`.
+[IMPORTANT]
+The NEORV32 `mtval` CSR is **read-only**. However, a write access will _not_ raise an illegal instruction exception.
 
 [cols="^5,^5"]
 [options="header",grid="rows"]
@@ -409,8 +405,7 @@ the according **de-compressed** instruction word (32-bit ) is written to `mtval`
 | Trap cause | `mtval` content
 | misaligned instruction fetch address or instruction fetch access fault | address of faulting instruction fetch
 | misaligned load address, load access fault, misaligned store address or store access fault | program counter (= address) of faulting instruction
-| illegal instruction | actual instruction word of faulting instruction (decoded 32-bit instruction word if caused by a compressed instruction)
-| anything else including interrupts | _0x00000000_ (always zero)
+| everything else (including all interrupts) | 0x00000000 (all-zero)
 |=======================
 
 [NOTE]

--- a/docs/datasheet/software_rte.adoc
+++ b/docs/datasheet/software_rte.adoc
@@ -160,15 +160,15 @@ neorv32_rte_exception_uninstall(RTE_TRAP_MTI);
 
 ==== Default RTE Trap Handlers
 
-The default RTE trap handlers are executed when a certain trap is triggered that is not handled by a user-defined
-application-specific trap handler. These default handler will just output a message giving additional debug information
-via UART0 to inform the user and will try to resume normal execution of the application.
+The default RTE trap handlers are executed when a certain trap is triggered that is not (yet) handled by a user-defined
+application-specific trap handler. The default handler will output a message giving additional debug information
+via UART0 to inform the user and will try to resume normal program execution.
 
 .Continuing Execution
 [IMPORTAN]
-In most cases the RTE can successfully continue operation when it catches an interrupt request, which is not handled
-by the actual application program. However, if the RTE catches an un_handled exception like a bus access fault
-continuing execution will most likely fail and the CPU will crash.
+In most cases the RTE can successfully continue operation - for example if it catches an **interrupt** request that is not handled
+by the actual application program. However, if the RTE catches an un-handled **exception** like a bus access fault
+continuing execution will most likely fail making the CPU crash.
 
 .RTE Default Trap Handler Output Examples
 [source]

--- a/docs/datasheet/software_rte.adoc
+++ b/docs/datasheet/software_rte.adoc
@@ -174,12 +174,14 @@ continuing execution will most likely fail making the CPU crash.
 [source]
 ----
 <RTE> Illegal instruction @ PC=0x000002d6, INST=0x000000FF </RTE> <1>
-<RTE> Load address misaligned @ PC=0x00000440, ADDR=0x80000101 </RTE> <2>
-<RTE> Fast IRQ 0x00000003 @ PC=0x00000820 </RTE> <3>
+<RTE> Illegal instruction @ PC=0x00000302, INST=0x0000 </RTE> <2>
+<RTE> Load address misaligned @ PC=0x00000440, ADDR=0x80000101 </RTE> <3>
+<RTE> Fast IRQ 0x00000003 @ PC=0x00000820 </RTE> <4>
 ----
-<1> Illegal instruction at address 0x000002d6.
-<2> Misaligned load access at address 0x00000440 (trying to load a full word from 0x80000101).
-<3> Fast interrupt request from channel 3 before executing instruction at address 0x00000820.
+<1> Illegal 32-bit instruction at address 0x000002d6.
+<3> Illegal 16-bit instruction at address 0x00000302.
+<3> Misaligned load access at address 0x00000440 (trying to load a full word from 0x80000101).
+<4> Fast interrupt request from channel 3 before executing instruction at address 0x00000820.
 
 The specific _message_ right at the beginning of the debug trap handler message corresponds to the trap code from the
 <<_mcause>> CSR (see <<_neorv32_trap_listing>>). A full list of all messages and the according `mcause` trap codes is shown below.

--- a/docs/datasheet/software_rte.adoc
+++ b/docs/datasheet/software_rte.adoc
@@ -170,18 +170,19 @@ In most cases the RTE can successfully continue operation when it catches an int
 by the actual application program. However, if the RTE catches an un_handled exception like a bus access fault
 continuing execution will most likely fail and the CPU will crash.
 
-.RTE Default Trap Handler Output Example (Illegal Instruction)
+.RTE Default Trap Handler Output Examples
 [source]
 ----
-<RTE> Illegal instruction @ PC=0x000002d6, MTVAL=0x00001537 </RTE>
+<RTE> Illegal instruction @ PC=0x000002d6, INST=0x000000FF </RTE> <1>
+<RTE> Load address misaligned @ PC=0x00000440, ADDR=0x80000101 </RTE> <2>
+<RTE> Fast IRQ 0x00000003 @ PC=0x00000820 </RTE> <3>
 ----
+<1> Illegal instruction at address 0x000002d6.
+<2> Misaligned load access at address 0x00000440 (trying to load a full word from 0x80000101).
+<3> Fast interrupt request from channel 3 before executing instruction at address 0x00000820.
 
-In this example the "Illegal instruction" _message_ describes the cause of the trap, which is an illegal instruction
-exception here. `PC` shows the current program counter value when the trap occurred and `MTVAL` shows additional
-debug information from the <<_mtval>> CSR. In this case it shows the encoding of the illegal instruction.
-
-The specific _message_ corresponds to the trap code from the <<_mcause>> CSR (see <<_neorv32_trap_listing>>).
-A full list of all messages and the according `mcause` trap codes are shown below.
+The specific _message_ right at the beginning of the debug trap handler message corresponds to the trap code from the
+<<_mcause>> CSR (see <<_neorv32_trap_listing>>). A full list of all messages and the according `mcause` trap codes is shown below.
 
 .RTE Default Trap Handler Messages and According `mcause` Values
 [cols="<5,^5"]
@@ -198,26 +199,26 @@ A full list of all messages and the according `mcause` trap codes are shown belo
 | "Store access fault"             | `0x00000007`
 | "Environment call from U-mode"   | `0x00000008`
 | "Environment call from M-mode"   | `0x0000000b`
-| "Machine software interrupt"     | `0x80000003`
-| "Machine timer interrupt"        | `0x80000007`
-| "Machine external interrupt"     | `0x8000000b`
-| "Fast interrupt 0"               | `0x80000010`
-| "Fast interrupt 1"               | `0x80000011`
-| "Fast interrupt 2"               | `0x80000012`
-| "Fast interrupt 3"               | `0x80000013`
-| "Fast interrupt 4"               | `0x80000014`
-| "Fast interrupt 5"               | `0x80000015`
-| "Fast interrupt 6"               | `0x80000016`
-| "Fast interrupt 7"               | `0x80000017`
-| "Fast interrupt 8"               | `0x80000018`
-| "Fast interrupt 9"               | `0x80000019`
-| "Fast interrupt a"               | `0x8000001a`
-| "Fast interrupt b"               | `0x8000001b`
-| "Fast interrupt c"               | `0x8000001c`
-| "Fast interrupt d"               | `0x8000001d`
-| "Fast interrupt e"               | `0x8000001e`
-| "Fast interrupt f"               | `0x8000001f`
-| "Unknown trap cause"             | _not defined_
+| "Machine software IRQ"           | `0x80000003`
+| "Machine timer IRQ"              | `0x80000007`
+| "Machine external IRQ"           | `0x8000000b`
+| "Fast IRQ 0x00000000"            | `0x80000010`
+| "Fast IRQ 0x00000001"            | `0x80000011`
+| "Fast IRQ 0x00000002"            | `0x80000012`
+| "Fast IRQ 0x00000003"            | `0x80000013`
+| "Fast IRQ 0x00000004"            | `0x80000014`
+| "Fast IRQ 0x00000005"            | `0x80000015`
+| "Fast IRQ 0x00000006"            | `0x80000016`
+| "Fast IRQ 0x00000007"            | `0x80000017`
+| "Fast IRQ 0x00000008"            | `0x80000018`
+| "Fast IRQ 0x00000009"            | `0x80000019`
+| "Fast IRQ 0x0000000a"            | `0x8000001a`
+| "Fast IRQ 0x0000000b"            | `0x8000001b`
+| "Fast IRQ 0x0000000c"            | `0x8000001c`
+| "Fast IRQ 0x0000000d"            | `0x8000001d`
+| "Fast IRQ 0x0000000e"            | `0x8000001e`
+| "Fast IRQ 0x0000000f"            | `0x8000001f`
+| "Unknown trap cause"             | _unknown_
 |=======================
 
 ===== Bus Access Faults

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -59,7 +59,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070605"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070606"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1604,7 +1604,7 @@ int main() {
   neorv32_cpu_csr_read(0xfff); // CSR not available
 
   PRINT_STANDARD(" ");
-  if (neorv32_cpu_csr_read(CSR_MCAUSE) != mcause_never_c) {
+  if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_I_ILLEGAL) {
     test_ok();
   }
   else {

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -615,7 +615,6 @@ int main() {
 
   // make sure this has cause an illegal exception
   if ((neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_I_ILLEGAL) && // illegal instruction exception
-      (neorv32_cpu_csr_read(CSR_MTVAL) == 0x3020007f) && // correct instruction word
       ((neorv32_cpu_csr_read(CSR_MSTATUS) & (1 << CSR_MSTATUS_MIE)) == 0)) { // MIE should still be cleared
     test_ok();
   }

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -118,7 +118,7 @@ enum NEORV32_CSR_enum {
   CSR_MSCRATCH       = 0x340, /**< 0x340 - mscratch (r/w): Machine scratch register */
   CSR_MEPC           = 0x341, /**< 0x341 - mepc     (r/w): Machine exception program counter */
   CSR_MCAUSE         = 0x342, /**< 0x342 - mcause   (r/w): Machine trap cause */
-  CSR_MTVAL          = 0x343, /**< 0x343 - mtval    (r/-): Machine bad address or instruction */
+  CSR_MTVAL          = 0x343, /**< 0x343 - mtval    (r/-): Machine trap value register */
   CSR_MIP            = 0x344, /**< 0x344 - mip      (r/-): Machine interrupt pending register */
 
   /* physical memory protection */


### PR DESCRIPTION
This PR modifies the behavior of the `mtval` CSR (trap value register).

⚠️  In case of an illegal instruction exception `mtval` is **set to zero now**. Previously, it was written with the (de-compressed) 32-bit instruction word. However, the faulting instruction word can be retrieved by performing a load operation using the `mepc` CSR as address. Hence, this PR removes certain redundancies to reduce area requirements.

✔️ This simplification is explicitly allowed by the RISC-V priv. specs.