### PR TITLE
[sw] rework intrinsic libraries

### DIFF
--- a/sw/example/bitmanip_test/README.md
+++ b/sw/example/bitmanip_test/README.md
@@ -1,13 +1,136 @@
 # NEORV32 Bit-Manipulation `B` Extension
 
-:warning: The RISC-V bit-manipulation extension is frozen but not yet officially ratified.
+The provided test program `main.c` verifies all currently implemented instruction by checking the
+results against a pure-software emulation model. The emulation functions as well as the available
+**intrinsics** for the sub-extension are located in `neorv32_b_extension_intrinsics.h`.
 
-:warning: The NEORV32 bit manipulation extensions `B` only supports the `Zbb` and `Zba` sub-extension
-(basic bit-manipulation operation) yet.
+:information_source: See the according section of the NEORV32 data sheet for more information.
 
-The provided test program `main.c` verifies all currently implemented instruction by checking the results against a pure-software emulation model.
-The emulation functions as well as the available **intrinsics** for the sub-extension are located in `neorv32_b_extension_intrinsics.h`.
 
-:information_source: More information regarding the RISC-V bit manipulation extension can be found in the officail GitHub repo:
-[github.com/riscv/riscv-bitmanip](https://github.com/riscv/riscv-bitmanip).
-The specification of the bit-manipulation spec supported by the NEORV32 can be found in `docs/references/bitmanip-draft.pdf`.
+## Exemplary Test Output
+
+```
+<<< NEORV32 Bit-Manipulation Extension ('B') Test >>>
+
+Starting bit-manipulation extension tests (1000000 test cases per instruction)...
+
+--------------------------------------------
+Zbb - Basic bit-manipulation instructions
+--------------------------------------------
+
+ANDN:
+Errors: 0/1000000 [ok]
+
+ORN:
+Errors: 0/1000000 [ok]
+
+XNOR:
+Errors: 0/1000000 [ok]
+
+CLZ:
+Errors: 0/1000000 [ok]
+
+CTZ:
+Errors: 0/1000000 [ok]
+
+CPOP:
+Errors: 0/1000000 [ok]
+
+MAX:
+Errors: 0/1000000 [ok]
+
+MAXU:
+Errors: 0/1000000 [ok]
+
+MIN:
+Errors: 0/1000000 [ok]
+
+MINU:
+Errors: 0/1000000 [ok]
+
+SEXT.B:
+Errors: 0/1000000 [ok]
+
+SEXT.H:
+Errors: 0/1000000 [ok]
+
+ZEXT.H:
+Errors: 0/1000000 [ok]
+
+ROL:
+Errors: 0/1000000 [ok]
+
+ROR:
+Errors: 0/1000000 [ok]
+
+RORI (imm=20):
+Errors: 0/1000000 [ok]
+
+ORCB:
+Errors: 0/1000000 [ok]
+
+REV8:
+Errors: 0/1000000 [ok]
+
+
+--------------------------------------------
+Zba - Address-generation instructions
+--------------------------------------------
+
+SH1ADD:
+Errors: 0/1000000 [ok]
+
+SH2ADD:
+Errors: 0/1000000 [ok]
+
+SH3ADD:
+Errors: 0/1000000 [ok]
+
+
+--------------------------------------------
+Zbs - Single-bit instructions
+--------------------------------------------
+
+BCLR:
+Errors: 0/1000000 [ok]
+
+BCLRI (imm=20):
+Errors: 0/1000000 [ok]
+
+BEXT:
+Errors: 0/1000000 [ok]
+
+BEXTI (imm=20):
+Errors: 0/1000000 [ok]
+
+BINV:
+Errors: 0/1000000 [ok]
+
+BINVI (imm=20):
+Errors: 0/1000000 [ok]
+
+BSET:
+Errors: 0/1000000 [ok]
+
+BSETI (imm=20):
+Errors: 0/1000000 [ok]
+
+
+--------------------------------------------
+Zbc - Carry-less multiplication instructions
+--------------------------------------------
+
+NOTE: The emulation functions will take quite some time to execute.
+
+CLMUL:
+Errors: 0/1000000 [ok]
+
+CLMULH:
+Errors: 0/1000000 [ok]
+
+CLMULR:
+Errors: 0/1000000 [ok]
+
+
+B extension tests completed.
+```

--- a/sw/example/bitmanip_test/neorv32_b_extension_intrinsics.h
+++ b/sw/example/bitmanip_test/neorv32_b_extension_intrinsics.h
@@ -66,7 +66,7 @@
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clz(uint32_t rs1) {
 
-  return CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00000, rs1, 0b001, 0b0010011);
+  return CUSTOM_INSTR_R2_TYPE(0b0110000, 0b00000, rs1, 0b001, 0b0010011);
 }
 
 
