### PR TITLE
[rtl] instruction prefetch buffer (IPB) improvements

### DIFF
--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -454,11 +454,17 @@ The state of this generic can be retrieved by software via the <<_mxisa>> CSR.
 [cols="4,4,2"]
 [frame="all",grid="none"]
 |======
-| **CPU_IPB_ENTRIES** | _natural_ | 2
+| **CPU_IPB_ENTRIES** | _natural_ | 1
 3+| This generic configures the number of entries in the CPU's instruction prefetch buffer.
-The value has to be a power of two and has to be greater than or equal to two (>= 2).
-Long linear sequences of code can benefit from an increased IPB size.
+The value has to be a power of two and has to be greater than or equal to one (>= 1). The
+IPB can help improving memory access latency. Furthermore, long linear code sequences will
+benefit from an increased IPB size.
 |======
+
+[WARNING]
+If the compressed ISA extension `_CPU_EXTENSION_RISCV_C_` (<<_cpu_extension_riscv_c>>) is enabled and the IPB depth
+is set to 1, this configuration is internally overridden and the IPB will be implemented with **2** entries. This is required
+for handling unaligned 32-bit instructions.
 
 
 // ####################################################################################################################

--- a/docs/userguide/application_specific_configuration.adoc
+++ b/docs/userguide/application_specific_configuration.adoc
@@ -24,8 +24,7 @@ multiplications, `FAST_SHIFT_EN => true` use a fast barrel shifter for shift ope
 * Use as many _internal_ memory as possible to reduce memory access latency: `MEM_INT_IMEM_EN => true` and
 `MEM_INT_DMEM_EN => true`, maximize `MEM_INT_IMEM_SIZE` and `MEM_INT_DMEM_SIZE`
 * Increase the CPU's instruction prefetch buffer size: if **no** instruction cache is implemented `CPU_IPB_ENTRIES` should be
-quite large (recommended value is >= 8); if the instruction cache is implemented `CPU_IPB_ENTRIES` values above 4 are
-rather inefficient
+quite large
 * _To be continued..._
 
 
@@ -55,7 +54,7 @@ also reduces program code size by approximately 30%.
 * If not explicitly used/required, exclude the CPU standard counters `[m]instret[h]`
 (number of instruction) and `[m]cycle[h]` (number of cycles) from synthesis by disabling the `Zicntr` ISA extension
 (note, this is not RISC-V compliant).
-* Reduce the CPU's prefetch buffer size (`CPU_IPB_ENTRIES`).
+* Reduce the CPU's prefetch buffer size (`CPU_IPB_ENTRIES`) to its minimum (=1).
 * Map CPU shift operations to a small and iterative shifter unit (`FAST_SHIFT_EN => false`).
 * If you have unused DSP block available, you can map multiplication operations to those slices instead of
 using LUTs to implement the multiplier (`FAST_MUL_EN => true`).

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -73,7 +73,7 @@ entity neorv32_cpu_control is
     -- Tuning Options --
     FAST_MUL_EN                  : boolean; -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean; -- use barrel shifter for shift operations
-    CPU_IPB_ENTRIES              : natural; -- entries in instruction prefetch buffer, has to be a power of 2, min 2
+    CPU_IPB_ENTRIES              : natural; -- entries in instruction prefetch buffer, has to be a power of 2, min 1
     -- Physical memory protection (PMP) --
     PMP_NUM_REGIONS              : natural; -- number of regions (0..16)
     PMP_MIN_GRANULARITY          : natural; -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes

--- a/rtl/core/neorv32_fifo.vhd
+++ b/rtl/core/neorv32_fifo.vhd
@@ -140,30 +140,48 @@ begin
   fifo_half_level_simple:
   if (FIFO_DEPTH = 1) generate
     half_o <= fifo.full;
