### PR TITLE
🐛 [rtl] fix minor bug in mie CSR (FIRQs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 13.09.2022 | 1.7.6.8 | :bug: bug fix: clearing `mie`'s FIRQ bits did not clear the according _pending_ FIRQs; [#411](https://github.com/stnolting/neorv32/pull/411) |
 | 12.09.2022 | 1.7.6.7 | minor rtl edits and cleanups; [#410](https://github.com/stnolting/neorv32/pull/410) |
 | 10.09.2022 | 1.7.6.6 | :warning: set `mtval` to _zero_ on any illegal instruction exception - removes redundancies, simplifies hardware; [#409](https://github.com/stnolting/neorv32/pull/409) |
 | 09.09.2022 | 1.7.6.5 | minor rtl edits; add "output gate" to FIFO component; [#408](https://github.com/stnolting/neorv32/pull/408) |

--- a/docs/datasheet/software.adoc
+++ b/docs/datasheet/software.adoc
@@ -483,14 +483,14 @@ The `crt0.S` start-up performs the following operations:
 . Initialize all integer registers `x1 - x31` (or just `x1 - x15` when using the `E` CPU extension is enabled) to a defined value.
 . Initialize all CPU core CSRs and also install a default "dummy" trap handler for _all_ exceptions. This is used for the very early boot
 phase where the application might not provide a trap handling yet.
-** Set <<_mstatus>>`.mpp` to `11`; previous mode is machine mode.
-** All interrupt sources are disabled and all pending interrupts are cleared.
+** Clear <<_mstatus>>`.
+** Clear <<_mie>> disabling all interrupt sources and clearing all pending interrupts.
+** Clear <<_cycleh>> and <<_instreth>> counter CSRs.
 . Initialize the global pointer `gp` and the stack pointer `sp` according to the <<_ram_layout>> provided by the linker script.
 during the early boot phase.
-. Clear <<_cycleh>> and <<_instreth>> counter CSRs.
 . Clear the `.bss` section defined by the linker script.
 . Copy read-only data from the `.text` section to the `.data` section to set initialized variables.
-. Call and execute all _constructors_ (if there are any)
+. Call and execute all _constructors_ (if there are any).
 . Call the application's `main` function (with no arguments: `argc` = `argv` = 0).
 . If `main` returns:
 ** interrupts are globally disabled by clearing <<_mstatus>>`.mie`.

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -59,7 +59,7 @@ package neorv32_package is
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070607"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070608"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/common/crt0.S
+++ b/sw/common/crt0.S
@@ -74,8 +74,7 @@ __crt0_cpu_csr_init:
   csrw mtvec, x10
 
   csrw mstatus,   zero // also disables IRQs globally
-  csrw mie,       zero // disable all interrupt sources
-  csrw mip,       zero // clear all pending interrupts
+  csrw mie,       zero // disable all interrupt sources; also clears all pending IRQs
 
   csrw mcycle,    zero // reset cycle counter
   csrw mcycleh,   zero


### PR DESCRIPTION
Fixes a minor bug that did not clear pending FIRQs when clearing the according `mie` bits.