### PR TITLE
🧪 [OCD] optimize firmware (park-loop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 16.12.2022 | 1.7.8.6 | optimized park-loop code (**on-chip debugger firmware**) provind slightly faster debugging response; added explicit address generics for defining debug mode entry points; [#456](https://github.com/stnolting/neorv32/pull/456) |
 | 13.12.2022 | 1.7.8.5 | code cleanup of FIFO module; improved **instruction prefetch buffer (IPB)** - IPD depth can be as small as "1" and will be adjusted automatically when enabling the `C` ISA extension; update hardware implementation results; [#455](https://github.com/stnolting/neorv32/pull/455) |
 | 09.12.2022 | 1.7.8.4 | :sparkles: new option to add custom **R5-type** (4 source registers, 1 destination register) instructions to **Custom Functions Unit (CFU)**; [#452](https://github.com/stnolting/neorv32/pull/452) |
 | 08.12.2022 | 1.7.8.3 | :bug: fix interrupt behavior when in user-mode; minor core rtl fixes; do not check registers specifiers in CFU instructions (i.e. using registers above `x15` when `E` ISA extension is enabled); [#450](https://github.com/stnolting/neorv32/pull/450) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
-| 16.12.2022 | 1.7.8.6 | optimized park-loop code (**on-chip debugger firmware**) provind slightly faster debugging response; added explicit address generics for defining debug mode entry points; [#456](https://github.com/stnolting/neorv32/pull/456) |
+| 16.12.2022 | 1.7.8.6 | :test_tube: optimized park-loop code (**on-chip debugger firmware**) provind slightly faster debugging response; added explicit address generics for defining debug mode entry points; [#456](https://github.com/stnolting/neorv32/pull/456) |
 | 13.12.2022 | 1.7.8.5 | code cleanup of FIFO module; improved **instruction prefetch buffer (IPB)** - IPD depth can be as small as "1" and will be adjusted automatically when enabling the `C` ISA extension; update hardware implementation results; [#455](https://github.com/stnolting/neorv32/pull/455) |
 | 09.12.2022 | 1.7.8.4 | :sparkles: new option to add custom **R5-type** (4 source registers, 1 destination register) instructions to **Custom Functions Unit (CFU)**; [#452](https://github.com/stnolting/neorv32/pull/452) |
 | 08.12.2022 | 1.7.8.3 | :bug: fix interrupt behavior when in user-mode; minor core rtl fixes; do not check registers specifiers in CFU instructions (i.e. using registers above `x15` when `E` ISA extension is enabled); [#450](https://github.com/stnolting/neorv32/pull/450) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -323,6 +323,10 @@ and are not listed here. However, the CPU provides some _specific_ generics that
 NEORV32 processor setup. These generics are assigned by the processor setup only and are not available for user defined configuration.
 The _specific_ generics are listed below.
 
+
+:sectnums!:
+==== _CPU_BOOT_ADDR_
+
 [cols="4,4,2"]
 [frame="all",grid="none"]
 |======
@@ -332,13 +336,33 @@ generic is configured with the base address of the bootloader ROM (default) or w
 memory (IMEM) if the bootloader is disabled (_INT_BOOTLOADER_EN_ = _false_). See section <<_address_space>> for more information.
 |======
 
+
+:sectnums!:
+==== _CPU_DEBUG_PARK_ADDR_
+
 [cols="4,4,2"]
 [frame="all",grid="none"]
 |======
-| **CPU_DEBUG_ADDR** | _std_ulogic_vector(31 downto 0)_ | _no default value_
-3+| This address defines the entry address for the "execution based" on-chip debugger. By default, this generic is configured with the base address
-of the debugger memory. See section <<_on_chip_debugger_ocd>> for more information.
+| **CPU_DEBUG_PARK_ADDR** | _std_ulogic_vector(31 downto 0)_ | _no default value_
+3+| This address defines the "park loop" entry address for the "execution based" on-chip debugger.
+See section <<_on_chip_debugger_ocd>> for more information.
 |======
+
+
+:sectnums!:
+==== _CPU_DEBUG_EXC_ADDR_
+
+[cols="4,4,2"]
+[frame="all",grid="none"]
+|======
+| **CPU_DEBUG_EXC_ADDR** | _std_ulogic_vector(31 downto 0)_ | _no default value_
+3+| This address defines the "exception" entry address for the "execution based" on-chip debugger.
+See section <<_on_chip_debugger_ocd>> for more information.
+|======
+
+
+:sectnums!:
+==== _CPU_EXTENSION_RISCV_DEBUG_
 
 [cols="4,4,2"]
 [frame="all",grid="none"]

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -451,14 +451,16 @@ address space. However, these effective addresses are mirrored to fill up the wh
 Hence, any CPU access within this address space will succeed.
 
 .DM CPU access - address map (divided into four sections)
-[cols="^2,^4,^2,<7"]
+[cols="^3,^4,^2,<7"]
 [options="header",grid="rows"]
 |=======================
-| Base address | Name [VHDL package]              | Actual size | Description
-| `0xfffff800` | `dm_code_base_c` (= `dm_base_c`) |   128 bytes | Code ROM for the "park loop" code
-| `0xfffff880` | `dm_pbuf_base_c`                 |    16 bytes | Program buffer, provided by DM
-| `0xfffff900` | `dm_data_base_c`                 |     4 bytes | Data buffer (`dm.data0`)
-| `0xfffff980` | `dm_sreg_base_c`                 |     4 bytes | Control and status register
+| Base address          | Name [VHDL package]              | Actual size | Description
+| `0xfffff800`          | `dm_code_base_c` (= `dm_base_c`) |   128 bytes | Code ROM for the "park loop" code
+| `0xfffff880`          | `dm_pbuf_base_c`                 |    16 bytes | Program buffer, provided by DM
+| `0xfffff900`          | `dm_data_base_c`                 |     4 bytes | Data buffer (`dm.data0`)
+| `0xfffff980`          | `dm_sreg_base_c`                 |     4 bytes | Control and status register
+| `dm_code_base_c` + 16 | `dm_park_entry_c`                |           - | Normal entry address
+| `dm_code_base_c` +  0 | `dm_exc_entry_c`                 |           - | Exception entry address
 |=======================
 
 [NOTE]
@@ -466,10 +468,12 @@ From the CPU's point of view, the DM is mapped to an _"unused"_ address range wi
 <<_address_space>> right between the bootloader ROM (BOOTROM) and the actual processor-internal IO
 space at addresses `0xfffff800` - `0xfffff9ff`
 
-When the CPU enters or re-enters (for example via `ebreak` in the DM's program buffer) debug mode, it jumps to
-the beginning of the DM's "park loop" code ROM at `dm_code_base_c`. This is the _normal entry point_ for the
-park loop code. If an exception is encountered during debug mode, the CPU jumps to `dm_code_base_c + 4`,
-which is the _exception entry point_.
+When the CPU enters or re-enters debug mode (for example via an `ebreak` in the DM's program buffer), it jumps to
+address of the _normal entry point_ for the park loop code defined by the <<_cpu_debug_park_addr>> generic.
+By default, this generic is set to `dm_park_entry_c`, which is defined in main package file.
+If an exception is encountered during debug mode, the CPU jumps to the address of the _exception entry point_
+defined  by the <<_cpu_debug_exc_addr>> generic. By default, this generic is set to `dm_exc_entry_c`, which is
+defined in main package file.
 
 **Status Register**
 
@@ -537,8 +541,8 @@ From a hardware point of view, these "entry conditions" are special synchronous 
 * the `wfi` instruction acts as a `nop` (also during single-stepping)
 * if an exception occurs:
 ** if the exception was caused by any debug-mode entry action the CPU jumps to the _normal entry point_
-   (= _CPU_DEBUG_ADDR_) of the park loop again (for example when executing `ebreak` _in_ debug-mode)
-** for all other exception sources the CPU jumps to the _exception entry point_ ( = _CPU_DEBUG_ADDR_ + 4)
+   (defined by <<_cpu_debug_park_addr>> generic) of the park loop again (for example when executing `ebreak` _in_ debug-mode)
+** for all other exception sources the CPU jumps to the _exception entry point_ (defined by <<_cpu_debug_exc_addr>> generic)
    to signal an exception to the DM; the CPU restarts the park loop again afterwards
 * interrupts are disabled; however, they will remain pending and will get executed after the CPU has left debug mode
 * if the DM makes a resume request, the park loop exits and the CPU leaves debug mode (executing `dret`)

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -49,7 +49,8 @@ entity neorv32_cpu is
     -- General --
     HW_THREAD_ID                 : natural; -- hardware thread id (32-bit)
     CPU_BOOT_ADDR                : std_ulogic_vector(31 downto 0); -- cpu boot address
-    CPU_DEBUG_ADDR               : std_ulogic_vector(31 downto 0); -- cpu debug mode start address
+    CPU_DEBUG_PARK_ADDR          : std_ulogic_vector(31 downto 0); -- cpu debug mode parking loop entry address
+    CPU_DEBUG_EXC_ADDR           : std_ulogic_vector(31 downto 0); -- cpu debug mode exception entry address
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_B        : boolean; -- implement bit-manipulation extension?
     CPU_EXTENSION_RISCV_C        : boolean; -- implement compressed extension?
@@ -262,7 +263,8 @@ begin
     XLEN                         => XLEN,                         -- data path width
     HW_THREAD_ID                 => HW_THREAD_ID,                 -- hardware thread id
     CPU_BOOT_ADDR                => CPU_BOOT_ADDR,                -- cpu boot address
-    CPU_DEBUG_ADDR               => CPU_DEBUG_ADDR,               -- cpu debug mode start address
+    CPU_DEBUG_PARK_ADDR          => CPU_DEBUG_PARK_ADDR,          -- cpu debug mode parking loop entry address
+    CPU_DEBUG_EXC_ADDR           => CPU_DEBUG_EXC_ADDR,           -- cpu debug mode exception entry address
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_B        => CPU_EXTENSION_RISCV_B,        -- implement bit-manipulation extension?
     CPU_EXTENSION_RISCV_C        => CPU_EXTENSION_RISCV_C,        -- implement compressed extension?

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -149,7 +149,7 @@ package neorv32_package is
   constant dm_pbuf_base_c       : std_ulogic_vector(31 downto 0) := x"fffff880";
   constant dm_data_base_c       : std_ulogic_vector(31 downto 0) := x"fffff900";
   constant dm_sreg_base_c       : std_ulogic_vector(31 downto 0) := x"fffff980";
-  -- OCD firmware entry points - this needs to be sync with the OCD firmware (sw/ocd-firmware/park_loop.S) --
+  -- park loop entry points - these need to be sync with the OCD firmware (sw/ocd-firmware/park_loop.S) --
   constant dm_park_entry_c      : std_ulogic_vector(31 downto 0) := std_ulogic_vector(unsigned(dm_code_base_c) + 16); -- normal entry point
   constant dm_exc_entry_c       : std_ulogic_vector(31 downto 0) := std_ulogic_vector(unsigned(dm_code_base_c) +  0); -- entry point for exceptions
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070805"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070806"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -149,6 +149,9 @@ package neorv32_package is
   constant dm_pbuf_base_c       : std_ulogic_vector(31 downto 0) := x"fffff880";
   constant dm_data_base_c       : std_ulogic_vector(31 downto 0) := x"fffff900";
   constant dm_sreg_base_c       : std_ulogic_vector(31 downto 0) := x"fffff980";
+  -- OCD firmware entry points - this needs to be sync with the OCD firmware (sw/ocd-firmware/park_loop.S) --
+  constant dm_park_entry_c      : std_ulogic_vector(31 downto 0) := std_ulogic_vector(unsigned(dm_code_base_c) + 16); -- normal entry point
+  constant dm_exc_entry_c       : std_ulogic_vector(31 downto 0) := std_ulogic_vector(unsigned(dm_code_base_c) +  0); -- entry point for exceptions
 
   -- IO: Peripheral Devices ("IO") Area --
   -- Control register(s) (including the device-enable flag) should be located at the base address of each device
@@ -1155,7 +1158,8 @@ package neorv32_package is
       -- General --
       HW_THREAD_ID                 : natural; -- hardware thread id (32-bit)
       CPU_BOOT_ADDR                : std_ulogic_vector(31 downto 0); -- cpu boot address
-      CPU_DEBUG_ADDR               : std_ulogic_vector(31 downto 0); -- cpu debug mode start address
+      CPU_DEBUG_PARK_ADDR          : std_ulogic_vector(31 downto 0); -- cpu debug mode parking loop entry address
+      CPU_DEBUG_EXC_ADDR           : std_ulogic_vector(31 downto 0); -- cpu debug mode exception entry address
       -- RISC-V CPU Extensions --
       CPU_EXTENSION_RISCV_B        : boolean; -- implement bit-manipulation extension?
       CPU_EXTENSION_RISCV_C        : boolean; -- implement compressed extension?
@@ -1227,7 +1231,8 @@ package neorv32_package is
       XLEN                         : natural; -- data path width
       HW_THREAD_ID                 : natural; -- hardware thread id (32-bit)
       CPU_BOOT_ADDR                : std_ulogic_vector(31 downto 0); -- cpu boot address
-      CPU_DEBUG_ADDR               : std_ulogic_vector(31 downto 0); -- cpu debug mode start address
+      CPU_DEBUG_PARK_ADDR          : std_ulogic_vector(31 downto 0); -- cpu debug mode parking loop entry address
+      CPU_DEBUG_EXC_ADDR           : std_ulogic_vector(31 downto 0); -- cpu debug mode exception entry address
       -- RISC-V CPU Extensions --
       CPU_EXTENSION_RISCV_B        : boolean; -- implement bit-manipulation extension?
       CPU_EXTENSION_RISCV_C        : boolean; -- implement compressed extension?

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -546,7 +546,8 @@ begin
     -- General --
     HW_THREAD_ID                 => HW_THREAD_ID,                 -- hardware thread id
     CPU_BOOT_ADDR                => cpu_boot_addr_c,              -- cpu boot address
-    CPU_DEBUG_ADDR               => dm_base_c,                    -- cpu debug mode start address
+    CPU_DEBUG_PARK_ADDR          => dm_park_entry_c,              -- cpu debug mode parking loop entry address
+    CPU_DEBUG_EXC_ADDR           => dm_exc_entry_c,               -- cpu debug mode exception entry address
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_B        => CPU_EXTENSION_RISCV_B,        -- implement bit-manipulation extension?
     CPU_EXTENSION_RISCV_C        => CPU_EXTENSION_RISCV_C,        -- implement compressed extension?

--- a/sw/ocd-firmware/README.md
+++ b/sw/ocd-firmware/README.md
@@ -1,18 +1,20 @@
-# NEORV32 On-Chip Debugger (OCD) - "Park Loop" Code
+# NEORV32 On-Chip Debugger (OCD) - "Park Loop" Code (Firmware)
 
-This folder contains the ASM sources for the *execution-based* debugger code ROM.
-`park_loop.S` contains the "park loop" that is executed when the CPU is in debug mode. This code is used to communicate
-with the *debug module (DM)* and is responsible for:
+This folder contains the source code for the *execution-based* debugger code ROM (firmware).
+`park_loop.S` contains the "park loop" that is executed when the CPU is in debug mode. This code
+is used to communicate with the *debug module (DM)* and is responsible for:
 
 * acknowledging halt requests
 * processing and acknowledging resume requests
 * processing and acknowledging "execute program buffer" requests
 * executing the program buffer (provided by the DM)
-* catching exceptions while in debug mode
+* catching and acknowledging exceptions while in debug mode
 
-The park loop code is implemented as endless loop that polls the status register of the *debug memory (DBMEM)* module
-to check for requests from the DM and sets according flags in the status register to acknowledge these requests.
+The park loop code is implemented as endless loop that polls the status register of
+the _debug memory (DM)_ module to check for requests from the DM and sets according flags in the
+status register to acknowledge these requests.
 
-:warning: Executing `make clean_all all` will **NOT** update the actual debugger code ROM that will be synthesized.
-The interface with the DM will break if there are any bugs in this code. However, if you wish to update the code ROM,
-copy the array content from `neorv32_debug_mem.code.vhd` to the `code_rom_file` constant in `rtl/core/neorv32_debug_dbmem.vhd`.
+:warning: Executing `make clean_all all` will **NOT** update the actual debugger code ROM that
+will be synthesized. The interface with the DM will break if there are any bugs in this code.
+However, if you wish to update the code ROM, copy the array content from `neorv32_debug_mem.code.vhd`
+to the `code_rom_file` constant in `rtl/core/neorv32_debug_dm.vhd`.

--- a/sw/ocd-firmware/debug_rom.ld
+++ b/sw/ocd-firmware/debug_rom.ld
@@ -1,7 +1,7 @@
 /* ################################################################################################# */
 /* # << NEORV32 - RISC-V GCC Linker Script >>                                                      # */
 /* # ********************************************************************************************* # */
-/* # For the execution based on-chip debugger code memory (/ROM() - "park loop" code               # */
+/* # For the execution-based on-chip debugger code memory (/ROM() - "park loop" code (firmware)    # */
 /* # ********************************************************************************************* # */
 /* # BSD 3-Clause License                                                                          # */
 /* #                                                                                               # */
@@ -34,37 +34,19 @@
 /* # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting # */
 /* ################################################################################################# */
 
-/* Default linker script, for normal executables */
-/* Copyright (C) 2014-2020 Free Software Foundation, Inc.
-   Copying and distribution of this script, with or without modification,
-   are permitted in any medium without royalty provided the copyright
-   notice and this notice are preserved.  */
-
-/* modified for the NEORV32 processor by Stephan Nolting */
-
-
 OUTPUT_FORMAT("elf32-littleriscv")
 OUTPUT_ARCH(riscv)
-ENTRY(_start)
-SEARCH_DIR("/opt/riscv/riscv32-unknown-elf/lib")
-SEARCH_DIR("=/usr/local/lib")
-SEARCH_DIR("=/lib")
-SEARCH_DIR("=/usr/lib")
+ENTRY(__start)
 
 MEMORY
 {
-  debug_mem  (rx) : ORIGIN = 0xFFFFF800, LENGTH = 128
+  debug_mem (rx) : ORIGIN = 0xFFFFF800, LENGTH = 128
 }
-/* ************************************************************************* */
 
 SECTIONS
 {
-
-  /* Actual instructions */
   .text :
   {
     KEEP(*(.text));
-
   } > debug_mem
-
 }

--- a/sw/ocd-firmware/park_loop.S
+++ b/sw/ocd-firmware/park_loop.S
@@ -1,9 +1,9 @@
 /* ################################################################################################# */
-/* # << NEORV32 - park_loop.S - Execution-Based On-Chip Debugger - Park Loop Code >>               # */
+/* # << NEORV32 - park_loop.S - Execution-Based On-Chip Debugger Firmware - Park Loop Code >>      # */
 /* # ********************************************************************************************* # */
 /* # BSD 3-Clause License                                                                          # */
 /* #                                                                                               # */
-/* # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     # */
+/* # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     # */
 /* #                                                                                               # */
 /* # Redistribution and use in source and binary forms, with or without modification, are          # */
 /* # permitted provided that the following conditions are met:                                     # */
@@ -50,42 +50,36 @@
 .section .text
 .balign 4
 .option norvc
-.global _start
-.global entry_normal
+.global __start
 .global entry_exception
+.global entry_normal
 
+__start:
 
-_start:
-
-// BASE + 0: entry for ebreak in debug-mode, halt request or return from single-stepped instruction
-entry_normal:
-    jal    zero, parking_loop_start
-
-// BASE + 4: entry for exceptions - signal EXCEPTION to DM and restart parking loop
+// BASE + 0: entry for exceptions - signal EXCEPTION to DM and restart parking loop
 entry_exception:
     csrw   dscratch0, s0                    // save s0 to dscratch0 so we have a general purpose register available
-    addi   s0, zero, SREG_EXCEPTION_ACK     // mask exception acknowledge flag
+    addi   s0, zero, SREG_EXCEPTION_ACK     // set exception acknowledge flag
     sw     s0, DBMEM_SREG_BASE(zero)        // trigger exception acknowledge to inform DM
-    csrr   s0, dscratch0                    // restore s0 from dscratch0
-    ebreak                                  // restart parking loop
+    jal    zero, parking_loop_halt          // start parking loop
 
+// BASE + 16: entry for ebreak in debug-mode, halt request or return from single-stepped instruction
 // "parking loop": endless loop that polls the status register to check if the DM
 // wants to execute code from the program buffer or to resume normal CPU/application operation
-parking_loop_start:
+entry_normal:
     csrw   dscratch0, s0                    // save s0 to dscratch0 so we have a general purpose register available
+parking_loop_halt:
     addi   s0, zero, SREG_HALTED_ACK
     sw     s0, DBMEM_SREG_BASE(zero)        // ACK that CPU has halted
 
 parking_loop:
     lw     s0, DBMEM_SREG_BASE(zero)        // get status register
     andi   s0, s0, SREG_EXECUTE_REQ         // request to execute program buffer?
-    bnez   s0, execute_progbuf              // execute program buffer
+    bnez   s0, execute                      // execute program buffer
 
     lw     s0, DBMEM_SREG_BASE(zero)        // get status register
     andi   s0, s0, SREG_RESUME_REQ          // request to resume?
-    bnez   s0, resume                       // resume normal operation
-
-    jal    zero, parking_loop               // restart parking loop polling
+    beqz   s0, parking_loop                 // no: restart parking loop; yes: resume normal operation
 
 // resume normal operation
 resume:
@@ -95,7 +89,7 @@ resume:
     dret                                    // end debug mode
 
 // execute program buffer
-execute_progbuf:
+execute:
     addi   s0, zero, SREG_EXECUTE_ACK
     sw     s0, DBMEM_SREG_BASE(zero)        // ACK that execution is about to start
     csrr   s0, dscratch0                    // restore s0 from dscratch0


### PR DESCRIPTION
* optimize park loop code (slightly faster debugging response)
* add explicit debug-entry address generics to CPU (`CPU_DEBUG_PARK_ADDR`, `CPU_DEBUG_EXC_ADDR`)