### PR TITLE
Add HW reset to CPU counter CSRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
-| 09.10.2022| 1.7.0.1 | fix Quartus synthesis issue (VHDL): make sure reset state is the _first_ entry in a state list [#423](https://github.com/stnolting/neorv32/pull/423) |
+| 12.10.2022 | 1.7.7.2 | add dedicated hardware reset to _all_ CPU counters (`[m]cycle[h]`, `[m]instret[h]`, `[m]hpmcounter[h]`); :sparkles: **all CSRs now provide a dedicated hardware reset**; [#426](https://github.com/stnolting/neorv32/pull/426) |
+| 09.10.2022 | 1.7.7.1 | fix Quartus synthesis issue (VHDL): make sure reset state is the _first_ entry in a state list [#423](https://github.com/stnolting/neorv32/pull/423) |
 | 24.08.2022 | [**:rocket:1.7.7**](https://github.com/stnolting/neorv32/releases/tag/v1.7.7) | **New release** |
 | 23.09.2022 | 1.7.6.10 | cleanup native data path size (remove `data_width_c` package constant); initial preparations to **support RV64 ISA extension** somewhere in the future; [#417](https://github.com/stnolting/neorv32/pull/417) |
 | 18.09.2022 | 1.7.6.9 | :bug: fixed instruction decoding collision in **`B` ISA extensions** - `B` extension is now fully operational and verified (see [neorv32-riscof](https://github.com/stnolting/neorv32-riscof))! [#413](https://github.com/stnolting/neorv32/pull/413) |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -7,12 +7,6 @@ the CSR access instructions. The *[ASM]* name can be used for (inline) assembly 
 understood by the assembler/compiler. The *[C]* names are defined by the NEORV32 core library and can be
 used as immediate in plain C code. The *R/W* column shows whether the CSR can be read and/or written.
 
-.CSR Reset Value
-[IMPORTANT]
-Please note that some CSRs do *not* provide a dedicated reset. Hence, these CSRs are not initialized by a
-hardware reset and provide an **UNDEFINED** state after reset. In general, all CSRs should be explicitly initialized
-by software before being used.
-
 .Not Implemented CSRs / Bits
 [NOTE]
 All CSR bits that are unused / not implemented / not shown are _hardwired to zero_. All CSRs that are not
@@ -90,8 +84,8 @@ information about those CSRs.
 |=======================
 
 [NOTE]
-The following CSR sections provide a "headline" for each CSRs. It shows the 12-bit CSR address, the assembly name of the CSR,
-a short description and, ISA extension(s) that are required for implementing the according CSR and the reset value.
+The following CSR sections provide a "headline" for each CSRs. It shows the 12-bit CSR address, the register's ISA/assembly name,
+a short description, the reset value and all ISA extension(s) that are required for implementing the according CSR.
 
 
 <<<
@@ -229,7 +223,7 @@ The features of this CSR are not implemented yet. The register is read-only and 
 [frame="topbot",grid="none"]
 |=======================
 | 0x301 | `misa` - **ISA and extensions** | `Zicsr`
-3+<| Reset value: `define`
+3+<| Reset value: `DEFINED`
 |=======================
 
 [NOTE]
@@ -348,7 +342,7 @@ The features of this CSR are not implemented yet. The register is read-only and 
 [frame="topbot",grid="none"]
 |=======================
 | 0x340 | `mscratch` - **Scratch register for machine trap handlers** | `Zicsr`
-3+<| Reset value: `UNDEFINED`
+3+<| Reset value: `DEFINED`
 |=======================
 
 
@@ -525,11 +519,6 @@ The two MSBs of each `pmpaddr` are hardwired to zero (= bits 33:32 of the physic
 :sectnums:
 ==== (Machine) Counter and Timer CSRs
 
-.Counter Reset
-[IMPORTANT]
-The counter CSRs do **not** provide a hardware reset. Hence, the CSRs have to be explicitly initialized by software
-before being used.
-
 .Counter Size
 [NOTE]
 When implemented (by enabling the `Zicntr` ISA extension) the standard CPU counters are always 64-bit wide (low-word + high-word).
@@ -543,7 +532,7 @@ When implemented (by enabling the `Zicntr` ISA extension) the standard CPU count
 |=======================
 | 0xc00 | `cycle` - **Cycle counter - low word** | `Zicsr` + `Zicntr`
 | 0xc80 | `cycleh` - **Cycle counter - high word** | `Zicsr` + `Zicntr`
-3+<| Reset value: all `UNDEFINED`
+3+<| Reset value: all `0x00000000`
 |=======================
 
 
@@ -567,7 +556,7 @@ When implemented (by enabling the `Zicntr` ISA extension) the standard CPU count
 |=======================
 | 0xc02 | `instret` - **Instructions-retired counter - low word** | `Zicsr` + `Zicntr`
 | 0xc82 | `instreth` - **Instructions-retired counter - high word** | `Zicsr` + `Zicntr`
-3+<| Reset value: all `UNDEFINED`
+3+<| Reset value: all `0x00000000`
 |=======================
 
 
@@ -579,7 +568,7 @@ When implemented (by enabling the `Zicntr` ISA extension) the standard CPU count
 |=======================
 | 0xb00 | `mcycle` - **Machine cycle counter - low word** | `Zicsr` + `Zicntr`
 | 0xb80 | `mcycleh` - **Machine cycle counter - high word** | `Zicsr` + `Zicntr`
-3+<| Reset value: all `UNDEFINED`
+3+<| Reset value: all `0x00000000`
 |=======================
 
 
@@ -591,7 +580,7 @@ When implemented (by enabling the `Zicntr` ISA extension) the standard CPU count
 |=======================
 | 0xb02 | `minstret` - **Machine instructions-retired counter - low word** | `Zicsr` + `Zicntr`
 | 0xb82 | `minstreth` - **Machine instructions-retired counter - high word** | `Zicsr` + `Zicntr`
-3+<| Reset value: all `UNDEFINED`
+3+<| Reset value: all `0x00000000`
 |=======================
 
 
@@ -670,7 +659,7 @@ cycle even if more than one trigger event is observed.
 | 0xb83 | `mhpmcounter3h` - **Machine hardware performance monitor - counter 3 high** | `Zicsr` + `Zihpm`
 3+<| ...
 | 0xb9f | `mhpmcounter31h` - **Machine hardware performance monitor - counter 31 high** | `Zicsr` + `Zihpm`
-3+<| Reset value: all `UNDEFINED`
+3+<| Reset value: all `0x00000000`
 |=======================
 
 
@@ -741,7 +730,7 @@ The `marchid` CSR is read-only and shows the NEORV32 official RISC-V open-source
 [frame="topbot",grid="none"]
 |=======================
 | 0xf13 | `mimpid` - **Machine implementation ID** | `Zicsr`
-3+<| Reset value: `define`
+3+<| Reset value: `DEFINED`
 |=======================
 
 The `mimpid` CSR is read-only and shows the version of the
@@ -755,7 +744,7 @@ NEORV32 as BCD-coded number (example: `mimpid` = _0x01020312_ â†’ 01.02.03.12 â†
 [frame="topbot",grid="none"]
 |=======================
 | 0xf14 | `mhartid` - **Machine hardware thread ID** | `Zicsr`
-3+<| Reset value: `define`
+3+<| Reset value: `DEFINED`
 |=======================
 
 The `mhartid` CSR is read-only and shows the core's hart ID, which is assigned via the <<_hw_thread_id>> top generic.
@@ -791,7 +780,7 @@ outside of machine-mode will raise an illegal instruction exception.
 [frame="topbot",grid="none"]
 |=======================
 | 0x7c0 | `mxisa` - **Machine EXTENDED ISA and Extensions register** | `Zicsr` + `X`
-3+<| Reset value: `define`
+3+<| Reset value: `DEFINED`
 |=======================
 
 NEORV32-specific read-only CSR that helps machine-mode software to discover `Z*` sub-extensions and CPU options.

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -58,7 +58,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070701"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070702"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/common/crt0.S
+++ b/sw/common/crt0.S
@@ -67,7 +67,7 @@ __crt0_pointer_init:
 
 
 // ************************************************************************************************
-// Setup CPU core CSRs (some of them DO NOT have a dedicated reset and need to be explicitly initialized)
+// Setup CPU core CSRs
 // ************************************************************************************************
 __crt0_cpu_csr_init:
   la   x10,   __crt0_trap_handler // configure early-boot trap handler


### PR DESCRIPTION
This PR add a dedicated hardware reset to the CPU's `[m]cycle[h]`, `[m]instret[h]` and `[m]hpmcounter[h]` CSRs.

With this PR **all** CSRs now do provide a dedicated hardware reset.