### PR TITLE
[rtl/test_setups] add on-chip debugger test setup

### DIFF
--- a/docs/userguide/general_hw_setup.adoc
+++ b/docs/userguide/general_hw_setup.adoc
@@ -153,9 +153,13 @@ to the host interface (e.g. USB-UART converter).
 . Program the generated bitstream into your FPGA and press the button connected to the reset signal.
 . Done! The LED(s) connected to `gpio_o` should be flashing now.
 
+.Going Further
 [TIP]
-After the GCC toolchain for compiling RISC-V source code is ready (chapter <<_general_software_framework_setup>>),
-you can advance to one of these chapters to learn how to get a software executable into your processor setup:
-* If you are using the `neorv32_testsetup_approm.vhd` setup: See section <<_installing_an_executable_directly_into_memory>>.
-* If you are using the `neorv32_testsetup_bootloader.vhd` setup: See section <<_uploading_and_starting_of_a_binary_executable_image_via_uart>>.
-* If you are using the `neorv32_testsetup_on_chip_debugger.vhd` setup: See section <<_debugging_using_the_on_chip_debugger>>.
+Now that the hardware is ready, you can advance to one of these chapters to learn how to get a software executable
+into your processor setup (setup the GCC toolchain before; next section <<_general_software_framework_setup>>): +
+ +
+`neorv32_testsetup_approm.vhd`: <<_installing_an_executable_directly_into_memory>>
+ +
+`neorv32_testsetup_bootloader.vhd`: <<_uploading_and_starting_of_a_binary_executable_image_via_uart>>
+ +
+`neorv32_testsetup_on_chip_debugger.vhd`: <<_debugging_using_the_on_chip_debugger>>

--- a/docs/userguide/general_hw_setup.adoc
+++ b/docs/userguide/general_hw_setup.adoc
@@ -11,10 +11,10 @@ on _your_ FPGA board.
 If you want to use a more sophisticated pre-defined setup to start with, check out the
 `setups` folder, which provides example setups for various FPGA, boards and toolchains.
 
-The NEORV32 project features two minimalistic pre-configured test setups in
+The NEORV32 project features three minimalistic pre-configured test setups in
 https://github.com/stnolting/neorv32/blob/main/rtl/test_setups[`rtl/test_setups`].
-Both test setups only implement very basic processor and CPU features.
-The main difference between the two setups is the processor boot concept - so how to get a software executable
+These test setups only implement very basic processor and CPU features.
+The main difference between the setups is the processor boot concept - so how to get a software executable
 _into_ the processor:
 
 * **`rtl/test_setups/neorv32_testsetup_approm.vhd`**: this setup does not require a connection via UART. The
@@ -22,6 +22,9 @@ software executable is "installed" into the bitstream to initialize a read-only 
 if your FPGA board does _not_ provide a UART interface.
 * **`rtl/test_setups/neorv32_testsetup_bootloader.vhd`**: this setups uses the UART and the default NEORV32
 bootloader to upload new software executables. Use this setup if your board _does_ provide a UART interface.
+* **`rtl/test_setups/neorv32_testsetup_on_chip_debugger.vhd`**: besides the UARt bootloader, this setups uses
+on-chip debugger to upload and inspect new software executables. Use this setup if your board _does_ provide a JTAG
+interface (the UART is optional).
 
 .NEORV32 "hello world" test setup (`rtl/test_setups/neorv32_testsetup_bootloader.vhd`)
 image::neorv32_test_setup.png[align=center]
