### PR TITLE
[rt] SoC: rework r/w access logic and reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
-| 18.12.2022 | 1.7.8.9 | `mtval` is no longer read-only and can now be written by machine-mode code; [#460](https://github.com/stnolting/neorv32/pull/460) |
+| 20.12.2022 | 1.7.8.10 | SOC: rework r/w access logic; split read and write accesses into two processes; removed explicit reset-to-don't-care; [#461](https://github.com/stnolting/neorv32/pull/461) |
+| 18.12.2022 | 1.7.8.9 | `mtval` is no longer read-only and can now be written by machine-mode software; [#460](https://github.com/stnolting/neorv32/pull/460) |
 | 17.12.2022 | 1.7.8.8 | :bug: fix incorrect value written to `mepc` when encountering an "instruction access fault" exception; [#458](https://github.com/stnolting/neorv32/pull/458) |
 | 16.12.2022 | 1.7.8.7 | :bug: fix **instruction cache** block invalidation when a bus access error occurs during memory block fetch (after cache miss); [#457](https://github.com/stnolting/neorv32/pull/457) |
 | 16.12.2022 | 1.7.8.6 | :test_tube: optimized park-loop code (**on-chip debugger firmware**) providing slightly faster debugging response; added explicit address generics for defining debug mode entry points; [#456](https://github.com/stnolting/neorv32/pull/456) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -1133,7 +1133,7 @@ _enable_ bit in the according module's control register), it is automatically de
 
 The processor-wide reset can be triggered at any of the following sources:
 
-* the asynchronous, low-active `rstn_i` top entity signal
+* the asynchronous low-active `rstn_i` top entity input signal
 * the <<_on_chip_debugger_ocd>>
 * the <<_watchdog_timer_wdt>>
 
@@ -1143,33 +1143,19 @@ _aysynchronoulsy_ if triggered by the external `rstn_i` signal. For internal sou
 _synchronously_. If the reset cause gets inactive the internal reset is de-asserted _synchronously_ at a falling
 clock edge.
 
-Internally, all the processor registers that do provide a hardware reset use an **asynchronous reset**. Using a
-synchronous reset might increase logic utilization (and increase the critical path) for FPGAs that do not provide a
-"native" synchronous reset for their flip flops. For an ASIC implementation an asynchronous reset ensures that the
-whole logic is set to a defined state even if the clock is not yet operational.
+Internally, all processor registers that actually do provide a hardware reset use an **asynchronous reset**. Using a
+synchronous reset might increase logic utilization (and might increase the critical path) for FPGAs that do not provide a
+"native" synchronous reset for their flip flops. Furthermore, an asynchronous reset ensures that the
+entire processor logic is reset to a defined state even if the main clock is not yet operational.
 
 In order to reduce routing constraints (and by this the actual hardware requirements), some _uncritical registers_
-of the NEORV32 CPU as well as many registers of the whole NEORV32 Processor **do not use a dedicated hardware reset**.
-"Uncritical registers" in this context means that the initial value of the according register(s) after power-up/reset
-is not relevant for a defined CPU boot/start process and will "swing in" (get updated) by the controlling logic right
-after the reset has been de-asserted.
-
-In terms of the NEORV32 CPU, there are several pipeline registers, state machine registers and even some status
-and control registers (CSRs) that do not require a defined initial state to ensure a correct boot process. The
-pipeline register will get initialized by the CPU's internal state machines, which are initialized from the main
-control engine that actually features a defined hardware reset
-
-Many CPU-internal register do provide an asynchronous reset described in the VHDL code, but the "don't care" value
-(VHDL `'-'`) is used for initialization of uncritical registers - effectively generating a flip-flop without a
-reset input.
-
-[TIP]
-The EE Times provided a nice article about FPGA resets. The reset system of the NEORV32 is loosely based on this
-article: https://www.eetimes.com/how-do-i-reset-my-fpga/
+of the NEORV32 CPU as well as many registers of the entire NEORV32 Processor **do not use a dedicated hardware reset**.
+For example there are several pipeline registers and "buffer" registers that do not require a defined
+initial state to ensure correct operation.
 
 [NOTE]
-The system reset will only reset the control registers of each implemented IO/peripheral module. This will also
-reset the according "module enable flag" to zero, which - in turn - will cause a _synchronous_ and
+The system reset will only reset the control registers of each implemented IO/peripheral module. This control register
+reset will also reset the according "module enable flag" to zero, which - in turn - will cause a _synchronous_
 module-internal reset of the remaining logic.
 
 

--- a/rtl/core/neorv32_cfs.vhd
+++ b/rtl/core/neorv32_cfs.vhd
@@ -214,8 +214,8 @@ begin
       cfs_reg_wr(2) <= (others => '0');
       cfs_reg_wr(3) <= (others => '0');
       --
-      ack_o  <= '-'; -- no actual reset required
-      data_o <= (others => '-'); -- no actual reset required
+      ack_o  <= '0';
+      data_o <= (others => '0');
     elsif rising_edge(clk_i) then -- synchronous interface for read and write accesses
       -- transfer/access acknowledge --
       -- default: required for the CPU to check the CFS is answering a bus read OR write request;

--- a/rtl/core/neorv32_mtime.vhd
+++ b/rtl/core/neorv32_mtime.vhd
@@ -46,7 +46,7 @@ entity neorv32_mtime is
   port (
     -- host access --
     clk_i  : in  std_ulogic; -- global clock line
-    rstn_i : in  std_ulogic; -- global reset line, low-active
+    rstn_i : in  std_ulogic; -- global reset line, low-active, async
     addr_i : in  std_ulogic_vector(31 downto 0); -- address
     rden_i : in  std_ulogic; -- read enable
     wren_i : in  std_ulogic; -- write enable
@@ -102,10 +102,9 @@ begin
 
   -- Write Access ---------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  wr_access: process(rstn_i, clk_i)
+  write_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      ack_o         <= '-';
       mtimecmp_lo   <= (others => '1'); -- all-one to prevent accidental interrupt after reset
       mtimecmp_hi   <= (others => '1');
       mtime_lo_we   <= '0';
@@ -114,9 +113,6 @@ begin
       mtime_lo_ovfl <= (others => '0');
       mtime_hi      <= (others => '0');
     elsif rising_edge(clk_i) then
-      -- bus handshake --
-      ack_o <= rden or wren;
-
       -- mtimecmp --
       if (wren = '1') then
         if (addr = mtime_cmp_lo_addr_c) then
@@ -153,7 +149,7 @@ begin
         mtime_hi <= std_ulogic_vector(unsigned(mtime_hi) + unsigned(mtime_lo_ovfl));
       end if;
     end if;
-  end process wr_access;
+  end process write_access;
 
   -- mtime.time_LO increment --
   mtime_lo_nxt <= std_ulogic_vector(unsigned('0' & mtime_lo) + 1);
@@ -161,9 +157,10 @@ begin
 
   -- Read Access ----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  rd_access: process(clk_i)
+  read_access: process(clk_i)
   begin
     if rising_edge(clk_i) then
+      ack_o  <= rden or wren; -- bus handshake
       data_o <= (others => '0'); -- default
       if (rden = '1') then
         case addr(3 downto 2) is
@@ -174,7 +171,7 @@ begin
         end case;
       end if;
     end if;
-  end process rd_access;
+  end process read_access;
 
   -- system time output for cpu --
   time_o <= mtime_hi & mtime_lo; -- NOTE: low and high words are not in-sync here!

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070809"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070810"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -1710,7 +1710,7 @@ package neorv32_package is
     port (
       -- host access --
       clk_i  : in  std_ulogic; -- global clock line
-      rstn_i : in  std_ulogic; -- global reset line, low-active
+      rstn_i : in  std_ulogic; -- global reset line, low-active, async
       addr_i : in  std_ulogic_vector(31 downto 0); -- address
       rden_i : in  std_ulogic; -- read enable
       wren_i : in  std_ulogic; -- write enable
@@ -1730,7 +1730,7 @@ package neorv32_package is
     port (
       -- host access --
       clk_i  : in  std_ulogic; -- global clock line
-      rstn_i : in  std_ulogic; -- global reset line, low-active
+      rstn_i : in  std_ulogic; -- global reset line, low-active, async
       addr_i : in  std_ulogic_vector(31 downto 0); -- address
       rden_i : in  std_ulogic; -- read enable
       wren_i : in  std_ulogic; -- write enable
@@ -1781,7 +1781,7 @@ package neorv32_package is
     port (
       -- host access --
       clk_i       : in  std_ulogic; -- global clock line
-      rstn_i      : in  std_ulogic; -- global reset line, low-active
+      rstn_i      : in  std_ulogic; -- global reset line, low-active, async
       addr_i      : in  std_ulogic_vector(31 downto 0); -- address
       rden_i      : in  std_ulogic; -- read enable
       wren_i      : in  std_ulogic; -- write enable
@@ -1812,7 +1812,7 @@ package neorv32_package is
     port (
       -- host access --
       clk_i       : in  std_ulogic; -- global clock line
-      rstn_i      : in  std_ulogic; -- global reset line, low-active
+      rstn_i      : in  std_ulogic; -- global reset line, low-active, async
       addr_i      : in  std_ulogic_vector(31 downto 0); -- address
       rden_i      : in  std_ulogic; -- read enable
       wren_i      : in  std_ulogic; -- write enable
@@ -1838,7 +1838,7 @@ package neorv32_package is
     port (
       -- host access --
       clk_i       : in  std_ulogic; -- global clock line
-      rstn_i      : in  std_ulogic; -- global reset line, low-active
+      rstn_i      : in  std_ulogic; -- global reset line, low-active, async
       addr_i      : in  std_ulogic_vector(31 downto 0); -- address
       rden_i      : in  std_ulogic; -- read enable
       wren_i      : in  std_ulogic; -- write enable
@@ -1867,7 +1867,7 @@ package neorv32_package is
     port (
       -- host access --
       clk_i       : in  std_ulogic; -- global clock line
-      rstn_i      : in  std_ulogic; -- global reset line, low-active
+      rstn_i      : in  std_ulogic; -- global reset line, low-active, async
       addr_i      : in  std_ulogic_vector(31 downto 0); -- address
       rden_i      : in  std_ulogic; -- read enable
       wren_i      : in  std_ulogic; -- write enable
@@ -1891,7 +1891,7 @@ package neorv32_package is
     port (
       -- host access --
       clk_i  : in  std_ulogic; -- global clock line
-      rstn_i : in  std_ulogic; -- global reset line, low-active
+      rstn_i : in  std_ulogic; -- global reset line, low-active, async
       addr_i : in  std_ulogic_vector(31 downto 0); -- address
       rden_i : in  std_ulogic; -- read enable
       wren_i : in  std_ulogic; -- write enable

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -689,8 +689,8 @@ begin
   end generate;
 
   -- yet unused --
-  i_cache.fence <= '-';
-  i_cache.src   <= '-';
+  i_cache.fence <= '0';
+  i_cache.src   <= '0';
 
 
   -- CPU Bus Switch -------------------------------------------------------------------------
@@ -903,7 +903,7 @@ begin
     port map (
       -- global control --
       clk_i      => clk_i,                         -- global clock line
-      rstn_i     => rstn_int,                      -- global reset line, low-active
+      rstn_i     => rstn_int,                      -- global reset line, low-active, async
       -- host access --
       src_i      => p_bus.src,                     -- access type (0: data, 1:instruction)
       addr_i     => p_bus.addr,                    -- address
@@ -958,7 +958,7 @@ begin
     port map (
       -- global control --
       clk_i       => clk_i,                        -- global clock line
-      rstn_i      => rstn_int,                     -- global reset line, low-active
+      rstn_i      => rstn_int,                     -- global reset line, low-active, async
       -- host access: control register access port --
       ct_addr_i   => p_bus.addr,                   -- address
       ct_rden_i   => io_rden,                      -- read enable
@@ -1067,7 +1067,7 @@ begin
     port map (
       -- host access --
       clk_i  => clk_i,                     -- global clock line
-      rstn_i => rstn_int,                  -- global reset line, low-active
+      rstn_i => rstn_int,                  -- global reset line, low-active, async
       addr_i => p_bus.addr,                -- address
       rden_i => io_rden,                   -- read enable
       wren_i => io_wren,                   -- write enable
@@ -1136,7 +1136,7 @@ begin
     port map (
       -- host access --
       clk_i  => clk_i,                      -- global clock line
-      rstn_i => rstn_int,                   -- global reset line, low-active
+      rstn_i => rstn_int,                   -- global reset line, low-active, async
       addr_i => p_bus.addr,                 -- address
       rden_i => io_rden,                    -- read enable
       wren_i => io_wren,                    -- write enable
@@ -1192,7 +1192,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                      -- global clock line
-      rstn_i      => rstn_int,                   -- global reset line, low-active
+      rstn_i      => rstn_int,                   -- global reset line, low-active, async
       addr_i      => p_bus.addr,                 -- address
       rden_i      => io_rden,                    -- read enable
       wren_i      => io_wren,                    -- write enable
@@ -1240,7 +1240,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                      -- global clock line
-      rstn_i      => rstn_int,                   -- global reset line, low-active
+      rstn_i      => rstn_int,                   -- global reset line, low-active, async
       addr_i      => p_bus.addr,                 -- address
       rden_i      => io_rden,                    -- read enable
       wren_i      => io_wren,                    -- write enable
@@ -1286,7 +1286,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                    -- global clock line
-      rstn_i      => rstn_int,                 -- global reset line, low-active
+      rstn_i      => rstn_int,                 -- global reset line, low-active, async
       addr_i      => p_bus.addr,               -- address
       rden_i      => io_rden,                  -- read enable
       wren_i      => io_wren,                  -- write enable
@@ -1327,7 +1327,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                    -- global clock line
-      rstn_i      => rstn_int,                 -- global reset line, low-active
+      rstn_i      => rstn_int,                 -- global reset line, low-active, async
       addr_i      => p_bus.addr,               -- address
       rden_i      => io_rden,                  -- read enable
       wren_i      => io_wren,                  -- write enable
@@ -1376,7 +1376,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                    -- global clock line
-      rstn_i      => rstn_int,                 -- global reset line, low-active
+      rstn_i      => rstn_int,                 -- global reset line, low-active, async
       addr_i      => p_bus.addr,               -- address
       rden_i      => io_rden,                  -- read enable
       wren_i      => io_wren,                  -- write enable
@@ -1412,7 +1412,7 @@ begin
     port map (
       -- host access --
       clk_i  => clk_i,                     -- global clock line
-      rstn_i => rstn_int,                  -- global reset line, low-active
+      rstn_i => rstn_int,                  -- global reset line, low-active, async
       addr_i => p_bus.addr,                -- address
       rden_i => io_rden,                   -- read enable
       wren_i => io_wren,                   -- write enable
@@ -1440,7 +1440,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                       -- global clock line
-      rstn_i      => rstn_int,                    -- global reset line, low-active
+      rstn_i      => rstn_int,                    -- global reset line, low-active, async
       addr_i      => p_bus.addr,                  -- address
       rden_i      => io_rden,                     -- read enable
       wren_i      => io_wren,                     -- write enable
@@ -1482,7 +1482,7 @@ begin
     port map (
       -- host access --
       clk_i          => clk_i,                      -- global clock line
-      rstn_i         => rstn_int,                   -- global reset line, low-active
+      rstn_i         => rstn_int,                   -- global reset line, low-active, async
       addr_i         => p_bus.addr,                 -- address
       rden_i         => io_rden,                    -- read enable
       wren_i         => io_wren,                    -- write enable
@@ -1532,7 +1532,7 @@ begin
     port map (
       -- host access --
       clk_i     => clk_i,                     -- global clock line
-      rstn_i    => rstn_int,                  -- global reset line, low-active
+      rstn_i    => rstn_int,                  -- global reset line, low-active, async
       addr_i    => p_bus.addr,                -- address
       rden_i    => io_rden,                   -- read enable
       wren_i    => io_wren,                   -- write enable
@@ -1563,7 +1563,7 @@ begin
     port map (
       -- host access --
       clk_i       => clk_i,                      -- global clock line
-      rstn_i      => rstn_int,                   -- global reset line, low-active
+      rstn_i      => rstn_int,                   -- global reset line, low-active, async
       addr_i      => p_bus.addr,                 -- address
       rden_i      => io_rden,                    -- read enable
       wren_i      => io_wren,                    -- write enable
@@ -1596,7 +1596,7 @@ begin
     port map (
     -- host access --
       clk_i       => clk_i,                        -- global clock line
-      rstn_i      => rstn_int,                     -- global reset line, low-active
+      rstn_i      => rstn_int,                     -- global reset line, low-active, async
       addr_i      => p_bus.addr,                   -- address
       rden_i      => io_rden,                      -- read enable
       wren_i      => io_wren,                      -- write enable

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -74,7 +74,7 @@ entity neorv32_uart is
   port (
     -- host access --
     clk_i       : in  std_ulogic; -- global clock line
-    rstn_i      : in  std_ulogic; -- global reset line, low-active
+    rstn_i      : in  std_ulogic; -- global reset line, low-active, async
     addr_i      : in  std_ulogic_vector(31 downto 0); -- address
     rden_i      : in  std_ulogic; -- read enable
     wren_i      : in  std_ulogic; -- write enable
@@ -255,19 +255,13 @@ begin
   rden   <= acc_en and rden_i;
 
 
-  -- Read/Write Access ----------------------------------------------------------------------
+  -- Write Access ---------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  rw_access: process(rstn_i, clk_i)
+  write_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
       ctrl   <= (others => '0');
-      ack_o  <= '-';
-      data_o <= (others => '0');
     elsif rising_edge(clk_i) then
-      -- bus access acknowledge --
-      ack_o <= wren or rden;
-
-      -- write access --
       if (wren = '1') then
         if (addr = uart_id_ctrl_addr_c) then
           ctrl <= (others => '0');
@@ -282,8 +276,27 @@ begin
           ctrl(ctrl_en_c)                          <= data_i(ctrl_en_c);
         end if;
       end if;
+    end if;
+  end process write_access;
 
-      -- read access --
+  -- number of bits to be sampled --
+  -- if parity flag is ENABLED:  11 bit -> "1011" (1 start bit + 8 data bits + 1 parity bit + 1 stop bit)
+  -- if parity flag is DISABLED: 10 bit -> "1010" (1 start bit + 8 data bits + 1 stop bit)
+  num_bits <= "1011" when (ctrl(ctrl_pmode1_c) = '1') else "1010";
+
+  -- clock enable --
+  clkgen_en_o <= ctrl(ctrl_en_c);
+
+  -- uart clock select --
+  uart_clk <= clkgen_i(to_integer(unsigned(ctrl(ctrl_prsc2_c downto ctrl_prsc0_c))));
+
+
+  -- Read Access ----------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  read_access: process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      ack_o  <= wren or rden; -- bus access acknowledge
       data_o <= (others => '0');
       if (rden = '1') then
         if (addr = uart_id_ctrl_addr_c) then
@@ -313,21 +326,7 @@ begin
         end if;
       end if;
     end if;
-  end process rw_access;
-
-  -- number of bits to be sampled --
-  -- if parity flag is ENABLED:  11 bit -> "1011" (1 start bit + 8 data bits + 1 parity bit + 1 stop bit)
-  -- if parity flag is DISABLED: 10 bit -> "1010" (1 start bit + 8 data bits + 1 stop bit)
-  num_bits <= "1011" when (ctrl(ctrl_pmode1_c) = '1') else "1010";
-
-
-  -- Clock Selection ------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  -- clock enable --
-  clkgen_en_o <= ctrl(ctrl_en_c);
-
-  -- uart clock select --
-  uart_clk <= clkgen_i(to_integer(unsigned(ctrl(ctrl_prsc2_c downto ctrl_prsc0_c))));
+  end process read_access;
 
 
   -- TX FIFO --------------------------------------------------------------------------------
@@ -343,7 +342,7 @@ begin
   port map (
     -- control --
     clk_i   => clk_i,           -- clock, rising edge
-    rstn_i  => '1',             -- async reset, low-active
+    rstn_i  => rstn_i,          -- async reset, low-active
     clear_i => tx_buffer.clear, -- sync reset, high-active
     half_o  => tx_buffer.half,  -- FIFO at least half-full
     -- write port --
@@ -519,7 +518,7 @@ begin
   port map (
     -- control --
     clk_i   => clk_i,           -- clock, rising edge
-    rstn_i  => '1',             -- async reset, low-active
+    rstn_i  => rstn_i,          -- async reset, low-active
     clear_i => rx_buffer.clear, -- sync reset, high-active
     half_o  => rx_buffer.half,  -- FIFO at least half-full
     -- write port --

--- a/rtl/core/neorv32_wishbone.vhd
+++ b/rtl/core/neorv32_wishbone.vhd
@@ -183,11 +183,11 @@ begin
       ctrl.we       <= '0';
       ctrl.adr      <= (others => '0');
       ctrl.wdat     <= (others => '0');
-      ctrl.rdat     <= (others => '-');
+      ctrl.rdat     <= (others => '0');
       ctrl.sel      <= (others => '0');
-      ctrl.timeout  <= (others => '-');
-      ctrl.ack      <= '-';
-      ctrl.err      <= '-';
+      ctrl.timeout  <= (others => '0');
+      ctrl.ack      <= '0';
+      ctrl.err      <= '0';
       ctrl.tmo      <= '0';
       ctrl.src      <= '0';
       ctrl.priv     <= '0';


### PR DESCRIPTION
For each SoC module:
* split read/write access logic into two processes - one for write access logic, one for read access logic and bus handshake
* removed explicit reset to don't care (`'-'`)