### PR TITLE
⚠️ rework CPU debug spec ISA configuration; ✨ enhance trigger module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 The most recent version of the **NEORV32** project can be found at the top of this list.
 "Stable releases" are linked and highlighted :rocket:.
 The latest release is [![release](https://img.shields.io/github/v/release/stnolting/neorv32)](https://github.com/stnolting/neorv32/releases).
-A list of all releases can be found [here](https://github.com/stnolting/neorv32/releases). The most recent version of the *NEORV32 data sheet*
-can be found [online at GitHub-pages](https://stnolting.github.io/neorv32).
+A list of all releases can be found [here](https://github.com/stnolting/neorv32/releases).
 
 Starting with version `1.5.7` this project uses [semantic versioning](https://semver.org).
 The _hardware version identifier_ uses an additional custom element (`MAJOR.MINOR.PATCH.custom`) to track _individual_ changes.
@@ -22,17 +21,18 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 ### Version History
 
-* :bug: = bug-fix
-* :sparkles: = new feature
-* :test_tube: = new (experimental) feature
-* :warning: = (major) change that might impact compatibility with previous versions
-* :lock: = security-related
-* :rocket: = release
+* :bug: bug-fix
+* :sparkles: new feature
+* :test_tube: new (experimental) feature
+* :warning: (major) change that might impact compatibility with previous versions
+* :lock: security-related
+* :rocket: release
 
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
-| 23.12.2022 | 1.7.9.2 | :sparkles: upgrade the **on-chip debugger (OCD)** to spec. version 1.0; major logic and debugging response time optimizations ;[#463](https://github.com/stnolting/neorv32/pull/463) |
+| 23.12.2022 | 1.7.9.3 | :warning: add explicit `Sdext` and `Sdtrig` ISA extension generics (replacing `DEBUG`); :sparkles: trigger-module can now also be used by machine-mode software without the on-chip debugger, add minimal example program `sw/example/demo_trigger_module`; [#465](https://github.com/stnolting/neorv32/pull/465) |
+| 23.12.2022 | 1.7.9.2 | :sparkles: upgrade the **on-chip debugger (OCD)** to spec. version 1.0; major logic and debugging response time optimizations; [#463](https://github.com/stnolting/neorv32/pull/463) |
 | 22.12.2022 | 1.7.9.1 | remove signal initialization (in reset generator) as some FPGAs do not support FF initialization via bitstream; [#464](https://github.com/stnolting/neorv32/pull/464) |
 | 21.12.2022 | [**:rocket:1.7.9**](https://github.com/stnolting/neorv32/releases/tag/v1.7.9) | **New release** |
 | 21.12.2022 | 1.7.8.11 | CPU: remove explicit reset-to-don't-care; branch and CSR access check logic optimizations; close further illegal instruction encoding hole; [#462](https://github.com/stnolting/neorv32/pull/462) |

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ see the [_open-source architecture ID list_](https://github.com/riscv/riscv-isa-
 [[`Zmmul`](https://stnolting.github.io/neorv32/#_zmmul_integer_multiplication)]
 [[`Zxcfu`](https://stnolting.github.io/neorv32/#_zxcfu_custom_instructions_extension_cfu)]
 [[`PMP`](https://stnolting.github.io/neorv32/#_pmp_physical_memory_protection)]
-[[`DEBUG`](https://stnolting.github.io/neorv32/#_cpu_debug_mode)]
+[[`Sdext`](https://stnolting.github.io/neorv32/#_sdext_external_debug_support)]
+[[`Sdtrig`](https://stnolting.github.io/neorv32/#_sdtrig_trigger_module)]
 * compatible to subsets of the RISC-V
 *Unprivileged ISA Specification* ([pdf](https://github.com/stnolting/neorv32/blob/main/docs/references/riscv-spec.pdf))
 and *Privileged Architecture Specification* ([pdf](https://github.com/stnolting/neorv32/blob/main/docs/references/riscv-privileged.pdf)).
@@ -204,7 +205,7 @@ using Xilinx Vivado 2019.2 (no constraints except for clock speed).
 |:------------------------------------------------------------------------------------------------------|:----:|:----:|:-----:|:----:|:-------:|
 | CPU: `rv32imcu_Zicsr_Zicnt_DEBUG` + `FST_MUL` + `FAST_SHIFT`; Peripherals: `UART0` + `MTIME` + `GPIO` | 2488 | 1807 |     7 |    4 | 150 MHz |
 
-:bulb: An incremental list of the CPU extensions and the Processor modules found in the
+:bulb: An incremental list of the CPU extensions and the Processor modules can be found in the
 [_Data Sheet: FPGA Implementation Results_](https://stnolting.github.io/neorv32/#_fpga_implementation_results).
 
 [[back to top](#The-NEORV32-RISC-V-Processor)]

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -746,6 +746,10 @@ A simple PMP example program can be found in `sw/example/demo_pmp`.
 Reducing the minimal PMP region size / granularity via the <<_pmp_min_granularity>> top entity generic
 will reduce hardware utilization and also reduces impact on critical path.
 
+.PMP Rules when in Debug Mode
+[NOTE]
+When in debug-mode all PMP rules are ignored making the debugger have maximum access rights.
+
 
 === **`Sdext** External Debug Support
 

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -32,7 +32,8 @@ image::neorv32_cpu_block.png[width=600,align=center]
 ** `Zmmul` - integer multiplication hardware
 ** `Zxcfu` - custom instructions extension
 ** `PMP` - physical memory protection
-** `Debug` - <<_cpu_debug_mode>> (part of the on.chip debugger) including hardware <<_trigger_module>>
+** `Sdext` - external debug support
+** `Sdtrig` - trigger module
 * <<_risc_v_compatibility>>: Compatible to the RISC-V user specifications and a subset of the RISC-V privileged architecture specifications - passes the official RISC-V Architecture Tests (v2+)
 * Official https://github.com/riscv/riscv-isa-manual/blob/master/marchid.md[RISC-V open source architecture ID]: decimal **19**; hexadecimal `0x00000013`
 * Supports _all_ of the machine-level <<_traps_exceptions_and_interrupts>> from the RISC-V specifications (including bus access exceptions and all unimplemented/illegal/malformed instructions)
@@ -363,13 +364,25 @@ See section <<_on_chip_debugger_ocd>> for more information.
 
 
 :sectnums!:
-==== _CPU_EXTENSION_RISCV_DEBUG_
+==== _CPU_EXTENSION_RISCV_Sdext_
 
 [cols="4,4,2"]
 [frame="all",grid="none"]
 |======
-| **CPU_EXTENSION_RISCV_DEBUG** | _boolean_ | _no default value_
-3+| Implement RISC-V-compatible "debug" CPU operation mode. See section <<_cpu_debug_mode>> for more information.
+| **CPU_EXTENSION_RISCV_Sdext** | _boolean_ | _no default value_
+3+| Implement RISC-V-compatible "debug" CPU operation mode required for the on-chip debugger.
+See section <<_cpu_debug_mode>> for more information.
+|======
+
+
+:sectnums!:
+==== _CPU_EXTENSION_RISCV_Sdtrig_
+
+[cols="4,4,2"]
+[frame="all",grid="none"]
+|======
+| **CPU_EXTENSION_RISCV_Sdtrig** | _boolean_ | _no default value_
+3+| Implement RISC-V-compatible trigger module. See section <<_cpu_debug_mode>> for more information.
 |======
 
 
@@ -732,6 +745,19 @@ A simple PMP example program can be found in `sw/example/demo_pmp`.
 [TIP]
 Reducing the minimal PMP region size / granularity via the <<_pmp_min_granularity>> top entity generic
 will reduce hardware utilization and also reduces impact on critical path.
+
+
+=== **`Sdext** External Debug Support
+
+This ISA extension enables the RISC-V-compatible "external debug support" by implementing
+the CPU "debug mode", which is required for the on-chip debugger.
+See section <<_on_chip_debugger_ocd>> / <<_cpu_debug_mode>> for more information.
+
+
+=== **`Sdtrig`** Trigger Module
+
+This ISA extension implements the RISC-V-compatible trigger module.
+See section <<_on_chip_debugger_ocd>> / <<_trigger_module>> for more information.
 
 
 <<<

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -16,13 +16,7 @@ implemented, not supported or disabled will raise an illegal instruction excepti
 [IMPORTANT]
 All writable CSRs provide **WARL** behavior (write all values; read only legal values). Application software
 should always read back a CSR after writing to check if the targeted bits can actually be modified (or are
-just read-only). 
-
-.Debug-Mode CSRs
-[NOTE]
-The CSRs related to the CPU's debug mode (used by the <<_on_chip_debugger_ocd>>) are not listed here as they are
-not accessible by "normal" software. See sections <<_cpu_debug_mode_csrs>> and <<_trigger_module_csrs>> for more
-information about those CSRs.
+just read-only).
 
 .NEORV32 Control and Status Registers (CSRs)
 [cols="<2,<4,<5,^1,<11"]
@@ -56,6 +50,19 @@ information about those CSRs.
 | 0x3b0   | <<_pmpaddr, `pmpaddr0`>>            | _CSR_PMPADDR0_       | r/w | Physical memory protection address register region 0
 5+<| ...
 | 0x3ef   | <<_pmpaddr, `pmpaddr15`>>           | _CSR_PMPADDR15_      | r/w | Physical memory protection address register region 15
+5+^| **<<_trigger_module_csrs>>**
+| 0x7a0   | <<_tselect>>                        | _CSR_TSELECT_        | r/w | Trigger select register
+| 0x7a1   | <<_tdata1>>                         | _CSR_TDATA1_         | r/w | Trigger data register 1
+| 0x7a2   | <<_tdata2>>                         | _CSR_TDATA2_         | r/w | Trigger data register 2
+| 0x7a3   | <<_tdata3>>                         | _CSR_TDATA3_         | r/w | Trigger data register 3
+| 0x7a4   | <<_tinfo>>                          | _CSR_TINFO_          | r/w | Trigger information register
+| 0x7a5   | <<_tcontrol>>                       | _CSR_TCONTROL_       | r/w | Trigger control register
+| 0x7a8   | <<_mcontext>>                       | _CSR_MCONTEXT_       | r/w | Machine context register
+| 0x7aa   | <<_scontext>>                       | _CSR_SCONTEXT_       | r/w | Supervisor context register
+5+^| **<<_cpu_debug_mode_csrs>>**
+| 0x7b0   | <<_dcsr>>                           | -                    | r/w | Debug control and status register
+| 0x7b1   | <<_dpc>>                            | -                    | r/w | Debug program counter
+| 0x7b2   | <<_dscratch0>>                      | -                    | r/w | Debug scratch register 0
 5+^| **<<_machine_counter_and_timer_csrs>>**
 | 0xb00   | <<_mcycleh, `mcycle`>>              | _CSR_MCYCLE_         | r/w | Machine cycle counter low word
 | 0xb02   | <<_minstreth, `minstret`>>          | _CSR_MINSTRET_       | r/w | Machine instruction-retired counter low word
@@ -803,7 +810,8 @@ NEORV32-specific read-only CSR that helps machine-mode software to discover `Z*`
 | 31:21 | -                     | r/- | _reserved_, read as zero
 | 20    | _CSR_MXISA_IS_SIM_    | r/- | set if CPU is being **simulated** (⚠️ not guaranteed)
 | 19:11 | -                     | r/- | _reserved_, read as zero
-| 10    | _CSR_MXISA_DEBUGMODE_ | r/- | RISC-V CPU `debug_mode` available when set (via top's <<_on_chip_debugger_en>> generic)
+| 11    | _CSR_MXISA_SDTRIG_    | r/- | `Sdtrig`extension (trigger module) available when set (via top's <<_cpu_extension_riscv_sdtrig>> generic)
+| 10    | _CSR_MXISA_SDEXT_     | r/- | `Sdext` extension (debug mode) available when set (via top's <<_cpu_extension_riscv_sdext>> generic)
 |  9    | _CSR_MXISA_ZIHPM_     | r/- | `Zihpm` (hardware performance monitors) extension available when set (via top's <<_cpu_extension_riscv_zihpm>> generic)
 |  8    | _CSR_MXISA_PMP_       | r/- | PMP` (physical memory protection) extension available when set (via top's <<_pmp_num_regions>> generic)
 |  7    | _CSR_MXISA_ZICNTR_    | r/- | `Zicntr` extension (`I` sub-extension) available when set - `[m]cycle`, `[m]instret` and `[m]time` CSRs available when set (via top's <<_cpu_extension_riscv_zicntr>> generic)

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -538,7 +538,7 @@ as only the sub-byte accesses (so, the actual bus transactions) are tracked by t
 === CPU Debug Mode
 
 The NEORV32 CPU Debug Mode `DB` or `DEBUG` is compatible to the **Minimal RISC-V Debug Specification 1.0**
-`Sdext` (external debug) ISA extension. When enabled via the <<_cpu_extension_riscv_debug>> generic (CPU) and/or
+`Sdext` (external debug) ISA extension. When enabled via the <<_cpu_extension_riscv_sdext>> generic (CPU) and/or
 the <<_on_chip_debugger_en>> (Processor) it adds a new CPU operation mode ("debug mode"), three additional CSRs
 (section <<_cpu_debug_mode_csrs>>) and one additional instruction (`dret`) to the core.
 
@@ -676,29 +676,28 @@ debug mode is entered. The `dret` instruction will return to `dpc` by moving `dp
 :sectnums:
 === Trigger Module
 
-The NEORV32 trigger module implements a subset of the features described in the "RISC-V Debug Specification / Trigger Module"
-(RISC-V `Sdtrig` ISA extension). It is always implemented when the CPU debug mode / the on-chip debugger is implemented.
+The RISC-V `Sdtrig` ISA extension add a programmable _trigger module_ to the processor when enabled
+(via the <<_cpu_extension_riscv_sdtrig>>). The NEORV32 trigger module implements a subset of the features
+described in the "RISC-V Debug Specification / Trigger Module".
 
-[IMPORTANT]
-The trigger module only provides a single trigger of _instruction address match_ type. This trigger will fire
-**after** the instruction at the specific address has been executed.
-
-The trigger module only provides a single trigger supporting only the "instruction address match" type. This limitation
+The trigger module only provides a _single_ trigger supporting only the "instruction address match" type. This limitation
 is granted by the RISC-V specs. and is sufficient to **debug code executed from read-only memory (ROM)**.
 "Normal" _software_ breakpoints (using GDB's `b`/`break` command) are implemented by temporarily replacing the according
-instruction word by a BREAK instruction. This is not possible when debugging code that is executed from read-only memory
+instruction word by an `ebreak` instruction. This is not possible when debugging code that is executed from read-only memory
 (for example when debugging programs that are executed via the <<_execute_in_place_module_xip>>).
 Therefore, the NEORV32 trigger module provides a single "instruction address match" trigger to enter debug mode when
 executing the instruction at a specific address. These "hardware-assisted breakpoints" are used by GDB's `hb`/`hbreak` command.
 
+The trigger module can also be used independently of the CPU debug-mode (so independent of the on-chip debugger).
+Machine-mode software can use the trigger module to raise a Break exception when the instruction at a programmable
+address gets executed.
 
 :sectnums:
 ==== Trigger Module CSRs
 
-The trigger module provides 8 additional CSRs, which accessible in debug mode and also in machine-mode. Since the
-trigger module does not support _native mode_ writes from machine-mode software to those CSRs are ignored.
-Hence, the CSRs of this module are only relevant for the debugger.
-
+The `Sdtrig` ISA extension add 8 additional CSRs, which are accessible in debug-mode and also in machine-mode.
+Machine-level accesses can be ignore by setting <<_tdata1>>`.dmode´. This is automatically done by GDB if it uses the trigger module
+for implementing a "hardware breakpoint"
 
 :sectnums!:
 ===== **`tselect`**
@@ -719,7 +718,7 @@ Hence, the CSRs of this module are only relevant for the debugger.
 [frame="topbot",grid="none"]
 |======
 | 0x7a1 | **Trigger data register 1 / match control register** | `tdata1` / `mcontrol`
-3+<| Reset value: `0x28041048`
+3+<| Reset value: `0x20040040`
 3+<| This CSR is used to configure the address match trigger. Only one bit is writable, the remaining bits are hardwired (see table below).
 Write attempts to the hardwired bits are ignored.
 |======
@@ -730,13 +729,13 @@ Write attempts to the hardwired bits are ignored.
 |=======================
 | Bit   | Name [RISC-V] | R/W | Description
 | 31:28 | `type`        | r/- | `0010` - address match trigger
-| 27    | `dmode`       | r/- | `1` - only debug-mode can write to the `tdata*` CSRs
+| 27    | `dmode`       | r/w | set to ignore `tdata*` CSR accesses from machine-mode
 | 26:21 | `maskmax`     | r/- | `000000` - only exact values
 | 20    | `hit`         | r/- | `0` - feature not supported
 | 19    | `select`      | r/- | `0` - fire trigger on address match
 | 18    | `timing`      | r/- | `1` - trigger **after** executing the triggering instruction
 | 17:16 | `sizelo`      | r/- | `00` - match against an access of any size
-| 15:12 | `action`      | r/- | `0001` - enter debug mode on trigger fire
+| 15:12 | `action`      | r/w | `0001` = enter debug-mode on trigger fire; `0000` = normal m-mode break exception on trigger fire
 | 11    | `chain`       | r/- | `0` - chaining is not supported - there is only one trigger
 | 10:6  | `match`       | r/- | `0000` - only full-address match
 | 6     | `m`           | r/- | `1` - trigger enabled when in machine-mode
@@ -757,7 +756,7 @@ Write attempts to the hardwired bits are ignored.
 |======
 | 0x7a2 | **Trigger data register 2** | `tdata2`
 3+<| Reset value: `0x00000000`
-3+<| Since only the "address match trigger" type is supported, this r/w CSR is used to store the address of the triggering instruction.
+3+<| Since only the "address match trigger" type is supported, this r/w CSR is used to configure the address of the triggering instruction.
 |======
 
 
@@ -819,4 +818,3 @@ Write attempts to the hardwired bits are ignored.
 3+<| Reset value: `0x00000000`
 3+<| This CSR is not required for the NEORV32 trigger module. Hence, it is hardwired to zero and any write access is ignored.
 |======
-

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -326,7 +326,7 @@ are configured as "zero" and are read-only. Writing '1' to these bits/fields wil
 [frame="topbot",grid="none"]
 |======
 | 0x16 | **Abstract control and status** | `abstracts`
-3+| Reset value: _see below_
+3+| Reset value: `0x02000801`
 3+| Command execution info and status.
 |======
 
@@ -336,13 +336,13 @@ are configured as "zero" and are read-only. Writing '1' to these bits/fields wil
 |=======================
 | Bit   | Name [RISC-V] | R/W | Description
 | 31:29 | _reserved_    | r/- | reserved; always zero
-| 28:24 | `progbufsize` | r/- | `0010`; size of the program buffer (`progbuf`) = 2 entries
+| 28:24 | `progbufsize` | r/- | always `0010`: size of the program buffer (`progbuf`) = 2 entries
 | 23:11 | _reserved_    | r/- | reserved; always zero
 | 12    | `busy`        | r/- | `1` when a command is being executed
-| 11    | _reserved_    | r/- | reserved; always zero
+| 11    | `relaxedpriv` | r/- | always `1`: PMP rules are ignored when in debug mode
 | 10:8  | `cmderr`      | r/w | error during command execution (see below); has to be cleared by writing `111`
 | 7:4   | _reserved_    | r/- | reserved; always zero
-| 3:0   | `datacount`   | r/- | `0001`; number of implemented `data` registers for abstract commands = 1
+| 3:0   | `datacount`   | r/- | always `0001`: number of implemented `data` registers for abstract commands = 1
 |=======================
 
 Error codes in `cmderr` (highest priority first):
@@ -352,6 +352,10 @@ Error codes in `cmderr` (highest priority first):
 * `011` - exception during command execution
 * `010` - unsupported command
 * `001` - invalid DM register read/write while command is/was executing
+
+.PMP Rules
+[NOTE]
+When in debug-mode all PMP rules are ignored making the debugger have maximum access rights.
 
 
 :sectnums!:

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -252,7 +252,8 @@ Software can retrieve this value from the <<_system_configuration_information_me
 [frame="all",grid="none"]
 |======
 | **ON_CHIP_DEBUGGER_EN** | _boolean_ | false
-3+| Implement the on-chip debugger (OCD) and the CPU debug mode when true.
+3+| Implement the on-chip debugger (OCD) and the CPU debug mode when true. This generic is directly passed
+to the CPU's <<_cpu_extension_riscv_sdext>> and <<_cpu_extension_riscv_sdtrig>> generics.
 See section <<_on_chip_debugger_ocd>> for more information.
 |======
 

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -64,7 +64,8 @@ entity neorv32_cpu is
     CPU_EXTENSION_RISCV_Zifencei : boolean; -- implement instruction stream sync.?
     CPU_EXTENSION_RISCV_Zmmul    : boolean; -- implement multiply-only M sub-extension?
     CPU_EXTENSION_RISCV_Zxcfu    : boolean; -- implement custom (instr.) functions unit?
-    CPU_EXTENSION_RISCV_DEBUG    : boolean; -- implement CPU debug mode?
+    CPU_EXTENSION_RISCV_Sdext    : boolean; -- implement external debug mode extension?
+    CPU_EXTENSION_RISCV_Sdtrig   : boolean; -- implement trigger module extension?
     -- Extension Options --
     FAST_MUL_EN                  : boolean; -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                : boolean; -- use barrel shifter for shift operations
@@ -180,7 +181,8 @@ begin
     cond_sel_string_f(CPU_EXTENSION_RISCV_Zfinx,    "_Zfinx", "") &
     cond_sel_string_f(CPU_EXTENSION_RISCV_Zmmul,    "_Zmmul", "") &
     cond_sel_string_f(CPU_EXTENSION_RISCV_Zxcfu,    "_Zxcfu", "") &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_DEBUG,    "_<DebugMode>", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Sdext,    "_Sdext", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Sdtrig,   "_Sdtrig", "") &
     ""
     severity note;
 
@@ -241,9 +243,9 @@ begin
     "NEORV32 CPU CONFIG ERROR! <M> and <Zmmul> extensions cannot co-exist!" severity error;
 
   -- Debug mode --
-  assert not ((CPU_EXTENSION_RISCV_DEBUG = true) and (CPU_EXTENSION_RISCV_Zicsr = false)) report
+  assert not ((CPU_EXTENSION_RISCV_Sdext = true) and (CPU_EXTENSION_RISCV_Zicsr = false)) report
     "NEORV32 CPU CONFIG ERROR! Debug mode requires <CPU_EXTENSION_RISCV_Zicsr> extension to be enabled." severity error;
-  assert not ((CPU_EXTENSION_RISCV_DEBUG = true) and (CPU_EXTENSION_RISCV_Zifencei = false)) report
+  assert not ((CPU_EXTENSION_RISCV_Sdext = true) and (CPU_EXTENSION_RISCV_Zifencei = false)) report
     "NEORV32 CPU CONFIG ERROR! Debug mode requires <CPU_EXTENSION_RISCV_Zifencei> extension to be enabled." severity error;
 
   -- fast multiplication option --
@@ -278,7 +280,8 @@ begin
     CPU_EXTENSION_RISCV_Zifencei => CPU_EXTENSION_RISCV_Zifencei, -- implement instruction stream sync.?
     CPU_EXTENSION_RISCV_Zmmul    => CPU_EXTENSION_RISCV_Zmmul,    -- implement multiply-only M sub-extension?
     CPU_EXTENSION_RISCV_Zxcfu    => CPU_EXTENSION_RISCV_Zxcfu,    -- implement custom (instr.) functions unit?
-    CPU_EXTENSION_RISCV_DEBUG    => CPU_EXTENSION_RISCV_DEBUG,    -- implement CPU debug mode?
+    CPU_EXTENSION_RISCV_Sdext    => CPU_EXTENSION_RISCV_Sdext,    -- implement external debug mode extension?
+    CPU_EXTENSION_RISCV_Sdtrig   => CPU_EXTENSION_RISCV_Sdtrig,   -- implement trigger module extension?
     -- Tuning Options --
     FAST_MUL_EN                  => FAST_MUL_EN,                  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => FAST_SHIFT_EN,                -- use barrel shifter for shift operations

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1945,6 +1945,9 @@ begin
             if (CPU_EXTENSION_RISCV_Sdext = true) and (debug_ctrl.running = '1') then
               if (CPU_EXTENSION_RISCV_U = true) then
                 csr.privilege <= csr.dcsr_prv;
+                if (csr.dcsr_prv /= priv_mode_m_c) then
+                  csr.mstatus_mprv <= '0'; -- clear if return priv. mode is less than M
+                end if;
               end if;
 
             -- return from "normal trap" --

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -586,7 +586,7 @@ begin
           dmi_resp_data_o(31 downto 24) <= (others => '0');           -- reserved (r/-)
           dmi_resp_data_o(28 downto 24) <= "00010";                   -- progbufsize (r/-): number of words in program buffer = 2
           dmi_resp_data_o(12)           <= dm_ctrl.busy;              -- busy (r/-): abstract command in progress (1) / idle (0)
-          dmi_resp_data_o(11)           <= '0';                       -- reserved (r/-)
+          dmi_resp_data_o(11)           <= '1';                       -- relaxedpriv (r/-): PMP rules are ignored when in debug-mode
           dmi_resp_data_o(10 downto 08) <= dm_ctrl.cmderr;            -- cmderr (r/w1c): any error during execution?
           dmi_resp_data_o(07 downto 04) <= (others => '0');           -- reserved (r/-)
           dmi_resp_data_o(03 downto 00) <= "0001";                    -- datacount (r/-): number of implemented data registers = 1

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070902"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070903"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -1174,7 +1174,8 @@ package neorv32_package is
       CPU_EXTENSION_RISCV_Zifencei : boolean; -- implement instruction stream sync.?
       CPU_EXTENSION_RISCV_Zmmul    : boolean; -- implement multiply-only M sub-extension?
       CPU_EXTENSION_RISCV_Zxcfu    : boolean; -- implement custom (instr.) functions unit?
-      CPU_EXTENSION_RISCV_DEBUG    : boolean; -- implement CPU debug mode?
+      CPU_EXTENSION_RISCV_Sdext    : boolean; -- implement external debug mode extension?
+      CPU_EXTENSION_RISCV_Sdtrig   : boolean; -- implement trigger module extension?
       -- Tuning Options --
       FAST_MUL_EN                  : boolean; -- use DSPs for M extension's multiplier
       FAST_SHIFT_EN                : boolean; -- use barrel shifter for shift operations
@@ -1247,7 +1248,8 @@ package neorv32_package is
       CPU_EXTENSION_RISCV_Zifencei : boolean; -- implement instruction stream sync.?
       CPU_EXTENSION_RISCV_Zmmul    : boolean; -- implement multiply-only M sub-extension?
       CPU_EXTENSION_RISCV_Zxcfu    : boolean; -- implement custom (instr.) functions unit?
-      CPU_EXTENSION_RISCV_DEBUG    : boolean; -- implement CPU debug mode?
+      CPU_EXTENSION_RISCV_Sdext    : boolean; -- implement external debug mode extension?
+      CPU_EXTENSION_RISCV_Sdtrig   : boolean; -- implement trigger module extension?
       -- Extension Options --
       FAST_MUL_EN                  : boolean; -- use DSPs for M extension's multiplier
       FAST_SHIFT_EN                : boolean; -- use barrel shifter for shift operations

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -565,7 +565,8 @@ begin
     CPU_EXTENSION_RISCV_Zifencei => CPU_EXTENSION_RISCV_Zifencei, -- implement instruction stream sync.?
     CPU_EXTENSION_RISCV_Zmmul    => CPU_EXTENSION_RISCV_Zmmul,    -- implement multiply-only M sub-extension?
     CPU_EXTENSION_RISCV_Zxcfu    => CPU_EXTENSION_RISCV_Zxcfu,    -- implement custom (instr.) functions unit?
-    CPU_EXTENSION_RISCV_DEBUG    => ON_CHIP_DEBUGGER_EN,          -- implement CPU debug mode?
+    CPU_EXTENSION_RISCV_Sdext    => ON_CHIP_DEBUGGER_EN,          -- implement external debug mode extension?
+    CPU_EXTENSION_RISCV_Sdtrig   => ON_CHIP_DEBUGGER_EN,          -- implement debug mode trigger module extension?
     -- Extension Options --
     FAST_MUL_EN                  => FAST_MUL_EN,                  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => FAST_SHIFT_EN,                -- use barrel shifter for shift operations

--- a/sw/example/demo_trigger_module/main.c
+++ b/sw/example/demo_trigger_module/main.c
@@ -1,0 +1,107 @@
+// #################################################################################################
+// # << NEORV32 - RISC-V Trigger Module Example >>                                                 #
+// # ********************************************************************************************* #
+// # BSD 3-Clause License                                                                          #
+// #                                                                                               #
+// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+// #                                                                                               #
+// # Redistribution and use in source and binary forms, with or without modification, are          #
+// # permitted provided that the following conditions are met:                                     #
+// #                                                                                               #
+// # 1. Redistributions of source code must retain the above copyright notice, this list of        #
+// #    conditions and the following disclaimer.                                                   #
+// #                                                                                               #
+// # 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
+// #    conditions and the following disclaimer in the documentation and/or other materials        #
+// #    provided with the distribution.                                                            #
+// #                                                                                               #
+// # 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
+// #    endorse or promote products derived from this software without specific prior written      #
+// #    permission.                                                                                #
+// #                                                                                               #
+// # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
+// # OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
+// # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
+// # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
+// # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
+// # GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
+// # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
+// # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
+// # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
+// # ********************************************************************************************* #
+// # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+// #################################################################################################
+
+/**********************************************************************//**
+ * @file demo_trigger_module/main.c
+ * @author Stephan Nolting
+ * @brief Using the RISC-V trigger module from machine-mode.
+ **************************************************************************/
+#include <neorv32.h>
+#include <string.h>
+
+
+/**********************************************************************//**
+ * @name User configuration
+ **************************************************************************/
+/**@{*/
+/** UART BAUD rate */
+#define BAUD_RATE 19200
+/**@}*/
+
+// Prototypes
+void dummy_function(void);
+
+
+/**********************************************************************//**
+ * Example program to show how to cause an exception when reaching a specific
+ * instruction address using the RISC-V trigger module.
+ *
+ * @note This program requires the 'Sdtrig' ISA extension.
+ *
+ * @return 0 if execution was successful
+ **************************************************************************/
+int main() {
+
+  neorv32_rte_setup();
+
+  // setup UART at default baud rate, no parity bits, no HW flow control
+  neorv32_uart0_setup(BAUD_RATE, PARITY_NONE, FLOW_CONTROL_NONE);
+
+  // intro
+  neorv32_uart0_printf("\n<< RISC-V Trigger Module Example >>\n\n");
+
+  // check if trigger module unit is implemented at all
+  if ((neorv32_cpu_csr_read(CSR_MXISA) & (1<<CSR_MXISA_SDTRIG)) == 0) {
+    neorv32_uart0_printf("Trigger module ('Sdtrig' ISA extension) not implemented!");
+    return -1;
+  }
+
+  // info
+  neorv32_uart0_printf("This program show how to use the trigger module to raise an EBREAK exception\n"
+                       "when the instruction at a specific address gets executed.\n\n");
+
+  // configure trigger module
+  uint32_t trig_addr = (uint32_t)(&dummy_function);
+  neorv32_cpu_csr_write(CSR_TDATA2, trig_addr); // trigger address
+  neorv32_cpu_csr_write(CSR_TDATA1, (1<<2)); // set 'exe': enable trigger
+  neorv32_uart0_printf("Trigger address set to 0x%x.\n", trig_addr);
+
+  neorv32_uart0_printf("Calling dummy function... (this will cause the EBREAK exception)\n");
+  // call function - this will cause the trigger module to fire, which will result in an EBREAK
+  // exception that is captured by the RTE's debug handler
+  dummy_function();
+
+  neorv32_uart0_printf("\nProgram completed.\n");
+  return 0;
+}
+
+
+/**********************************************************************//**
+ * Just a simple dummy function that will fire the trigger module.
+ * @note Make sure this is not inlined.
+ **************************************************************************/
+void __attribute__ ((noinline)) dummy_function(void) {
+
+  neorv32_uart0_printf("Hello from the dummy program!\n");
+}

--- a/sw/example/demo_trigger_module/makefile
+++ b/sw/example/demo_trigger_module/makefile
@@ -1,0 +1,4 @@
+# Modify this variable to fit your NEORV32 setup (neorv32 home folder)
+NEORV32_HOME ?= ../../..
+
+include $(NEORV32_HOME)/sw/common/common.mk

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -460,7 +460,8 @@ enum NEORV32_CSR_XISA_enum {
   CSR_MXISA_ZICNTR    =  7, /**< CPU mxisa CSR  (7): standard instruction, cycle and time counter CSRs (r/-)*/
   CSR_MXISA_PMP       =  8, /**< CPU mxisa CSR  (8): physical memory protection (also "Smpmp") (r/-)*/
   CSR_MXISA_ZIHPM     =  9, /**< CPU mxisa CSR  (9): hardware performance monitors (r/-)*/
-  CSR_MXISA_DEBUGMODE = 10, /**< CPU mxisa CSR (10): RISC-V debug mode (r/-)*/
+  CSR_MXISA_SDEXT     = 10, /**< CPU mxisa CSR (10): RISC-V debug mode (r/-)*/
+  CSR_MXISA_SDTRIG    = 11, /**< CPU mxisa CSR (11): RISC-V trigger module (r/-)*/
 
   // Misc
   CSR_MXISA_IS_SIM    = 20, /**< CPU mxisa CSR (20): this might be a simulation when set (r/-)*/

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -374,8 +374,11 @@ void neorv32_rte_print_hw_config(void) {
   if (tmp & (1<<CSR_MXISA_ZXCFU)) {
     neorv32_uart0_printf("Zxcfu ");
   }
-  if (tmp & (1<<CSR_MXISA_DEBUGMODE)) {
-    neorv32_uart0_printf("DebugMode ");
+  if (tmp & (1<<CSR_MXISA_SDEXT)) {
+    neorv32_uart0_printf("Sdext ");
+  }
+  if (tmp & (1<<CSR_MXISA_SDTRIG)) {
+    neorv32_uart0_printf("Sdtrig ");
   }
 
   // CPU tuning options


### PR DESCRIPTION
⚠️ This PR removes the CPU's `CPU_EXTENSION_RISCV_DEBUG` generic, which is replaced by two new generics to allow a finer configuration of the available debug spec. ISA extensions:

* `CPU_EXTENSION_RISCV_Sdext`: set _true_ to enable the RISC-V `Sdext` ISA extension (external debug support, required for the on-chip debugger)
* `CPU_EXTENSION_RISCV_Sdtrig`: set _true_ to enable the RISC-V `Sdtrig` ISA extension (trigger module)

✨ This PR also enhances the capabilities of the **RISC-V trigger module** (`Sdtrig` ISA extension), which can now also be used _independently_ of the on-chip debugger. The trigger module can raise a machine-mode breakpoint exception when execution reaches a programmable address. A simple example program will be added to `sw/example/demo_trigger_module`.