### PR TITLE
[sw/example/demo_spi_irq]: make read/write data pointer and busy flag…

### DIFF
--- a/sw/example/demo_spi_irq/drv/neorv32_spi_irq.h
+++ b/sw/example/demo_spi_irq/drv/neorv32_spi_irq.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -54,14 +54,14 @@
 // data handle for ISR
 typedef struct t_neorv32_spi
 {
-  void*     ptrSpiBuf;    /**< SPI buffer data pointer */
-  uint8_t   uint8SzElem;  /**< Element Size in byte */
-  uint8_t   uint8Csn;     /**< SPI chip select channel */
-  uint16_t  uint32Fifo;   /**< Number of elements in Fifo */
-  uint32_t  uint32Total;  /**< Number of elements in buffer */
-  uint32_t  uint32Write;  /**< To SPI core write elements */
-  uint32_t  uint32Read;   /**< From SPI core read elements */
-  uint8_t uint8IsBusy;    /**< Spi Core is Busy*/
+  void*             ptrSpiBuf;    /**< SPI buffer data pointer */
+  uint8_t           uint8SzElem;  /**< Element Size in byte */
+  uint8_t           uint8Csn;     /**< SPI chip select channel */
+  uint16_t          uint16Fifo;   /**< Number of elements in Fifo */
+  uint32_t          uint32Total;  /**< Number of elements in buffer */
+  volatile uint32_t uint32Write;  /**< To SPI core write elements */
+  volatile uint32_t uint32Read;   /**< From SPI core read elements */
+  volatile uint8_t  uint8IsBusy;  /**< Spi Core is Busy*/
 } t_neorv32_spi;
 
 


### PR DESCRIPTION
Hi Stephan,

I saw in the spi_irq driver that it could be better to have the data pointer ```volatile``` to ensure in switching between ISR/non-ISR context to have the latest register value always available.

BR,
Andreas
