### PR TITLE
🐛 [rtl] core trap fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 08.12.2022 | 1.7.8.3 | :bug: fix interrupt behavior when in user-mode; minor core rtl fixes; do not check registers specifiers in CFU instructions (i.e. using registers above `x15` when `E` ISA extension is enabled); [#450](https://github.com/stnolting/neorv32/pull/450) |
 | 03.12.2022 | 1.7.8.2 | :sparkles: new option to add custom R4-type RISC-V instructions to **CFU**; rework CFU hardware module, intrinsic library and example program; [#449](https://github.com/stnolting/neorv32/pull/449) |
 | 01.12.2022 | 1.7.8.1 | package cleanup; [#447](https://github.com/stnolting/neorv32/pull/447) |
 | 28.11.2022 | [**:rocket:1.7.8**](https://github.com/stnolting/neorv32/releases/tag/v1.7.8) | **New release** |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -796,16 +796,22 @@ In this document the following nomenclature regarding traps is used:
 * _exceptions_ = synchronous exceptions
 * _traps_ = exceptions + interrupts (synchronous or asynchronous exceptions)
 
-Whenever an exception or interrupt is triggered, the CPU transfers control to the address stored in <<_mtvec>>
-CSR. The cause of the according interrupt or exception can be determined via the content of <<_mcause>>
-CSR. The address that reflects the current program counter when a trap was taken is stored to <<_mepc>> CSR.
-Additional information regarding the cause of the trap can be retrieved from <<_mtval>> CSR and the processor's
-<<_internal_bus_monitor_buskeeper>> (for memory access exceptions)
+Whenever an exception or interrupt is triggered, the CPU switches to machine-mode (if not already in machine-mode)
+and transfers control to the address stored in <<_mtvec>> CSR. The cause of the according interrupt or exception can
+be determined via the content of the <<_mcause>> CSR (a list of all possible `mcause` values and the according description
+can be found below in section <<_neorv32_traplisting>. The address that reflects the current program counter when a trap
+was taken is stored to <<_mepc>> CSR. Additional information regarding the cause of the trap can be retrieved from the
+<<_mtval>> CSR and the processor's <<_internal_bus_monitor_buskeeper>> (for memory access exceptions).
 
-The traps are prioritized. If several _synchronous exceptions_ occur at once only the one with highest priority is triggered
+All traps are prioritized. If several _synchronous exceptions_ occur at once only the one with highest priority is triggered
 while all remaining exceptions are ignored. If several _asynchronous exceptions_ (interrupts) trigger at once, the one with highest priority
 is serviced first while the remaining ones stay _pending_. After completing the interrupt handler the interrupt with
 the second highest priority will get serviced and so on until no further interrupts are pending.
+
+.Interrupts when in User-Mode
+[IMPORTANT]
+When the core is currently operating in less privileged user-mode, (machine-mode) interrupts are globally enabled
+even if <<_mstatus>>`.mie` is cleared.
 
 .Interrupt Signal Requirements - Standard RISC-V Interrupts
 [IMPORTANT]

--- a/docs/datasheet/cpu_cfu.adoc
+++ b/docs/datasheet/cpu_cfu.adoc
@@ -38,9 +38,11 @@ implement custom **R4-type** instructions. The according binary encoding of thes
 * `custom-1`: `0101011` (R4-type instructions)
 
 .CFU Instructions - Exceptions
-[NOTE]
+[IMPORTANT]
 The CPU control logic will only analyze the opcode of the custom instructions to check if the
 instruction word is valid. All remaining bit-fields are **not checked** by the CPU instruction decoding logic.
+This also means that the MSB of the register fields is not evaluated even if the `E` ISA extension is enabled
+(for standard RISC-V instructions this would cause an exception).
 Hence, a custom CFU instruction can never raise an illegal instruction exception. If the CFU is not
 implemented at all (`Zxcfu` ISA extension is not enabled) any instruction with opcode custom-0 or custom-1
 will raise an illegal instruction exception.
@@ -64,7 +66,7 @@ image::cfu_r3type_instruction.png[align=center]
 * `rs1`: address of first source register
 * `funct3`: 3-bit immediate
 * `rd`: address of destination register
-* `opcode`: always `0001011` (RISC-V "custom-0" opcode)
+* `opcode`: `0001011` (RISC-V "custom-0" opcode)
 
 .RISC-V compatibility
 [NOTE]
@@ -94,7 +96,7 @@ image::cfu_r4type_instruction.png[align=center]
 * `rs1`: address of first source register
 * `funct3`: 3-bit immediate
 * `rd`: address of destination register
-* `opcode`: always `0101011` (RISC-V "custom-1" opcode)
+* `opcode`: `0101011` (RISC-V "custom-1" opcode)
 
 .RISC-V compatibility
 [NOTE]

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -215,6 +215,10 @@ The features of this CSR are not implemented yet. The register is read-only and 
 | 3     | _CSR_MSTATUS_MIE_  | r/w | **MIE**: Machine global interrupt enable flag
 |=======================
 
+[NOTE]
+If the core is in user-mode, machine-mod interrupts are globally **enabled** even if `mstatus.mie` is cleared:
+"Interrupts for higher-privilege modes, y>x, are always globally enabled regardless of the setting of the global yIE
+bit for the higher-privilege mode." - RISC-V ISA Spec.
 
 :sectnums!:
 ===== **`misa`**

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -216,7 +216,7 @@ The features of this CSR are not implemented yet. The register is read-only and 
 |=======================
 
 [NOTE]
-If the core is in user-mode, machine-mod interrupts are globally **enabled** even if `mstatus.mie` is cleared:
+If the core is in user-mode, machine-mode interrupts are globally **enabled** even if `mstatus.mie` is cleared:
 "Interrupts for higher-privilege modes, y>x, are always globally enabled regardless of the setting of the global yIE
 bit for the higher-privilege mode." - RISC-V ISA Spec.
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070802"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070803"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/lib/source/neorv32_cpu.c
+++ b/sw/lib/source/neorv32_cpu.c
@@ -671,7 +671,7 @@ uint32_t neorv32_cpu_hpm_get_size(void) {
  *
  * @warning This function requires the U ISA extension to be implemented.
  **************************************************************************/
-void __attribute__((naked)) neorv32_cpu_goto_user_mode(void) {
+void __attribute__((naked,noinline)) neorv32_cpu_goto_user_mode(void) {
 
   // make sure to use NO registers in here! -> naked
 


### PR DESCRIPTION
* Fix a bug in the core's interrupt system: when in user-mode, interrupts are globally enabled even if `mstatus.mie` is cleared. Quote from the RISC-V privilege specification:

> When a hart is executing in privilege mode x, interrupts are globally enabled when xIE=1 and
globally disabled when xIE=0. Interrupts for lower-privilege modes, w<x, are always globally
disabled regardless of the setting of any global wIE bit for the lower-privilege mode. **Interrupts for
higher-privilege modes, y>x, are always globally enabled regardless of the setting of the global yIE
bit for the higher-privilege mode.** Higher-privilege-level code can use separate per-interrupt enable
bits to disable selected higher-privilege-mode interrupts before ceding control to a lower-privilege
mode.

* The illegal instruction check for CFU (custom functions unit) is changed: instructions targeting the CFU (using `custom-0` or `custom-1` opcodes) are not checked for illegal registers when the `E` ISA extension is enabled (registers above `x15`).

* Rework the handling of the hardware-based `mstatus.mie`/`mstatus.mpie`, `mstatus.mprv` and privilege stacks.