### PR TITLE
Remove signal initalizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 22.12.2022 | 1.7.9.1 | remove signal initialization (in reset generator) as some FPGAs do not support FF initialization via bitstream; [#464](https://github.com/stnolting/neorv32/pull/464) |
 | 21.12.2022 | [**:rocket:1.7.9**](https://github.com/stnolting/neorv32/releases/tag/v1.7.9) | **New release** |
 | 21.12.2022 | 1.7.8.11 | CPU: remove explicit reset-to-don't-care; branch and CSR access check logic optimizations; close further illegal instruction encoding hole; [#462](https://github.com/stnolting/neorv32/pull/462) |
 | 20.12.2022 | 1.7.8.10 | SOC: rework r/w access logic; split read and write accesses into two processes; removed explicit reset-to-don't-care; [#461](https://github.com/stnolting/neorv32/pull/461) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -1131,6 +1131,11 @@ _enable_ bit in the according module's control register), it is automatically de
 :sectnums:
 === Processor Reset
 
+.Processor Reset Signal
+[IMPORTANT]
+Always make sure to connect the processor's reset signal `rstn_i` to a valid reset source (a button, the "locked"
+signal of a PLL, a dedicated reset controller, etc.). **Do not assign a static value / connect a static signal to it!**
+
 The processor-wide reset can be triggered at any of the following sources:
 
 * the asynchronous low-active `rstn_i` top entity input signal

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070900"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070901"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -253,8 +253,8 @@ architecture neorv32_top_rtl of neorv32_top is
   constant io_slink_en_c : boolean := boolean(SLINK_NUM_RX > 0) or boolean(SLINK_NUM_TX > 0); -- implement slink at all?
 
   -- reset generator --
-  signal rstn_ext_sreg : std_ulogic_vector(3 downto 0) := (others => '0'); -- initialize (reset) via bitstream
-  signal rstn_int_sreg : std_ulogic_vector(3 downto 0) := (others => '0'); -- initialize (reset) via bitstream
+  signal rstn_ext_sreg : std_ulogic_vector(3 downto 0);
+  signal rstn_int_sreg : std_ulogic_vector(3 downto 0);
   signal rstn_ext      : std_ulogic;
   signal rstn_int      : std_ulogic;
   signal rstn_wdt      : std_ulogic;


### PR DESCRIPTION
Initialization of registers via bitstream isn't compatible with at least two FPGA architectures:

- Gatemate FPGA -> leads to an error during systhesis with Yosys
- Microchip SmartFusion & Polarfire FPGAs / SoCs -> init value ignored during synthesis

Both aren't nice, the 2nd one can lead to nasty misbehavior if you rely on the initialization value.

There are two signals with init values in the neorv32 design:

```vhdl
neorv32_top.vhd:  signal rstn_ext_sreg : std_ulogic_vector(3 downto 0) := (others => '0'); -- initialize (reset) via bitstream
neorv32_top.vhd:  signal rstn_int_sreg : std_ulogic_vector(3 downto 0)  := (others => '0'); -- initialize (reset) via bitstream
```

I propose to remove the initialization resulting in this:

```vhdl
neorv32_top.vhd:  signal rstn_ext_sreg : std_ulogic_vector(3 downto 0);
neorv32_top.vhd:  signal rstn_int_sreg : std_ulogic_vector(3 downto 0);
```