### PR TITLE
[rtl] OCD: update DTM and DM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 04.01.2023 | 1.7.9.4 | update **on-chip debugger**: :test_tube: remove debug module's `haltsum0` register; rework DMI to comply with RISC-V debug spec.; minor edits, updates and fixes; [#468](https://github.com/stnolting/neorv32/pull/468) |
 | 23.12.2022 | 1.7.9.3 | :warning: add explicit `Sdext` and `Sdtrig` ISA extension generics (replacing `DEBUG`); :sparkles: trigger-module can now also be used by machine-mode software without the on-chip debugger, add minimal example program `sw/example/demo_trigger_module`; [#465](https://github.com/stnolting/neorv32/pull/465) |
 | 23.12.2022 | 1.7.9.2 | :sparkles: upgrade the **on-chip debugger (OCD)** to spec. version 1.0; major logic and debugging response time optimizations; [#463](https://github.com/stnolting/neorv32/pull/463) |
 | 22.12.2022 | 1.7.9.1 | remove signal initialization (in reset generator) as some FPGAs do not support FF initialization via bitstream; [#464](https://github.com/stnolting/neorv32/pull/464) |

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -43,7 +43,8 @@ image::neorv32_ocd_complex.png[align=center]
 
 [start=1]
 . <<_debug_transport_module_dtm>> (`rtl/core/neorv32_debug_dtm.vhd`): JTAG access tap to allow an external
-  adapter to interface with the _debug module(DM)_ using the _debug module interface (dmi)_.
+  adapter to interface with the _debug module(DM)_ using the _debug module interface (dmi)_ - this interface is compatible to
+  the interface description shown in Appendix 3 of the "RISC-V debug stable" specification.
 . <<_debug_module_dm>> (`rtl/core/neorv32_debug_tm.vhd`): Debugger control unit that is configured by the DTM via the
   the _dmi_. From the CPU's "point of view" this module behaves as another memory-mapped "peripheral" that can be accessed
   via the processor-internal bus. The memory-mapped registers provide an internal _data buffer_ for data transfer
@@ -112,11 +113,10 @@ The accesses are controlled by TAP-internal registers, which are selected by the
 and accessed through the JTAG data register (`DR`).
 
 [NOTE]
-The DTM's instruction and data registers can be accessed using OpenOCDs `irscan` and `drscan` commands.
-OpenOCD also provides low-level RISC-V-specific commands (`riscv dmi_read` & `riscv dmi_write`) for direct accesses
-via the debug module interface.
+The DTM's instruction and data registers can be accessed using OpenOCD's `irscan` and `drscan` commands.
+OpenOCD also provides low-level RISC-V-specific commands for direct DMI accesses (`riscv dmi_read` & `riscv dmi_write`).
 
-JTAG accesses are based on the *instruction register* `IR`, which is 5 bit wide, and several *data registers* `DR`
+JTAG accesses are based on a single _instruction register_ `IR`, which is 5 bit wide, and several _data registers_ `DR`
 with different sizes. The individual data registers are accessed by writing the according address to the instruction
 register. The following table shows the available data registers and their addresses:
 
@@ -127,7 +127,7 @@ register. The following table shows the available data registers and their addre
 | Address (via `IR`) | Name     | Size [bits] | Description
 | `00001`            | `IDCODE` | 32          | identifier, default: `0x0CAFE001` (configurable via package's `jtag_tap_idcode_*` constants)
 | `10000`            | `DTMCS`  | 32          | debug transport module control and status register
-| `10001`            | `DMI`    | 41          | debug module interface (_dmi_); 7-bit address, 32-bit read/write data, 2-bit operation (`00` = NOP; `10` = write; `01` = read)
+| `10001`            | `DMI`    | 40          | debug module interface (_dmi_); 6-bit address, 32-bit read/write data, 2-bit operation (`00` = NOP; `10` = write; `01` = read)
 | others             | `BYPASS` | 1           | default JTAG bypass register
 |=======================
 
@@ -137,12 +137,12 @@ register. The following table shows the available data registers and their addre
 |=======================
 | Bit(s) | Name           | R/W | Description
 | 31:18  | -              | r/- | _reserved_, hardwired to zero
-| 17     | `dmihardreset` | r/w | setting this bit will reset the DM interface; this bit auto-clears
+| 17     | `dmihardreset` | r/w | setting this bit will reset the debug module interface; this bit auto-clears
 | 16     | `dmireset`     | r/w | setting this bit will clear the sticky error state; this bit auto-clears
 | 15     | -              | r/- | _reserved_, hardwired to zero
 | 14:12  | `idle`         | r/- | recommended idle states (= 0, no idle states required)
 | 11:10  | `dmistat`      | r/- | DMI status: `00` = no error, `01` = reserved, `10` = operation failed, `11` = failed operation during pending DMI operation
-| 9:4    | `abits`        | r/- | number of address bits in `DMI` register (= 7)
+| 9:4    | `abits`        | r/- | number of address bits in `DMI` register (= 6)
 | 3:0    | `version`      | r/- | `0001` = DTM is compatible to spec. version 0.13 & 1.0
 |=======================
 
@@ -214,7 +214,6 @@ their functionality.
 |  `0x20` | `progbuf0`     | Program buffer 0
 |  `0x21` | `progbuf1`     | Program buffer 1
 |  `0x38` | (`sbcs`)       | System bus access control and status; reads as zero to indicate there is no _direct_ system bus access
-|  `0x40` | `haltsum0`     | Halt summary 0
 |=======================
 
 
@@ -422,18 +421,6 @@ hart's GPRs (abstract command register index `0x1000` - `0x101f`).
 | 0x21 | **Program buffer 1** | `progbuf1`
 3+| Reset value: `0x00000013` ("NOP")
 3+| Program buffer (two entries) for the DM. Note that this register is read-only for the DM (allowed since spec. version 1.0)!
-|======
-
-
-:sectnums!:
-===== **`haltsum0`**
-
-[cols="4,27,>7"]
-[frame="topbot",grid="none"]
-|======
-| 0x40 | **Halt summary 0** | `haltsum0`
-3+| Reset value: `0x00000000`
-3+| Bit 0 of this register is set if the hart is halted (all remaining bits are always zero). The entire register is read-only.
 |======
 
 

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -19,7 +19,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -58,55 +58,59 @@ use neorv32.neorv32_package.all;
 entity neorv32_debug_dm is
   port (
     -- global control --
-    clk_i            : in  std_ulogic; -- global clock line
-    rstn_i           : in  std_ulogic; -- global reset line, low-active
+    clk_i             : in  std_ulogic; -- global clock line
+    rstn_i            : in  std_ulogic; -- global reset line, low-active
     -- debug module interface (DMI) --
-    dmi_rstn_i       : in  std_ulogic;
-    dmi_req_valid_i  : in  std_ulogic;
-    dmi_req_ready_o  : out std_ulogic; -- DMI is allowed to make new requests when set
-    dmi_req_addr_i   : in  std_ulogic_vector(06 downto 0);
-    dmi_req_op_i     : in  std_ulogic; -- 0=read, 1=write
-    dmi_req_data_i   : in  std_ulogic_vector(31 downto 0);
-    dmi_resp_valid_o : out std_ulogic; -- response valid when set
-    dmi_resp_ready_i : in  std_ulogic; -- ready to receive respond
-    dmi_resp_data_o  : out std_ulogic_vector(31 downto 0);
-    dmi_resp_err_o   : out std_ulogic; -- 0=ok, 1=error
+    dmi_req_valid_i   : in  std_ulogic;
+    dmi_req_ready_o   : out std_ulogic; -- DMI is allowed to make new requests when set
+    dmi_req_address_i : in  std_ulogic_vector(05 downto 0);
+    dmi_req_op_i      : in  std_ulogic_vector(01 downto 0);
+    dmi_req_data_i    : in  std_ulogic_vector(31 downto 0);
+    dmi_rsp_valid_o   : out std_ulogic; -- response valid when set
+    dmi_rsp_ready_i   : in  std_ulogic; -- ready to receive respond
+    dmi_rsp_data_o    : out std_ulogic_vector(31 downto 0);
+    dmi_rsp_op_o      : out std_ulogic_vector(01 downto 0);
     -- CPU bus access --
-    cpu_debug_i      : in  std_ulogic; -- CPU is in debug mode
-    cpu_addr_i       : in  std_ulogic_vector(31 downto 0); -- address
-    cpu_rden_i       : in  std_ulogic; -- read enable
-    cpu_wren_i       : in  std_ulogic; -- write enable
-    cpu_ben_i        : in  std_ulogic_vector(03 downto 0); -- byte write enable
-    cpu_data_i       : in  std_ulogic_vector(31 downto 0); -- data in
-    cpu_data_o       : out std_ulogic_vector(31 downto 0); -- data out
-    cpu_ack_o        : out std_ulogic; -- transfer acknowledge
+    cpu_debug_i       : in  std_ulogic; -- CPU is in debug mode
+    cpu_addr_i        : in  std_ulogic_vector(31 downto 0); -- address
+    cpu_rden_i        : in  std_ulogic; -- read enable
+    cpu_wren_i        : in  std_ulogic; -- write enable
+    cpu_ben_i         : in  std_ulogic_vector(03 downto 0); -- byte write enable
+    cpu_data_i        : in  std_ulogic_vector(31 downto 0); -- data in
+    cpu_data_o        : out std_ulogic_vector(31 downto 0); -- data out
+    cpu_ack_o         : out std_ulogic; -- transfer acknowledge
     -- CPU control --
-    cpu_ndmrstn_o    : out std_ulogic; -- soc reset
-    cpu_halt_req_o   : out std_ulogic  -- request hart to halt (enter debug mode)
+    cpu_ndmrstn_o     : out std_ulogic; -- soc reset
+    cpu_halt_req_o    : out std_ulogic  -- request hart to halt (enter debug mode)
   );
 end neorv32_debug_dm;
 
 architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
 
   -- DM configuration --
-  constant nscratch_c   : std_ulogic_vector(03 downto 0) := "0001"; -- number of dscratch* registers in CPU
+  constant nscratch_c   : std_ulogic_vector(03 downto 0) := "0001"; -- number of dscratch registers in CPU
   constant datasize_c   : std_ulogic_vector(03 downto 0) := "0001"; -- number of data registers in memory/CSR space
   constant dataaddr_c   : std_ulogic_vector(11 downto 0) := dm_data_base_c(11 downto 0); -- signed base address of data registers in memory/CSR space
   constant dataaccess_c : std_ulogic                     := '1';    -- 1: abstract data is memory-mapped, 0: abstract data is CSR-mapped
 
+  -- DM operations --
+  constant dmi_nop_c      : std_ulogic_vector(1 downto 0) := "00"; -- no operation
+  constant dmi_read_c     : std_ulogic_vector(1 downto 0) := "01"; -- read data
+  constant dmi_write_c    : std_ulogic_vector(1 downto 0) := "10"; -- write data
+  constant dmi_reserved_c : std_ulogic_vector(1 downto 0) := "11"; -- reserved
+
   -- available DMI registers --
-  constant addr_data0_c        : std_ulogic_vector(6 downto 0) := "000" & x"4";
-  constant addr_dmcontrol_c    : std_ulogic_vector(6 downto 0) := "001" & x"0";
-  constant addr_dmstatus_c     : std_ulogic_vector(6 downto 0) := "001" & x"1";
-  constant addr_hartinfo_c     : std_ulogic_vector(6 downto 0) := "001" & x"2";
-  constant addr_abstractcs_c   : std_ulogic_vector(6 downto 0) := "001" & x"6";
-  constant addr_command_c      : std_ulogic_vector(6 downto 0) := "001" & x"7";
-  constant addr_abstractauto_c : std_ulogic_vector(6 downto 0) := "001" & x"8";
-  constant addr_nextdm_c       : std_ulogic_vector(6 downto 0) := "001" & x"d";
-  constant addr_progbuf0_c     : std_ulogic_vector(6 downto 0) := "010" & x"0";
-  constant addr_progbuf1_c     : std_ulogic_vector(6 downto 0) := "010" & x"1";
-  constant addr_sbcs_c         : std_ulogic_vector(6 downto 0) := "011" & x"8";
-  constant addr_haltsum0_c     : std_ulogic_vector(6 downto 0) := "100" & x"0";
+  constant addr_data0_c        : std_ulogic_vector(5 downto 0) := "00" & x"4";
+  constant addr_dmcontrol_c    : std_ulogic_vector(5 downto 0) := "01" & x"0";
+  constant addr_dmstatus_c     : std_ulogic_vector(5 downto 0) := "01" & x"1";
+  constant addr_hartinfo_c     : std_ulogic_vector(5 downto 0) := "01" & x"2";
+  constant addr_abstractcs_c   : std_ulogic_vector(5 downto 0) := "01" & x"6";
+  constant addr_command_c      : std_ulogic_vector(5 downto 0) := "01" & x"7";
+  constant addr_abstractauto_c : std_ulogic_vector(5 downto 0) := "01" & x"8";
+  constant addr_nextdm_c       : std_ulogic_vector(5 downto 0) := "01" & x"d";
+  constant addr_progbuf0_c     : std_ulogic_vector(5 downto 0) := "10" & x"0";
+  constant addr_progbuf1_c     : std_ulogic_vector(5 downto 0) := "10" & x"1";
+  constant addr_sbcs_c         : std_ulogic_vector(5 downto 0) := "11" & x"8";
 
   -- RISC-V 32-bit instruction prototypes --
   constant instr_nop_c    : std_ulogic_vector(31 downto 0) := x"00000013"; -- nop
@@ -233,7 +237,7 @@ begin
   dm_controller: process(clk_i)
   begin
     if rising_edge(clk_i) then
-      if (dm_reg.dmcontrol_dmactive = '0') or (dmi_rstn_i = '0') then -- DM reset / DM disabled
+      if (dm_reg.dmcontrol_dmactive = '0') then -- DM reset / DM disabled
         dm_ctrl.state           <= CMD_IDLE;
         dm_ctrl.ldsw_progbuf    <= instr_sw_c;
         dci.execute_req         <= '0';
@@ -259,8 +263,8 @@ begin
 
           when CMD_IDLE => -- wait for new abstract command
           -- ------------------------------------------------------------
-            if (dmi_req_valid_i = '1') and (dmi_req_op_i = '1') then -- valid DM write access
-              if (dmi_req_addr_i = addr_command_c) then
+            if (dmi_req_valid_i = '1') and (dmi_req_op_i = dmi_write_c) then -- valid DM write access
+              if (dmi_req_address_i = addr_command_c) then
                 if (dm_ctrl.cmderr = "000") then -- only execute if no error
                   dm_ctrl.state <= CMD_EXE_CHECK;
                 end if;
@@ -428,10 +432,10 @@ begin
       dm_reg.autoexec_wr <= '0';
 
       -- DMI access --
-      if (dmi_req_valid_i = '1') and (dmi_req_op_i = '1') then -- valid DMI write request
+      if (dmi_req_valid_i = '1') and (dmi_req_op_i = dmi_write_c) then -- valid DMI write request
 
         -- debug module control --
-        if (dmi_req_addr_i = addr_dmcontrol_c) then
+        if (dmi_req_address_i = addr_dmcontrol_c) then
           dm_reg.halt_req           <= dmi_req_data_i(31); -- haltreq (-/w): write 1 to request halt; has to be cleared again by debugger
           dm_reg.resume_req         <= dmi_req_data_i(30); -- resumereq (-/w1): write 1 to request resume; auto-clears
           dm_reg.reset_ack          <= dmi_req_data_i(28); -- ackhavereset (-/w1): write 1 to ACK reset; auto-clears
@@ -440,14 +444,14 @@ begin
         end if;
 
         -- write abstract command --
-        if (dmi_req_addr_i = addr_command_c) then
+        if (dmi_req_address_i = addr_command_c) then
           if (dm_ctrl.busy = '0') and (dm_ctrl.cmderr = "000") then -- idle and no errors yet
             dm_reg.command <= dmi_req_data_i;
           end if;
         end if;
 
         -- write abstract command autoexec --
-        if (dmi_req_addr_i = addr_abstractauto_c) then
+        if (dmi_req_address_i = addr_abstractauto_c) then
           if (dm_ctrl.busy = '0') then -- idle and no errors yet
             dm_reg.abstractauto_autoexecdata       <= dmi_req_data_i(00);
             dm_reg.abstractauto_autoexecprogbuf(0) <= dmi_req_data_i(16);
@@ -456,23 +460,23 @@ begin
         end if;
 
         -- auto execution trigger --
-        if ((dmi_req_addr_i = addr_data0_c)    and (dm_reg.abstractauto_autoexecdata = '1')) or
-           ((dmi_req_addr_i = addr_progbuf0_c) and (dm_reg.abstractauto_autoexecprogbuf(0) = '1')) or
-           ((dmi_req_addr_i = addr_progbuf1_c) and (dm_reg.abstractauto_autoexecprogbuf(1) = '1')) then
+        if ((dmi_req_address_i = addr_data0_c)    and (dm_reg.abstractauto_autoexecdata = '1')) or
+           ((dmi_req_address_i = addr_progbuf0_c) and (dm_reg.abstractauto_autoexecprogbuf(0) = '1')) or
+           ((dmi_req_address_i = addr_progbuf1_c) and (dm_reg.abstractauto_autoexecprogbuf(1) = '1')) then
           dm_reg.autoexec_wr <= '1';
         end if;
 
         -- acknowledge command error --
-        if (dmi_req_addr_i = addr_abstractcs_c) then
+        if (dmi_req_address_i = addr_abstractcs_c) then
           if (dmi_req_data_i(10 downto 8) = "111") then
             dm_reg.clr_acc_err <= '1';
           end if;
         end if;
 
         -- write program buffer --
-        if (dmi_req_addr_i(dmi_req_addr_i'left downto 1) = addr_progbuf0_c(dmi_req_addr_i'left downto 1)) then
+        if (dmi_req_address_i(dmi_req_address_i'left downto 1) = addr_progbuf0_c(dmi_req_address_i'left downto 1)) then
           if (dm_ctrl.busy = '0') then -- idle
-            if (dmi_req_addr_i(0) = addr_progbuf0_c(0)) then
+            if (dmi_req_address_i(0) = addr_progbuf0_c(0)) then
               dm_reg.progbuf(0) <= dmi_req_data_i;
             else
               dm_reg.progbuf(1) <= dmi_req_data_i;
@@ -482,12 +486,12 @@ begin
 
         -- invalid access while command is executing --
         if (dm_ctrl.busy = '1') then -- busy
-          if (dmi_req_addr_i = addr_abstractcs_c) or
-             (dmi_req_addr_i = addr_command_c) or
-             (dmi_req_addr_i = addr_abstractauto_c) or
-             (dmi_req_addr_i = addr_data0_c) or
-             (dmi_req_addr_i = addr_progbuf0_c) or
-             (dmi_req_addr_i = addr_progbuf1_c) then
+          if (dmi_req_address_i = addr_abstractcs_c) or
+             (dmi_req_address_i = addr_command_c) or
+             (dmi_req_address_i = addr_abstractauto_c) or
+             (dmi_req_address_i = addr_data0_c) or
+             (dmi_req_address_i = addr_progbuf0_c) or
+             (dmi_req_address_i = addr_progbuf1_c) then
             dm_reg.wr_acc_err <= '1';
           end if;
         end if;
@@ -500,7 +504,7 @@ begin
   -- Direct Control -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   -- write to abstract data register --
-  dci.data_we <= '1' when (dmi_req_valid_i = '1') and (dmi_req_op_i = '1') and (dmi_req_addr_i = addr_data0_c) and (dm_ctrl.busy = '0') else '0';
+  dci.data_we <= '1' when (dmi_req_valid_i = '1') and (dmi_req_op_i = dmi_write_c) and (dmi_req_address_i = addr_data0_c) and (dm_ctrl.busy = '0') else '0';
   dci.wdata   <= dmi_req_data_i;
 
   -- CPU halt/resume request --
@@ -517,7 +521,7 @@ begin
   cpu_progbuf(3) <= instr_ebreak_c; -- implicit ebreak instruction
 
   -- DMI status --
-  dmi_resp_err_o  <= '0'; -- what can go wrong? ;)
+  dmi_rsp_op_o    <= "00"; -- operation success
   dmi_req_ready_o <= '1'; -- always ready for new read/write access
 
 
@@ -526,116 +530,112 @@ begin
   dmi_read_access: process(clk_i)
   begin
     if rising_edge(clk_i) then
-      dmi_resp_valid_o   <= dmi_req_valid_i; -- DMI transfer ack
-      dmi_resp_data_o    <= (others => '0'); -- default
+      dmi_rsp_valid_o    <= dmi_req_valid_i; -- DMI transfer ack
+      dmi_rsp_data_o     <= (others => '0'); -- default
       dm_reg.rd_acc_err  <= '0';
       dm_reg.autoexec_rd <= '0';
 
-      case dmi_req_addr_i is
+      case dmi_req_address_i is
 
         -- debug module status register --
         when addr_dmstatus_c =>
-          dmi_resp_data_o(31 downto 23) <= (others => '0');           -- reserved (r/-)
-          dmi_resp_data_o(22)           <= '1';                       -- impebreak (r/-): there is an implicit ebreak instruction after the visible program buffer
-          dmi_resp_data_o(21 downto 20) <= (others => '0');           -- reserved (r/-)
-          dmi_resp_data_o(19)           <= dm_ctrl.hart_reset;        -- allhavereset (r/-): there is only one hart that can be reset
-          dmi_resp_data_o(18)           <= dm_ctrl.hart_reset;        -- anyhavereset (r/-): there is only one hart that can be reset
-          dmi_resp_data_o(17)           <= dm_ctrl.hart_resume_ack;   -- allresumeack (r/-): there is only one hart that can acknowledge resume request
-          dmi_resp_data_o(16)           <= dm_ctrl.hart_resume_ack;   -- anyresumeack (r/-): there is only one hart that can acknowledge resume request
-          dmi_resp_data_o(15)           <= '0';                       -- allnonexistent (r/-): there is only one hart that is always existent
-          dmi_resp_data_o(14)           <= '0';                       -- anynonexistent (r/-): there is only one hart that is always existent
-          dmi_resp_data_o(13)           <= dm_reg.dmcontrol_ndmreset; -- allunavail (r/-): there is only one hart that is unavailable during reset
-          dmi_resp_data_o(12)           <= dm_reg.dmcontrol_ndmreset; -- anyunavail (r/-): there is only one hart that is unavailable during reset
-          dmi_resp_data_o(11)           <= not dm_ctrl.hart_halted;   -- allrunning (r/-): there is only one hart that can be RUNNING or HALTED
-          dmi_resp_data_o(10)           <= not dm_ctrl.hart_halted;   -- anyrunning (r/-): there is only one hart that can be RUNNING or HALTED
-          dmi_resp_data_o(09)           <= dm_ctrl.hart_halted;       -- allhalted (r/-): there is only one hart that can be RUNNING or HALTED
-          dmi_resp_data_o(08)           <= dm_ctrl.hart_halted;       -- anyhalted (r/-): there is only one hart that can be RUNNING or HALTED
-          dmi_resp_data_o(07)           <= '1';                       -- authenticated (r/-): authentication passed since there is no authentication
-          dmi_resp_data_o(06)           <= '0';                       -- authbusy (r/-): always ready since there is no authentication
-          dmi_resp_data_o(05)           <= '0';                       -- hasresethaltreq (r/-): halt-on-reset not implemented
-          dmi_resp_data_o(04)           <= '0';                       -- confstrptrvalid (r/-): no configuration string available
-          dmi_resp_data_o(03 downto 00) <= "0011";                    -- version (r/-): compatible to spec. version 1.0
+          dmi_rsp_data_o(31 downto 23) <= (others => '0');           -- reserved (r/-)
+          dmi_rsp_data_o(22)           <= '1';                       -- impebreak (r/-): there is an implicit ebreak instruction after the visible program buffer
+          dmi_rsp_data_o(21 downto 20) <= (others => '0');           -- reserved (r/-)
+          dmi_rsp_data_o(19)           <= dm_ctrl.hart_reset;        -- allhavereset (r/-): there is only one hart that can be reset
+          dmi_rsp_data_o(18)           <= dm_ctrl.hart_reset;        -- anyhavereset (r/-): there is only one hart that can be reset
+          dmi_rsp_data_o(17)           <= dm_ctrl.hart_resume_ack;   -- allresumeack (r/-): there is only one hart that can acknowledge resume request
+          dmi_rsp_data_o(16)           <= dm_ctrl.hart_resume_ack;   -- anyresumeack (r/-): there is only one hart that can acknowledge resume request
+          dmi_rsp_data_o(15)           <= '0';                       -- allnonexistent (r/-): there is only one hart that is always existent
+          dmi_rsp_data_o(14)           <= '0';                       -- anynonexistent (r/-): there is only one hart that is always existent
+          dmi_rsp_data_o(13)           <= dm_reg.dmcontrol_ndmreset; -- allunavail (r/-): there is only one hart that is unavailable during reset
+          dmi_rsp_data_o(12)           <= dm_reg.dmcontrol_ndmreset; -- anyunavail (r/-): there is only one hart that is unavailable during reset
+          dmi_rsp_data_o(11)           <= not dm_ctrl.hart_halted;   -- allrunning (r/-): there is only one hart that can be RUNNING or HALTED
+          dmi_rsp_data_o(10)           <= not dm_ctrl.hart_halted;   -- anyrunning (r/-): there is only one hart that can be RUNNING or HALTED
+          dmi_rsp_data_o(09)           <= dm_ctrl.hart_halted;       -- allhalted (r/-): there is only one hart that can be RUNNING or HALTED
+          dmi_rsp_data_o(08)           <= dm_ctrl.hart_halted;       -- anyhalted (r/-): there is only one hart that can be RUNNING or HALTED
+          dmi_rsp_data_o(07)           <= '1';                       -- authenticated (r/-): authentication passed since there is no authentication
+          dmi_rsp_data_o(06)           <= '0';                       -- authbusy (r/-): always ready since there is no authentication
+          dmi_rsp_data_o(05)           <= '0';                       -- hasresethaltreq (r/-): halt-on-reset not implemented
+          dmi_rsp_data_o(04)           <= '0';                       -- confstrptrvalid (r/-): no configuration string available
+          dmi_rsp_data_o(03 downto 00) <= "0011";                    -- version (r/-): compatible to spec. version 1.0
 
         -- debug module control --
         when addr_dmcontrol_c =>
-          dmi_resp_data_o(31)           <= '0';                       -- haltreq (-/w): write-only
-          dmi_resp_data_o(30)           <= '0';                       -- resumereq (-/w1): write-only
-          dmi_resp_data_o(29)           <= '0';                       -- hartreset (r/w): not supported
-          dmi_resp_data_o(28)           <= '0';                       -- ackhavereset (-/w1): write-only
-          dmi_resp_data_o(27)           <= '0';                       -- reserved (r/-)
-          dmi_resp_data_o(26)           <= '0';                       -- hasel (r/-) - there is a single currently selected hart
-          dmi_resp_data_o(25 downto 16) <= (others => '0');           -- hartsello (r/-) - there is only one hart
-          dmi_resp_data_o(15 downto 06) <= (others => '0');           -- hartselhi (r/-) - there is only one hart
-          dmi_resp_data_o(05 downto 04) <= (others => '0');           -- reserved (r/-)
-          dmi_resp_data_o(03)           <= '0';                       -- setresethaltreq (-/w1): halt-on-reset request - halt-on-reset not implemented
-          dmi_resp_data_o(02)           <= '0';                       -- clrresethaltreq (-/w1): halt-on-reset ack - halt-on-reset not implemented
-          dmi_resp_data_o(01)           <= dm_reg.dmcontrol_ndmreset; -- ndmreset (r/w): soc reset
-          dmi_resp_data_o(00)           <= dm_reg.dmcontrol_dmactive; -- dmactive (r/w): DM reset
+          dmi_rsp_data_o(31)           <= '0';                       -- haltreq (-/w): write-only
+          dmi_rsp_data_o(30)           <= '0';                       -- resumereq (-/w1): write-only
+          dmi_rsp_data_o(29)           <= '0';                       -- hartreset (r/w): not supported
+          dmi_rsp_data_o(28)           <= '0';                       -- ackhavereset (-/w1): write-only
+          dmi_rsp_data_o(27)           <= '0';                       -- reserved (r/-)
+          dmi_rsp_data_o(26)           <= '0';                       -- hasel (r/-) - there is a single currently selected hart
+          dmi_rsp_data_o(25 downto 16) <= (others => '0');           -- hartsello (r/-) - there is only one hart
+          dmi_rsp_data_o(15 downto 06) <= (others => '0');           -- hartselhi (r/-) - there is only one hart
+          dmi_rsp_data_o(05 downto 04) <= (others => '0');           -- reserved (r/-)
+          dmi_rsp_data_o(03)           <= '0';                       -- setresethaltreq (-/w1): halt-on-reset request - halt-on-reset not implemented
+          dmi_rsp_data_o(02)           <= '0';                       -- clrresethaltreq (-/w1): halt-on-reset ack - halt-on-reset not implemented
+          dmi_rsp_data_o(01)           <= dm_reg.dmcontrol_ndmreset; -- ndmreset (r/w): soc reset
+          dmi_rsp_data_o(00)           <= dm_reg.dmcontrol_dmactive; -- dmactive (r/w): DM reset
 
         -- hart info --
         when addr_hartinfo_c =>
-          dmi_resp_data_o(31 downto 24) <= (others => '0');           -- reserved (r/-)
-          dmi_resp_data_o(23 downto 20) <= nscratch_c;                -- nscratch (r/-): number of dscratch CSRs
-          dmi_resp_data_o(19 downto 17) <= (others => '0');           -- reserved (r/-)
-          dmi_resp_data_o(16)           <= dataaccess_c;              -- dataaccess (r/-): 1: data registers are memory-mapped, 0: data reisters are CSR-mapped
-          dmi_resp_data_o(15 downto 12) <= datasize_c;                -- datasize (r/-): number data registers in memory/CSR space
-          dmi_resp_data_o(11 downto 00) <= dataaddr_c;                -- dataaddr (r/-): data registers base address (memory/CSR)
+          dmi_rsp_data_o(31 downto 24) <= (others => '0');           -- reserved (r/-)
+          dmi_rsp_data_o(23 downto 20) <= nscratch_c;                -- nscratch (r/-): number of dscratch CSRs
+          dmi_rsp_data_o(19 downto 17) <= (others => '0');           -- reserved (r/-)
+          dmi_rsp_data_o(16)           <= dataaccess_c;              -- dataaccess (r/-): 1: data registers are memory-mapped, 0: data reisters are CSR-mapped
+          dmi_rsp_data_o(15 downto 12) <= datasize_c;                -- datasize (r/-): number data registers in memory/CSR space
+          dmi_rsp_data_o(11 downto 00) <= dataaddr_c;                -- dataaddr (r/-): data registers base address (memory/CSR)
 
         -- abstract control and status --
         when addr_abstractcs_c =>
-          dmi_resp_data_o(31 downto 24) <= (others => '0');           -- reserved (r/-)
-          dmi_resp_data_o(28 downto 24) <= "00010";                   -- progbufsize (r/-): number of words in program buffer = 2
-          dmi_resp_data_o(12)           <= dm_ctrl.busy;              -- busy (r/-): abstract command in progress (1) / idle (0)
-          dmi_resp_data_o(11)           <= '1';                       -- relaxedpriv (r/-): PMP rules are ignored when in debug-mode
-          dmi_resp_data_o(10 downto 08) <= dm_ctrl.cmderr;            -- cmderr (r/w1c): any error during execution?
-          dmi_resp_data_o(07 downto 04) <= (others => '0');           -- reserved (r/-)
-          dmi_resp_data_o(03 downto 00) <= "0001";                    -- datacount (r/-): number of implemented data registers = 1
+          dmi_rsp_data_o(31 downto 24) <= (others => '0');           -- reserved (r/-)
+          dmi_rsp_data_o(28 downto 24) <= "00010";                   -- progbufsize (r/-): number of words in program buffer = 2
+          dmi_rsp_data_o(12)           <= dm_ctrl.busy;              -- busy (r/-): abstract command in progress (1) / idle (0)
+          dmi_rsp_data_o(11)           <= '1';                       -- relaxedpriv (r/-): PMP rules are ignored when in debug-mode
+          dmi_rsp_data_o(10 downto 08) <= dm_ctrl.cmderr;            -- cmderr (r/w1c): any error during execution?
+          dmi_rsp_data_o(07 downto 04) <= (others => '0');           -- reserved (r/-)
+          dmi_rsp_data_o(03 downto 00) <= "0001";                    -- datacount (r/-): number of implemented data registers = 1
 
 --      -- abstract command (-/w) --
 --      when addr_command_c =>
---        dmi_resp_data_o <= (others => '0'); -- register is write-only
+--        dmi_rsp_data_o <= (others => '0'); -- register is write-only
 
         -- abstract command autoexec (r/w) --
         when addr_abstractauto_c =>
-          dmi_resp_data_o(00) <= dm_reg.abstractauto_autoexecdata;       -- autoexecdata(0):    read/write access to data0 triggers execution of program buffer
-          dmi_resp_data_o(16) <= dm_reg.abstractauto_autoexecprogbuf(0); -- autoexecprogbuf(0): read/write access to progbuf0 triggers execution of program buffer
-          dmi_resp_data_o(17) <= dm_reg.abstractauto_autoexecprogbuf(1); -- autoexecprogbuf(1): read/write access to progbuf1 triggers execution of program buffer
+          dmi_rsp_data_o(00) <= dm_reg.abstractauto_autoexecdata;       -- autoexecdata(0):    read/write access to data0 triggers execution of program buffer
+          dmi_rsp_data_o(16) <= dm_reg.abstractauto_autoexecprogbuf(0); -- autoexecprogbuf(0): read/write access to progbuf0 triggers execution of program buffer
+          dmi_rsp_data_o(17) <= dm_reg.abstractauto_autoexecprogbuf(1); -- autoexecprogbuf(1): read/write access to progbuf1 triggers execution of program buffer
 
 --      -- next debug module (r/-) --
 --      when addr_nextdm_c =>
---        dmi_resp_data_o <= (others => '0'); -- this is the only DM
+--        dmi_rsp_data_o <= (others => '0'); -- this is the only DM
 
         -- abstract data 0 (r/w) --
         when addr_data0_c =>
-          dmi_resp_data_o <= dci.rdata;
+          dmi_rsp_data_o <= dci.rdata;
 
 --      -- program buffer (-/w) --
 --      when addr_progbuf0_c =>
---        dmi_resp_data_o <= dm_reg.progbuf(0); -- program buffer 0
+--        dmi_rsp_data_o <= dm_reg.progbuf(0); -- program buffer 0
 --      when addr_progbuf1_c =>
---        dmi_resp_data_o <= dm_reg.progbuf(1); -- program buffer 1
+--        dmi_rsp_data_o <= dm_reg.progbuf(1); -- program buffer 1
 
 --      -- system bus access control and status (r/-) --
 --      when addr_sbcs_c =>
---        dmi_resp_data_o <= (others => '0'); -- bus access not implemented
-
-        -- halt summary 0 (r/-) --
-        when addr_haltsum0_c =>
-          dmi_resp_data_o(0) <= dm_ctrl.hart_halted; -- hart is halted
+--        dmi_rsp_data_o <= (others => '0'); -- bus access not implemented
 
         -- not implemented (r/-) --
         when others =>
-          dmi_resp_data_o <= (others => '0');
+          dmi_rsp_data_o <= (others => '0');
 
       end case;
 
       -- invalid read access while command is executing --
       -- ------------------------------------------------------------
-      if (dmi_req_valid_i = '1') and (dmi_req_op_i = '0') then -- valid DMI read request
+      if (dmi_req_valid_i = '1') and (dmi_req_op_i = dmi_read_c) then -- valid DMI read request
         if (dm_ctrl.busy = '1') then -- busy
-          if (dmi_req_addr_i = addr_data0_c) or
-             (dmi_req_addr_i = addr_progbuf0_c) or
-             (dmi_req_addr_i = addr_progbuf1_c) then
+          if (dmi_req_address_i = addr_data0_c) or
+             (dmi_req_address_i = addr_progbuf0_c) or
+             (dmi_req_address_i = addr_progbuf1_c) then
             dm_reg.rd_acc_err <= '1';
           end if;
         end if;
@@ -643,10 +643,10 @@ begin
 
       -- auto execution trigger --
       -- ------------------------------------------------------------
-      if (dmi_req_valid_i = '1') and (dmi_req_op_i = '0') then -- valid DMI read request
-        if ((dmi_req_addr_i = addr_data0_c)    and (dm_reg.abstractauto_autoexecdata = '1')) or
-           ((dmi_req_addr_i = addr_progbuf0_c) and (dm_reg.abstractauto_autoexecprogbuf(0) = '1')) or
-           ((dmi_req_addr_i = addr_progbuf1_c) and (dm_reg.abstractauto_autoexecprogbuf(1) = '1')) then
+      if (dmi_req_valid_i = '1') and (dmi_req_op_i = dmi_read_c) then -- valid DMI read request
+        if ((dmi_req_address_i = addr_data0_c)    and (dm_reg.abstractauto_autoexecdata = '1')) or
+           ((dmi_req_address_i = addr_progbuf0_c) and (dm_reg.abstractauto_autoexecprogbuf(0) = '1')) or
+           ((dmi_req_address_i = addr_progbuf1_c) and (dm_reg.abstractauto_autoexecprogbuf(1) = '1')) then
           dm_reg.autoexec_rd <= '1';
         end if;
       end if;

--- a/rtl/core/neorv32_debug_dtm.vhd
+++ b/rtl/core/neorv32_debug_dtm.vhd
@@ -6,7 +6,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -46,25 +46,24 @@ entity neorv32_debug_dtm is
   );
   port (
     -- global control --
-    clk_i            : in  std_ulogic; -- global clock line
-    rstn_i           : in  std_ulogic; -- global reset line, low-active
+    clk_i             : in  std_ulogic; -- global clock line
+    rstn_i            : in  std_ulogic; -- global reset line, low-active
     -- jtag connection --
-    jtag_trst_i      : in  std_ulogic;
-    jtag_tck_i       : in  std_ulogic;
-    jtag_tdi_i       : in  std_ulogic;
-    jtag_tdo_o       : out std_ulogic;
-    jtag_tms_i       : in  std_ulogic;
+    jtag_trst_i       : in  std_ulogic;
+    jtag_tck_i        : in  std_ulogic;
+    jtag_tdi_i        : in  std_ulogic;
+    jtag_tdo_o        : out std_ulogic;
+    jtag_tms_i        : in  std_ulogic;
     -- debug module interface (DMI) --
-    dmi_rstn_o       : out std_ulogic;
-    dmi_req_valid_o  : out std_ulogic;
-    dmi_req_ready_i  : in  std_ulogic; -- DMI is allowed to make new requests when set
-    dmi_req_addr_o   : out std_ulogic_vector(06 downto 0);
-    dmi_req_op_o     : out std_ulogic; -- 0=read, 1=write
-    dmi_req_data_o   : out std_ulogic_vector(31 downto 0);
-    dmi_resp_valid_i : in  std_ulogic; -- response valid when set
-    dmi_resp_ready_o : out std_ulogic; -- ready to receive respond
-    dmi_resp_data_i  : in  std_ulogic_vector(31 downto 0);
-    dmi_resp_err_i   : in  std_ulogic -- 0=ok, 1=error
+    dmi_req_valid_o   : out std_ulogic;
+    dmi_req_ready_i   : in  std_ulogic; -- DMI is allowed to make new requests when set
+    dmi_req_address_o : out std_ulogic_vector(05 downto 0);
+    dmi_req_data_o    : out std_ulogic_vector(31 downto 0);
+    dmi_req_op_o      : out std_ulogic_vector(01 downto 0);
+    dmi_rsp_valid_i   : in  std_ulogic; -- response valid when set
+    dmi_rsp_ready_o   : out std_ulogic; -- ready to receive response
+    dmi_rsp_data_i    : in  std_ulogic_vector(31 downto 0);
+    dmi_rsp_op_i      : in  std_ulogic_vector(01 downto 0)
   );
 end neorv32_debug_dtm;
 
@@ -73,7 +72,7 @@ architecture neorv32_debug_dtm_rtl of neorv32_debug_dtm is
   -- DMI Configuration (fixed!) --
   constant dmi_idle_c    : std_ulogic_vector(02 downto 0) := "000"; -- no idle cycles required
   constant dmi_version_c : std_ulogic_vector(03 downto 0) := "0001"; -- debug spec. version (0.13 & 1.0)
-  constant dmi_abits_c   : std_ulogic_vector(05 downto 0) := "000111"; -- number of DMI address bits (7)
+  constant dmi_abits_c   : std_ulogic_vector(05 downto 0) := "000110"; -- number of DMI address bits (6)
 
   -- tap JTAG signal synchronizer --
   type tap_sync_t is record
@@ -110,7 +109,7 @@ architecture neorv32_debug_dtm_rtl of neorv32_debug_dtm is
     bypass           : std_ulogic;
     idcode           : std_ulogic_vector(31 downto 0);
     dtmcs, dtmcs_nxt : std_ulogic_vector(31 downto 0);
-    dmi,   dmi_nxt   : std_ulogic_vector((7+32+2)-1 downto 0); -- 7-bit address + 32-bit data + 2-bit operation
+    dmi,   dmi_nxt   : std_ulogic_vector((6+32+2)-1 downto 0); -- 6-bit address + 32-bit data + 2-bit operation
   end record;
   signal tap_reg : tap_reg_t;
 
@@ -121,10 +120,10 @@ architecture neorv32_debug_dtm_rtl of neorv32_debug_dtm is
     state        : dmi_ctrl_state_t;
     dmihardreset : std_ulogic;
     dmireset     : std_ulogic;
-    err          : std_ulogic; -- sticky error
+    rsp          : std_ulogic_vector(01 downto 0); -- sticky response status
     rdata        : std_ulogic_vector(31 downto 0);
     wdata        : std_ulogic_vector(31 downto 0);
-    addr         : std_ulogic_vector(06 downto 0);
+    addr         : std_ulogic_vector(05 downto 0);
   end record;
   signal dmi_ctrl : dmi_ctrl_t;
 
@@ -264,9 +263,9 @@ begin
   tap_reg.dtmcs_nxt(03 downto 00) <= dmi_version_c; -- version
 
   -- DMI register read access --
-  tap_reg.dmi_nxt(40 downto 34) <= dmi_ctrl.addr; -- address
+  tap_reg.dmi_nxt(39 downto 34) <= dmi_ctrl.addr; -- address
   tap_reg.dmi_nxt(33 downto 02) <= dmi_ctrl.rdata; -- read data
-  tap_reg.dmi_nxt(01 downto 00) <= "11" when (dmi_ctrl.state /= DMI_IDLE) else (dmi_ctrl.err & '0'); -- status
+  tap_reg.dmi_nxt(01 downto 00) <= "11" when (dmi_ctrl.state /= DMI_IDLE) else (dmi_ctrl.rsp); -- status
 
 
   -- Debug Module Interface -----------------------------------------------------------------
@@ -277,7 +276,7 @@ begin
       dmi_ctrl.state        <= DMI_IDLE;
       dmi_ctrl.dmihardreset <= '1';
       dmi_ctrl.dmireset     <= '1';
-      dmi_ctrl.err          <= '0';
+      dmi_ctrl.rsp          <= "00";
       dmi_ctrl.rdata        <= (others => '0');
       dmi_ctrl.wdata        <= (others => '0');
       dmi_ctrl.addr         <= (others => '0');
@@ -299,7 +298,7 @@ begin
 
           when DMI_IDLE => -- waiting for new request
             if (dr_update_trig.valid = '1') and (tap_reg.ireg = "10001") then
-              dmi_ctrl.addr  <= tap_reg.dmi(40 downto 34);
+              dmi_ctrl.addr  <= tap_reg.dmi(39 downto 34);
               dmi_ctrl.wdata <= tap_reg.dmi(33 downto 02);
               if (tap_reg.dmi(1 downto 0) = "01") then -- read
                 dmi_ctrl.state <= DMI_READ_WAIT;
@@ -313,12 +312,12 @@ begin
               dmi_ctrl.state <= DMI_READ;
             end if;
 
-          when DMI_READ => -- start read access
+          when DMI_READ => -- trigger/start read access
             dmi_ctrl.state <= DMI_READ_BUSY;
 
           when DMI_READ_BUSY => -- pending read access
-            if (dmi_resp_valid_i = '1') then
-              dmi_ctrl.rdata <= dmi_resp_data_i;
+            if (dmi_rsp_valid_i = '1') then
+              dmi_ctrl.rdata <= dmi_rsp_data_i;
               dmi_ctrl.state <= DMI_IDLE;
             end if;
 
@@ -327,11 +326,11 @@ begin
               dmi_ctrl.state <= DMI_WRITE;
             end if;
 
-          when DMI_WRITE => -- start write access
+          when DMI_WRITE => -- trigger/start write access
             dmi_ctrl.state <= DMI_WRITE_BUSY;
 
           when DMI_WRITE_BUSY => -- pending write access
-            if (dmi_resp_valid_i = '1') then
+            if (dmi_rsp_valid_i = '1') then
               dmi_ctrl.state <= DMI_IDLE;
             end if;
 
@@ -339,19 +338,21 @@ begin
             dmi_ctrl.state <= DMI_IDLE;
 
         end case;
+      end if;
 
-        -- sticky error flag --
-        if (dmi_ctrl.dmireset = '1') or (dmi_ctrl.dmihardreset = '1') then
-          dmi_ctrl.err <= '0';
-        elsif (dmi_ctrl.state = DMI_READ) or (dmi_ctrl.state = DMI_READ_BUSY) or
-              (dmi_ctrl.state = DMI_WRITE) or (dmi_ctrl.state = DMI_WRITE_BUSY) then
-          dmi_ctrl.err <= dmi_ctrl.err or dmi_resp_err_i; -- sticky error
+      -- sticky response flags --
+      if (dmi_ctrl.dmireset = '1') or (dmi_ctrl.dmihardreset = '1') then
+        dmi_ctrl.rsp <= "00";
+      else
+        if (dmi_ctrl.state /= DMI_IDLE) and (dr_update_trig.valid = '1') and (tap_reg.ireg = "10001") then -- access attempt while DMI is busy
+          dmi_ctrl.rsp <= "11";
+        elsif (dmi_ctrl.state = DMI_READ_BUSY) or (dmi_ctrl.state = DMI_WRITE_BUSY) then -- accumulate DMI response
+          dmi_ctrl.rsp <= dmi_ctrl.rsp or dmi_rsp_op_i;
         end if;
       end if;
 
     end if;
   end process dmi_controller;
-
 
   -- trigger for UPDATE state --
   tap_update_trigger: process(rstn_i, clk_i)
@@ -363,17 +364,15 @@ begin
     end if;
   end process tap_update_trigger;
 
-  dr_update_trig.is_update <= '1' when (tap_ctrl_state = DR_UPDATE) else '0'; -- we are in DR update state
-  dr_update_trig.valid     <= '1' when (dr_update_trig.is_update = '1') and -- we ARE in DR update
-                                       (dr_update_trig.is_update_ff = '0') else '0'; -- but we were not before
+  dr_update_trig.is_update <= '1' when (tap_ctrl_state = DR_UPDATE) else '0';
+  dr_update_trig.valid     <= '1' when (dr_update_trig.is_update = '1') and (dr_update_trig.is_update_ff = '0') else '0';
 
   -- direct DMI output --
-  dmi_rstn_o       <= '0' when (dmi_ctrl.dmihardreset = '1') else '1';
-  dmi_req_valid_o  <= '1' when (dmi_ctrl.state = DMI_READ) or (dmi_ctrl.state = DMI_WRITE) else '0';
-  dmi_req_op_o     <= '1' when (dmi_ctrl.state = DMI_WRITE) or (dmi_ctrl.state = DMI_WRITE_BUSY) else '0';
-  dmi_resp_ready_o <= '1' when (dmi_ctrl.state = DMI_READ_BUSY) or (dmi_ctrl.state = DMI_WRITE_BUSY) else '0';
-  dmi_req_addr_o   <= dmi_ctrl.addr;
-  dmi_req_data_o   <= dmi_ctrl.wdata;
+  dmi_req_valid_o   <= '1' when (dmi_ctrl.state = DMI_READ) or (dmi_ctrl.state = DMI_WRITE) else '0';
+  dmi_req_op_o      <= tap_reg.dmi(1 downto 0);
+  dmi_rsp_ready_o   <= '1' when (dmi_ctrl.state = DMI_READ_BUSY) or (dmi_ctrl.state = DMI_WRITE_BUSY) else '0';
+  dmi_req_address_o <= dmi_ctrl.addr;
+  dmi_req_data_o    <= dmi_ctrl.wdata;
 
 
 end neorv32_debug_dtm_rtl;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -3,7 +3,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070903"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070904"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -2241,31 +2241,30 @@ package neorv32_package is
   component neorv32_debug_dm
     port (
       -- global control --
-      clk_i            : in  std_ulogic; -- global clock line
-      rstn_i           : in  std_ulogic; -- global reset line, low-active
+      clk_i             : in  std_ulogic; -- global clock line
+      rstn_i            : in  std_ulogic; -- global reset line, low-active
       -- debug module interface (DMI) --
-      dmi_rstn_i       : in  std_ulogic;
-      dmi_req_valid_i  : in  std_ulogic;
-      dmi_req_ready_o  : out std_ulogic; -- DMI is allowed to make new requests when set
-      dmi_req_addr_i   : in  std_ulogic_vector(06 downto 0);
-      dmi_req_op_i     : in  std_ulogic; -- 0=read, 1=write
-      dmi_req_data_i   : in  std_ulogic_vector(31 downto 0);
-      dmi_resp_valid_o : out std_ulogic; -- response valid when set
-      dmi_resp_ready_i : in  std_ulogic; -- ready to receive respond
-      dmi_resp_data_o  : out std_ulogic_vector(31 downto 0);
-      dmi_resp_err_o   : out std_ulogic; -- 0=ok, 1=error
+      dmi_req_valid_i   : in  std_ulogic;
+      dmi_req_ready_o   : out std_ulogic; -- DMI is allowed to make new requests when set
+      dmi_req_address_i : in  std_ulogic_vector(05 downto 0);
+      dmi_req_data_i    : in  std_ulogic_vector(31 downto 0);
+      dmi_req_op_i      : in  std_ulogic_vector(01 downto 0);
+      dmi_rsp_valid_o   : out std_ulogic; -- response valid when set
+      dmi_rsp_ready_i   : in  std_ulogic; -- ready to receive respond
+      dmi_rsp_data_o    : out std_ulogic_vector(31 downto 0);
+      dmi_rsp_op_o      : out std_ulogic_vector(01 downto 0);
       -- CPU bus access --
-      cpu_debug_i      : in  std_ulogic; -- CPU is in debug mode
-      cpu_addr_i       : in  std_ulogic_vector(31 downto 0); -- address
-      cpu_rden_i       : in  std_ulogic; -- read enable
-      cpu_wren_i       : in  std_ulogic; -- write enable
-      cpu_ben_i        : in  std_ulogic_vector(03 downto 0); -- byte write enable
-      cpu_data_i       : in  std_ulogic_vector(31 downto 0); -- data in
-      cpu_data_o       : out std_ulogic_vector(31 downto 0); -- data out
-      cpu_ack_o        : out std_ulogic; -- transfer acknowledge
+      cpu_debug_i       : in  std_ulogic; -- CPU is in debug mode
+      cpu_addr_i        : in  std_ulogic_vector(31 downto 0); -- address
+      cpu_rden_i        : in  std_ulogic; -- read enable
+      cpu_wren_i        : in  std_ulogic; -- write enable
+      cpu_ben_i         : in  std_ulogic_vector(03 downto 0); -- byte write enable
+      cpu_data_i        : in  std_ulogic_vector(31 downto 0); -- data in
+      cpu_data_o        : out std_ulogic_vector(31 downto 0); -- data out
+      cpu_ack_o         : out std_ulogic; -- transfer acknowledge
       -- CPU control --
-      cpu_ndmrstn_o    : out std_ulogic; -- soc reset
-      cpu_halt_req_o   : out std_ulogic  -- request hart to halt (enter debug mode)
+      cpu_ndmrstn_o     : out std_ulogic; -- soc reset
+      cpu_halt_req_o    : out std_ulogic  -- request hart to halt (enter debug mode)
     );
   end component;
 
@@ -2279,25 +2278,24 @@ package neorv32_package is
     );
     port (
       -- global control --
-      clk_i            : in  std_ulogic; -- global clock line
-      rstn_i           : in  std_ulogic; -- global reset line, low-active
+      clk_i             : in  std_ulogic; -- global clock line
+      rstn_i            : in  std_ulogic; -- global reset line, low-active
       -- jtag connection --
-      jtag_trst_i      : in  std_ulogic;
-      jtag_tck_i       : in  std_ulogic;
-      jtag_tdi_i       : in  std_ulogic;
-      jtag_tdo_o       : out std_ulogic;
-      jtag_tms_i       : in  std_ulogic;
+      jtag_trst_i       : in  std_ulogic;
+      jtag_tck_i        : in  std_ulogic;
+      jtag_tdi_i        : in  std_ulogic;
+      jtag_tdo_o        : out std_ulogic;
+      jtag_tms_i        : in  std_ulogic;
       -- debug module interface (DMI) --
-      dmi_rstn_o       : out std_ulogic;
-      dmi_req_valid_o  : out std_ulogic;
-      dmi_req_ready_i  : in  std_ulogic; -- DMI is allowed to make new requests when set
-      dmi_req_addr_o   : out std_ulogic_vector(06 downto 0);
-      dmi_req_op_o     : out std_ulogic; -- 0=read, 1=write
-      dmi_req_data_o   : out std_ulogic_vector(31 downto 0);
-      dmi_resp_valid_i : in  std_ulogic; -- response valid when set
-      dmi_resp_ready_o : out std_ulogic; -- ready to receive respond
-      dmi_resp_data_i  : in  std_ulogic_vector(31 downto 0);
-      dmi_resp_err_i   : in  std_ulogic -- 0=ok, 1=error
+      dmi_req_valid_o   : out std_ulogic;
+      dmi_req_ready_i   : in  std_ulogic; -- DMI is allowed to make new requests when set
+      dmi_req_address_o : out std_ulogic_vector(05 downto 0);
+      dmi_req_data_o    : out std_ulogic_vector(31 downto 0);
+      dmi_req_op_o      : out std_ulogic_vector(01 downto 0);
+      dmi_rsp_valid_i   : in  std_ulogic; -- response valid when set
+      dmi_rsp_ready_o   : out std_ulogic; -- ready to receive response
+      dmi_rsp_data_i    : in  std_ulogic_vector(31 downto 0);
+      dmi_rsp_op_i      : in  std_ulogic_vector(01 downto 0)
     );
   end component;
 


### PR DESCRIPTION
- remove DM's `haltsum0` register (🧪 experimental; allowed by RISC-V debug spec. v1.0)
- the DTM's DMI register now uses one bit less for addressing the DM registers
- use RISC-V-compatible DMI signals (as shown in Appendix 3 of the RISC-V debug spec.)
- fix DTM error flag logic
- fix DM reset logic
- minor edits and updates

