### PR TITLE
[rtl] Try to fix Quartus latch warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 24.10.2022 | 1.7.7.5 | :test_tube: remove weird Quartus latch warnings by modifying VHDL coding style; [#434](https://github.com/stnolting/neorv32/pull/434) |
 | 19.10.2022 | 1.7.7.4 | optimize UART's `RTS` (hardware flow control) behavior; [#433](https://github.com/stnolting/neorv32/pull/433) |
 | 15.10.2022 | 1.7.7.3 | :bug: fix bug in `is_power_of_two_f` VHDL function (thanks Alan!); [#482](https://github.com/stnolting/neorv32/pull/428) |
 | 12.10.2022 | 1.7.7.2 | add dedicated hardware reset to _all_ CPU counters (`[m]cycle[h]`, `[m]instret[h]`, `[m]hpmcounter[h]`); :sparkles: **all CSRs now provide a dedicated hardware reset**; [#426](https://github.com/stnolting/neorv32/pull/426) |

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1501,6 +1501,11 @@ begin
           trap_ctrl.exc_buf(exc_db_hw_c)    <= (trap_ctrl.exc_buf(exc_db_hw_c)    or debug_ctrl.trig_hw)    and (not trap_ctrl.env_start_ack);
           trap_ctrl.irq_buf(irq_db_halt_c)  <= debug_ctrl.trig_halt;
           trap_ctrl.irq_buf(irq_db_step_c)  <= debug_ctrl.trig_step;
+        else
+          trap_ctrl.exc_buf(exc_db_break_c) <= '0';
+          trap_ctrl.exc_buf(exc_db_hw_c)    <= '0';
+          trap_ctrl.irq_buf(irq_db_halt_c)  <= '0';
+          trap_ctrl.irq_buf(irq_db_step_c)  <= '0';
         end if;
 
         -- interrupt buffer: machine software/external/timer interrupt --
@@ -1684,9 +1689,10 @@ begin
       csr.mip_firq_nclr <= (others => '1'); -- active low
 
       if (CPU_EXTENSION_RISCV_Zicsr = true) then
-        -- --------------------------------------------------------------------------------
-        -- CSR access by application software
-        -- --------------------------------------------------------------------------------
+
+        -- ********************************************************************************
+        -- Manual CSR access by application software
+        -- ********************************************************************************
         if (csr.we = '1') then -- manual write access and not illegal instruction
 
           -- user floating-point CSRs --
@@ -1860,9 +1866,9 @@ begin
           end if;
 
 
-        -- --------------------------------------------------------------------------------
-        -- CSR access by hardware
-        -- --------------------------------------------------------------------------------
+        -- ********************************************************************************
+        -- Automatic CSR access by hardware
+        -- ********************************************************************************
         else
 
           -- --------------------------------------------------------------------
@@ -1960,7 +1966,8 @@ begin
           end if;
 
         end if; -- /hardware csr access
-      end if;
+      end if; -- /Zicsr implemented
+
     end if;
   end process csr_write_access;
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -58,7 +58,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070704"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070705"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------


### PR DESCRIPTION
Quartus 21.1 shows the following message:

> Warning (10631): VHDL Process Statement warning at neorv32_cpu_control.vhd(1635): inferring latch(es) for signal or variable "csr", which holds its previous value in one or more paths through the process

But there are no latches in the code! The CSR read and write processes are entirely synchronous. Furthermore, the synthesis report does not show any latches (Compilation Report -> Analysis & Synthesis -> Optimization Results -> Register Statistics).

This PR tries to fix this issue by reformatting certain parts of the VHDL code.

See discussion #421 for more information.