### PR TITLE
[rtl] XLEN cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
-| ??.09.2022 | 1.7.6.10 | cleanup native data path size (remove `data_width_c` package constant); initial preparations to **support RV64 ISA extension**; [#417](https://github.com/stnolting/neorv32/pull/417) |
+| 23.09.2022 | 1.7.6.10 | cleanup native data path size (remove `data_width_c` package constant); initial preparations to **support RV64 ISA extension** somewhere in the future; [#417](https://github.com/stnolting/neorv32/pull/417) |
 | 18.09.2022 | 1.7.6.9 | :bug: fixed instruction decoding collision in **`B` ISA extensions** - `B` extension is now fully operational and verified (see [neorv32-riscof](https://github.com/stnolting/neorv32-riscof))! [#413](https://github.com/stnolting/neorv32/pull/413) |
 | 13.09.2022 | 1.7.6.8 | :bug: bug fix: clearing `mie`'s FIRQ bits did not clear the according _pending_ FIRQs; [#411](https://github.com/stnolting/neorv32/pull/411) |
 | 12.09.2022 | 1.7.6.7 | minor rtl edits and cleanups; [#410](https://github.com/stnolting/neorv32/pull/410) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => 01.04.03.12 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| ??.09.2022 | 1.7.6.10 | cleanup native data path size (remove `data_width_c` package constant); initial preparations to **support RV64 ISA extension**; [#417](https://github.com/stnolting/neorv32/pull/417) |
 | 18.09.2022 | 1.7.6.9 | :bug: fixed instruction decoding collision in **`B` ISA extensions** - `B` extension is now fully operational and verified (see [neorv32-riscof](https://github.com/stnolting/neorv32-riscof))! [#413](https://github.com/stnolting/neorv32/pull/413) |
 | 13.09.2022 | 1.7.6.8 | :bug: bug fix: clearing `mie`'s FIRQ bits did not clear the according _pending_ FIRQs; [#411](https://github.com/stnolting/neorv32/pull/411) |
 | 12.09.2022 | 1.7.6.7 | minor rtl edits and cleanups; [#410](https://github.com/stnolting/neorv32/pull/410) |

--- a/rtl/core/neorv32_busswitch.vhd
+++ b/rtl/core/neorv32_busswitch.vhd
@@ -54,9 +54,9 @@ entity neorv32_busswitch is
     -- controller interface a --
     ca_bus_priv_i   : in  std_ulogic; -- current privilege level
     ca_bus_cached_i : in  std_ulogic; -- set if cached transfer
-    ca_bus_addr_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-    ca_bus_rdata_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
-    ca_bus_wdata_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
+    ca_bus_addr_i   : in  std_ulogic_vector(31 downto 0); -- bus access address
+    ca_bus_rdata_o  : out std_ulogic_vector(31 downto 0); -- bus read data
+    ca_bus_wdata_i  : in  std_ulogic_vector(31 downto 0); -- bus write data
     ca_bus_ben_i    : in  std_ulogic_vector(03 downto 0); -- byte enable
     ca_bus_we_i     : in  std_ulogic; -- write enable
     ca_bus_re_i     : in  std_ulogic; -- read enable
@@ -65,9 +65,9 @@ entity neorv32_busswitch is
     -- controller interface b --
     cb_bus_priv_i   : in  std_ulogic; -- current privilege level
     cb_bus_cached_i : in  std_ulogic; -- set if cached transfer
-    cb_bus_addr_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-    cb_bus_rdata_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
-    cb_bus_wdata_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
+    cb_bus_addr_i   : in  std_ulogic_vector(31 downto 0); -- bus access address
+    cb_bus_rdata_o  : out std_ulogic_vector(31 downto 0); -- bus read data
+    cb_bus_wdata_i  : in  std_ulogic_vector(31 downto 0); -- bus write data
     cb_bus_ben_i    : in  std_ulogic_vector(03 downto 0); -- byte enable
     cb_bus_we_i     : in  std_ulogic; -- write enable
     cb_bus_re_i     : in  std_ulogic; -- read enable
@@ -77,9 +77,9 @@ entity neorv32_busswitch is
     p_bus_priv_o    : out std_ulogic; -- current privilege level
     p_bus_cached_o  : out std_ulogic; -- set if cached transfer
     p_bus_src_o     : out std_ulogic; -- access source: 0 = A, 1 = B
-    p_bus_addr_o    : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-    p_bus_rdata_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
-    p_bus_wdata_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
+    p_bus_addr_o    : out std_ulogic_vector(31 downto 0); -- bus access address
+    p_bus_rdata_i   : in  std_ulogic_vector(31 downto 0); -- bus read data
+    p_bus_wdata_o   : out std_ulogic_vector(31 downto 0); -- bus write data
     p_bus_ben_o     : out std_ulogic_vector(03 downto 0); -- byte enable
     p_bus_we_o      : out std_ulogic; -- write enable
     p_bus_re_o      : out std_ulogic; -- read enable

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -47,6 +47,7 @@ use neorv32.neorv32_package.all;
 entity neorv32_cpu is
   generic (
     -- General --
+    XLEN                         : natural := 32; -- data path width
     HW_THREAD_ID                 : natural; -- hardware thread id (32-bit)
     CPU_BOOT_ADDR                : std_ulogic_vector(31 downto 0); -- cpu boot address
     CPU_DEBUG_ADDR               : std_ulogic_vector(31 downto 0); -- cpu debug mode start address
@@ -82,18 +83,18 @@ entity neorv32_cpu is
     sleep_o       : out std_ulogic; -- cpu is in sleep mode when set
     debug_o       : out std_ulogic; -- cpu is in debug mode when set
     -- instruction bus interface --
-    i_bus_addr_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-    i_bus_rdata_i : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
+    i_bus_addr_o  : out std_ulogic_vector(XLEN-1 downto 0); -- bus access address
+    i_bus_rdata_i : in  std_ulogic_vector(31 downto 0); -- bus read data
     i_bus_re_o    : out std_ulogic; -- read request
     i_bus_ack_i   : in  std_ulogic; -- bus transfer acknowledge
     i_bus_err_i   : in  std_ulogic; -- bus transfer error
     i_bus_fence_o : out std_ulogic; -- executed FENCEI operation
     i_bus_priv_o  : out std_ulogic; -- current effective privilege level
     -- data bus interface --
-    d_bus_addr_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-    d_bus_rdata_i : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
-    d_bus_wdata_o : out std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
-    d_bus_ben_o   : out std_ulogic_vector(03 downto 0); -- byte enable
+    d_bus_addr_o  : out std_ulogic_vector(XLEN-1 downto 0); -- bus access address
+    d_bus_rdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- bus read data
+    d_bus_wdata_o : out std_ulogic_vector(XLEN-1 downto 0); -- bus write data
+    d_bus_ben_o   : out std_ulogic_vector((XLEN/8)-1 downto 0); -- byte enable
     d_bus_we_o    : out std_ulogic; -- write request
     d_bus_re_o    : out std_ulogic; -- read request
     d_bus_ack_i   : in  std_ulogic; -- bus transfer acknowledge
@@ -117,23 +118,23 @@ architecture neorv32_cpu_rtl of neorv32_cpu is
 
   -- local signals --
   signal ctrl        : std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
-  signal imm         : std_ulogic_vector(data_width_c-1 downto 0); -- immediate
-  signal rs1, rs2    : std_ulogic_vector(data_width_c-1 downto 0); -- source registers
-  signal alu_res     : std_ulogic_vector(data_width_c-1 downto 0); -- alu result
-  signal alu_add     : std_ulogic_vector(data_width_c-1 downto 0); -- alu address result
+  signal imm         : std_ulogic_vector(XLEN-1 downto 0); -- immediate
+  signal rs1, rs2    : std_ulogic_vector(XLEN-1 downto 0); -- source registers
+  signal alu_res     : std_ulogic_vector(XLEN-1 downto 0); -- alu result
+  signal alu_add     : std_ulogic_vector(XLEN-1 downto 0); -- alu address result
   signal alu_cmp     : std_ulogic_vector(1 downto 0); -- comparator result
-  signal mem_rdata   : std_ulogic_vector(data_width_c-1 downto 0); -- memory read data
+  signal mem_rdata   : std_ulogic_vector(XLEN-1 downto 0); -- memory read data
   signal alu_idone   : std_ulogic; -- iterative alu operation done
   signal bus_d_wait  : std_ulogic; -- wait for current bus data access
-  signal csr_rdata   : std_ulogic_vector(data_width_c-1 downto 0); -- csr read data
-  signal mar         : std_ulogic_vector(data_width_c-1 downto 0); -- current memory address register
+  signal csr_rdata   : std_ulogic_vector(XLEN-1 downto 0); -- csr read data
+  signal mar         : std_ulogic_vector(XLEN-1 downto 0); -- current memory address register
   signal ma_load     : std_ulogic; -- misaligned load data address
   signal ma_store    : std_ulogic; -- misaligned store data address
   signal be_load     : std_ulogic; -- bus error on load data access
   signal be_store    : std_ulogic; -- bus error on store data access
-  signal fetch_pc    : std_ulogic_vector(data_width_c-1 downto 0); -- pc for instruction fetch
-  signal curr_pc     : std_ulogic_vector(data_width_c-1 downto 0); -- current pc (for current executed instruction)
-  signal next_pc     : std_ulogic_vector(data_width_c-1 downto 0); -- next pc (for next executed instruction)
+  signal fetch_pc    : std_ulogic_vector(XLEN-1 downto 0); -- pc for instruction fetch
+  signal curr_pc     : std_ulogic_vector(XLEN-1 downto 0); -- current pc (for current executed instruction)
+  signal next_pc     : std_ulogic_vector(XLEN-1 downto 0); -- next pc (for next executed instruction)
   signal fpu_flags   : std_ulogic_vector(4 downto 0); -- FPU exception flags
   signal i_pmp_fault : std_ulogic; -- instruction fetch PMP fault
 
@@ -143,39 +144,36 @@ architecture neorv32_cpu_rtl of neorv32_cpu is
 
 begin
 
-  -- CPU ISA Configuration ---------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  assert false report
-  "NEORV32 CPU CONFIG NOTE: Core ISA ('MARCH') = " &
-  cond_sel_string_f(boolean(data_width_c = 32), "RV32", "RV64") &
-  cond_sel_string_f(CPU_EXTENSION_RISCV_E, "E", "I") &
-  cond_sel_string_f(CPU_EXTENSION_RISCV_M, "M", "") &
-  cond_sel_string_f(CPU_EXTENSION_RISCV_C, "C", "") &
-  cond_sel_string_f(CPU_EXTENSION_RISCV_B, "B", "") &
-  cond_sel_string_f(CPU_EXTENSION_RISCV_U, "U", "") &
-  cond_sel_string_f(CPU_EXTENSION_RISCV_Zicsr, "_Zicsr", "") &
-  cond_sel_string_f(CPU_EXTENSION_RISCV_Zicntr, "_Zicntr", "") &
-  cond_sel_string_f(CPU_EXTENSION_RISCV_Zihpm, "_Zihpm", "") &
-  cond_sel_string_f(CPU_EXTENSION_RISCV_Zifencei, "_Zifencei", "") &
-  cond_sel_string_f(CPU_EXTENSION_RISCV_Zfinx, "_Zfinx", "") &
-  cond_sel_string_f(CPU_EXTENSION_RISCV_Zmmul, "_Zmmul", "") &
-  cond_sel_string_f(CPU_EXTENSION_RISCV_Zxcfu, "_Zxcfu", "") &
-  cond_sel_string_f(CPU_EXTENSION_RISCV_DEBUG, "_<DebugMode>", "") &
-  ""
-  severity note;
-
-
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   -- say hello --
   assert false report "The NEORV32 RISC-V Processor - github.com/stnolting/neorv32" severity note;
+
+  -- CPU ISA configuration --
+  assert false report
+    "NEORV32 CPU CONFIG NOTE: Core ISA ('MARCH') = RV32" &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_E, "E", "I") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_M, "M", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_C, "C", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_B, "B", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_U, "U", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Zicsr, "_Zicsr", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Zicntr, "_Zicntr", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Zihpm, "_Zihpm", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Zifencei, "_Zifencei", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Zfinx, "_Zfinx", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Zmmul, "_Zmmul", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Zxcfu, "_Zxcfu", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_DEBUG, "_<DebugMode>", "") &
+    ""
+    severity note;
 
   -- simulation notifier --
   assert not (is_simulation_c = true)  report "NEORV32 CPU WARNING! Assuming this is a simulation." severity warning;
   assert not (is_simulation_c = false) report "NEORV32 CPU NOTE: Assuming this is real hardware." severity note;
 
   -- native data width check --
-  assert not ((data_width_c /= 32) and (data_width_c /= 64)) report "NEORV32 CPU CONFIG ERROR! Invalid <data_width_c> data path width (has to be 32 or 64)." severity error; 
+  assert not (XLEN /= 32) report "NEORV32 CPU CONFIG ERROR! <XLEN> native data path width has to be 32 (bit)." severity error; 
 
   -- CPU boot address --
   assert not (CPU_BOOT_ADDR(1 downto 0) /= "00") report "NEORV32 CPU CONFIG ERROR! <CPU_BOOT_ADDR> has to be 32-bit aligned." severity error;
@@ -223,6 +221,7 @@ begin
   neorv32_cpu_control_inst: neorv32_cpu_control
   generic map (
     -- General --
+    XLEN                         => XLEN,                         -- data path width
     HW_THREAD_ID                 => HW_THREAD_ID,                 -- hardware thread id
     CPU_BOOT_ADDR                => CPU_BOOT_ADDR,                -- cpu boot address
     CPU_DEBUG_ADDR               => CPU_DEBUG_ADDR,               -- cpu debug mode start address
@@ -312,6 +311,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_regfile_inst: neorv32_cpu_regfile
   generic map (
+    XLEN                  => XLEN,                 -- data path width
     CPU_EXTENSION_RISCV_E => CPU_EXTENSION_RISCV_E -- implement embedded RF extension?
   )
   port map (
@@ -333,6 +333,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_alu_inst: neorv32_cpu_alu
   generic map (
+    XLEN                      => XLEN,                      -- data path width
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_B     => CPU_EXTENSION_RISCV_B,     -- implement bit-manipulation extension?
     CPU_EXTENSION_RISCV_M     => CPU_EXTENSION_RISCV_M,     -- implement mul/div extension?
@@ -367,6 +368,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_bus_inst: neorv32_cpu_bus
   generic map (
+    XLEN                => XLEN,               -- data path width
     PMP_NUM_REGIONS     => PMP_NUM_REGIONS,    -- number of regions (0..16)
     PMP_MIN_GRANULARITY => PMP_MIN_GRANULARITY -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
   )

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -47,7 +47,6 @@ use neorv32.neorv32_package.all;
 entity neorv32_cpu is
   generic (
     -- General --
-    XLEN                         : natural := 32; -- data path width
     HW_THREAD_ID                 : natural; -- hardware thread id (32-bit)
     CPU_BOOT_ADDR                : std_ulogic_vector(31 downto 0); -- cpu boot address
     CPU_DEBUG_ADDR               : std_ulogic_vector(31 downto 0); -- cpu debug mode start address
@@ -83,7 +82,7 @@ entity neorv32_cpu is
     sleep_o       : out std_ulogic; -- cpu is in sleep mode when set
     debug_o       : out std_ulogic; -- cpu is in debug mode when set
     -- instruction bus interface --
-    i_bus_addr_o  : out std_ulogic_vector(XLEN-1 downto 0); -- bus access address
+    i_bus_addr_o  : out std_ulogic_vector(31 downto 0); -- bus access address
     i_bus_rdata_i : in  std_ulogic_vector(31 downto 0); -- bus read data
     i_bus_re_o    : out std_ulogic; -- read request
     i_bus_ack_i   : in  std_ulogic; -- bus transfer acknowledge
@@ -91,10 +90,10 @@ entity neorv32_cpu is
     i_bus_fence_o : out std_ulogic; -- executed FENCEI operation
     i_bus_priv_o  : out std_ulogic; -- current effective privilege level
     -- data bus interface --
-    d_bus_addr_o  : out std_ulogic_vector(XLEN-1 downto 0); -- bus access address
-    d_bus_rdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- bus read data
-    d_bus_wdata_o : out std_ulogic_vector(XLEN-1 downto 0); -- bus write data
-    d_bus_ben_o   : out std_ulogic_vector((XLEN/8)-1 downto 0); -- byte enable
+    d_bus_addr_o  : out std_ulogic_vector(31 downto 0); -- bus access address
+    d_bus_rdata_i : in  std_ulogic_vector(31 downto 0); -- bus read data
+    d_bus_wdata_o : out std_ulogic_vector(31 downto 0); -- bus write data
+    d_bus_ben_o   : out std_ulogic_vector(3 downto 0); -- byte enable
     d_bus_we_o    : out std_ulogic; -- write request
     d_bus_re_o    : out std_ulogic; -- read request
     d_bus_ack_i   : in  std_ulogic; -- bus transfer acknowledge
@@ -115,6 +114,11 @@ entity neorv32_cpu is
 end neorv32_cpu;
 
 architecture neorv32_cpu_rtl of neorv32_cpu is
+
+  -- RV64: WORK IN PROGRESS -----------------------------------------------------------------------
+  -- not available as CPU generic as rv64 ISA extension is not (fully) supported yet
+  constant XLEN : natural := 32; -- data path width
+  -- ----------------------------------------------------------------------------------------------
 
   -- local signals --
   signal ctrl        : std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -43,6 +43,7 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_alu is
   generic (
+    XLEN                      : natural; -- data path width
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_B     : boolean; -- implement bit-manipulation extension?
     CPU_EXTENSION_RISCV_M     : boolean; -- implement mul/div extension?
@@ -59,14 +60,14 @@ entity neorv32_cpu_alu is
     rstn_i      : in  std_ulogic; -- global reset, low-active, async
     ctrl_i      : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
     -- data input --
-    rs1_i       : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 1
-    rs2_i       : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 2
-    pc_i        : in  std_ulogic_vector(data_width_c-1 downto 0); -- current PC
-    imm_i       : in  std_ulogic_vector(data_width_c-1 downto 0); -- immediate
+    rs1_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+    rs2_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
+    pc_i        : in  std_ulogic_vector(XLEN-1 downto 0); -- current PC
+    imm_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- immediate
     -- data output --
     cmp_o       : out std_ulogic_vector(1 downto 0); -- comparator status
-    res_o       : out std_ulogic_vector(data_width_c-1 downto 0); -- ALU result
-    add_o       : out std_ulogic_vector(data_width_c-1 downto 0); -- address computation result
+    res_o       : out std_ulogic_vector(XLEN-1 downto 0); -- ALU result
+    add_o       : out std_ulogic_vector(XLEN-1 downto 0); -- address computation result
     fpu_flags_o : out std_ulogic_vector(4 downto 0); -- FPU exception flags
     -- status --
     idone_o     : out std_ulogic -- iterative processing units done?
@@ -76,19 +77,19 @@ end neorv32_cpu_alu;
 architecture neorv32_cpu_cpu_rtl of neorv32_cpu_alu is
 
   -- comparator --
-  signal cmp_opx : std_ulogic_vector(data_width_c downto 0);
-  signal cmp_opy : std_ulogic_vector(data_width_c downto 0);
+  signal cmp_opx : std_ulogic_vector(XLEN downto 0);
+  signal cmp_opy : std_ulogic_vector(XLEN downto 0);
   signal cmp     : std_ulogic_vector(1 downto 0); -- comparator status
 
   -- operands --
-  signal opa, opb : std_ulogic_vector(data_width_c-1 downto 0);
+  signal opa, opb : std_ulogic_vector(XLEN-1 downto 0);
 
   -- intermediate results --
-  signal addsub_res : std_ulogic_vector(data_width_c downto 0);
-  signal cp_res     : std_ulogic_vector(data_width_c-1 downto 0);
+  signal addsub_res : std_ulogic_vector(XLEN downto 0);
+  signal cp_res     : std_ulogic_vector(XLEN-1 downto 0);
 
   -- co-processor interface --
-  type cp_data_if_t  is array (0 to 5) of std_ulogic_vector(data_width_c-1 downto 0);
+  type cp_data_if_t  is array (0 to 5) of std_ulogic_vector(XLEN-1 downto 0);
   signal cp_result : cp_data_if_t; -- co-processor i result
   signal cp_start  : std_ulogic_vector(5 downto 0); -- trigger co-processor i
   signal cp_valid  : std_ulogic_vector(5 downto 0); -- co-processor i done
@@ -114,7 +115,7 @@ begin
   -- Adder/Subtracter Core ------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   arithmetic_core: process(ctrl_i, opa, opb)
-    variable opa_v, opb_v : std_ulogic_vector(data_width_c downto 0);
+    variable opa_v, opb_v : std_ulogic_vector(XLEN downto 0);
   begin
     -- operand sign-extension --
     opa_v := (opa(opa'left) and (not ctrl_i(ctrl_alu_unsigned_c))) & opa;
@@ -128,7 +129,7 @@ begin
   end process arithmetic_core;
 
   -- direct output of adder result --
-  add_o <= addsub_res(data_width_c-1 downto 0);
+  add_o <= addsub_res(XLEN-1 downto 0);
 
 
   -- ALU Operation Select -------------------------------------------------------------------
@@ -136,15 +137,15 @@ begin
   alu_core: process(ctrl_i, addsub_res, cp_res, rs1_i, opb)
   begin
     case ctrl_i(ctrl_alu_op2_c downto ctrl_alu_op0_c) is
-      when alu_op_add_c  => res_o <= addsub_res(data_width_c-1 downto 0); -- default
-      when alu_op_sub_c  => res_o <= addsub_res(data_width_c-1 downto 0);
+      when alu_op_add_c  => res_o <= addsub_res(XLEN-1 downto 0); -- default
+      when alu_op_sub_c  => res_o <= addsub_res(XLEN-1 downto 0);
       when alu_op_cp_c   => res_o <= cp_res;
       when alu_op_slt_c  => res_o <= (others => '0'); res_o(0) <= addsub_res(addsub_res'left); -- carry/borrow
       when alu_op_movb_c => res_o <= opb;
       when alu_op_xor_c  => res_o <= rs1_i xor opb; -- only rs1 required for logic ops (opa would also contain pc)
       when alu_op_or_c   => res_o <= rs1_i or  opb;
       when alu_op_and_c  => res_o <= rs1_i and opb;
-      when others        => res_o <= addsub_res(data_width_c-1 downto 0); -- don't care
+      when others        => res_o <= addsub_res(XLEN-1 downto 0); -- don't care
     end case;
   end process alu_core;
 
@@ -170,6 +171,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_cp_shifter_inst: neorv32_cpu_cp_shifter
   generic map (
+    XLEN          => XLEN,         -- data path width
     FAST_SHIFT_EN => FAST_SHIFT_EN -- use barrel shifter for shift operations
   )
   port map (
@@ -180,7 +182,7 @@ begin
     start_i => cp_start(0),  -- trigger operation
     -- data input --
     rs1_i   => rs1_i,        -- rf source 1
-    shamt_i => opb(index_size_f(data_width_c)-1 downto 0), -- shift amount
+    shamt_i => opb(index_size_f(XLEN)-1 downto 0), -- shift amount
     -- result and status --
     res_o   => cp_result(0), -- operation result
     valid_o => cp_valid(0)   -- data output valid
@@ -193,6 +195,7 @@ begin
   if (CPU_EXTENSION_RISCV_M = true) or (CPU_EXTENSION_RISCV_Zmmul = true) generate
     neorv32_cpu_cp_muldiv_inst: neorv32_cpu_cp_muldiv
     generic map (
+      XLEN        => XLEN,                 -- data path width
       FAST_MUL_EN => FAST_MUL_EN,          -- use DSPs for faster multiplication
       DIVISION_EN => CPU_EXTENSION_RISCV_M -- implement divider hardware
     )
@@ -224,6 +227,7 @@ begin
   if (CPU_EXTENSION_RISCV_B = true) generate
     neorv32_cpu_cp_bitmanip_inst: neorv32_cpu_cp_bitmanip
     generic map (
+      XLEN          => XLEN,         -- data path width
       FAST_SHIFT_EN => FAST_SHIFT_EN -- use barrel shifter for shift operations
     )
     port map (
@@ -236,7 +240,7 @@ begin
       cmp_i   => cmp,          -- comparator status
       rs1_i   => rs1_i,        -- rf source 1
       rs2_i   => rs2_i,        -- rf source 2
-      shamt_i => opb(index_size_f(data_width_c)-1 downto 0), -- shift amount
+      shamt_i => opb(index_size_f(XLEN)-1 downto 0), -- shift amount
       -- result and status --
       res_o   => cp_result(2), -- operation result
       valid_o => cp_valid(2)   -- data output valid
@@ -255,6 +259,9 @@ begin
   neorv32_cpu_cp_fpu_inst_true:
   if (CPU_EXTENSION_RISCV_Zfinx = true) generate
     neorv32_cpu_cp_fpu_inst: neorv32_cpu_cp_fpu
+    generic map (
+      XLEN => XLEN -- data path width
+    )
     port map (
       -- global control --
       clk_i    => clk_i,        -- global clock, rising edge  
@@ -285,6 +292,9 @@ begin
   neorv32_cpu_cp_cfu_inst_true:
   if (CPU_EXTENSION_RISCV_Zxcfu = true) generate
     neorv32_cpu_cp_cfu_inst: neorv32_cpu_cp_cfu
+    generic map (
+    XLEN => XLEN -- data path width
+    )
     port map (
       -- global control --
       clk_i   => clk_i,        -- global clock, rising edge

--- a/rtl/core/neorv32_cpu_cp_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_cp_bitmanip.vhd
@@ -53,7 +53,8 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_cp_bitmanip is
   generic (
-    FAST_SHIFT_EN : boolean -- use barrel shifter for shift operations
+    XLEN          : natural; -- data path width
+    FAST_SHIFT_EN : boolean  -- use barrel shifter for shift operations
   );
   port (
     -- global control --
@@ -63,11 +64,11 @@ entity neorv32_cpu_cp_bitmanip is
     start_i : in  std_ulogic; -- trigger operation
     -- data input --
     cmp_i   : in  std_ulogic_vector(1 downto 0); -- comparator status
-    rs1_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 1
-    rs2_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 2
-    shamt_i : in  std_ulogic_vector(index_size_f(data_width_c)-1 downto 0); -- shift amount
+    rs1_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+    rs2_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
+    shamt_i : in  std_ulogic_vector(index_size_f(XLEN)-1 downto 0); -- shift amount
     -- result and status --
-    res_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- operation result
+    res_o   : out std_ulogic_vector(XLEN-1 downto 0); -- operation result
     valid_o : out std_ulogic -- data output valid
   );
 end neorv32_cpu_cp_bitmanip;
@@ -128,43 +129,43 @@ architecture neorv32_cpu_cp_bitmanip_rtl of neorv32_cpu_cp_bitmanip is
   signal valid        : std_ulogic;
 
   -- operand buffers --
-  signal rs1_reg  : std_ulogic_vector(data_width_c-1 downto 0);
-  signal rs2_reg  : std_ulogic_vector(data_width_c-1 downto 0);
-  signal sha_reg  : std_ulogic_vector(index_size_f(data_width_c)-1 downto 0);
+  signal rs1_reg  : std_ulogic_vector(XLEN-1 downto 0);
+  signal rs2_reg  : std_ulogic_vector(XLEN-1 downto 0);
+  signal sha_reg  : std_ulogic_vector(index_size_f(XLEN)-1 downto 0);
   signal less_reg : std_ulogic;
 
   -- serial shifter --
   type shifter_t is record
     start   : std_ulogic;
     run     : std_ulogic;
-    bcnt    : std_ulogic_vector(index_size_f(data_width_c) downto 0); -- bit counter
-    cnt     : std_ulogic_vector(index_size_f(data_width_c) downto 0); -- iteration counter
-    cnt_max : std_ulogic_vector(index_size_f(data_width_c) downto 0);
-    sreg    : std_ulogic_vector(data_width_c-1 downto 0);
+    bcnt    : std_ulogic_vector(index_size_f(XLEN) downto 0); -- bit counter
+    cnt     : std_ulogic_vector(index_size_f(XLEN) downto 0); -- iteration counter
+    cnt_max : std_ulogic_vector(index_size_f(XLEN) downto 0);
+    sreg    : std_ulogic_vector(XLEN-1 downto 0);
   end record;
   signal shifter : shifter_t;
 
   -- barrel shifter --
-  type bs_level_t is array (index_size_f(data_width_c) downto 0) of std_ulogic_vector(data_width_c-1 downto 0);
+  type bs_level_t is array (index_size_f(XLEN) downto 0) of std_ulogic_vector(XLEN-1 downto 0);
   signal bs_level : bs_level_t;
 
   -- operation results --
-  type res_t is array (0 to op_width_c-1) of std_ulogic_vector(data_width_c-1 downto 0);
+  type res_t is array (0 to op_width_c-1) of std_ulogic_vector(XLEN-1 downto 0);
   signal res_int, res_out : res_t;
 
   -- shifted-add unit --
-  signal adder_core : std_ulogic_vector(data_width_c-1 downto 0);
+  signal adder_core : std_ulogic_vector(XLEN-1 downto 0);
 
   -- one-hot decoder --
-  signal one_hot_core : std_ulogic_vector(data_width_c-1 downto 0);
+  signal one_hot_core : std_ulogic_vector(XLEN-1 downto 0);
 
   -- carry-less multiplier --
   type clmultiplier_t is record
     start : std_ulogic;
     busy  : std_ulogic;
-    rs2   : std_ulogic_vector(data_width_c-1 downto 0);
-    cnt   : std_ulogic_vector(index_size_f(data_width_c) downto 0);
-    prod  : std_ulogic_vector(2*data_width_c-1 downto 0);
+    rs2   : std_ulogic_vector(XLEN-1 downto 0);
+    cnt   : std_ulogic_vector(index_size_f(XLEN) downto 0);
+    prod  : std_ulogic_vector(2*XLEN-1 downto 0);
   end record;
   signal clmul : clmultiplier_t;
 
@@ -366,15 +367,15 @@ begin
     begin
       -- input level: convert left shifts to right shifts --
       if (cmd_buf(op_rol_c) = '1') then -- is left shift?
-        bs_level(index_size_f(data_width_c)) <= bit_rev_f(rs1_reg); -- reverse bit order of input operand
+        bs_level(index_size_f(XLEN)) <= bit_rev_f(rs1_reg); -- reverse bit order of input operand
       else
-        bs_level(index_size_f(data_width_c)) <= rs1_reg;
+        bs_level(index_size_f(XLEN)) <= rs1_reg;
       end if;
       -- shifter array --
-      for i in index_size_f(data_width_c)-1 downto 0 loop
+      for i in index_size_f(XLEN)-1 downto 0 loop
         if (sha_reg(i) = '1') then
-          bs_level(i)(data_width_c-1 downto data_width_c-(2**i)) <= bs_level(i+1)((2**i)-1 downto 0);
-          bs_level(i)((data_width_c-(2**i))-1 downto 0) <= bs_level(i+1)(data_width_c-1 downto 2**i);
+          bs_level(i)(XLEN-1 downto XLEN-(2**i)) <= bs_level(i+1)((2**i)-1 downto 0);
+          bs_level(i)((XLEN-(2**i))-1 downto 0) <= bs_level(i+1)(XLEN-1 downto 2**i);
         else
           bs_level(i) <= bs_level(i+1);
         end if;
@@ -399,7 +400,7 @@ begin
   -- Shifted-Add Core -----------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   shift_adder: process(rs1_reg, rs2_reg, ctrl_i)
-    variable opb_v : std_ulogic_vector(data_width_c-1 downto 0);
+    variable opb_v : std_ulogic_vector(XLEN-1 downto 0);
   begin
     case ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_1_c) is
       when "01"   => opb_v := rs1_reg(rs1_reg'left-1 downto 0) & '0';   -- << 1
@@ -463,12 +464,12 @@ begin
   res_int(op_xnor_c) <= rs1_reg xor (not rs2_reg);
 
   -- count leading/trailing zeros --
-  res_int(op_clz_c)(data_width_c-1 downto shifter.cnt'left+1) <= (others => '0');
+  res_int(op_clz_c)(XLEN-1 downto shifter.cnt'left+1) <= (others => '0');
   res_int(op_clz_c)(shifter.cnt'left downto 0) <= shifter.cnt;
   res_int(op_ctz_c) <= (others => '0'); -- unused/redundant
 
   -- count set bits --
-  res_int(op_cpop_c)(data_width_c-1 downto shifter.bcnt'left+1) <= (others => '0');
+  res_int(op_cpop_c)(XLEN-1 downto shifter.bcnt'left+1) <= (others => '0');
   res_int(op_cpop_c)(shifter.bcnt'left downto 0) <= shifter.bcnt;
 
   -- min/max select --
@@ -476,11 +477,11 @@ begin
   res_int(op_max_c) <= (others => '0'); -- unused/redundant
 
   -- sign-extension --
-  res_int(op_sextb_c)(data_width_c-1 downto 8) <= (others => rs1_reg(7));
+  res_int(op_sextb_c)(XLEN-1 downto 8) <= (others => rs1_reg(7));
   res_int(op_sextb_c)(7 downto 0) <= rs1_reg(7 downto 0); -- sign-extend byte
-  res_int(op_sexth_c)(data_width_c-1 downto 16) <= (others => rs1_reg(15));
+  res_int(op_sexth_c)(XLEN-1 downto 16) <= (others => rs1_reg(15));
   res_int(op_sexth_c)(15 downto 0) <= rs1_reg(15 downto 0); -- sign-extend half-word
-  res_int(op_zexth_c)(data_width_c-1 downto 16) <= (others => '0');
+  res_int(op_zexth_c)(XLEN-1 downto 16) <= (others => '0');
   res_int(op_zexth_c)(15 downto 0) <= rs1_reg(15 downto 0); -- zero-extend half-word
 
   -- rotate right/left --
@@ -489,7 +490,7 @@ begin
 
   -- or-combine.byte --
   or_combine_gen:
-  for i in 0 to (data_width_c/8)-1 generate -- sub-byte loop
+  for i in 0 to (XLEN/8)-1 generate -- sub-byte loop
     res_int(op_orcb_c)(i*8+7 downto i*8) <= (others => or_reduce_f(rs1_reg(i*8+7 downto i*8)));
   end generate; -- i
 
@@ -503,7 +504,7 @@ begin
 
   -- single-bit instructions --
   res_int(op_bclr_c) <= rs1_reg and (not one_hot_core);
-  res_int(op_bext_c)(data_width_c-1 downto 1) <= (others => '0');
+  res_int(op_bext_c)(XLEN-1 downto 1) <= (others => '0');
   res_int(op_bext_c)(0) <= '1' when (or_reduce_f(rs1_reg and one_hot_core) = '1') else '0';
   res_int(op_binv_c) <= rs1_reg xor one_hot_core;
   res_int(op_bset_c) <= rs1_reg or one_hot_core;

--- a/rtl/core/neorv32_cpu_cp_cfu.vhd
+++ b/rtl/core/neorv32_cpu_cp_cfu.vhd
@@ -45,6 +45,9 @@ library neorv32;
 use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_cp_cfu is
+  generic (
+    XLEN : natural -- data path width
+  );
   port (
     -- global control --
     clk_i   : in  std_ulogic; -- global clock, rising edge
@@ -52,10 +55,10 @@ entity neorv32_cpu_cp_cfu is
     ctrl_i  : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
     start_i : in  std_ulogic; -- trigger operation
     -- data input --
-    rs1_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 1
-    rs2_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 2
+    rs1_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+    rs2_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
     -- result and status --
-    res_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- operation result
+    res_o   : out std_ulogic_vector(XLEN-1 downto 0); -- operation result
     valid_o : out std_ulogic -- data output valid
   );
 end neorv32_cpu_cp_cfu;
@@ -66,7 +69,7 @@ architecture neorv32_cpu_cp_cfu_rtl of neorv32_cpu_cp_cfu is
   type control_t is record
     busy   : std_ulogic; -- CFU is busy
     done   : std_ulogic; -- set to '1' when processing is done
-    result : std_ulogic_vector(data_width_c-1 downto 0); -- user's processing result (for write-back to register file)
+    result : std_ulogic_vector(XLEN-1 downto 0); -- user's processing result (for write-back to register file)
     funct3 : std_ulogic_vector(2 downto 0); -- "funct3" bit-field from custom instruction
     funct7 : std_ulogic_vector(6 downto 0); -- "funct7" bit-field from custom instruction
   end record;

--- a/rtl/core/neorv32_cpu_cp_fpu.vhd
+++ b/rtl/core/neorv32_cpu_cp_fpu.vhd
@@ -56,6 +56,9 @@ library neorv32;
 use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_cp_fpu is
+  generic (
+    XLEN : natural -- data path width
+  );
   port (
     -- global control --
     clk_i    : in  std_ulogic; -- global clock, rising edge
@@ -64,10 +67,10 @@ entity neorv32_cpu_cp_fpu is
     start_i  : in  std_ulogic; -- trigger operation
     -- data input --
     cmp_i    : in  std_ulogic_vector(1 downto 0); -- comparator status
-    rs1_i    : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 1
-    rs2_i    : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 2
+    rs1_i    : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+    rs2_i    : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
     -- result and status --
-    res_o    : out std_ulogic_vector(data_width_c-1 downto 0); -- operation result
+    res_o    : out std_ulogic_vector(XLEN-1 downto 0); -- operation result
     fflags_o : out std_ulogic_vector(4 downto 0); -- exception flags
     valid_o  : out std_ulogic -- data output valid
   );

--- a/rtl/core/neorv32_cpu_regfile.vhd
+++ b/rtl/core/neorv32_cpu_regfile.vhd
@@ -52,33 +52,34 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_regfile is
   generic (
-    CPU_EXTENSION_RISCV_E : boolean -- implement embedded RF extension?
+    XLEN                  : natural; -- data path width
+    CPU_EXTENSION_RISCV_E : boolean  -- implement embedded RF extension?
   );
   port (
     -- global control --
     clk_i  : in  std_ulogic; -- global clock, rising edge
     ctrl_i : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
     -- data input --
-    alu_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- ALU result
-    mem_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- memory read data
-    csr_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- CSR read data
-    pc2_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- next PC
+    alu_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- ALU result
+    mem_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- memory read data
+    csr_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- CSR read data
+    pc2_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- next PC
     -- data output --
-    rs1_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- operand 1
-    rs2_o  : out std_ulogic_vector(data_width_c-1 downto 0)  -- operand 2
+    rs1_o  : out std_ulogic_vector(XLEN-1 downto 0); -- operand 1
+    rs2_o  : out std_ulogic_vector(XLEN-1 downto 0)  -- operand 2
   );
 end neorv32_cpu_regfile;
 
 architecture neorv32_cpu_regfile_rtl of neorv32_cpu_regfile is
 
   -- register file --
-  type   reg_file_t is array (31 downto 0) of std_ulogic_vector(data_width_c-1 downto 0);
-  type   reg_file_emb_t is array (15 downto 0) of std_ulogic_vector(data_width_c-1 downto 0);
+  type   reg_file_t is array (31 downto 0) of std_ulogic_vector(XLEN-1 downto 0);
+  type   reg_file_emb_t is array (15 downto 0) of std_ulogic_vector(XLEN-1 downto 0);
   signal reg_file     : reg_file_t;
   signal reg_file_emb : reg_file_emb_t;
 
   -- access --
-  signal rf_wdata : std_ulogic_vector(data_width_c-1 downto 0); -- actual write-back data
+  signal rf_wdata : std_ulogic_vector(XLEN-1 downto 0); -- actual write-back data
   signal rf_we    : std_ulogic; -- write enable
   signal rd_zero  : std_ulogic; -- writing to x0?
   signal opa_addr : std_ulogic_vector(4 downto 0); -- rs1/dst address

--- a/rtl/core/neorv32_icache.vhd
+++ b/rtl/core/neorv32_icache.vhd
@@ -55,15 +55,15 @@ entity neorv32_icache is
     clear_i      : in  std_ulogic; -- cache clear
     miss_o       : out std_ulogic; -- cache miss
     -- host controller interface --
-    host_addr_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-    host_rdata_o : out std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
+    host_addr_i  : in  std_ulogic_vector(31 downto 0); -- bus access address
+    host_rdata_o : out std_ulogic_vector(31 downto 0); -- bus read data
     host_re_i    : in  std_ulogic; -- read enable
     host_ack_o   : out std_ulogic; -- bus transfer acknowledge
     host_err_o   : out std_ulogic; -- bus transfer error
     -- peripheral bus interface --
     bus_cached_o : out std_ulogic; -- set if cached (!) access in progress
-    bus_addr_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-    bus_rdata_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
+    bus_addr_o   : out std_ulogic_vector(31 downto 0); -- bus access address
+    bus_rdata_i  : in  std_ulogic_vector(31 downto 0); -- bus read data
     bus_re_o     : out std_ulogic; -- read enable
     bus_ack_i    : in  std_ulogic; -- bus transfer acknowledge
     bus_err_i    : in  std_ulogic  -- bus transfer error

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -58,8 +58,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant data_width_c : natural := 32; -- native data path width - do not change!
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070609"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070610"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -118,8 +117,8 @@ package neorv32_package is
   -- Processor-Internal Address Space Layout ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   -- Internal Instruction Memory (IMEM) and Date Memory (DMEM) --
-  constant imem_base_c          : std_ulogic_vector(data_width_c-1 downto 0) := ispace_base_c; -- internal instruction memory base address
-  constant dmem_base_c          : std_ulogic_vector(data_width_c-1 downto 0) := dspace_base_c; -- internal data memory base address
+  constant imem_base_c          : std_ulogic_vector(31 downto 0) := ispace_base_c; -- internal instruction memory base address
+  constant dmem_base_c          : std_ulogic_vector(31 downto 0) := dspace_base_c; -- internal data memory base address
   --> internal data/instruction memory sizes are configured via top's generics
 
   -- !!! IMPORTANT: The base address of each component/module has to be aligned to the !!!
@@ -128,198 +127,198 @@ package neorv32_package is
 
   -- Internal Bootloader ROM --
   -- Actual bootloader size is determined during runtime via the length of the bootloader initialization image
-  constant boot_rom_base_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"ffff0000"; -- bootloader base address, fixed!
+  constant boot_rom_base_c      : std_ulogic_vector(31 downto 0) := x"ffff0000"; -- bootloader base address, fixed!
   constant boot_rom_max_size_c  : natural := 32*1024; -- max module's address space size in bytes, fixed!
 
   -- On-Chip Debugger: Debug Module --
-  constant dm_base_c            : std_ulogic_vector(data_width_c-1 downto 0) := x"fffff800"; -- base address, fixed!
+  constant dm_base_c            : std_ulogic_vector(31 downto 0) := x"fffff800"; -- base address, fixed!
   constant dm_size_c            : natural := 4*32*4; -- debug ROM address space size in bytes, fixed
-  constant dm_code_base_c       : std_ulogic_vector(data_width_c-1 downto 0) := x"fffff800";
-  constant dm_pbuf_base_c       : std_ulogic_vector(data_width_c-1 downto 0) := x"fffff880";
-  constant dm_data_base_c       : std_ulogic_vector(data_width_c-1 downto 0) := x"fffff900";
-  constant dm_sreg_base_c       : std_ulogic_vector(data_width_c-1 downto 0) := x"fffff980";
+  constant dm_code_base_c       : std_ulogic_vector(31 downto 0) := x"fffff800";
+  constant dm_pbuf_base_c       : std_ulogic_vector(31 downto 0) := x"fffff880";
+  constant dm_data_base_c       : std_ulogic_vector(31 downto 0) := x"fffff900";
+  constant dm_sreg_base_c       : std_ulogic_vector(31 downto 0) := x"fffff980";
 
   -- IO: Peripheral Devices ("IO") Area --
   -- Control register(s) (including the device-enable flag) should be located at the base address of each device
-  constant io_base_c            : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe00";
+  constant io_base_c            : std_ulogic_vector(31 downto 0) := x"fffffe00";
   constant io_size_c            : natural := 512; -- IO address space size in bytes, fixed!
 
   -- Custom Functions Subsystem (CFS) --
-  constant cfs_base_c           : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe00"; -- base address
+  constant cfs_base_c           : std_ulogic_vector(31 downto 0) := x"fffffe00"; -- base address
   constant cfs_size_c           : natural := 32*4; -- module's address space in bytes
-  constant cfs_reg0_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe00";
-  constant cfs_reg1_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe04";
-  constant cfs_reg2_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe08";
-  constant cfs_reg3_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe0c";
-  constant cfs_reg4_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe10";
-  constant cfs_reg5_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe14";
-  constant cfs_reg6_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe18";
-  constant cfs_reg7_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe1c";
-  constant cfs_reg8_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe20";
-  constant cfs_reg9_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe24";
-  constant cfs_reg10_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe28";
-  constant cfs_reg11_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe2c";
-  constant cfs_reg12_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe30";
-  constant cfs_reg13_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe34";
-  constant cfs_reg14_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe38";
-  constant cfs_reg15_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe3c";
-  constant cfs_reg16_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe40";
-  constant cfs_reg17_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe44";
-  constant cfs_reg18_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe48";
-  constant cfs_reg19_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe4c";
-  constant cfs_reg20_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe50";
-  constant cfs_reg21_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe54";
-  constant cfs_reg22_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe58";
-  constant cfs_reg23_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe5c";
-  constant cfs_reg24_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe60";
-  constant cfs_reg25_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe64";
-  constant cfs_reg26_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe68";
-  constant cfs_reg27_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe6c";
-  constant cfs_reg28_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe70";
-  constant cfs_reg29_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe74";
-  constant cfs_reg30_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe78";
-  constant cfs_reg31_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe7c";
+  constant cfs_reg0_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe00";
+  constant cfs_reg1_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe04";
+  constant cfs_reg2_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe08";
+  constant cfs_reg3_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe0c";
+  constant cfs_reg4_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe10";
+  constant cfs_reg5_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe14";
+  constant cfs_reg6_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe18";
+  constant cfs_reg7_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe1c";
+  constant cfs_reg8_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe20";
+  constant cfs_reg9_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe24";
+  constant cfs_reg10_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe28";
+  constant cfs_reg11_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe2c";
+  constant cfs_reg12_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe30";
+  constant cfs_reg13_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe34";
+  constant cfs_reg14_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe38";
+  constant cfs_reg15_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe3c";
+  constant cfs_reg16_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe40";
+  constant cfs_reg17_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe44";
+  constant cfs_reg18_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe48";
+  constant cfs_reg19_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe4c";
+  constant cfs_reg20_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe50";
+  constant cfs_reg21_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe54";
+  constant cfs_reg22_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe58";
+  constant cfs_reg23_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe5c";
+  constant cfs_reg24_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe60";
+  constant cfs_reg25_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe64";
+  constant cfs_reg26_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe68";
+  constant cfs_reg27_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe6c";
+  constant cfs_reg28_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe70";
+  constant cfs_reg29_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe74";
+  constant cfs_reg30_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe78";
+  constant cfs_reg31_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe7c";
 
   -- Pulse-Width Modulation Controller (PWM) --
-  constant pwm_base_c           : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe80"; -- base address
+  constant pwm_base_c           : std_ulogic_vector(31 downto 0) := x"fffffe80"; -- base address
   constant pwm_size_c           : natural := 16*4; -- module's address space size in bytes
-  constant pwm_ctrl_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe80";
-  constant pwm_duty0_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe84";
-  constant pwm_duty1_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe88";
-  constant pwm_duty2_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe8c";
-  constant pwm_duty3_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe90";
-  constant pwm_duty4_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe94";
-  constant pwm_duty5_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe98";
-  constant pwm_duty6_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffe9c";
-  constant pwm_duty7_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffea0";
-  constant pwm_duty8_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffea4";
-  constant pwm_duty9_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffea8";
-  constant pwm_duty10_addr_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffeac";
-  constant pwm_duty11_addr_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffeb0";
-  constant pwm_duty12_addr_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffeb4";
-  constant pwm_duty13_addr_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffeb8";
-  constant pwm_duty14_addr_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffebc";
+  constant pwm_ctrl_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe80";
+  constant pwm_duty0_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe84";
+  constant pwm_duty1_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe88";
+  constant pwm_duty2_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe8c";
+  constant pwm_duty3_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe90";
+  constant pwm_duty4_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe94";
+  constant pwm_duty5_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe98";
+  constant pwm_duty6_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe9c";
+  constant pwm_duty7_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffea0";
+  constant pwm_duty8_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffea4";
+  constant pwm_duty9_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffea8";
+  constant pwm_duty10_addr_c    : std_ulogic_vector(31 downto 0) := x"fffffeac";
+  constant pwm_duty11_addr_c    : std_ulogic_vector(31 downto 0) := x"fffffeb0";
+  constant pwm_duty12_addr_c    : std_ulogic_vector(31 downto 0) := x"fffffeb4";
+  constant pwm_duty13_addr_c    : std_ulogic_vector(31 downto 0) := x"fffffeb8";
+  constant pwm_duty14_addr_c    : std_ulogic_vector(31 downto 0) := x"fffffebc";
 
   -- Stream Link Interface (SLINK) --
-  constant slink_base_c         : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffec0"; -- base address
+  constant slink_base_c         : std_ulogic_vector(31 downto 0) := x"fffffec0"; -- base address
   constant slink_size_c         : natural := 16*4; -- module's address space size in bytes
-  constant slink_ctrl_c         : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffec0";
-  constant slink_irq_c          : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffec4";
-  constant slink_rx_status_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffec8";
-  constant slink_tx_status_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffecc";
---constant slink_reserved_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffed0";
---constant slink_reserved_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffed4";
---constant slink_reserved_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffed8";
---constant slink_reserved_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffedc";
-  constant slink_link0_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffee0";
-  constant slink_link1_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffee4";
-  constant slink_link2_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffee8";
-  constant slink_link3_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffeec";
-  constant slink_link4_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffef0";
-  constant slink_link5_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffef4";
-  constant slink_link6_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffef7";
-  constant slink_link7_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"fffffefc";
+  constant slink_ctrl_c         : std_ulogic_vector(31 downto 0) := x"fffffec0";
+  constant slink_irq_c          : std_ulogic_vector(31 downto 0) := x"fffffec4";
+  constant slink_rx_status_c    : std_ulogic_vector(31 downto 0) := x"fffffec8";
+  constant slink_tx_status_c    : std_ulogic_vector(31 downto 0) := x"fffffecc";
+--constant slink_reserved_c     : std_ulogic_vector(31 downto 0) := x"fffffed0";
+--constant slink_reserved_c     : std_ulogic_vector(31 downto 0) := x"fffffed4";
+--constant slink_reserved_c     : std_ulogic_vector(31 downto 0) := x"fffffed8";
+--constant slink_reserved_c     : std_ulogic_vector(31 downto 0) := x"fffffedc";
+  constant slink_link0_c        : std_ulogic_vector(31 downto 0) := x"fffffee0";
+  constant slink_link1_c        : std_ulogic_vector(31 downto 0) := x"fffffee4";
+  constant slink_link2_c        : std_ulogic_vector(31 downto 0) := x"fffffee8";
+  constant slink_link3_c        : std_ulogic_vector(31 downto 0) := x"fffffeec";
+  constant slink_link4_c        : std_ulogic_vector(31 downto 0) := x"fffffef0";
+  constant slink_link5_c        : std_ulogic_vector(31 downto 0) := x"fffffef4";
+  constant slink_link6_c        : std_ulogic_vector(31 downto 0) := x"fffffef7";
+  constant slink_link7_c        : std_ulogic_vector(31 downto 0) := x"fffffefc";
 
   -- reserved --
---constant reserved_base_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff00"; -- base address
+--constant reserved_base_c      : std_ulogic_vector(31 downto 0) := x"ffffff00"; -- base address
 --constant reserved_size_c      : natural := 16*4; -- module's address space size in bytes
 
   -- Execute In Place Module (XIP) --
-  constant xip_base_c           : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff40"; -- base address
+  constant xip_base_c           : std_ulogic_vector(31 downto 0) := x"ffffff40"; -- base address
   constant xip_size_c           : natural := 4*4; -- module's address space size in bytes
-  constant xip_ctrl_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff40";
---constant xip_reserved_addr_c  : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff44";
-  constant xip_data_lo_addr_c   : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff48";
-  constant xip_data_hi_addr_c   : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff4C";
+  constant xip_ctrl_addr_c      : std_ulogic_vector(31 downto 0) := x"ffffff40";
+--constant xip_reserved_addr_c  : std_ulogic_vector(31 downto 0) := x"ffffff44";
+  constant xip_data_lo_addr_c   : std_ulogic_vector(31 downto 0) := x"ffffff48";
+  constant xip_data_hi_addr_c   : std_ulogic_vector(31 downto 0) := x"ffffff4C";
 
   -- reserved --
---constant reserved_base_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff50"; -- base address
+--constant reserved_base_c      : std_ulogic_vector(31 downto 0) := x"ffffff50"; -- base address
 --constant reserved_size_c      : natural := 4*4; -- module's address space size in bytes
 
   -- General Purpose Timer (GPTMR) --
-  constant gptmr_base_c         : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff60"; -- base address
+  constant gptmr_base_c         : std_ulogic_vector(31 downto 0) := x"ffffff60"; -- base address
   constant gptmr_size_c         : natural := 4*4; -- module's address space size in bytes
-  constant gptmr_ctrl_addr_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff60";
-  constant gptmr_thres_addr_c   : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff64";
-  constant gptmr_count_addr_c   : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff68";
---constant gptmr_reserve_addr_c : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff6c";
+  constant gptmr_ctrl_addr_c    : std_ulogic_vector(31 downto 0) := x"ffffff60";
+  constant gptmr_thres_addr_c   : std_ulogic_vector(31 downto 0) := x"ffffff64";
+  constant gptmr_count_addr_c   : std_ulogic_vector(31 downto 0) := x"ffffff68";
+--constant gptmr_reserve_addr_c : std_ulogic_vector(31 downto 0) := x"ffffff6c";
 
   -- 1-Wire Interface Controller (ONEWIRE) --
-  constant onewire_base_c       : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff70"; -- base address
+  constant onewire_base_c       : std_ulogic_vector(31 downto 0) := x"ffffff70"; -- base address
   constant onewire_size_c       : natural := 2*4; -- module's address space size in bytes
-  constant onewire_ctrl_addr_c  : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff70";
-  constant onewire_data_addr_c  : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff74";
+  constant onewire_ctrl_addr_c  : std_ulogic_vector(31 downto 0) := x"ffffff70";
+  constant onewire_data_addr_c  : std_ulogic_vector(31 downto 0) := x"ffffff74";
 
   -- Bus Access Monitor (BUSKEEPER) --
-  constant buskeeper_base_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff78"; -- base address
+  constant buskeeper_base_c     : std_ulogic_vector(31 downto 0) := x"ffffff78"; -- base address
   constant buskeeper_size_c     : natural := 2*4; -- module's address space size in bytes
 
   -- External Interrupt Controller (XIRQ) --
-  constant xirq_base_c          : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff80"; -- base address
+  constant xirq_base_c          : std_ulogic_vector(31 downto 0) := x"ffffff80"; -- base address
   constant xirq_size_c          : natural := 4*4; -- module's address space size in bytes
-  constant xirq_enable_addr_c   : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff80";
-  constant xirq_pending_addr_c  : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff84";
-  constant xirq_source_addr_c   : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff88";
---constant xirq_reserved_addr_c : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff8c";
+  constant xirq_enable_addr_c   : std_ulogic_vector(31 downto 0) := x"ffffff80";
+  constant xirq_pending_addr_c  : std_ulogic_vector(31 downto 0) := x"ffffff84";
+  constant xirq_source_addr_c   : std_ulogic_vector(31 downto 0) := x"ffffff88";
+--constant xirq_reserved_addr_c : std_ulogic_vector(31 downto 0) := x"ffffff8c";
 
   -- Machine System Timer (MTIME) --
-  constant mtime_base_c         : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff90"; -- base address
+  constant mtime_base_c         : std_ulogic_vector(31 downto 0) := x"ffffff90"; -- base address
   constant mtime_size_c         : natural := 4*4; -- module's address space size in bytes
-  constant mtime_time_lo_addr_c : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff90";
-  constant mtime_time_hi_addr_c : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff94";
-  constant mtime_cmp_lo_addr_c  : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff98";
-  constant mtime_cmp_hi_addr_c  : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffff9c";
+  constant mtime_time_lo_addr_c : std_ulogic_vector(31 downto 0) := x"ffffff90";
+  constant mtime_time_hi_addr_c : std_ulogic_vector(31 downto 0) := x"ffffff94";
+  constant mtime_cmp_lo_addr_c  : std_ulogic_vector(31 downto 0) := x"ffffff98";
+  constant mtime_cmp_hi_addr_c  : std_ulogic_vector(31 downto 0) := x"ffffff9c";
 
   -- Primary Universal Asynchronous Receiver/Transmitter (UART0) --
-  constant uart0_base_c         : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffa0"; -- base address
+  constant uart0_base_c         : std_ulogic_vector(31 downto 0) := x"ffffffa0"; -- base address
   constant uart0_size_c         : natural := 2*4; -- module's address space size in bytes
-  constant uart0_ctrl_addr_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffa0";
-  constant uart0_rtx_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffa4";
+  constant uart0_ctrl_addr_c    : std_ulogic_vector(31 downto 0) := x"ffffffa0";
+  constant uart0_rtx_addr_c     : std_ulogic_vector(31 downto 0) := x"ffffffa4";
 
   -- Serial Peripheral Interface (SPI) --
-  constant spi_base_c           : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffa8"; -- base address
+  constant spi_base_c           : std_ulogic_vector(31 downto 0) := x"ffffffa8"; -- base address
   constant spi_size_c           : natural := 2*4; -- module's address space size in bytes
-  constant spi_ctrl_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffa8";
-  constant spi_rtx_addr_c       : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffac";
+  constant spi_ctrl_addr_c      : std_ulogic_vector(31 downto 0) := x"ffffffa8";
+  constant spi_rtx_addr_c       : std_ulogic_vector(31 downto 0) := x"ffffffac";
 
   -- Two Wire Interface (TWI) --
-  constant twi_base_c           : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffb0"; -- base address
+  constant twi_base_c           : std_ulogic_vector(31 downto 0) := x"ffffffb0"; -- base address
   constant twi_size_c           : natural := 2*4; -- module's address space size in bytes
-  constant twi_ctrl_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffb0";
-  constant twi_rtx_addr_c       : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffb4";
+  constant twi_ctrl_addr_c      : std_ulogic_vector(31 downto 0) := x"ffffffb0";
+  constant twi_rtx_addr_c       : std_ulogic_vector(31 downto 0) := x"ffffffb4";
 
   -- True Random Number Generator (TRNG) --
-  constant trng_base_c          : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffb8"; -- base address
+  constant trng_base_c          : std_ulogic_vector(31 downto 0) := x"ffffffb8"; -- base address
   constant trng_size_c          : natural := 1*4; -- module's address space size in bytes
-  constant trng_ctrl_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffb8";
+  constant trng_ctrl_addr_c     : std_ulogic_vector(31 downto 0) := x"ffffffb8";
 
   -- Watch Dog Timer (WDT) --
-  constant wdt_base_c           : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffbc"; -- base address
+  constant wdt_base_c           : std_ulogic_vector(31 downto 0) := x"ffffffbc"; -- base address
   constant wdt_size_c           : natural := 1*4; -- module's address space size in bytes
-  constant wdt_ctrl_addr_c      : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffbc";
+  constant wdt_ctrl_addr_c      : std_ulogic_vector(31 downto 0) := x"ffffffbc";
 
   -- General Purpose Input/Output Controller (GPIO) --
-  constant gpio_base_c          : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffc0"; -- base address
+  constant gpio_base_c          : std_ulogic_vector(31 downto 0) := x"ffffffc0"; -- base address
   constant gpio_size_c          : natural := 4*4; -- module's address space size in bytes
-  constant gpio_in_lo_addr_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffc0";
-  constant gpio_in_hi_addr_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffc4";
-  constant gpio_out_lo_addr_c   : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffc8";
-  constant gpio_out_hi_addr_c   : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffcc";
+  constant gpio_in_lo_addr_c    : std_ulogic_vector(31 downto 0) := x"ffffffc0";
+  constant gpio_in_hi_addr_c    : std_ulogic_vector(31 downto 0) := x"ffffffc4";
+  constant gpio_out_lo_addr_c   : std_ulogic_vector(31 downto 0) := x"ffffffc8";
+  constant gpio_out_hi_addr_c   : std_ulogic_vector(31 downto 0) := x"ffffffcc";
 
   -- Secondary Universal Asynchronous Receiver/Transmitter (UART1) --
-  constant uart1_base_c         : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffd0"; -- base address
+  constant uart1_base_c         : std_ulogic_vector(31 downto 0) := x"ffffffd0"; -- base address
   constant uart1_size_c         : natural := 2*4; -- module's address space size in bytes
-  constant uart1_ctrl_addr_c    : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffd0";
-  constant uart1_rtx_addr_c     : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffd4";
+  constant uart1_ctrl_addr_c    : std_ulogic_vector(31 downto 0) := x"ffffffd0";
+  constant uart1_rtx_addr_c     : std_ulogic_vector(31 downto 0) := x"ffffffd4";
 
   -- Smart LED (WS2811/WS2812) Interface (NEOLED) --
-  constant neoled_base_c        : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffd8"; -- base address
+  constant neoled_base_c        : std_ulogic_vector(31 downto 0) := x"ffffffd8"; -- base address
   constant neoled_size_c        : natural := 2*4; -- module's address space size in bytes
-  constant neoled_ctrl_addr_c   : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffd8";
-  constant neoled_data_addr_c   : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffdc";
+  constant neoled_ctrl_addr_c   : std_ulogic_vector(31 downto 0) := x"ffffffd8";
+  constant neoled_data_addr_c   : std_ulogic_vector(31 downto 0) := x"ffffffdc";
 
   -- System Information Memory (SYSINFO) --
-  constant sysinfo_base_c       : std_ulogic_vector(data_width_c-1 downto 0) := x"ffffffe0"; -- base address
+  constant sysinfo_base_c       : std_ulogic_vector(31 downto 0) := x"ffffffe0"; -- base address
   constant sysinfo_size_c       : natural := 8*4; -- module's address space size in bytes
 
   -- Main CPU Control Bus -------------------------------------------------------------------
@@ -462,11 +461,14 @@ package neorv32_package is
   constant funct3_lb_c     : std_ulogic_vector(2 downto 0) := "000"; -- load byte
   constant funct3_lh_c     : std_ulogic_vector(2 downto 0) := "001"; -- load half word
   constant funct3_lw_c     : std_ulogic_vector(2 downto 0) := "010"; -- load word
+  constant funct3_ld_c     : std_ulogic_vector(2 downto 0) := "011"; -- load half word (unsigned, rv64-only)
   constant funct3_lbu_c    : std_ulogic_vector(2 downto 0) := "100"; -- load byte (unsigned)
   constant funct3_lhu_c    : std_ulogic_vector(2 downto 0) := "101"; -- load half word (unsigned)
+  constant funct3_lwu_c    : std_ulogic_vector(2 downto 0) := "110"; -- load word (unsigned, rv64-only)
   constant funct3_sb_c     : std_ulogic_vector(2 downto 0) := "000"; -- store byte
   constant funct3_sh_c     : std_ulogic_vector(2 downto 0) := "001"; -- store half word
   constant funct3_sw_c     : std_ulogic_vector(2 downto 0) := "010"; -- store word
+  constant funct3_sd_c     : std_ulogic_vector(2 downto 0) := "011"; -- store double-word (rv64-only)
   -- alu --
   constant funct3_subadd_c : std_ulogic_vector(2 downto 0) := "000"; -- sub/add via funct7
   constant funct3_sll_c    : std_ulogic_vector(2 downto 0) := "001"; -- shift logical left
@@ -1118,6 +1120,7 @@ package neorv32_package is
   component neorv32_cpu
     generic (
       -- General --
+      XLEN                         : natural := 32; -- data path width
       HW_THREAD_ID                 : natural; -- hardware thread id (32-bit)
       CPU_BOOT_ADDR                : std_ulogic_vector(31 downto 0); -- cpu boot address
       CPU_DEBUG_ADDR               : std_ulogic_vector(31 downto 0); -- cpu debug mode start address
@@ -1153,18 +1156,18 @@ package neorv32_package is
       sleep_o       : out std_ulogic; -- cpu is in sleep mode when set
       debug_o       : out std_ulogic; -- cpu is in debug mode when set
       -- instruction bus interface --
-      i_bus_addr_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-      i_bus_rdata_i : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
+      i_bus_addr_o  : out std_ulogic_vector(XLEN-1 downto 0); -- bus access address
+      i_bus_rdata_i : in  std_ulogic_vector(31 downto 0); -- bus read data
       i_bus_re_o    : out std_ulogic; -- read request
       i_bus_ack_i   : in  std_ulogic; -- bus transfer acknowledge
       i_bus_err_i   : in  std_ulogic; -- bus transfer error
       i_bus_fence_o : out std_ulogic; -- executed FENCEI operation
       i_bus_priv_o  : out std_ulogic; -- current effective privilege level
       -- data bus interface --
-      d_bus_addr_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-      d_bus_rdata_i : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
-      d_bus_wdata_o : out std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
-      d_bus_ben_o   : out std_ulogic_vector(03 downto 0); -- byte enable
+      d_bus_addr_o  : out std_ulogic_vector(XLEN-1 downto 0); -- bus access address
+      d_bus_rdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- bus read data
+      d_bus_wdata_o : out std_ulogic_vector(XLEN-1 downto 0); -- bus write data
+      d_bus_ben_o   : out std_ulogic_vector((XLEN/8)-1 downto 0); -- byte enable
       d_bus_we_o    : out std_ulogic; -- write request
       d_bus_re_o    : out std_ulogic; -- read request
       d_bus_ack_i   : in  std_ulogic; -- bus transfer acknowledge
@@ -1189,6 +1192,7 @@ package neorv32_package is
   component neorv32_cpu_control
     generic (
       -- General --
+      XLEN                         : natural; -- data path width
       HW_THREAD_ID                 : natural; -- hardware thread id (32-bit)
       CPU_BOOT_ADDR                : std_ulogic_vector(31 downto 0); -- cpu boot address
       CPU_DEBUG_ADDR               : std_ulogic_vector(31 downto 0); -- cpu debug mode start address
@@ -1223,8 +1227,8 @@ package neorv32_package is
       rstn_i        : in  std_ulogic; -- global reset, low-active, async
       ctrl_o        : out std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
       -- instruction fetch interface --
-      i_bus_addr_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-      i_bus_rdata_i : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
+      i_bus_addr_o  : out std_ulogic_vector(XLEN-1 downto 0); -- bus access address
+      i_bus_rdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- bus read data
       i_bus_re_o    : out std_ulogic; -- read enable
       i_bus_ack_i   : in  std_ulogic; -- bus transfer acknowledge
       i_bus_err_i   : in  std_ulogic; -- bus transfer error
@@ -1234,15 +1238,15 @@ package neorv32_package is
       bus_d_wait_i  : in  std_ulogic; -- wait for bus
       -- data input --
       cmp_i         : in  std_ulogic_vector(1 downto 0); -- comparator status
-      alu_add_i     : in  std_ulogic_vector(data_width_c-1 downto 0); -- ALU address result
-      rs1_i         : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 1
+      alu_add_i     : in  std_ulogic_vector(XLEN-1 downto 0); -- ALU address result
+      rs1_i         : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
       -- data output --
-      imm_o         : out std_ulogic_vector(data_width_c-1 downto 0); -- immediate
-      curr_pc_o     : out std_ulogic_vector(data_width_c-1 downto 0); -- current PC (corresponding to current instruction)
-      next_pc_o     : out std_ulogic_vector(data_width_c-1 downto 0); -- next PC (corresponding to next instruction)
-      csr_rdata_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- CSR read data
+      imm_o         : out std_ulogic_vector(XLEN-1 downto 0); -- immediate
+      curr_pc_o     : out std_ulogic_vector(XLEN-1 downto 0); -- current PC (corresponding to current instruction)
+      next_pc_o     : out std_ulogic_vector(XLEN-1 downto 0); -- next PC (corresponding to next instruction)
+      csr_rdata_o   : out std_ulogic_vector(XLEN-1 downto 0); -- CSR read data
       -- FPU interface --
-      fpu_flags_i   : in  std_ulogic_vector(04 downto 0); -- exception flags
+      fpu_flags_i   : in  std_ulogic_vector(4 downto 0); -- exception flags
       -- debug mode (halt) request --
       db_halt_req_i : in  std_ulogic;
       -- interrupts (risc-v compliant) --
@@ -1257,7 +1261,7 @@ package neorv32_package is
       pmp_addr_o    : out pmp_addr_if_t; -- addresses
       pmp_ctrl_o    : out pmp_ctrl_if_t; -- configs
       -- bus access exceptions --
-      mar_i         : in  std_ulogic_vector(data_width_c-1 downto 0); -- memory address register
+      mar_i         : in  std_ulogic_vector(XLEN-1 downto 0); -- memory address register
       ma_load_i     : in  std_ulogic; -- misaligned load data address
       ma_store_i    : in  std_ulogic; -- misaligned store data address
       be_load_i     : in  std_ulogic; -- bus error on load data access
@@ -1269,20 +1273,21 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_regfile
     generic (
-      CPU_EXTENSION_RISCV_E : boolean -- implement embedded RF extension?
+      XLEN                  : natural; -- data path width
+      CPU_EXTENSION_RISCV_E : boolean  -- implement embedded RF extension?
     );
     port (
       -- global control --
       clk_i  : in  std_ulogic; -- global clock, rising edge
       ctrl_i : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
       -- data input --
-      alu_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- ALU result
-      mem_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- memory read data
-      csr_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- CSR read data
-      pc2_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- next PC
+      alu_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- ALU result
+      mem_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- memory read data
+      csr_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- CSR read data
+      pc2_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- next PC
       -- data output --
-      rs1_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- operand 1
-      rs2_o  : out std_ulogic_vector(data_width_c-1 downto 0)  -- operand 2
+      rs1_o  : out std_ulogic_vector(XLEN-1 downto 0); -- operand 1
+      rs2_o  : out std_ulogic_vector(XLEN-1 downto 0)  -- operand 2
     );
   end component;
 
@@ -1290,6 +1295,7 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_alu
     generic (
+      XLEN                      : natural; -- data path width
       -- RISC-V CPU Extensions --
       CPU_EXTENSION_RISCV_B     : boolean; -- implement bit-manipulation extension?
       CPU_EXTENSION_RISCV_M     : boolean; -- implement mul/div extension?
@@ -1306,14 +1312,14 @@ package neorv32_package is
       rstn_i      : in  std_ulogic; -- global reset, low-active, async
       ctrl_i      : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
       -- data input --
-      rs1_i       : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 1
-      rs2_i       : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 2
-      pc_i        : in  std_ulogic_vector(data_width_c-1 downto 0); -- current PC
-      imm_i       : in  std_ulogic_vector(data_width_c-1 downto 0); -- immediate
+      rs1_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+      rs2_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
+      pc_i        : in  std_ulogic_vector(XLEN-1 downto 0); -- current PC
+      imm_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- immediate
       -- data output --
       cmp_o       : out std_ulogic_vector(1 downto 0); -- comparator status
-      res_o       : out std_ulogic_vector(data_width_c-1 downto 0); -- ALU result
-      add_o       : out std_ulogic_vector(data_width_c-1 downto 0); -- address computation result
+      res_o       : out std_ulogic_vector(XLEN-1 downto 0); -- ALU result
+      add_o       : out std_ulogic_vector(XLEN-1 downto 0); -- address computation result
       fpu_flags_o : out std_ulogic_vector(4 downto 0); -- FPU exception flags
       -- status --
       idone_o     : out std_ulogic -- iterative processing units done?
@@ -1324,7 +1330,8 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_cp_shifter
     generic (
-      FAST_SHIFT_EN : boolean -- use barrel shifter for shift operations
+      XLEN          : natural; -- data path width
+      FAST_SHIFT_EN : boolean  -- use barrel shifter for shift operations
     );
     port (
       -- global control --
@@ -1333,10 +1340,10 @@ package neorv32_package is
       ctrl_i  : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
       start_i : in  std_ulogic; -- trigger operation
       -- data input --
-      rs1_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 1
-      shamt_i : in  std_ulogic_vector(index_size_f(data_width_c)-1 downto 0); -- shift amount
+      rs1_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+      shamt_i : in  std_ulogic_vector(index_size_f(XLEN)-1 downto 0); -- shift amount
       -- result and status --
-      res_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- operation result
+      res_o   : out std_ulogic_vector(XLEN-1 downto 0); -- operation result
       valid_o : out std_ulogic -- data output valid
     );
   end component;
@@ -1345,6 +1352,7 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_cp_muldiv
     generic (
+      XLEN        : natural; -- data path width
       FAST_MUL_EN : boolean; -- use DSPs for faster multiplication
       DIVISION_EN : boolean  -- implement divider hardware
     );
@@ -1355,10 +1363,10 @@ package neorv32_package is
       ctrl_i  : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
       start_i : in  std_ulogic; -- trigger operation
       -- data input --
-      rs1_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 1
-      rs2_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 2
+      rs1_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+      rs2_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
       -- result and status --
-      res_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- operation result
+      res_o   : out std_ulogic_vector(XLEN-1 downto 0); -- operation result
       valid_o : out std_ulogic -- data output valid
     );
   end component;
@@ -1367,6 +1375,7 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_cp_bitmanip is
     generic (
+      XLEN          : natural; -- data path width
       FAST_SHIFT_EN : boolean  -- use barrel shifter for shift operations
     );
     port (
@@ -1377,11 +1386,11 @@ package neorv32_package is
       start_i : in  std_ulogic; -- trigger operation
       -- data input --
       cmp_i   : in  std_ulogic_vector(1 downto 0); -- comparator status
-      rs1_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 1
-      rs2_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 2
-      shamt_i : in  std_ulogic_vector(index_size_f(data_width_c)-1 downto 0); -- shift amount
+      rs1_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+      rs2_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
+      shamt_i : in  std_ulogic_vector(index_size_f(XLEN)-1 downto 0); -- shift amount
       -- result and status --
-      res_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- operation result
+      res_o   : out std_ulogic_vector(XLEN-1 downto 0); -- operation result
       valid_o : out std_ulogic -- data output valid
     );
   end component;
@@ -1389,6 +1398,9 @@ package neorv32_package is
   -- Component: CPU Co-Processor 32-bit FPU ('Zfinx' extension) -----------------------------
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_cp_fpu
+    generic (
+      XLEN : natural -- data path width
+    );
     port (
       -- global control --
       clk_i    : in  std_ulogic; -- global clock, rising edge
@@ -1397,10 +1409,10 @@ package neorv32_package is
       start_i  : in  std_ulogic; -- trigger operation
       -- data input --
       cmp_i    : in  std_ulogic_vector(1 downto 0); -- comparator status
-      rs1_i    : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 1
-      rs2_i    : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 2
+      rs1_i    : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+      rs2_i    : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
       -- result and status --
-      res_o    : out std_ulogic_vector(data_width_c-1 downto 0); -- operation result
+      res_o    : out std_ulogic_vector(XLEN-1 downto 0); -- operation result
       fflags_o : out std_ulogic_vector(4 downto 0); -- exception flags
       valid_o  : out std_ulogic -- data output valid
     );
@@ -1409,6 +1421,9 @@ package neorv32_package is
   -- Component: CPU Co-Processor Custom (Instr.) Functions Unit ('Zxcfu' extension) ---------
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_cp_cfu
+    generic (
+      XLEN : natural -- data path width
+    );
     port (
       -- global control --
       clk_i   : in  std_ulogic; -- global clock, rising edge
@@ -1416,10 +1431,10 @@ package neorv32_package is
       ctrl_i  : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
       start_i : in  std_ulogic; -- trigger operation
       -- data input --
-      rs1_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 1
-      rs2_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- rf source 2
+      rs1_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+      rs2_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
       -- result and status --
-      res_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- operation result
+      res_o   : out std_ulogic_vector(XLEN-1 downto 0); -- operation result
       valid_o : out std_ulogic -- data output valid
     );
   end component;
@@ -1428,6 +1443,7 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_bus
     generic (
+      XLEN                : natural; -- data path width
       PMP_NUM_REGIONS     : natural; -- number of regions (0..16)
       PMP_MIN_GRANULARITY : natural  -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
     );
@@ -1437,13 +1453,13 @@ package neorv32_package is
       rstn_i        : in  std_ulogic := '0'; -- global reset, low-active, async
       ctrl_i        : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
       -- cpu instruction fetch interface --
-      fetch_pc_i    : in  std_ulogic_vector(data_width_c-1 downto 0); -- PC for instruction fetch
+      fetch_pc_i    : in  std_ulogic_vector(XLEN-1 downto 0); -- PC for instruction fetch
       i_pmp_fault_o : out std_ulogic; -- instruction fetch pmp fault
       -- cpu data access interface --
-      addr_i        : in  std_ulogic_vector(data_width_c-1 downto 0); -- ALU result -> access address
-      wdata_i       : in  std_ulogic_vector(data_width_c-1 downto 0); -- write data
-      rdata_o       : out std_ulogic_vector(data_width_c-1 downto 0); -- read data
-      mar_o         : out std_ulogic_vector(data_width_c-1 downto 0); -- current memory address register
+      addr_i        : in  std_ulogic_vector(XLEN-1 downto 0); -- ALU result -> access address
+      wdata_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- write data
+      rdata_o       : out std_ulogic_vector(XLEN-1 downto 0); -- read data
+      mar_o         : out std_ulogic_vector(XLEN-1 downto 0); -- current memory address register
       d_wait_o      : out std_ulogic; -- wait for access to complete
       ma_load_o     : out std_ulogic; -- misaligned load data address
       ma_store_o    : out std_ulogic; -- misaligned store data address
@@ -1453,10 +1469,10 @@ package neorv32_package is
       pmp_addr_i    : in  pmp_addr_if_t; -- addresses
       pmp_ctrl_i    : in  pmp_ctrl_if_t; -- configs
       -- data bus --
-      d_bus_addr_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-      d_bus_rdata_i : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
-      d_bus_wdata_o : out std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
-      d_bus_ben_o   : out std_ulogic_vector(03 downto 0); -- byte enable
+      d_bus_addr_o  : out std_ulogic_vector(XLEN-1 downto 0); -- bus access address
+      d_bus_rdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- bus read data
+      d_bus_wdata_o : out std_ulogic_vector(XLEN-1 downto 0); -- bus write data
+      d_bus_ben_o   : out std_ulogic_vector((XLEN/8)-1 downto 0); -- byte enable
       d_bus_we_o    : out std_ulogic; -- write enable
       d_bus_re_o    : out std_ulogic; -- read enable
       d_bus_ack_i   : in  std_ulogic; -- bus transfer acknowledge
@@ -1507,15 +1523,15 @@ package neorv32_package is
       clear_i      : in  std_ulogic; -- cache clear
       miss_o       : out std_ulogic; -- cache miss
       -- host controller interface --
-      host_addr_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-      host_rdata_o : out std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
+      host_addr_i  : in  std_ulogic_vector(31 downto 0); -- bus access address
+      host_rdata_o : out std_ulogic_vector(31 downto 0); -- bus read data
       host_re_i    : in  std_ulogic; -- read enable
       host_ack_o   : out std_ulogic; -- bus transfer acknowledge
       host_err_o   : out std_ulogic; -- bus transfer error
       -- peripheral bus interface --
       bus_cached_o : out std_ulogic; -- set if cached (!) access in progress
-      bus_addr_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-      bus_rdata_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
+      bus_addr_o   : out std_ulogic_vector(31 downto 0); -- bus access address
+      bus_rdata_i  : in  std_ulogic_vector(31 downto 0); -- bus read data
       bus_re_o     : out std_ulogic; -- read enable
       bus_ack_i    : in  std_ulogic; -- bus transfer acknowledge
       bus_err_i    : in  std_ulogic  -- bus transfer error
@@ -1536,9 +1552,9 @@ package neorv32_package is
       -- controller interface a --
       ca_bus_priv_i   : in  std_ulogic; -- current privilege level
       ca_bus_cached_i : in  std_ulogic; -- set if cached transfer
-      ca_bus_addr_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-      ca_bus_rdata_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
-      ca_bus_wdata_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
+      ca_bus_addr_i   : in  std_ulogic_vector(31 downto 0); -- bus access address
+      ca_bus_rdata_o  : out std_ulogic_vector(31 downto 0); -- bus read data
+      ca_bus_wdata_i  : in  std_ulogic_vector(31 downto 0); -- bus write data
       ca_bus_ben_i    : in  std_ulogic_vector(03 downto 0); -- byte enable
       ca_bus_we_i     : in  std_ulogic; -- write enable
       ca_bus_re_i     : in  std_ulogic; -- read enable
@@ -1547,9 +1563,9 @@ package neorv32_package is
       -- controller interface b --
       cb_bus_priv_i   : in  std_ulogic; -- current privilege level
       cb_bus_cached_i : in  std_ulogic; -- set if cached transfer
-      cb_bus_addr_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-      cb_bus_rdata_o  : out std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
-      cb_bus_wdata_i  : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
+      cb_bus_addr_i   : in  std_ulogic_vector(31 downto 0); -- bus access address
+      cb_bus_rdata_o  : out std_ulogic_vector(31 downto 0); -- bus read data
+      cb_bus_wdata_i  : in  std_ulogic_vector(31 downto 0); -- bus write data
       cb_bus_ben_i    : in  std_ulogic_vector(03 downto 0); -- byte enable
       cb_bus_we_i     : in  std_ulogic; -- write enable
       cb_bus_re_i     : in  std_ulogic; -- read enable
@@ -1559,9 +1575,9 @@ package neorv32_package is
       p_bus_priv_o    : out std_ulogic; -- current privilege level
       p_bus_cached_o  : out std_ulogic; -- set if cached transfer
       p_bus_src_o     : out std_ulogic; -- access source: 0 = A, 1 = B
-      p_bus_addr_o    : out std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-      p_bus_rdata_i   : in  std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
-      p_bus_wdata_o   : out std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
+      p_bus_addr_o    : out std_ulogic_vector(31 downto 0); -- bus access address
+      p_bus_rdata_i   : in  std_ulogic_vector(31 downto 0); -- bus read data
+      p_bus_wdata_o   : out std_ulogic_vector(31 downto 0); -- bus write data
       p_bus_ben_o     : out std_ulogic_vector(03 downto 0); -- byte enable
       p_bus_we_o      : out std_ulogic; -- write enable
       p_bus_re_o      : out std_ulogic; -- read enable

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -1120,7 +1120,6 @@ package neorv32_package is
   component neorv32_cpu
     generic (
       -- General --
-      XLEN                         : natural := 32; -- data path width
       HW_THREAD_ID                 : natural; -- hardware thread id (32-bit)
       CPU_BOOT_ADDR                : std_ulogic_vector(31 downto 0); -- cpu boot address
       CPU_DEBUG_ADDR               : std_ulogic_vector(31 downto 0); -- cpu debug mode start address
@@ -1156,7 +1155,7 @@ package neorv32_package is
       sleep_o       : out std_ulogic; -- cpu is in sleep mode when set
       debug_o       : out std_ulogic; -- cpu is in debug mode when set
       -- instruction bus interface --
-      i_bus_addr_o  : out std_ulogic_vector(XLEN-1 downto 0); -- bus access address
+      i_bus_addr_o  : out std_ulogic_vector(31 downto 0); -- bus access address
       i_bus_rdata_i : in  std_ulogic_vector(31 downto 0); -- bus read data
       i_bus_re_o    : out std_ulogic; -- read request
       i_bus_ack_i   : in  std_ulogic; -- bus transfer acknowledge
@@ -1164,10 +1163,10 @@ package neorv32_package is
       i_bus_fence_o : out std_ulogic; -- executed FENCEI operation
       i_bus_priv_o  : out std_ulogic; -- current effective privilege level
       -- data bus interface --
-      d_bus_addr_o  : out std_ulogic_vector(XLEN-1 downto 0); -- bus access address
-      d_bus_rdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- bus read data
-      d_bus_wdata_o : out std_ulogic_vector(XLEN-1 downto 0); -- bus write data
-      d_bus_ben_o   : out std_ulogic_vector((XLEN/8)-1 downto 0); -- byte enable
+      d_bus_addr_o  : out std_ulogic_vector(31 downto 0); -- bus access address
+      d_bus_rdata_i : in  std_ulogic_vector(31 downto 0); -- bus read data
+      d_bus_wdata_o : out std_ulogic_vector(31 downto 0); -- bus write data
+      d_bus_ben_o   : out std_ulogic_vector(3 downto 0); -- byte enable
       d_bus_we_o    : out std_ulogic; -- write request
       d_bus_re_o    : out std_ulogic; -- read request
       d_bus_ack_i   : in  std_ulogic; -- bus transfer acknowledge

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -287,8 +287,8 @@ architecture neorv32_top_rtl of neorv32_top is
 
   -- bus interface - instruction fetch --
   type bus_i_interface_t is record
-    addr   : std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-    rdata  : std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
+    addr   : std_ulogic_vector(31 downto 0); -- bus access address
+    rdata  : std_ulogic_vector(31 downto 0); -- bus read data
     re     : std_ulogic; -- read request
     ack    : std_ulogic; -- bus transfer acknowledge
     err    : std_ulogic; -- bus transfer error
@@ -301,9 +301,9 @@ architecture neorv32_top_rtl of neorv32_top is
 
   -- bus interface - data access --
   type bus_d_interface_t is record
-    addr   : std_ulogic_vector(data_width_c-1 downto 0); -- bus access address
-    rdata  : std_ulogic_vector(data_width_c-1 downto 0); -- bus read data
-    wdata  : std_ulogic_vector(data_width_c-1 downto 0); -- bus write data
+    addr   : std_ulogic_vector(31 downto 0); -- bus access address
+    rdata  : std_ulogic_vector(31 downto 0); -- bus read data
+    wdata  : std_ulogic_vector(31 downto 0); -- bus write data
     ben    : std_ulogic_vector(03 downto 0); -- byte enable
     we     : std_ulogic; -- write request
     re     : std_ulogic; -- read request
@@ -345,10 +345,12 @@ architecture neorv32_top_rtl of neorv32_top is
 
   -- module response bus - entry type --
   type resp_bus_entry_t is record
-    rdata : std_ulogic_vector(data_width_c-1 downto 0);
+    rdata : std_ulogic_vector(31 downto 0);
     ack   : std_ulogic;
     err   : std_ulogic;
   end record;
+
+  -- termination for unused/unimplemented bus endpoints --
   constant resp_bus_entry_terminate_c : resp_bus_entry_t := (rdata => (others => '0'), ack => '0', err => '0');
 
   -- module response bus - device ID --
@@ -724,7 +726,7 @@ begin
 
   -- bus response --
   bus_response: process(resp_bus)
-    variable rdata_v : std_ulogic_vector(data_width_c-1 downto 0);
+    variable rdata_v : std_ulogic_vector(31 downto 0);
     variable ack_v   : std_ulogic;
     variable err_v   : std_ulogic;
   begin
@@ -990,7 +992,7 @@ begin
 
   -- IO Access? -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  io_acc  <= '1' when (p_bus.addr(data_width_c-1 downto index_size_f(io_size_c)) = io_base_c(data_width_c-1 downto index_size_f(io_size_c))) else '0';
+  io_acc  <= '1' when (p_bus.addr(31 downto index_size_f(io_size_c)) = io_base_c(31 downto index_size_f(io_size_c))) else '0';
   io_rden <= '1' when (io_acc = '1') and (p_bus.re = '1') and (p_bus.src = '0')    else '0'; -- PMA: read access only from data interface
   io_wren <= '1' when (io_acc = '1') and (p_bus.we = '1') and (p_bus.ben = "1111") else '0'; -- PMA: full-word write accesses only (reduces HW complexity)
 

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -99,10 +99,10 @@ end neorv32_uart;
 architecture neorv32_uart_rtl of neorv32_uart is
 
   -- interface configuration for UART0 / UART1 --
-  constant uart_id_base_c      : std_ulogic_vector(data_width_c-1 downto 0) := cond_sel_stdulogicvector_f(UART_PRIMARY, uart0_base_c,      uart1_base_c);
-  constant uart_id_size_c      : natural                                    := cond_sel_natural_f(        UART_PRIMARY, uart0_size_c,      uart1_size_c);
-  constant uart_id_ctrl_addr_c : std_ulogic_vector(data_width_c-1 downto 0) := cond_sel_stdulogicvector_f(UART_PRIMARY, uart0_ctrl_addr_c, uart1_ctrl_addr_c);
-  constant uart_id_rtx_addr_c  : std_ulogic_vector(data_width_c-1 downto 0) := cond_sel_stdulogicvector_f(UART_PRIMARY, uart0_rtx_addr_c,  uart1_rtx_addr_c);
+  constant uart_id_base_c      : std_ulogic_vector(31 downto 0) := cond_sel_stdulogicvector_f(UART_PRIMARY, uart0_base_c,      uart1_base_c);
+  constant uart_id_size_c      : natural                        := cond_sel_natural_f(        UART_PRIMARY, uart0_size_c,      uart1_size_c);
+  constant uart_id_ctrl_addr_c : std_ulogic_vector(31 downto 0) := cond_sel_stdulogicvector_f(UART_PRIMARY, uart0_ctrl_addr_c, uart1_ctrl_addr_c);
+  constant uart_id_rtx_addr_c  : std_ulogic_vector(31 downto 0) := cond_sel_stdulogicvector_f(UART_PRIMARY, uart0_rtx_addr_c,  uart1_rtx_addr_c);
 
   -- IO space: module base address --
   constant hi_abb_c : natural := index_size_f(io_size_c)-1; -- high address boundary bit


### PR DESCRIPTION
This PR removes the `data_width_c` package constant, which defines the "native data width" of the whole NEORV32 processor.

This is very a first step towards supporting the **RISC-V 64-bit ISA `rv64`**.

The SoC (so all memories and peripherals) will be 32-bit only. The CPU core itself will provide a new configuration generic `XLEN` that allows to specify the core's native data width (32-bit or 64-bit). This generic is not yet available!

This is still very early stuff and highly experimental! Full RV64 support will/might be added somewhere in the future.