### PR TITLE
🐛 [.github] disable Windows/MSYS2 workflows for now

### DIFF
--- a/.github/workflows/Processor.yml
+++ b/.github/workflows/Processor.yml
@@ -77,56 +77,56 @@ jobs:
         cmd: ./sim/run.py --ci-mode -v
 
 
-  Windows:
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include: [
-          {icon: '⬛', installs: 'MINGW32' },
-          {icon: '🟦', installs: 'MINGW64' },
-        ]
-    name: '${{ matrix.icon }} ${{ matrix.installs }} | VUnit'
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-
-    - name: '⚙️ git config'
-      run: git config --global core.autocrlf input
-      shell: bash
-
-    - name: '🧰 Checkout'
-      uses: actions/checkout@v2
-      with:
-        # The command 'git describe' (used for version) needs the history.
-        fetch-depth: 0
-
-    - name: '${{ matrix.icon }} Setup MSYS2'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: ${{ matrix.installs }}
-        update: true
-        install: make
-        pacboy: >
-          ghdl:p
-          python-pip:p
-          riscv64-unknown-elf-gcc:p
-
-    - name: '⚙️ Build and install Processor Check software'
-      run: |
-        make -C sw/example/processor_check \
-          RISCV_PREFIX=riscv64-unknown-elf- \
-          clean_all \
-          USER_FLAGS+=-DRUN_CHECK \
-          USER_FLAGS+=-DUART0_SIM_MODE \
-          USER_FLAGS+=-DSUPPRESS_OPTIONAL_UART_PRINT \
-          MARCH=rv32imc \
-          info \
-          all
-
-    - name: '🐍 Install VUnit'
-      run: pip install vunit_hdl
-
-    - name: '🚧 Run Processor Hardware Tests with VUnit'
-      run: ./sim/run.py --ci-mode -v
+# Windows:
+#   runs-on: windows-latest
+#   strategy:
+#     fail-fast: false
+#     matrix:
+#       include: [
+#         {icon: '⬛', installs: 'MINGW32' },
+#         {icon: '🟦', installs: 'MINGW64' },
+#       ]
+#   name: '${{ matrix.icon }} ${{ matrix.installs }} | VUnit'
+#   defaults:
+#     run:
+#       shell: msys2 {0}
+#   steps:
+#
+#   - name: '⚙️ git config'
+#     run: git config --global core.autocrlf input
+#     shell: bash
+#
+#   - name: '🧰 Checkout'
+#     uses: actions/checkout@v2
+#     with:
+#       # The command 'git describe' (used for version) needs the history.
+#       fetch-depth: 0
+#
+#   - name: '${{ matrix.icon }} Setup MSYS2'
+#     uses: msys2/setup-msys2@v2
+#     with:
+#       msystem: ${{ matrix.installs }}
+#       update: true
+#       install: make
+#       pacboy: >
+#         ghdl:p
+#         python-pip:p
+#         riscv64-unknown-elf-gcc:p
+#
+#   - name: '⚙️ Build and install Processor Check software'
+#     run: |
+#       make -C sw/example/processor_check \
+#         RISCV_PREFIX=riscv64-unknown-elf- \
+#         clean_all \
+#         USER_FLAGS+=-DRUN_CHECK \
+#         USER_FLAGS+=-DUART0_SIM_MODE \
+#         USER_FLAGS+=-DSUPPRESS_OPTIONAL_UART_PRINT \
+#         MARCH=rv32imc \
+#         info \
+#         all
+#
+#   - name: '🐍 Install VUnit'
+#     run: pip install vunit_hdl
+#
+#   - name: '🚧 Run Processor Hardware Tests with VUnit'
+#     run: ./sim/run.py --ci-mode -v


### PR DESCRIPTION
This PR temporarily disables the Windows-based msys2 workflows.

The latest version of the MSYS2 [mingw-w64-riscv64-unknown-elf-gcc](https://packages.msys2.org/base/mingw-w64-riscv64-unknown-elf-gcc) package does not work with the current NEORV32 setup:

```
d:/a/_temp/msys64/mingw32/bin/../lib/gcc/riscv64-unknown-elf/12.2.0/../../../../riscv64-unknown-elf/bin/ld.exe: d:/a/_temp/msys64/mingw32/bin/../lib/gcc/riscv64-unknown-elf/12.2.0/../../../../riscv64-unknown-elf/lib\libc.a(lib_a-memcpy.o): ABI is incompatible with that of the selected emulation:
  target emulation `elf64-littleriscv' does not match `elf32-littleriscv'
```

This package uses RISC-V GCC version 12.2. I am not sure if there is a problem with the compiler flags (`-misa-spec`?!) or with the package itself (compiled without rv32 support?!). However, I am analyzing this issue.