### PR TITLE
🐛 [rtl] fix iCache block error bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
-| 16.12.2022 | 1.7.8.6 | :test_tube: optimized park-loop code (**on-chip debugger firmware**) provind slightly faster debugging response; added explicit address generics for defining debug mode entry points; [#456](https://github.com/stnolting/neorv32/pull/456) |
+| 16.12.2022 | 1.7.8.7 | :bug: fix **instruction cache** block invalidation when a bus access error occurs during memory block fetch (after cache miss); [#457](https://github.com/stnolting/neorv32/pull/457) |
+| 16.12.2022 | 1.7.8.6 | :test_tube: optimized park-loop code (**on-chip debugger firmware**) providing slightly faster debugging response; added explicit address generics for defining debug mode entry points; [#456](https://github.com/stnolting/neorv32/pull/456) |
 | 13.12.2022 | 1.7.8.5 | code cleanup of FIFO module; improved **instruction prefetch buffer (IPB)** - IPD depth can be as small as "1" and will be adjusted automatically when enabling the `C` ISA extension; update hardware implementation results; [#455](https://github.com/stnolting/neorv32/pull/455) |
 | 09.12.2022 | 1.7.8.4 | :sparkles: new option to add custom **R5-type** (4 source registers, 1 destination register) instructions to **Custom Functions Unit (CFU)**; [#452](https://github.com/stnolting/neorv32/pull/452) |
 | 08.12.2022 | 1.7.8.3 | :bug: fix interrupt behavior when in user-mode; minor core rtl fixes; do not check registers specifiers in CFU instructions (i.e. using registers above `x15` when `E` ISA extension is enabled); [#450](https://github.com/stnolting/neorv32/pull/450) |

--- a/docs/datasheet/soc_icache.adoc
+++ b/docs/datasheet/soc_icache.adoc
@@ -23,10 +23,8 @@ The cache is implemented if the _ICACHE_EN_ generic is true. The size of the cac
 _ICACHE_BLOCK_SIZE_ (the size of a single cache block/page/line in bytes; has to be a power of two and >=
 4 bytes), _ICACHE_NUM_BLOCKS_ (the total amount of cache blocks; has to be a power of two and >= 1) and
 the actual cache associativity _ICACHE_ASSOCIATIVITY_ (number of sets; 1 = direct-mapped, 2 = 2-way set-associative,
-has to be a power of two and >= 1).
-
-If the cache associativity (_ICACHE_ASSOCIATIVITY_) is greater than 1 the LRU replacement policy (least recently
-used) is used.
+has to be a power of two and >= 1). If the cache associativity (_ICACHE_ASSOCIATIVITY_) is greater than one
+the LRU replacement policy (least recently used) is used.
 
 .Cache Memory HDL
 [NOTE]
@@ -56,8 +54,8 @@ Software can retrieve the cache configuration/layout from the <<_sysinfo_cache_c
 
 **Bus Access Fault Handling**
 
-The cache always loads a complete cache block (_ICACHE_BLOCK_SIZE_ bytes) aligned to it's size every time a
-cache miss is detected. If any of the accessed addresses within a single block do not successfully
-acknowledge the transfer (i.e. issuing an error signal or timing out) the whole cache block is invalidated and
-any access to an address within this cache block will raise an instruction fetch bus error exception.
-
+The cache always loads a complete cache block (_ICACHE_BLOCK_SIZE_ bytes; aligned to the block size) every time a
+cache miss is detected. Each cached word from this block provides a single status bit that indicates if the
+according bus access was successful or caused a bus error. Hence, the whole cache block remains valid even
+if certain addresses inside caused a bus error. If the CPU accesses any of the faulty cache words, an
+instruction access error exception is raised.

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070806"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070807"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -1,5 +1,5 @@
 -- #################################################################################################
--- # << NEORV32 - Default Processor Testbench >>                                                   #
+-- # << NEORV32 - VUnit Processor Testbench >>                                                     #
 -- # ********************************************************************************************* #
 -- # The processor is configured to use a maximum of functional units (for testing purpose).       #
 -- # Use the "User Configuration" section to configure the testbench according to your needs.      #
@@ -73,6 +73,8 @@ architecture neorv32_tb_rtl of neorv32_tb is
   constant f_clock_c               : natural := 100000000; -- main clock in Hz
   constant baud0_rate_c            : natural := 19200; -- simulation UART0 (primary UART) baud rate
   constant baud1_rate_c            : natural := 19200; -- simulation UART1 (secondary UART) baud rate
+  constant icache_en_c             : boolean := true; -- implement i-cache
+  constant icache_block_size_c     : natural := 64; -- i-cache block size in bytes
   -- simulated external Wishbone memory A (can be used as external IMEM) --
   constant ext_mem_a_base_addr_c   : std_ulogic_vector(31 downto 0) := x"00000000"; -- wishbone memory base address (external IMEM base)
   constant ext_mem_a_size_c        : natural := imem_size_c; -- wishbone memory size in bytes
@@ -83,7 +85,7 @@ architecture neorv32_tb_rtl of neorv32_tb is
   constant ext_mem_b_latency_c     : natural := 8; -- latency in clock cycles (min 1, max 255), plus 1 cycle initial delay
   -- simulated external Wishbone memory C (can be used to simulate external IO access) --
   constant ext_mem_c_base_addr_c   : std_ulogic_vector(31 downto 0) := x"F0000000"; -- wishbone memory base address (default begin of EXTERNAL IO area)
-  constant ext_mem_c_size_c        : natural := 64; -- wishbone memory size in bytes
+  constant ext_mem_c_size_c        : natural := icache_block_size_c/2; -- wishbone memory size in bytes, should be smaller than an iCACHE block
   constant ext_mem_c_latency_c     : natural := 128; -- latency in clock cycles (min 1, max 255), plus 1 cycle initial delay
   -- simulation interrupt trigger --
   constant irq_trigger_base_addr_c : std_ulogic_vector(31 downto 0) := x"FF000000";
@@ -313,9 +315,9 @@ begin
     MEM_INT_DMEM_EN              => int_dmem_c,    -- implement processor-internal data memory
     MEM_INT_DMEM_SIZE            => dmem_size_c,   -- size of processor-internal data memory in bytes
     -- Internal Cache memory --
-    ICACHE_EN                    => true,          -- implement instruction cache
+    ICACHE_EN                    => icache_en_c,   -- implement instruction cache
     ICACHE_NUM_BLOCKS            => 8,             -- i-cache: number of blocks (min 2), has to be a power of 2
-    ICACHE_BLOCK_SIZE            => 64,            -- i-cache: block size in bytes (min 4), has to be a power of 2
+    ICACHE_BLOCK_SIZE            => icache_block_size_c, -- i-cache: block size in bytes (min 4), has to be a power of 2
     ICACHE_ASSOCIATIVITY         => 2,             -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
     -- External memory interface --
     MEM_EXT_EN                   => true,          -- implement external memory bus interface?

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -70,6 +70,8 @@ architecture neorv32_tb_simple_rtl of neorv32_tb_simple is
   constant f_clock_c               : natural := 100000000; -- main clock in Hz
   constant baud0_rate_c            : natural := 19200; -- simulation UART0 (primary UART) baud rate
   constant baud1_rate_c            : natural := 19200; -- simulation UART1 (secondary UART) baud rate
+  constant icache_en_c             : boolean := true; -- implement i-cache
+  constant icache_block_size_c     : natural := 64; -- i-cache block size in bytes
   -- simulated external Wishbone memory A (can be used as external IMEM) --
   constant ext_mem_a_base_addr_c   : std_ulogic_vector(31 downto 0) := x"00000000"; -- wishbone memory base address (external IMEM base)
   constant ext_mem_a_size_c        : natural := MEM_INT_IMEM_SIZE; -- wishbone memory size in bytes
@@ -80,7 +82,7 @@ architecture neorv32_tb_simple_rtl of neorv32_tb_simple is
   constant ext_mem_b_latency_c     : natural := 8; -- latency in clock cycles (min 1, max 255), plus 1 cycle initial delay
   -- simulated external Wishbone memory C (can be used to simulate external IO access) --
   constant ext_mem_c_base_addr_c   : std_ulogic_vector(31 downto 0) := x"F0000000"; -- wishbone memory base address (default begin of EXTERNAL IO area)
-  constant ext_mem_c_size_c        : natural := 64; -- wishbone memory size in bytes
+  constant ext_mem_c_size_c        : natural := icache_block_size_c/2; -- wishbone memory size in bytes, should be smaller than an iCACHE block
   constant ext_mem_c_latency_c     : natural := 128; -- latency in clock cycles (min 1, max 255), plus 1 cycle initial delay
   -- simulation interrupt trigger --
   constant irq_trigger_base_addr_c : std_ulogic_vector(31 downto 0) := x"FF000000";
@@ -204,9 +206,9 @@ begin
     MEM_INT_DMEM_EN              => int_dmem_c,    -- implement processor-internal data memory
     MEM_INT_DMEM_SIZE            => dmem_size_c,   -- size of processor-internal data memory in bytes
     -- Internal Cache memory --
-    ICACHE_EN                    => true,          -- implement instruction cache
+    ICACHE_EN                    => icache_en_c,   -- implement instruction cache
     ICACHE_NUM_BLOCKS            => 8,             -- i-cache: number of blocks (min 2), has to be a power of 2
-    ICACHE_BLOCK_SIZE            => 64,            -- i-cache: block size in bytes (min 4), has to be a power of 2
+    ICACHE_BLOCK_SIZE            => icache_block_size_c, -- i-cache: block size in bytes (min 4), has to be a power of 2
     ICACHE_ASSOCIATIVITY         => 2,             -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
     -- External memory interface --
     MEM_EXT_EN                   => true,          -- implement external memory bus interface?

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -467,6 +467,7 @@ int main() {
 
   // ----------------------------------------------------------
   // External memory interface test
+  // (and iCache block-/word-wise error check)
   // ----------------------------------------------------------
   neorv32_cpu_csr_write(CSR_MCAUSE, mcause_never_c);
   PRINT_STANDARD("[%i] Ext. memory access (@0x%x) ", cnt_test, (uint32_t)EXT_MEM_BASE);
@@ -485,8 +486,8 @@ int main() {
       test_fail();
     }
     else {
-
       // execute program
+      asm volatile("fence.i"); // flush i-cache
       tmp_a = (uint32_t)EXT_MEM_BASE; // call the dummy sub program
       asm volatile ("jalr ra, %[input_i]" :  : [input_i] "r" (tmp_a));
     


### PR DESCRIPTION
### Bug Description

Whenever the instruction cache detects a "miss" it fetches a complete block from main memory. If any address within that block does not assert a bus access ACKNOWLEDGE, or if any address within that block asserts a bus accesses ERROR, **the whole cache block** is invalidated and the CPU receives an ERROR - regardless of the actually accessed address.

Example:

* CPU jump to address `0x00001008`, which triggers an i-cache miss
* the i-cache fetches the according block from memory (starting with address `0x00001000`)
* address `0x00001000` asserts an ERROR while all other addresses inside the block assert an ACKNOWLEDGE
* the CPU receives an error because the whole block is treated as fault, even though only the (irrelevant) address `0x00001000` reported an ERROR

A more real-world example:

The same error occurs if the instruction cache is fetching a block from a memory that is smaller than the instruction cache block size: if the block size is configured to 64 bytes and the cache tries to access a "freestanding" memory module that implements 32 bytes (starting at a 64-byte-aligned address) then accesses to the upper 32 byte will result a bus ERROR marking the whole block as "faulty" even if the lower 32 bytes are just fine.

### Fix Description

Add an additional status bit to **each cache word** that shows the bus access status (failed/succeed).