### PR TITLE
🐛 [rtl] fix MEPC value for instruction access faults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 17.12.2022 | 1.7.8.8 | :bug: fix incorrect value written to `mepc` when encountering an "instruction access fault" exception; [#458](https://github.com/stnolting/neorv32/pull/458) |
 | 16.12.2022 | 1.7.8.7 | :bug: fix **instruction cache** block invalidation when a bus access error occurs during memory block fetch (after cache miss); [#457](https://github.com/stnolting/neorv32/pull/457) |
 | 16.12.2022 | 1.7.8.6 | :test_tube: optimized park-loop code (**on-chip debugger firmware**) providing slightly faster debugging response; added explicit address generics for defining debug mode entry points; [#456](https://github.com/stnolting/neorv32/pull/456) |
 | 13.12.2022 | 1.7.8.5 | code cleanup of FIFO module; improved **instruction prefetch buffer (IPB)** - IPD depth can be as small as "1" and will be adjusted automatically when enabling the `C` ISA extension; update hardware implementation results; [#455](https://github.com/stnolting/neorv32/pull/455) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -887,7 +887,7 @@ official RISC-V privileged architecture spec. The "ID [C]" names are defined by 
 be used in plain C code. The "`mepc`" and "`mtval`" columns show the value written to <<_mepc>> and <<_mtval>> CSRs when a trap is triggered:
 
 * **IPC** - address of interrupted instruction (instruction has not been executed yet)
-* **PC** - address of instruction that caused the trap
+* **PC** - address of instruction that caused the trap (instruction has been executed)
 * **ADR** - bad memory access address that caused the trap
 * **0** - zero
 
@@ -898,7 +898,7 @@ be used in plain C code. The "`mepc`" and "`mtval`" columns show the value writt
 | Prio. | `mcause`     | [RISC-V] | ID [C]                   | Cause                                  | `mepc`  | `mtval`
 7+^| **Synchronous Exceptions**
 | 1     | `0x00000000` | 0.0      | _TRAP_CODE_I_MISALIGNED_ | instruction address misaligned         | **PC**  | **ADR**
-| 2     | `0x00000001` | 0.1      | _TRAP_CODE_I_ACCESS_     | instruction access bus fault           | **PC**  | **ADR**
+| 2     | `0x00000001` | 0.1      | _TRAP_CODE_I_ACCESS_     | instruction access bus fault           | **IPC** | **ADR**
 | 3     | `0x00000002` | 0.2      | _TRAP_CODE_I_ILLEGAL_    | illegal instruction                    | **PC**  | **0**
 | 4     | `0x0000000B` | 0.11     | _TRAP_CODE_MENV_CALL_    | environment call from M-mode (`ecall`) | **PC**  | **0**
 | 5     | `0x00000008` | 0.8      | _TRAP_CODE_UENV_CALL_    | environment call from U-mode (`ecall`) | **PC**  | **0**
@@ -937,7 +937,7 @@ The following table provides a summarized description of the actual events for t
 [options="header",grid="rows"]
 |=======================
 | Trap ID [C] | Triggered when ...
-| _TRAP_CODE_I_MISALIGNED_ | fetching a 32-bit instruction word that is not 32-bit-aligned (_see note below!_)
+| _TRAP_CODE_I_MISALIGNED_ | fetching a 32-bit instruction word that is not 32-bit-aligned (see note below)
 | _TRAP_CODE_I_ACCESS_     | bus timeout or bus error during instruction word fetch
 | _TRAP_CODE_I_ILLEGAL_    | trying to execute an invalid instruction word (malformed or not supported) or on a privilege violation
 | _TRAP_CODE_MENV_CALL_    | executing `ecall` instruction in machine-mode
@@ -953,14 +953,12 @@ The following table provides a summarized description of the actual events for t
 | _TRAP_CODE_MTI_          | processor-internal machine timer overflow OR user-defined processor-external source (via dedicated top-entity signal)
 |=======================
 
-.Misaligned Instruction Address Exception
-[NOTE]
-For 32-bit-only instructions (= no `C` extension) the misaligned instruction exception
-is raised if bit 1 of the fetch address is set (i.e. not on a 32-bit boundary). If the `C` extension is implemented
-there will never be a misaligned instruction exception _at all_.
-In both cases bit 0 of the program counter (and all related CSRs) is hardwired to zero.
+.Resumable Exceptions
+[WARNING]
+Note that not all exceptions are resumable. For example, the "instruction access fault" exception or the "instruction address misaligned"
+exception are not resumable in most cases. These exception might indicate a fatal memory hardware failure.
 
-.Trigger Type
+.Interrupt Trigger Type
 [IMPORTANT]
 The RISC-V standard interrupts (MEI, MSI and MTI) are **level-triggered and high-active**. Once set the signal has to stay high until
 the interrupt request is explicitly acknowledged (e.g. writing to a memory-mapped register). The RISC-V standard interrupts
@@ -968,6 +966,13 @@ can **NOT** be acknowledged by writing zero to the according <<_mip>> CSR bit. +
 +
 In contrast, the NEORV32 fast interrupt request channels become pending after being triggering by **a rising edge**. A pending FIRQ has to
 be explicitly cleared by writing zero to the according <<_mip>> CSR bit.
+
+.Misaligned Instruction Address Exception
+[NOTE]
+For 32-bit-only instructions (= no `C` extension) the misaligned instruction exception
+is raised if bit 1 of the fetch address is set (i.e. not on a 32-bit boundary). If the `C` extension is implemented
+there will never be a misaligned instruction exception _at all_.
+In both cases bit 0 of the program counter (and all related CSRs) is hardwired to zero.
 
 
 

--- a/docs/datasheet/software_rte.adoc
+++ b/docs/datasheet/software_rte.adoc
@@ -165,7 +165,7 @@ application-specific trap handler. The default handler will output a message giv
 via UART0 to inform the user and will try to resume normal program execution.
 
 .Continuing Execution
-[IMPORTAN]
+[WARNING]
 In most cases the RTE can successfully continue operation - for example if it catches an **interrupt** request that is not handled
 by the actual application program. However, if the RTE catches an un-handled **exception** like a bus access fault
 continuing execution will most likely fail making the CPU crash.

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -2015,6 +2015,7 @@ begin
           csr.dcsr_step    <= '0';
           csr.dcsr_ebreaku <= '0';
           csr.dcsr_prv     <= priv_mode_m_c;
+          csr.dcsr_cause   <= (others => '0');
           csr.dpc          <= (others => '0');
           csr.dscratch0    <= (others => '0');
           csr.tdata1_exe   <= '0';

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070807"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070808"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -596,10 +596,19 @@ int main() {
   PRINT_STANDARD("[%i] I_ACC (instr. bus access) EXC ", cnt_test);
   cnt_test++;
 
-  // call unreachable aligned address
-  ((void (*)(void))ADDR_UNREACHABLE)();
+  // put two "ret" instructions to the beginning of the external memory module
+  neorv32_cpu_store_unsigned_word((uint32_t)EXT_MEM_BASE+0, 0x00008067); // exception handler hack will see this instruction as exception source
+  neorv32_cpu_store_unsigned_word((uint32_t)EXT_MEM_BASE+4, 0x00008067); // and will try to resume execution here
 
-  if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_I_ACCESS) {
+  // jump to beginning of external memory minus 4 bytes
+  // this will cause an instruction access fault as there is no module responding to the fetch request
+  // the exception handler will try to resume at the instruction 4 bytes ahead, which is the "ret" we just created
+  asm volatile("fence.i"); // flush i-cache
+  tmp_a = ((uint32_t)EXT_MEM_BASE) - 4;
+  asm volatile ("jalr ra, %[input_i]" :  : [input_i] "r" (tmp_a));
+
+  if ((neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_I_ACCESS) && // correct exception cause
+      (neorv32_cpu_csr_read(CSR_MTVAL) == tmp_a))  { // correct trap value (address of instruction that caused ifetch error)
     test_ok();
   }
   else {
@@ -1817,6 +1826,11 @@ void global_trap_handler(void) {
 
   // clear all pending FIRQs
   neorv32_cpu_csr_write(CSR_MIP, 0);
+
+  // hack: make "instruction access fault" exception resumable as we exactly know how to handle it here
+  if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_I_ACCESS) {
+    neorv32_cpu_csr_write(CSR_MEPC, neorv32_cpu_csr_read(CSR_MEPC) + 4);
+  }
 
   // hack: always come back in MACHINE MODE
   uint32_t mask = (1<<CSR_MSTATUS_MPP_H) | (1<<CSR_MSTATUS_MPP_L);


### PR DESCRIPTION
According to RISC-V priv. spec. the `xEPC` CSRs have to point to the address that caused an "instruction access fault" exception:
> 3.1.16 Machine Trap Value Register (mtval)
[...]
If mtval is written with a nonzero value when an instruction access-fault or page-fault exception occurs on a system with variable-length instructions, then mtval will contain the virtual address of the portion of the instruction that caused the fault, **while mepc will point to the beginning of the instruction**.



See https://github.com/riscv/riscv-isa-manual/issues/938