### PR TITLE
[rtl] mtval CSR is now r/w

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 18.12.2022 | 1.7.8.9 | `mtval` is no longer read-only and can now be written by machine-mode code; [#460](https://github.com/stnolting/neorv32/pull/460) |
 | 17.12.2022 | 1.7.8.8 | :bug: fix incorrect value written to `mepc` when encountering an "instruction access fault" exception; [#458](https://github.com/stnolting/neorv32/pull/458) |
 | 16.12.2022 | 1.7.8.7 | :bug: fix **instruction cache** block invalidation when a bus access error occurs during memory block fetch (after cache miss); [#457](https://github.com/stnolting/neorv32/pull/457) |
 | 16.12.2022 | 1.7.8.6 | :test_tube: optimized park-loop code (**on-chip debugger firmware**) providing slightly faster debugging response; added explicit address generics for defining debug mode entry points; [#456](https://github.com/stnolting/neorv32/pull/456) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -73,8 +73,8 @@ This list shows the currently identified issues regarding full RISC-V-compatibil
 
 .Read-Only "Read-Write" CSRs
 [IMPORTANT]
-The NEORV32 <<_misa>> and <<_mtval>> CSRs are _read-only_ - the RISC-V specs. declares
-these registers to be _read/write_. Any machine-mode write access to them is ignored and will _not_
+The NEORV32 <<_misa>> CSR is _read-only_. Hence, ISA capabilities are fixed at synthesis time and cannot be
+enabled/disabled dynamically at runtime. Any machine-mode write access to this CSR is ignored and will _not_
 cause any exceptions or side-effects to maintain RISC-V compatibility.
 
 .Physical Memory Protection (PMP)
@@ -83,7 +83,7 @@ The RISC-V-compatible NEORV32 <<_machine_physical_memory_protection_csrs>> only 
 (top of region) mode and only up to 16 PMP regions.
 
 .No Hardware Support of Misaligned Memory Accesses
-[WARNING]
+[IMPORTANT]
 The CPU does not support resolving unaligned memory access by the hardware (this is not a
 RISC-V-incompatibility issue but an important thing to know!). Any kind of unaligned memory access
 will raise an exception to allow a _software-based_ emulation provided by the application.

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -46,7 +46,7 @@ information about those CSRs.
 | 0x340   | <<_mscratch>>                       | _CSR_MSCRATCH_       | r/w | Machine scratch register
 | 0x341   | <<_mepc>>                           | _CSR_MEPC_           | r/w | Machine exception program counter
 | 0x342   | <<_mcause>>                         | _CSR_MCAUSE_         | r/w | Machine trap cause
-| 0x343   | <<_mtval>>                          | _CSR_MTVAL_          | r/- | Machine bad address or instruction
+| 0x343   | <<_mtval>>                          | _CSR_MTVAL_          | r/w | Machine bad address or instruction
 | 0x344   | <<_mip>>                            | _CSR_MIP_            | r/w | Machine interrupt pending register
 5+^| **<<_machine_physical_memory_protection_csrs>>**
 | 0x3a0   | <<_pmpcfg, `pmpcfg0`>>              | _CSR_PMPCFG0_        | r/w | Physical memory protection configuration for region 0-3
@@ -399,9 +399,6 @@ See section <<_neorv32_trap_listing>> for more information.
 3+<| Reset value: `0x00000000`
 |=======================
 
-[IMPORTANT]
-The NEORV32 `mtval` CSR is **read-only**. However, a write access will _not_ raise an illegal instruction exception.
-
 [cols="^5,^5"]
 [options="header",grid="rows"]
 |=======================
@@ -412,8 +409,8 @@ The NEORV32 `mtval` CSR is **read-only**. However, a write access will _not_ rai
 |=======================
 
 [NOTE]
-In case an invalid compressed instruction raised an illegal instruction exception, `mtval` will show the
-according de-compressed instruction word. To get the "real" 16-bit instruction that caused the exception
+In case an invalid **compressed instruction** raised an illegal instruction exception, `mtval` will show the
+according de-compressed instruction word. To get the actually 16-bit instruction that caused the exception
 perform a memory load using the address stored in <<_mepc>>.
 
 [TIP]

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1235,8 +1235,7 @@ begin
       -- machine trap setup/handling & counters --
       when csr_mstatus_c | csr_mstatush_c | csr_misa_c | csr_mie_c | csr_mtvec_c | csr_mscratch_c | csr_mepc_c | csr_mcause_c | csr_mip_c | csr_mtval_c |
            csr_mcycle_c | csr_mcycleh_c | csr_minstret_c | csr_minstreth_c | csr_mcountinhibit_c =>
-        -- NOTE: MISA and MTVAL are read-only in the NEORV32 but we do not cause an exception here for compatibility.
-        -- Machine-level code should read-back those CSRs after writing them to realize they are read-only.
+        -- NOTE: NEORV32's MISA CSR is read-only but we do not cause an exception here for compatibility.
         csr_acc_valid <= csr.privilege_eff; -- M-mode only 
 
       -- machine information registers & NEORV32-specific registers, read-only --
@@ -1775,6 +1774,10 @@ begin
             if (csr.addr(3 downto 0) = csr_mcause_c(3 downto 0)) then
               csr.mcause <= csr.wdata(31) & csr.wdata(4 downto 0); -- type (async/sync) & identifier
             end if;
+           -- R/W: mtval - machine trap value --
+           if (csr.addr(3 downto 0) = csr_mtval_c(3 downto 0)) then
+             csr.mtval <= csr.wdata;
+           end if;
             -- R/W: mip - machine interrupt pending --
             if (csr.addr(3 downto 0) = csr_mip_c(3 downto 0)) then
               csr.mip_firq_nclr <= csr.wdata(31 downto 16); -- set low to clear according bit (FIRQs only)
@@ -2134,7 +2137,7 @@ begin
             csr.rdata(31)         <= csr.mcause(5);
             csr.rdata(4 downto 0) <= csr.mcause(4 downto 0);
 
-          when csr_mtval_c => -- mtval (r/-): machine bad address or instruction
+          when csr_mtval_c => -- mtval (r/w): machine bad address or instruction
             csr.rdata <= csr.mtval;
 
           when csr_mip_c => -- mip (r/w): machine interrupt pending

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070808"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070809"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -118,8 +118,8 @@ enum NEORV32_CSR_enum {
   CSR_MSCRATCH       = 0x340, /**< 0x340 - mscratch (r/w): Machine scratch register */
   CSR_MEPC           = 0x341, /**< 0x341 - mepc     (r/w): Machine exception program counter */
   CSR_MCAUSE         = 0x342, /**< 0x342 - mcause   (r/w): Machine trap cause */
-  CSR_MTVAL          = 0x343, /**< 0x343 - mtval    (r/-): Machine trap value register */
-  CSR_MIP            = 0x344, /**< 0x344 - mip      (r/-): Machine interrupt pending register */
+  CSR_MTVAL          = 0x343, /**< 0x343 - mtval    (r/w): Machine trap value register */
+  CSR_MIP            = 0x344, /**< 0x344 - mip      (r/w): Machine interrupt pending register */
 
   /* physical memory protection */
   CSR_PMPCFG0        = 0x3a0, /**< 0x3a0 - pmpcfg0 (r/w): Physical memory protection configuration register 0 (entries 0..3) */
@@ -154,10 +154,10 @@ enum NEORV32_CSR_enum {
   CSR_MCONTEXT       = 0x7a8, /**< 0x7a8 - mcontext (r/(w)): Machine context register */
   CSR_SCONTEXT       = 0x7aa, /**< 0x7aa - scontext (r/(w)): Supervisor context register */
 
-  /* not accessible by m-mode software */
-//CSR_DCSR           = 0x7b0, /**< 0x7b0 - dcsr     (-/-): Debug status and control register */
-//CSR_DPC            = 0x7b1, /**< 0x7b1 - dpc      (-/-): Debug program counter */
-//CSR_DSCRATCH       = 0x7b2, /**< 0x7b2 - dscratch (-/-): Debug scratch register */
+  /* CPU debug mode CSRs - not accessible by software running outside of debug mode */
+  CSR_DCSR           = 0x7b0, /**< 0x7b0 - dcsr      (-/-): Debug status and control register */
+  CSR_DPC            = 0x7b1, /**< 0x7b1 - dpc       (-/-): Debug program counter */
+  CSR_DSCRATCH0      = 0x7b2, /**< 0x7b2 - dscratch0 (-/-): Debug scratch register */
 
   /* counter and timers - low word */
   CSR_MCYCLE         = 0xb00, /**< 0xb00 - mcycle   (r/w): Machine cycle counter low word */


### PR DESCRIPTION
`mtval` is no longer read-only and can now be written by machine-mode software.