@@ -143,14 +146,16 @@ or _inside_ the test setup if this is your top entity (low-active LEDs example: 
 your FPGA board. Check whether it is low-active or high-active - the reset signal of the processor is
 **low-active**, so maybe you need to invert the input signal.
 . If possible, connected _at least_ bit `0` of the GPIO output port `gpio_o` to a LED (see "Signal Polarity" note above).
-. Finally, if your are using the UART-based test setup (`neorv32_testsetup_bootloader.vhd`)
-connect the UART communication signals `uart0_txd_o` and `uart0_rxd_i` to the host interface (e.g. USB-UART converter).
+. If your are using a UART-based test setup connect the UART communication signals `uart0_txd_o` and `uart0_rxd_i`
+to the host interface (e.g. USB-UART converter).
+. If your are using the on-chip debugger setup connect the processor's JTAG signal `jtag_*` to a suitable JTAG adapter.
 . Perform the project HDL compilation (synthesis, mapping, bitstream generation).
 . Program the generated bitstream into your FPGA and press the button connected to the reset signal.
-. Done! The LED at `gpio_o(0)` should be flashing now.
+. Done! The LED(s) connected to `gpio_o` should be flashing now.
 
 [TIP]
 After the GCC toolchain for compiling RISC-V source code is ready (chapter <<_general_software_framework_setup>>),
 you can advance to one of these chapters to learn how to get a software executable into your processor setup:
 * If you are using the `neorv32_testsetup_approm.vhd` setup: See section <<_installing_an_executable_directly_into_memory>>.
 * If you are using the `neorv32_testsetup_bootloader.vhd` setup: See section <<_uploading_and_starting_of_a_binary_executable_image_via_uart>>.
+* If you are using the `neorv32_testsetup_on_chip_debugger.vhd` setup: See section <<_debugging_using_the_on_chip_debugger>>.

--- a/rtl/test_setups/README.md
+++ b/rtl/test_setups/README.md
@@ -9,7 +9,7 @@ optional peripheral modules can be enabled by specifying the according :book:
 [configuration generics](https://stnolting.github.io/neorv32/#_processor_top_entity_generics).
 
 
-### Setup's Top Entity
+### Setup Top Entities
 
 #### Clocking and Reset
 
@@ -24,29 +24,46 @@ your FPGA/board.
 * The clock speed in Hz **has to be specified** via the `CLOCK_SPEED` generic to fit your clock source.
 * The processor-internal instruction memory (IMEM) size _can be modified_ via the `MEM_INT_IMEM_SIZE` generic.
 * The processor-internal data memory (DMEM) size _can be modified_ via the `MEM_INT_DMEM_SIZE` generic.
-Note that this might require adaption of the NEORV32 linker script.
+
+:warning: Modifying the memory sizes might require adaption of the NEORV32 linker script.
 
 
 ### [`neorv32_test_setup_approm.vhd`](https://github.com/stnolting/neorv32/blob/main/rtl/test_setups/neorv32_test_setup_approm.vhd)
 
-This setup configures a `rv32imc_Zicsr` CPU with 16kB IMEM (as pre-initialized ROM),
-8kB DMEM and includes the GPIO module to drive 8 external signals (`gpio_o`)
-and the MTIME module for generating timer interrupts.
+This setup configures a `rv32imc_Zicsr_Zicntr` CPU with 16kB IMEM (as pre-initialized ROM),
+8kB DMEM and includes the **GPIO** module to drive 8 external signals (`gpio_o`)
+and the **MTIME** module for generating timer interrupts.
 The setup uses the ["indirect boot"](https://stnolting.github.io/neorv32/#_indirect_boot)
 configuration, so software applications are "installed" directly into the
 processor-internal IMEM during synthesis.
 
-:books: See User Guide section [_Installing an Executable Directly Into Memory_](https://stnolting.github.io/neorv32/ug/#_installing_an_executable_directly_into_memory).
+:books: See User Guide section
+[Installing an Executable Directly Into Memory](https://stnolting.github.io/neorv32/ug/#_installing_an_executable_directly_into_memory).
 
 
 ### [`neorv32_test_setup_bootloader.vhd`](https://github.com/stnolting/neorv32/blob/main/rtl/test_setups/neorv32_test_setup_bootloader.vhd)
 
-This setup configures a `rv32imc_Zicsr` CPU with 16kB IMEM (as RAM), 8kB DMEM
-and includes the GPIO module to drive 8 external signals (`gpio_o`), the MTIME
-module for generating timer interrupts and UART0 to interface with the bootloader
+This setup configures a `rv32imc_Zicsr_Zicntr` CPU with 16kB IMEM (as RAM), 8kB DMEM
+and includes the **GPIO** module to drive 8 external signals (`gpio_o`), the **MTIME**
+module for generating timer interrupts and **UART0** to interface with the bootloader or application
 (via `uart0_txd_o` and `uart0_rxd_i`) via a serial terminal.
 The setup uses the ["direct boot"](https://stnolting.github.io/neorv32/#_direct_boot)
 configuration, so software applications can be uploaded and run at any timer via a serial terminal.
 
 :books: See User Guide section
-[_Uploading and Starting of a Binary Executable Image via UART_](https://stnolting.github.io/neorv32/ug/#_uploading_and_starting_of_a_binary_executable_image_via_uart).
+[Uploading and Starting of a Binary Executable Image via UART](https://stnolting.github.io/neorv32/ug/#_uploading_and_starting_of_a_binary_executable_image_via_uart).
+
+
+### [`neorv32_test_setup_on_chip_debugger.vhd`](https://github.com/stnolting/neorv32/blob/main/rtl/test_setups/neorv32_test_setup_on_chip_debugger.vhd)
+
+This setup configures a `rv32imc_Zicsr_Zicntr_Zifencei` CPU with 16kB IMEM (as RAM), 8kB DMEM
+and includes the **GPIO** module to drive 8 external signals (`gpio_o`), the **MTIME**
+module for generating timer interrupts, **UART0** to interface with the bootloader or application
+(via `uart0_txd_o` and `uart0_rxd_i`) via a serial terminal and also the RISC-V-compatible
+on-chip debugger (**OCD**), which is accessible via a standard JTAG interface (`jtag_*`).
+The setup uses the ["direct boot"](https://stnolting.github.io/neorv32/#_direct_boot)
+configuration, so software applications can be uploaded and run at any timer via a serial terminal
+and also via the on-chip debugger.
+
+:books: See User Guide section
+[Debugging using the On-Chip Debugger](https://stnolting.github.io/neorv32/ug/#_debugging_using_the_on_chip_debugger).

--- a/rtl/test_setups/neorv32_test_setup_approm.vhd
+++ b/rtl/test_setups/neorv32_test_setup_approm.vhd
@@ -3,7 +3,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #

--- a/rtl/test_setups/neorv32_test_setup_bootloader.vhd
+++ b/rtl/test_setups/neorv32_test_setup_bootloader.vhd
@@ -1,9 +1,9 @@
 -- #################################################################################################
--- # << NEORV32 - Test Setup using the UART-Bootloader to upload and run executables >>            #
+-- # << NEORV32 - Test Setup using the default UART-Bootloader to upload and run executables >>    #
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #

--- a/rtl/test_setups/neorv32_test_setup_on_chip_debugger.vhd
+++ b/rtl/test_setups/neorv32_test_setup_on_chip_debugger.vhd
@@ -1,0 +1,120 @@
+-- #################################################################################################
+-- # << NEORV32 - Test Setup using the RISC-V-compatible On-Chip Debugger >>                       #
+-- # ********************************************************************************************* #
+-- # BSD 3-Clause License                                                                          #
+-- #                                                                                               #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+-- #                                                                                               #
+-- # Redistribution and use in source and binary forms, with or without modification, are          #
+-- # permitted provided that the following conditions are met:                                     #
+-- #                                                                                               #
+-- # 1. Redistributions of source code must retain the above copyright notice, this list of        #
+-- #    conditions and the following disclaimer.                                                   #
+-- #                                                                                               #
+-- # 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
+-- #    conditions and the following disclaimer in the documentation and/or other materials        #
+-- #    provided with the distribution.                                                            #
+-- #                                                                                               #
+-- # 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
+-- #    endorse or promote products derived from this software without specific prior written      #
+-- #    permission.                                                                                #
+-- #                                                                                               #
+-- # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
+-- # OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
+-- # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
+-- # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
+-- # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
+-- # GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
+-- # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
+-- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
+-- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
+-- # ********************************************************************************************* #
+-- # The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32                           #
+-- #################################################################################################
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library neorv32;
+use neorv32.neorv32_package.all;
+
+entity neorv32_test_on_chip_debugger is
+  generic (
+    -- adapt these for your setup --
+    CLOCK_FREQUENCY   : natural := 100000000; -- clock frequency of clk_i in Hz
+    MEM_INT_IMEM_SIZE : natural := 16*1024;   -- size of processor-internal instruction memory in bytes
+    MEM_INT_DMEM_SIZE : natural := 8*1024     -- size of processor-internal data memory in bytes
+  );
+  port (
+    -- Global control --
+    clk_i       : in  std_ulogic; -- global clock, rising edge
+    rstn_i      : in  std_ulogic; -- global reset, low-active, async
+    -- JTAG on-chip debugger interface --
+    jtag_trst_i : in  std_ulogic; -- low-active TAP reset (optional)
+    jtag_tck_i  : in  std_ulogic; -- serial clock
+    jtag_tdi_i  : in  std_ulogic; -- serial data input
+    jtag_tdo_o  : out std_ulogic; -- serial data output
+    jtag_tms_i  : in  std_ulogic; -- mode select
+    -- GPIO --
+    gpio_o      : out std_ulogic_vector(7 downto 0); -- parallel output
+    -- UART0 --
+    uart0_txd_o : out std_ulogic; -- UART0 send data
+    uart0_rxd_i : in  std_ulogic  -- UART0 receive data
+  );
+end entity;
+
+architecture neorv32_test_on_chip_debugger_rtl of neorv32_test_on_chip_debugger is
+
+  signal con_gpio_o : std_ulogic_vector(63 downto 0);
+
+begin
+
+  -- The Core Of The Problem ----------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  neorv32_top_inst: neorv32_top
+  generic map (
+    -- General --
+    CLOCK_FREQUENCY              => CLOCK_FREQUENCY,   -- clock frequency of clk_i in Hz
+    INT_BOOTLOADER_EN            => true,              -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
+    -- On-Chip Debugger (OCD) --
+    ON_CHIP_DEBUGGER_EN          => true,              -- implement on-chip debugger
+    -- RISC-V CPU Extensions --
+    CPU_EXTENSION_RISCV_C        => true,              -- implement compressed extension?
+    CPU_EXTENSION_RISCV_M        => true,              -- implement mul/div extension?
+    CPU_EXTENSION_RISCV_Zicsr    => true,              -- implement CSR system?
+    CPU_EXTENSION_RISCV_Zicntr   => true,              -- implement base counters?
+    CPU_EXTENSION_RISCV_Zifencei => true,              -- implement instruction stream sync.? (required for the on-chip debugger)
+    -- Internal Instruction memory --
+    MEM_INT_IMEM_EN              => true,              -- implement processor-internal instruction memory
+    MEM_INT_IMEM_SIZE            => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes
+    -- Internal Data memory --
+    MEM_INT_DMEM_EN              => true,              -- implement processor-internal data memory
+    MEM_INT_DMEM_SIZE            => MEM_INT_DMEM_SIZE, -- size of processor-internal data memory in bytes
+    -- Processor peripherals --
+    IO_GPIO_EN                   => true,              -- implement general purpose input/output port unit (GPIO)?
+    IO_MTIME_EN                  => true,              -- implement machine system timer (MTIME)?
+    IO_UART0_EN                  => true               -- implement primary universal asynchronous receiver/transmitter (UART0)?
+  )
+  port map (
+    -- Global control --
+    clk_i       => clk_i,       -- global clock, rising edge
+    rstn_i      => rstn_i,      -- global reset, low-active, async
+    -- JTAG on-chip debugger interface (available if ON_CHIP_DEBUGGER_EN = true) --
+    jtag_trst_i => jtag_trst_i, -- low-active TAP reset (optional)
+    jtag_tck_i  => jtag_tck_i,  -- serial clock
+    jtag_tdi_i  => jtag_tdi_i,  -- serial data input
+    jtag_tdo_o  => jtag_tdo_o,  -- serial data output
+    jtag_tms_i  => jtag_tms_i,  -- mode select
+    -- GPIO (available if IO_GPIO_EN = true) --
+    gpio_o      => con_gpio_o,  -- parallel output
+    -- primary UART0 (available if IO_UART0_EN = true) --
+    uart0_txd_o => uart0_txd_o, -- UART0 send data
+    uart0_rxd_i => uart0_rxd_i  -- UART0 receive data
+  );
+
+  -- GPIO output --
+  gpio_o <= con_gpio_o(7 downto 0);
+
+
+end architecture;


### PR DESCRIPTION
This PR adds a new test setup that also includes the RISC-V-compatible on-chip debugger (OCD).