-  end generate;
+  end generate; -- /fifo_half_level_simple
 
   fifo_half_level_complex:
   if (FIFO_DEPTH > 1) generate
     level_diff <= std_ulogic_vector(unsigned(fifo.w_pnt) - unsigned(fifo.r_pnt));
     half_o     <= level_diff(level_diff'left-1) or fifo.full;
-  end generate;
+  end generate; -- /fifo_half_level_complex
 
 
-  -- FIFO Memory ----------------------------------------------------------------------------
+  -- FIFO Memory - Write --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  fifo_write: process(clk_i)
-  begin
-    if rising_edge(clk_i) then
-      if (fifo.we = '1') then
-        if (FIFO_DEPTH = 1) then
-          fifo.buf <= wdata_i;
-        else
+  -- "real" FIFO memory (several entries) --
+  fifo_memory:
+  if (FIFO_DEPTH > 1) generate
+    fifo_write: process(clk_i)
+    begin
+      if rising_edge(clk_i) then
+        if (fifo.we = '1') then
           fifo.data(to_integer(unsigned(fifo.w_pnt(fifo.w_pnt'left-1 downto 0)))) <= wdata_i;
         end if;
       end if;
-    end if;
-  end process fifo_write;
+    end process fifo_write;
+    fifo.buf <= (others => '0'); -- unused
+  end generate; -- /fifo_memory
 
+  -- simple register/buffer (single entry) --
+  fifo_buffer:
+  if (FIFO_DEPTH = 1) generate
+    fifo_write: process(clk_i)
+    begin
+      if rising_edge(clk_i) then
+        if (fifo.we = '1') then
+          fifo.buf <= wdata_i;
+        end if;
+      end if;
+    end process fifo_write;
+    fifo.data <= (others => (others => '0')); -- unused
+  end generate; -- /fifo_buffer
+
+
+  -- FIFO Memory - Read ---------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
   -- "asynchronous" read --
   fifo_read_async:
   if (FIFO_RSYNC = false) generate
@@ -175,7 +193,7 @@ begin
         rdata <= fifo.data(to_integer(unsigned(fifo.r_pnt(fifo.r_pnt'left-1 downto 0))));
       end if;
     end process fifo_read;
-  end generate;
+  end generate; -- /fifo_read_async
 
   -- synchronous read --
   fifo_read_sync:
@@ -190,7 +208,7 @@ begin
         end if;
       end if;
     end process fifo_read;
-  end generate;
+  end generate; -- /fifo_read_sync
 
 
   -- Output Gate ----------------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070804"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070805"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -1007,7 +1007,7 @@ package neorv32_package is
       -- Tuning Options --
       FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
       FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
-      CPU_IPB_ENTRIES              : natural := 2;      -- entries in instruction prefetch buffer, has to be a power of 2, min 2
+      CPU_IPB_ENTRIES              : natural := 1;      -- entries in instruction prefetch buffer, has to be a power of 2, min 1
       -- Physical Memory Protection (PMP) --
       PMP_NUM_REGIONS              : natural := 0;      -- number of regions (0..16)
       PMP_MIN_GRANULARITY          : natural := 4;      -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
@@ -1173,7 +1173,7 @@ package neorv32_package is
       -- Tuning Options --
       FAST_MUL_EN                  : boolean; -- use DSPs for M extension's multiplier
       FAST_SHIFT_EN                : boolean; -- use barrel shifter for shift operations
-      CPU_IPB_ENTRIES              : natural; -- entries in instruction prefetch buffer, has to be a power of 2, min 2
+      CPU_IPB_ENTRIES              : natural; -- entries in instruction prefetch buffer, has to be a power of 2, min 1
       -- Physical Memory Protection (PMP) --
       PMP_NUM_REGIONS              : natural; -- number of regions (0..16)
       PMP_MIN_GRANULARITY          : natural; -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
@@ -1245,7 +1245,7 @@ package neorv32_package is
       -- Extension Options --
       FAST_MUL_EN                  : boolean; -- use DSPs for M extension's multiplier
       FAST_SHIFT_EN                : boolean; -- use barrel shifter for shift operations
-      CPU_IPB_ENTRIES              : natural; -- entries is instruction prefetch buffer, has to be a power of 2, min 2
+      CPU_IPB_ENTRIES              : natural; -- entries is instruction prefetch buffer, has to be a power of 2, min 1
       -- Physical memory protection (PMP) --
       PMP_NUM_REGIONS              : natural; -- number of regions (0..16)
       PMP_MIN_GRANULARITY          : natural; -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -72,7 +72,7 @@ entity neorv32_top is
     -- Tuning Options --
     FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
-    CPU_IPB_ENTRIES              : natural := 2;      -- entries in instruction prefetch buffer, has to be a power of 2, min 2
+    CPU_IPB_ENTRIES              : natural := 1;      -- entries in instruction prefetch buffer, has to be a power of 2, min 1
 
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              : natural := 0;      -- number of regions (0..16)
@@ -564,7 +564,7 @@ begin
     -- Extension Options --
     FAST_MUL_EN                  => FAST_MUL_EN,                  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => FAST_SHIFT_EN,                -- use barrel shifter for shift operations
-    CPU_IPB_ENTRIES              => CPU_IPB_ENTRIES,              -- entries is instruction prefetch buffer, has to be a power of 2
+    CPU_IPB_ENTRIES              => CPU_IPB_ENTRIES,              -- entries is instruction prefetch buffer, has to be a power of 1
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              => PMP_NUM_REGIONS,              -- number of regions (0..16)
     PMP_MIN_GRANULARITY          => PMP_MIN_GRANULARITY,          -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes

--- a/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
+++ b/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
@@ -64,6 +64,7 @@ entity neorv32_ProcessorTop_stdlogic is
     -- Extension Options --
     FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
+    CPU_IPB_ENTRIES              : natural := 1;      -- entries in instruction prefetch buffer, has to be a power of 2, min 1
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              : natural := 0;      -- number of regions (0..16)
     PMP_MIN_GRANULARITY          : natural := 4;      -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
@@ -311,6 +312,7 @@ begin
     -- Extension Options --
     FAST_MUL_EN                  => FAST_MUL_EN,        -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => FAST_SHIFT_EN,      -- use barrel shifter for shift operations
+    CPU_IPB_ENTRIES              => CPU_IPB_ENTRIES,    -- entries in instruction prefetch buffer, has to be a power of 2, min 1
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              => PMP_NUM_REGIONS,    -- number of regions (0..16)
     PMP_MIN_GRANULARITY          => PMP_MIN_GRANULARITY, -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes

--- a/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
@@ -70,7 +70,7 @@ entity neorv32_top_avalonmm is
     -- Extension Options --
     FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
-    CPU_IPB_ENTRIES              : natural := 2;      -- entries is instruction prefetch buffer, has to be a power of 2
+    CPU_IPB_ENTRIES              : natural := 1;      -- entries is instruction prefetch buffer, has to be a power of 1, min 1
 
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              : natural := 0;      -- number of regions (0..16)

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -309,6 +309,7 @@ begin
     -- Extension Options --
     FAST_MUL_EN                  => FAST_MUL_EN,        -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => FAST_SHIFT_EN,      -- use barrel shifter for shift operations
+    CPU_IPB_ENTRIES              => 2,                  -- entries is instruction prefetch buffer, has to be a power of 2, min 1
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS              => PMP_NUM_REGIONS,    -- number of regions (0..16)
     PMP_MIN_GRANULARITY          => PMP_MIN_GRANULARITY, -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes


### PR DESCRIPTION
The `CPU_IPB_ENTRIES` generic (defining the depth of the instruction prefetch buffer) can now be as small as "1". If the `C` ISA extensions is enabled and `CPU_IPB_ENTRIES = 1` is configured, the actual IPB depth is set to "2" automatically (as this is required for handling unaligned 32bit instructions).

Configuring `CPU_IPB_ENTRIES = 1` allows reduced hardware utilization. The exemplary hardware implementation results have been updated accordingly.