@@ -78,7 +78,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clz(uint32_t rs1
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_ctz(uint32_t rs1) {
 
-  return CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00001, rs1, 0b001, 0b0010011);
+  return CUSTOM_INSTR_R2_TYPE(0b0110000, 0b00001, rs1, 0b001, 0b0010011);
 }
 
 
@@ -90,7 +90,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_ctz(uint32_t rs1
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_cpop(uint32_t rs1) {
 
-  return CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00010, rs1, 0b001, 0b0010011);
+  return CUSTOM_INSTR_R2_TYPE(0b0110000, 0b00010, rs1, 0b001, 0b0010011);
 }
 
 
@@ -102,7 +102,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_cpop(uint32_t rs
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sextb(uint32_t rs1) {
 
-  return CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00100, rs1, 0b001, 0b0010011);
+  return CUSTOM_INSTR_R2_TYPE(0b0110000, 0b00100, rs1, 0b001, 0b0010011);
 }
 
 
@@ -114,7 +114,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sextb(uint32_t r
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sexth(uint32_t rs1) {
 
-  return CUSTOM_INSTR_R1_TYPE(0b0110000, 0b00101, rs1, 0b001, 0b0010011);
+  return CUSTOM_INSTR_R2_TYPE(0b0110000, 0b00101, rs1, 0b001, 0b0010011);
 }
 
 
@@ -126,7 +126,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sexth(uint32_t r
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_zexth(uint32_t rs1) {
 
-  return CUSTOM_INSTR_R1_TYPE(0b0000100, 0b00000, rs1, 0b100, 0b0110011);
+  return CUSTOM_INSTR_R2_TYPE(0b0000100, 0b00000, rs1, 0b100, 0b0110011);
 }
 
 
@@ -139,7 +139,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_zexth(uint32_t r
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_min(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs2, rs1, 0b100, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0000101, rs2, rs1, 0b100, 0b0110011);
 }
 
 
@@ -152,7 +152,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_min(uint32_t rs1
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_minu(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs2, rs1, 0b101, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0000101, rs2, rs1, 0b101, 0b0110011);
 }
 
 
@@ -165,7 +165,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_minu(uint32_t rs
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_max(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs2, rs1, 0b110, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0000101, rs2, rs1, 0b110, 0b0110011);
 }
 
 
@@ -178,7 +178,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_max(uint32_t rs1
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_maxu(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs2, rs1, 0b111, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0000101, rs2, rs1, 0b111, 0b0110011);
 }
 
 
@@ -191,7 +191,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_maxu(uint32_t rs
  **************************************************************************/
 inline inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_andn(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0100000, rs2, rs1, 0b111, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0100000, rs2, rs1, 0b111, 0b0110011);
 }
 
 
@@ -204,7 +204,7 @@ inline inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_andn(uint
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_orn(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0100000, rs2, rs1, 0b110, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0100000, rs2, rs1, 0b110, 0b0110011);
 }
 
 
@@ -217,7 +217,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_orn(uint32_t rs1
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_xnor(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0100000, rs2, rs1, 0b100, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0100000, rs2, rs1, 0b100, 0b0110011);
 }
 
 
@@ -230,7 +230,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_xnor(uint32_t rs
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_rol(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0110000, rs2, rs1, 0b001, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0110000, rs2, rs1, 0b001, 0b0110011);
 }
 
 
@@ -243,7 +243,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_rol(uint32_t rs1
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_ror(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0110000, rs2, rs1, 0b101, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0110000, rs2, rs1, 0b101, 0b0110011);
 }
 
 
@@ -256,7 +256,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_ror(uint32_t rs1
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_rori20(uint32_t rs1) {
 
-  return CUSTOM_INSTR_R1_TYPE(0b0110000, 0b10100, rs1, 0b101, 0b0010011);
+  return CUSTOM_INSTR_R2_TYPE(0b0110000, 0b10100, rs1, 0b101, 0b0010011);
 }
 
 
@@ -268,7 +268,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_rori20(uint32_t 
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_orcb(uint32_t rs1) {
 
-  return CUSTOM_INSTR_R1_TYPE(0b0010100, 0b00111, rs1, 0b101, 0b0010011);
+  return CUSTOM_INSTR_R2_TYPE(0b0010100, 0b00111, rs1, 0b101, 0b0010011);
 }
 
 
@@ -280,7 +280,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_orcb(uint32_t rs
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_rev8(uint32_t rs1) {
 
-  return CUSTOM_INSTR_R1_TYPE(0b0110100, 0b11000, rs1, 0b101, 0b0010011);
+  return CUSTOM_INSTR_R2_TYPE(0b0110100, 0b11000, rs1, 0b101, 0b0010011);
 }
 
 
@@ -297,7 +297,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_rev8(uint32_t rs
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sh1add(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0010000, rs2, rs1, 0b010, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0010000, rs2, rs1, 0b010, 0b0110011);
 }
 
 
@@ -310,7 +310,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sh1add(uint32_t 
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sh2add(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0010000, rs2, rs1, 0b100, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0010000, rs2, rs1, 0b100, 0b0110011);
 }
 
 /**********************************************************************//**
@@ -322,7 +322,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sh2add(uint32_t 
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sh3add(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0010000, rs2, rs1, 0b110, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0010000, rs2, rs1, 0b110, 0b0110011);
 }
 
 
@@ -340,7 +340,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_sh3add(uint32_t 
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bclr(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0100100, rs2, rs1, 0b001, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0100100, rs2, rs1, 0b001, 0b0110011);
 }
 
 
@@ -353,7 +353,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bclr(uint32_t rs
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bclri20(uint32_t rs1) {
 
-  return CUSTOM_INSTR_R1_TYPE(0b0100100, 0b10100, rs1, 0b001, 0b0010011);
+  return CUSTOM_INSTR_R2_TYPE(0b0100100, 0b10100, rs1, 0b001, 0b0010011);
 }
 
 
@@ -366,7 +366,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bclri20(uint32_t
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bext(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0100100, rs2, rs1, 0b101, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0100100, rs2, rs1, 0b101, 0b0110011);
 }
 
 
@@ -379,7 +379,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bext(uint32_t rs
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bexti20(uint32_t rs1) {
 
-  return CUSTOM_INSTR_R1_TYPE(0b0100100, 0b10100, rs1, 0b101, 0b0010011);
+  return CUSTOM_INSTR_R2_TYPE(0b0100100, 0b10100, rs1, 0b101, 0b0010011);
 }
 
 
@@ -392,7 +392,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bexti20(uint32_t
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_binv(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0110100, rs2, rs1, 0b001, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0110100, rs2, rs1, 0b001, 0b0110011);
 }
 
 
@@ -405,7 +405,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_binv(uint32_t rs
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_binvi20(uint32_t rs1) {
 
-  return CUSTOM_INSTR_R1_TYPE(0b0110100, 0b10100, rs1, 0b001, 0b0010011);
+  return CUSTOM_INSTR_R2_TYPE(0b0110100, 0b10100, rs1, 0b001, 0b0010011);
 }
 
 
@@ -418,7 +418,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_binvi20(uint32_t
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bset(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0010100, rs2, rs1, 0b001, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0010100, rs2, rs1, 0b001, 0b0110011);
 }
 
 
@@ -431,7 +431,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bset(uint32_t rs
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bseti20(uint32_t rs1) {
 
-  return CUSTOM_INSTR_R1_TYPE(0b0010100, 0b10100, rs1, 0b001, 0b0010011);
+  return CUSTOM_INSTR_R2_TYPE(0b0010100, 0b10100, rs1, 0b001, 0b0010011);
 }
 
 
@@ -449,7 +449,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_bseti20(uint32_t
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clmul(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs2, rs1, 0b001, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0000101, rs2, rs1, 0b001, 0b0110011);
 }
 
 
@@ -462,7 +462,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clmul(uint32_t r
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clmulh(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs2, rs1, 0b011, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0000101, rs2, rs1, 0b011, 0b0110011);
 }
 
 
@@ -475,7 +475,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clmulh(uint32_t 
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_clmulr(uint32_t rs1, uint32_t rs2) {
 
-  return CUSTOM_INSTR_R2_TYPE(0b0000101, rs1, rs2, 0b010, 0b0110011);
+  return CUSTOM_INSTR_R3_TYPE(0b0000101, rs1, rs2, 0b010, 0b0110011);
 }
 
 

--- a/sw/example/floating_point_test/README.md
+++ b/sw/example/floating_point_test/README.md
@@ -1,30 +1,24 @@
 # NEORV32 `Zfinx` Floating-Point Extension
 
-The NEORV32 floating-point unit (FPU) implements the `Zfinx` RISC-V extension. The extensions can be enabled via the `CPU_EXTENSION_RISCV_Zfinx` top configuration generic.
+The NEORV32 floating-point unit (FPU) implements the `Zfinx` RISC-V extension. The extension can be
+enabled via the `CPU_EXTENSION_RISCV_Zfinx` top configuration generic.
 
-The RISC-V `Zfinx` single-precision floating-point extensions uses the integer register file `x` instead of the dedicated floating-point `f` register file (which is
-defined by the RISC-V `F` single-precision floating-point extension). Hence, the standard data transfer instructions from the `F` extension are **not** available in `Zfinx`:
+The RISC-V `Zfinx` single-precision floating-point extensions uses the integer register file `x` instead
+of a dedicated floating-point `f` register file (which is defined by the RISC-V `F` single-precision
+floating-point extension). Hence, the standard data transfer instructions from the `F` extension are
+**not** available in `Zfinx`:
 
 * floating-point load/store operations (`FLW`, `FSW`) and their compressed versions
 * integer register file `x` <-> floating point register file `f` move operations (`FMV.W.X`, `FMV.X.W`)
 
-:information_source: More information regarding the RISC-V `Zfinx` single-precision floating-point extension can be found in the official GitHub repo:
-[`github.com/riscv/riscv-zfinx`](https://github.com/riscv/riscv-zfinx).
-
-:warning: The RISC-V `Zfinx` extension is not officially ratified yet, but it is assumed to remain unchanged. Hence, it is not supported by the upstream RISC-V GCC port.
-Make sure you **do not** use the `f` ISA attribute when compiling applications that use floating-point arithmetic (`MARCH=rv32i*f*` is **NOT ALLOWED!**).
-
-
-### :warning: FPU Limitations
-
-* The FPU **does not support subnormal numbers** yet. Subnormal FPU inputs and subnormal FPU results are always *flushed to zero*. The *classify* instruction `FCLASS` will never set the "subnormal" mask bits.
-* Rounding mode `ob100` "round to nearest, ties to max magnitude" is not supported yet (this and all invalid rounding mode configurations behave as "round towards zero" (truncation)).
+:information_source: See the according section of the NEORV32 data sheet for more information.
 
 
 ## Intrinsic Library
 
-The NEORV32 `Zfinx` floating-point extension can still be used using the provided **intrinsic library**. This library uses "custom" inline assmbly instructions
-wrapped within normal C-language functions. Each original instruction of the extension can be utilized using an according intrinsic function.
+The NEORV32 `Zfinx` floating-point extension can still be used using the provided **intrinsic library**. This
+library uses "custom" inline assembly instructions wrapped within normal C-language functions. Each original
+instruction of the extension can be utilized using an according intrinsic function.
 
 For example, the floating-point addition instruction `FADD.S` can be invoked using the according intrinsic function:
 
@@ -32,21 +26,98 @@ For example, the floating-point addition instruction `FADD.S` can be invoked usi
 float riscv_intrinsic_fadds(float rs1, float rs2)
 ```
 
-The pure-software emulation instruction, which uses the standard built-in functions to execute all floating-point operations, is available via wrapper function. The
-emulation function for the `FADD.S` instruction is:
+The pure-software emulation instruction, which uses the standard built-in functions to execute all
+floating-point operations, is available via wrapper function. The emulation function for the `FADD.S` instruction is:
 
 ```c
 float riscv_emulate_fadds(float rs1, float rs2)
 ```
 
-The emulation functions as well as the available intrinsics for the `Zfinx` extension are located in `neorv32_zfinx_extension_intrinsics.h`.
+The emulation functions as well as the available intrinsics for the `Zfinx` extension are located in
+`neorv32_zfinx_extension_intrinsics.h`. The provided test program `main.c` verifies all currently implemented
+`Zfinx` instructions by checking the functionality against the pure software-based emulation model (GCC soft-float library).
 
-The provided test program `main.c` verifies all currently implemented `Zfinx` instructions by checking the functionality against the pure software-based emulation model
-(GCC soft-float library).
+
+## Exemplary Test Output
+
+```
+<<< Zfinx extension test >>>
+SILENT_MODE enabled (only showing actual errors)
+Test cases per instruction: 1000000
+NOTE: The NEORV32 FPU does not support subnormal numbers yet. Subnormal numbers are flushed to zero.
 
 
-## Resources
+#0: FCVT.S.WU (unsigned integer to float)...
+Errors: 0/1000000 [ok]
 
-* Great page with online calculators for floating-point arithmetic: [http://www.ecs.umass.edu/ece/koren/arith/simulator/](http://www.ecs.umass.edu/ece/koren/arith/simulator/)
-* A handy tool for visualizing floating-point numbers in their binary representation: [https://www.h-schmidt.net/FloatConverter/IEEE754.html](https://www.h-schmidt.net/FloatConverter/IEEE754.html)
-* This helped me to understand what results the different FPU operation generate when having "special" inputs like NaN: [https://techdocs.altium.com/display/FPGA/IEEE+754+Standard+-+Overview](https://techdocs.altium.com/display/FPGA/IEEE+754+Standard+-+Overview)
+#1: FCVT.S.W (signed integer to float)...
+Errors: 0/1000000 [ok]
+
+#2: FCVT.WU.S (float to unsigned integer)...
+Errors: 0/1000000 [ok]
+
+#3: FCVT.W.S (float to signed integer)...
+Errors: 0/1000000 [ok]
+
+#4: FADD.S (addition)...
+Errors: 0/1000000 [ok]
+
+#5: FSUB.S (subtraction)...
+Errors: 0/1000000 [ok]
+
+#6: FMUL.S (multiplication)...
+Errors: 0/1000000 [ok]
+
+#7: FMIN.S (select minimum)...
+Errors: 0/1000000 [ok]
+
+#8: FMAX.S (select maximum)...
+Errors: 0/1000000 [ok]
+
+#9: FEQ.S (compare if equal)...
+Errors: 0/1000000 [ok]
+
+#10: FLT.S (compare if less-than)...
+Errors: 0/1000000 [ok]
+
+#11: FLE.S (compare if less-than-or-equal)...
+Errors: 0/1000000 [ok]
+
+#12: FSGNJ.S (sign-injection)...
+Errors: 0/1000000 [ok]
+
+#13: FSGNJN.S (sign-injection NOT)...
+Errors: 0/1000000 [ok]
+
+#14: FSGNJX.S (sign-injection XOR)...
+Errors: 0/1000000 [ok]
+
+#15: FCLASS.S (classify)...
+Errors: 0/1000000 [ok]
+
+# unsupported FDIV.S (division) [illegal instruction]...
+<RTE> Illegal instruction @ PC=0x000006A8, INST=0x18A484D3 </RTE>
+[ok]
+
+# unsupported FSQRT.S (square root) [illegal instruction]...
+<RTE> Illegal instruction @ PC=0x000006E0, INST=0x580484D3 </RTE>
+[ok]
+
+# unsupported FMADD.S (fused multiply-add) [illegal instruction]...
+<RTE> Illegal instruction @ PC=0x0000071E, INST=0x1EA484C3 </RTE>
+[ok]
+
+# unsupported FMSUB.S (fused multiply-sub) [illegal instruction]...
+<RTE> Illegal instruction @ PC=0x0000075C, INST=0x1EA484C7 </RTE>
+[ok]
+
+# unsupported FNMSUB.S (fused negated multiply-sub) [illegal instruction]...
+<RTE> Illegal instruction @ PC=0x0000079A, INST=0x1EA484CF </RTE>
+[ok]
+
+# unsupported FNMADD.S (fused negated multiply-add) [illegal instruction]...
+<RTE> Illegal instruction @ PC=0x000007D8, INST=0x1EA484CF </RTE>
+[ok]
+
+[Zfinx extension verification successful!]
+```

--- a/sw/example/floating_point_test/neorv32_zfinx_extension_intrinsics.h
+++ b/sw/example/floating_point_test/neorv32_zfinx_extension_intrinsics.h
@@ -178,7 +178,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fadds(float rs1, fl
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0000000, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
+  res.binary_value = CUSTOM_INSTR_R3_TYPE(0b0000000, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -196,7 +196,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsubs(float rs1, fl
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0000100, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
+  res.binary_value = CUSTOM_INSTR_R3_TYPE(0b0000100, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -214,7 +214,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmuls(float rs1, fl
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0001000, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
+  res.binary_value = CUSTOM_INSTR_R3_TYPE(0b0001000, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -232,7 +232,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmins(float rs1, fl
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0010100, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
+  res.binary_value = CUSTOM_INSTR_R3_TYPE(0b0010100, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -250,7 +250,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmaxs(float rs1, fl
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0010100, opb.binary_value, opa.binary_value, 0b001, 0b1010011);
+  res.binary_value = CUSTOM_INSTR_R3_TYPE(0b0010100, opb.binary_value, opa.binary_value, 0b001, 0b1010011);
   return res.float_value;
 }
 
@@ -266,7 +266,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_fcvt_wus(float r
   float_conv_t opa;
   opa.float_value = rs1;
 
-  return CUSTOM_INSTR_R1_TYPE(0b1100000, 0b00001, opa.binary_value, 0b000, 0b1010011);
+  return CUSTOM_INSTR_R2_TYPE(0b1100000, 0b00001, opa.binary_value, 0b000, 0b1010011);
 }
 
 
@@ -281,7 +281,7 @@ inline int32_t __attribute__ ((always_inline)) riscv_intrinsic_fcvt_ws(float rs1
   float_conv_t opa;
   opa.float_value = rs1;
 
-  return (int32_t)CUSTOM_INSTR_R1_TYPE(0b1100000, 0b00000, opa.binary_value, 0b000, 0b1010011);
+  return (int32_t)CUSTOM_INSTR_R2_TYPE(0b1100000, 0b00000, opa.binary_value, 0b000, 0b1010011);
 }
 
 
@@ -295,7 +295,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fcvt_swu(uint32_t r
 
   float_conv_t res;
 
-  res.binary_value = CUSTOM_INSTR_R1_TYPE(0b1101000, 0b00001, rs1, 0b000, 0b1010011);
+  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b1101000, 0b00001, rs1, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -310,7 +310,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fcvt_sw(int32_t rs1
 
   float_conv_t res;
 
-  res.binary_value = CUSTOM_INSTR_R1_TYPE(0b1101000, 0b00000, rs1, 0b000, 0b1010011);
+  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b1101000, 0b00000, rs1, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -328,7 +328,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_feqs(float rs1, 
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  return CUSTOM_INSTR_R2_TYPE(0b1010000, opb.binary_value, opa.binary_value, 0b010, 0b1010011);
+  return CUSTOM_INSTR_R3_TYPE(0b1010000, opb.binary_value, opa.binary_value, 0b010, 0b1010011);
 }
 
 
@@ -345,7 +345,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_flts(float rs1, 
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  return CUSTOM_INSTR_R2_TYPE(0b1010000, opb.binary_value, opa.binary_value, 0b001, 0b1010011);
+  return CUSTOM_INSTR_R3_TYPE(0b1010000, opb.binary_value, opa.binary_value, 0b001, 0b1010011);
 }
 
 
@@ -362,7 +362,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_fles(float rs1, 
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  return CUSTOM_INSTR_R2_TYPE(0b1010000, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
+  return CUSTOM_INSTR_R3_TYPE(0b1010000, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
 }
 
 
@@ -379,7 +379,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsgnjs(float rs1, f
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0010000, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
+  res.binary_value = CUSTOM_INSTR_R3_TYPE(0b0010000, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -397,7 +397,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsgnjns(float rs1, 
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0010000, opb.binary_value, opa.binary_value, 0b001, 0b1010011);
+  res.binary_value = CUSTOM_INSTR_R3_TYPE(0b0010000, opb.binary_value, opa.binary_value, 0b001, 0b1010011);
   return res.float_value;
 }
 
@@ -415,7 +415,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsgnjxs(float rs1, 
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0010000, opb.binary_value, opa.binary_value, 0b010, 0b1010011);
+  res.binary_value = CUSTOM_INSTR_R3_TYPE(0b0010000, opb.binary_value, opa.binary_value, 0b010, 0b1010011);
   return res.float_value;
 }
 
@@ -431,7 +431,7 @@ inline uint32_t __attribute__ ((always_inline)) riscv_intrinsic_fclasss(float rs
   float_conv_t opa;
   opa.float_value = rs1;
 
-  return CUSTOM_INSTR_R1_TYPE(0b1110000, 0b00000, opa.binary_value, 0b001, 0b1010011);
+  return CUSTOM_INSTR_R2_TYPE(0b1110000, 0b00000, opa.binary_value, 0b001, 0b1010011);
 }
 
 
@@ -454,7 +454,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fdivs(float rs1, fl
   opa.float_value = rs1;
   opb.float_value = rs2;
 
-  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0001100, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
+  res.binary_value = CUSTOM_INSTR_R3_TYPE(0b0001100, opb.binary_value, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -472,7 +472,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fsqrts(float rs1) {
   float_conv_t opa, res;
   opa.float_value = rs1;
 
-  res.binary_value = CUSTOM_INSTR_R1_TYPE(0b0101100, 0b00000, opa.binary_value, 0b000, 0b1010011);
+  res.binary_value = CUSTOM_INSTR_R2_TYPE(0b0101100, 0b00000, opa.binary_value, 0b000, 0b1010011);
   return res.float_value;
 }
 
@@ -494,7 +494,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmadds(float rs1, f
   opb.float_value = rs2;
   opc.float_value = rs3;
 
-  res.binary_value = CUSTOM_INSTR_R3_TYPE(opc.binary_value, opb.binary_value, opa.binary_value, 0b000, 0b1000011);
+  res.binary_value = CUSTOM_INSTR_R4_TYPE(opc.binary_value, opb.binary_value, opa.binary_value, 0b000, 0b1000011);
   return res.float_value;
 }
 
@@ -516,7 +516,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fmsubs(float rs1, f
   opb.float_value = rs2;
   opc.float_value = rs3;
 
-  res.binary_value = CUSTOM_INSTR_R3_TYPE(opc.binary_value, opb.binary_value, opa.binary_value, 0b000, 0b1000111);
+  res.binary_value = CUSTOM_INSTR_R4_TYPE(opc.binary_value, opb.binary_value, opa.binary_value, 0b000, 0b1000111);
   return res.float_value;
 }
 
@@ -538,7 +538,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fnmsubs(float rs1, 
   opb.float_value = rs2;
   opc.float_value = rs3;
 
-  res.binary_value = CUSTOM_INSTR_R3_TYPE(opc.binary_value, opb.binary_value, opa.binary_value, 0b000, 0b1001011);
+  res.binary_value = CUSTOM_INSTR_R4_TYPE(opc.binary_value, opb.binary_value, opa.binary_value, 0b000, 0b1001011);
   return res.float_value;
 }
 
@@ -560,7 +560,7 @@ inline float __attribute__ ((always_inline)) riscv_intrinsic_fnmadds(float rs1, 
   opb.float_value = rs2;
   opc.float_value = rs3;
 
-  res.binary_value = CUSTOM_INSTR_R3_TYPE(opc.binary_value, opb.binary_value, opa.binary_value, 0b000, 0b1001111);
+  res.binary_value = CUSTOM_INSTR_R4_TYPE(opc.binary_value, opb.binary_value, opa.binary_value, 0b000, 0b1001111);
   return res.float_value;
 }
 

--- a/sw/lib/include/neorv32_cpu_cfu.h
+++ b/sw/lib/include/neorv32_cpu_cfu.h
@@ -46,25 +46,35 @@ int neorv32_cpu_cfu_available(void);
 
 
 /**********************************************************************//**
- * @name CFU custom instructions ("intrinsics")
+ * @name Low-level CFU custom instruction wrappers ("intrinsics")
  **************************************************************************/
 /**@{*/
-/** CFU custom instruction 0 (funct3 = 000) */
-#define neorv32_cfu_cmd0(funct7, rs1, rs2) CUSTOM_INSTR_R2_TYPE(funct7, rs2, rs1, 0, RISCV_OPCODE_CUSTOM0)
-/** CFU custom instruction 1 (funct3 = 001) */
-#define neorv32_cfu_cmd1(funct7, rs1, rs2) CUSTOM_INSTR_R2_TYPE(funct7, rs2, rs1, 1, RISCV_OPCODE_CUSTOM0)
-/** CFU custom instruction 2 (funct3 = 010) */
-#define neorv32_cfu_cmd2(funct7, rs1, rs2) CUSTOM_INSTR_R2_TYPE(funct7, rs2, rs1, 2, RISCV_OPCODE_CUSTOM0)
-/** CFU custom instruction 3 (funct3 = 011) */
-#define neorv32_cfu_cmd3(funct7, rs1, rs2) CUSTOM_INSTR_R2_TYPE(funct7, rs2, rs1, 3, RISCV_OPCODE_CUSTOM0)
-/** CFU custom instruction 4 (funct3 = 100) */
-#define neorv32_cfu_cmd4(funct7, rs1, rs2) CUSTOM_INSTR_R2_TYPE(funct7, rs2, rs1, 4, RISCV_OPCODE_CUSTOM0)
-/** CFU custom instruction 5 (funct3 = 101) */
-#define neorv32_cfu_cmd5(funct7, rs1, rs2) CUSTOM_INSTR_R2_TYPE(funct7, rs2, rs1, 5, RISCV_OPCODE_CUSTOM0)
-/** CFU custom instruction 6 (funct3 = 110) */
-#define neorv32_cfu_cmd6(funct7, rs1, rs2) CUSTOM_INSTR_R2_TYPE(funct7, rs2, rs1, 6, RISCV_OPCODE_CUSTOM0)
-/** CFU custom instruction 7 (funct3 = 111) */
-#define neorv32_cfu_cmd7(funct7, rs1, rs2) CUSTOM_INSTR_R2_TYPE(funct7, rs2, rs1, 7, RISCV_OPCODE_CUSTOM0)
+/** R3-type CFU custom instruction prototype */
+#define neorv32_cfu_r3_instr(funct7, funct3, rs1, rs2) CUSTOM_INSTR_R3_TYPE(funct7, rs2, rs1, funct3, RISCV_OPCODE_CUSTOM0)
+/**@}*/
+
+
+/**********************************************************************//**
+ * @name Backward-compatibility layer (before version v1.7.8.x)
+ * do not use for new designs!
+ **************************************************************************/
+/**@{*/
+/** R3-type CFU custom instruction 0 (funct3 = 000) */
+#define neorv32_cfu_cmd0(funct7, rs1, rs2) neorv32_cfu_r3_instr(funct7, 0, rs1, rs2)
+/** R3-type CFU custom instruction 1 (funct3 = 001) */
+#define neorv32_cfu_cmd1(funct7, rs1, rs2) neorv32_cfu_r3_instr(funct7, 1, rs1, rs2)
+/** R3-type CFU custom instruction 2 (funct3 = 010) */
+#define neorv32_cfu_cmd2(funct7, rs1, rs2) neorv32_cfu_r3_instr(funct7, 2, rs1, rs2)
+/** R3-type CFU custom instruction 3 (funct3 = 011) */
+#define neorv32_cfu_cmd3(funct7, rs1, rs2) neorv32_cfu_r3_instr(funct7, 3, rs1, rs2)
+/** R3-type CFU custom instruction 4 (funct3 = 100) */
+#define neorv32_cfu_cmd4(funct7, rs1, rs2) neorv32_cfu_r3_instr(funct7, 4, rs1, rs2)
+/** R3-type CFU custom instruction 5 (funct3 = 101) */
+#define neorv32_cfu_cmd5(funct7, rs1, rs2) neorv32_cfu_r3_instr(funct7, 5, rs1, rs2)
+/** R3-type CFU custom instruction 6 (funct3 = 110) */
+#define neorv32_cfu_cmd6(funct7, rs1, rs2) neorv32_cfu_r3_instr(funct7, 6, rs1, rs2)
+/** R3-type CFU custom instruction 7 (funct3 = 111) */
+#define neorv32_cfu_cmd7(funct7, rs1, rs2) neorv32_cfu_r3_instr(funct7, 7, rs1, rs2)
 /**@}*/
 
 #endif // neorv32_cpu_cfu_h

--- a/sw/lib/include/neorv32_intrinsics.h
+++ b/sw/lib/include/neorv32_intrinsics.h
@@ -154,18 +154,20 @@ asm(".set regnum_t4  , 29");
 asm(".set regnum_t5  , 30");
 asm(".set regnum_t6  , 31");
 
-/** Official RISC-V opcodes for custom extensions (CUSTOM0, CUSTOM1) */
+/** Official RISC-V opcodes for custom extensions (custom-x) */
 asm(".set RISCV_OPCODE_CUSTOM0 , 0b0001011");
 asm(".set RISCV_OPCODE_CUSTOM1 , 0b0101011");
+asm(".set RISCV_OPCODE_CUSTOM2 , 0b1011011");
+asm(".set RISCV_OPCODE_CUSTOM3 , 0b1111011");
 /**@}*/
 
 
 /**********************************************************************//**
- * @name Custom instruction R1-type format
+ * @name Custom instruction R2-type format
  **************************************************************************/
-#define CUSTOM_INSTR_R1_TYPE(funct7, funct5, rs1, funct3, opcode) \
+#define CUSTOM_INSTR_R2_TYPE(funct7, funct5, rs1, funct3, opcode) \
 ({                                                                \
-    uint32_t __return;                                   \
+    uint32_t __return;                                            \
     asm volatile (                                                \
       ""                                                          \
       : [output] "=r" (__return)                                  \
@@ -188,11 +190,11 @@ asm(".set RISCV_OPCODE_CUSTOM1 , 0b0101011");
 
 
 /**********************************************************************//**
- * @name Custom instruction R2-type format
+ * @name Custom instruction R3-type format
  **************************************************************************/
-#define CUSTOM_INSTR_R2_TYPE(funct7, rs2, rs1, funct3, opcode) \
+#define CUSTOM_INSTR_R3_TYPE(funct7, rs2, rs1, funct3, opcode) \
 ({                                                             \
-    uint32_t __return;                                \
+    uint32_t __return;                                         \
     asm volatile (                                             \
       ""                                                       \
       : [output] "=r" (__return)                               \
@@ -217,11 +219,11 @@ asm(".set RISCV_OPCODE_CUSTOM1 , 0b0101011");
 
 
 /**********************************************************************//**
- * @name Custom instruction R3-type format
+ * @name Custom instruction R4-type format
  **************************************************************************/
-#define CUSTOM_INSTR_R3_TYPE(rs3, rs2, rs1, funct3, opcode) \
+#define CUSTOM_INSTR_R4_TYPE(rs3, rs2, rs1, funct3, opcode) \
 ({                                                          \
-    uint32_t __return;                             \
+    uint32_t __return;                                      \
     asm volatile (                                          \
       ""                                                    \
       : [output] "=r" (__return)                            \
@@ -252,7 +254,7 @@ asm(".set RISCV_OPCODE_CUSTOM1 , 0b0101011");
  **************************************************************************/
 #define CUSTOM_INSTR_I_TYPE(imm12, rs1, funct3, opcode) \
 ({                                                      \
-    uint32_t __return;                         \
+    uint32_t __return;                                  \
     asm volatile (                                      \
       ""                                                \
       : [output] "=r" (__return)                        \


### PR DESCRIPTION
This PR is a rework of the core's intrinsic / custom instruction library.

* fixed names of intrinsic prototypes: e.g. a "r3" type instruction consists of 3 registers (2 source registers, 1 destination register)
* `neorv32_cfu_r3_instr(funct7, funct3, rs1, rs2)`´is now the primitive for custom instructions (CFU); a compatibility layer is provided to further support the CFU's `neorv32_cfu_cmd0(funct7, rs1, rs2)` ... `neorv32_cfu_cmd7(funct7, rs1, rs2)` intrinsics
* the documentation will be updated/fixed in an upcoming PR