### PR TITLE
:warning: rework watchdog timer (WDT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 10.01.2023 | 1.7.9.7 | :warning: rework **watchdog timer (WDT)**; [#474](https://github.com/stnolting/neorv32/pull/474) |
 | 06.01.2023 | 1.7.9.6 | update [neoTRNG v2](https://github.com/stnolting/neoTRNG); [#472](https://github.com/stnolting/neorv32/pull/472) |
 | 06.01.2023 | 1.7.9.5 | CPU control: logic optimization and fix minor bug in trigger module; [#470](https://github.com/stnolting/neorv32/pull/470) |
 | 04.01.2023 | 1.7.9.4 | update **on-chip debugger**: :test_tube: remove debug module's `haltsum0` register; rework DMI to comply with RISC-V debug spec.; minor edits, updates and fixes; [#468](https://github.com/stnolting/neorv32/pull/468) |

--- a/docs/datasheet/soc_wdt.adoc
+++ b/docs/datasheet/soc_wdt.adoc
@@ -10,90 +10,69 @@
 |                          | neorv32_wdt.h |
 | Top entity port:         | none | 
 | Configuration generics:  | _IO_WDT_EN_ | implement watchdog when _true_
-| CPU interrupts:          | fast IRQ channel 0 | watchdog timer overflow (see <<_processor_interrupts>>)
+| CPU interrupts:          | fast IRQ channel 0 | watchdog timeout (see <<_processor_interrupts>>)
 |=======================
 
 
 **Theory of Operation**
 
-The watchdog (WDT) provides a last resort for safety-critical applications. The WDT provides an internal 20-bit
-wide counter that needs to be reset every now and then by the user program. If the counter overflows, either
-a system reset or an interrupt is generated depending on the configured operation mode.
+The watchdog (WDT) provides a last resort for safety-critical applications. The WDT provides a "bark and bite"
+concept. The timeout counter first triggers an optional CPU interrupt ("bark") when reaching half of the programmed
+interval to inform the application of the imminent timeout. When the full timeout value is reached
+a system-wide hardware reset is generated ("bite"). The internal counter has to be reset explicitly by the application
+program every now and then to prevent a timeout.
 
 
-**Access Password**
+**Configuration**
 
-Whenever the watchdog control register `NEORV32_WDT.CTRL` shall be written the upper-most (MSB-aligned) 16 bit of the
-write data have to contain the "watchdog access password". If the password is incorrect the write access is entirely ignored
-and the watchdog hardware module will **not acknowledge** the bus write access leading to a **store access fault exception**.
-Read accesses are not affected by the access password at all.
+The watchdog is enabled by setting the control register's `WDT_CTRL_EN_ bit. When this bit is cleared, the internal
+timeout counter is reset to zero and no interrupt and no system reset can be triggered.
 
-* Watchdog access password (`write_data[31:16]`) = **`0xCA36`**
+The internal 32-bit timeout counter is clocked at 1/4096th of the processor's main clock (f~WDT~[Hz] = f~main~[Hz] / 4096).
+Whenever this counter reaches the programmed timeout value (_WDT_CTRL_TIMEOUT_ bits in the control register) a
+hardware reset is triggered. In order to inform the application of an imminent timeout, an optional CPU interrupt is
+triggered when the timeout counter reaches **half** of the programmed timeout value.
 
+The watchdog is "fed" by writing `1` to the _WDT_CTRL_RESET_ control register bit, which
+will reset the internal timeout counter back to zero.
 
-**Timeout Configuration**
-
-The watchdog is enabled by setting the control register's `WDT_CTRL_EN_ bit. The clock used to increment the
-internal counter is selected via the 3-bit _WDT_CTRL_CLK_SELx_ prescaler:
-
-[cols="^3,^3,>4"]
-[options="header",grid="rows"]
-|=======================
-| **`WDT_CTRL_CLK_SELx`** | Main clock prescaler | Timeout period in clock cycles
-| `0b000` | 2 | 2 097 152
-| `0b001` | 4 | 4 194 304
-| `0b010` | 8 | 8 388 608
-| `0b011` | 64 | 67 108 864
-| `0b100` | 128 | 134 217 728
-| `0b101` | 1024 | 1 073 741 824
-| `0b110` | 2048 | 2 147 483 648
-| `0b111` | 4096 | 4 294 967 296
-|=======================
-
-The _WDT_CTRL_HALF_ flag of the control register `CTRL` indicates that at least half of the maximum timeout
-value has already been reached. The watchdog is "fed" by setting the _WDT_CTRL_RESET_ control register bit, which
-will reset the timeout counter.
-
-
-**Watchdog Action**
-
-Whenever the internal counter overflows the watchdog executes one of two possible actions: either a hard
-processor reset is triggered or an interrupt is requested via the CPU's fast interrupt channel #0. The
-_WDT_CTRL_MODE_ bit defines the action to be taken on an overflow: when cleared, the watchdog will assert an
-IRQ, when set the WDT will cause a system wide reset. The configured action can also be triggered manually at
-any time by setting the _WDT_CTRL_FORCE_ bit.
-
-The cause of the last system reset can be determined via the _WDT_CTRL_RCAUSE_ flag. If this flag is
-zero, the processor has been reset via the external reset signal (or the on-chip debugger). If this flag is set
-the last system reset was caused by the watchdog itself.
+[NOTE]
+Writing all-zero to the _WDT_CTRL_TIMEOUT_ bits will immediately trigger a system-wide reset.
 
 .Watchdog Interrupt
 [NOTE]
-A watchdog interrupt can only occur if the watchdog is enabled and interrupt mode is enabled.
-A triggered interrupt has to be cleared again by writing zero to the according <<_mip>> CSR bit.
+A watchdog interrupt occurs when the watchdog is enabled and the internal counter reaches half of the programmed
+timeout value. A triggered interrupt has to be explicitly cleared by writing zero to the according <<_mip>> CSR bit.
 
 .Watchdog Operation during Debugging
 [IMPORTANT]
 By default the watchdog stops operation when the CPU enters debug mode and will resume normal operation after
-the CPU has left debug mode again. This will prevent an unintended watchdog timeout (and a hardware reset if configured)
-during a debug session. However, the watchdog can also be configured to keep operating even when the CPU is in debug
-mode by setting the control register's _WDT_CTRL_DBEN_ bit.
+the CPU has left debug mode again. This will prevent an unintended watchdog timeout during a debug session. However,
+the watchdog can also be configured to keep operating even when the CPU is in debug mode by setting the control
+register's _WDT_CTRL_DBEN_ bit.
 
-.Watchdog Operation during CPU Sleep Mode
-[NOTE]
-By default the watchdog keeps operating when the CPU enters sleep mode. However, the watchdog can also be paused while
-the CPU is sleeping by setting the _WDT_CTRL_PAUSE_ control register bit.
+.Watchdog Operation during CPU Sleep
+[IMPORTANT]
+By default the watchdog stops operating when the CPU enters sleep mode. However, the watchdog can also be configured
+to keep operating even when the CPU is in sleep mode by setting the control register's _WDT_CTRL_SEN_ bit.
 
 
 **Configuration Lock**
 
-The watchdog control register can be locked to protect the current configuration from being modified. The lock is activated by
-setting the _WDT_CTRL_LOCK_ bit. In the locked state any write access to the control register's configuration flags is
-ignored (see table below, "writable if locked"). Read accesses to the control register as well as watchdog resets (_WDT_CTRL_RESET_)
-and forced watchdog actions (_WDT_CTRL_FORCE_) are not affected.
+The watchdog control register can be locked to protect the current configuration from being modified. The lock is
+activated by setting the _WDT_CTRL_LOCK_ bit. In the locked state any write access to the control register is entirely
+ignored (see table below, "writable if locked"). Read accesses to the control register as well as watchdog resets
+(by setting the _WDT_CTRL_RESET_ flag) are not affected.
 
-The lock is removed by a system reset, which can be triggered via the external hardware reset signal, the on-chip debugger
-or the watchdog itself (if _WDT_CTRL_MODE_ is set).
+The lock bit can only be set if the WDT is already enabled (_WDT_CTRL_EN_ is set).
+The lock bit can only be cleared again by a system-wide hardware reset.
+
+
+**Cause of last Hardware Reset**
+
+The cause of the last system hardware reset can be determined via the _WDT_CTRL_RCAUSE_ flag. If this flag is
+zero, the processor has been reset via the external reset signal (or the on-chip debugger). If this flag is set,
+the last system reset was caused by the watchdog itself.
 
 
 **Register Map**
@@ -103,18 +82,12 @@ or the watchdog itself (if _WDT_CTRL_MODE_ is set).
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Reset value | Writable if locked | Function
-.14+<| `0xffffffbc` .14+<| `NEORV32_WDT.CTRL` <|`0` _WDT_CTRL_EN_       ^| r/w ^| `0` ^| no  <| watchdog enable
-                                              <|`1` _WDT_CTRL_CLK_SEL0_ ^| r/w ^| `0` ^| no  .3+<| 3-bit clock prescaler select
-                                              <|`2` _WDT_CTRL_CLK_SEL1_ ^| r/w ^| `0` ^| no 
-                                              <|`3` _WDT_CTRL_CLK_SEL2_ ^| r/w ^| `0` ^| no 
-                                              <|`4` _WDT_CTRL_MODE_     ^| r/w ^| `0` ^| no  <| overflow action: `1`=reset, `0`=IRQ
-                                              <|`5` _WDT_CTRL_RCAUSE_   ^| r/- ^| `0` ^| -   <| cause of last system reset: `0`=caused by external reset signal, `1`=caused by watchdog
-                                              <|`6` _WDT_CTRL_RESET_    ^| -/w ^| -   ^| yes <| reset watchdog when set, auto-clears
-                                              <|`7` _WDT_CTRL_FORCE_    ^| -/w ^| -   ^| yes <| force configured watchdog action when set, auto-clears
-                                              <|`8` _WDT_CTRL_LOCK_     ^| r/w ^| `0` ^| no  <| lock access to configuration when set, clears only on system reset (via external reset signal OR watchdog reset action = reset)
-                                              <|`9` _WDT_CTRL_DBEN_     ^| r/w ^| `0` ^| no  <| allow WDT to continue operation even when CPU is in debug mode
-                                              <|`10` _WDT_CTRL_HALF_    ^| r/- ^| `0` ^| -   <| set if at least half of the max. timeout counter value has been reached
-                                              <|`11` _WDT_CTRL_PAUSE_   ^| r/w ^| `0` ^| no  <| pause WDT when CPU is in sleep mode
-                                              <|`15:12` -               ^| r/- ^| -   ^| -   <| _reserved_, reads as zero
-                                              <|`31:16` _WDT_CTRL_PWD_  ^| -/w ^| -   ^| -   <| watchdog write access password, has to be `0xCA36`, reads as zero
+.8+<| `0xffffffbc` .8+<| `NEORV32_WDT.CTRL` <|`0` _WDT_CTRL_EN_     ^| r/w ^| `0` ^| no  <| watchdog enable
+                                            <|`1  _WDT_CTRL_LOCK_   ^| r/w ^| `0` ^| no  <| lock configuration when set, clears only on system reset, can only be set if enable bit is set already
+                                            <|`2` _WDT_CTRL_DBEN_   ^| r/w ^| `0` ^| no  <| set to allow WDT to continue operation even when CPU is in debug mode
+                                            <|`3` _WDT_CTRL_SEN_    ^| r/w ^| `0` ^| no  <| set to allow WDT to continue operation even when CPU is in sleep mode
+                                            <|`4` _WDT_CTRL_RESET_  ^| -/w ^| -   ^| yes <| reset watchdog when set, auto-clears
+                                            <|`5` _WDT_CTRL_RCAUSE_ ^| r/- ^| `0` ^| -   <| cause of last system reset: `0`=caused by external reset signal, `1`=caused by watchdog
+                                            <|`7:6` -               ^| r/- ^| -   ^| -   <| _reserved_, reads as zero
+                                            <|`31:8` _WDT_CTRL_TIMEOUT_MSB_ : _WDT_CTRL_TIMEOUT_LSB_ ^| r/w ^| 0 ^| no <| 24-bit watchdog timeout value
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070906"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070907"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/example/demo_wdt/main.c
+++ b/sw/example/demo_wdt/main.c
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -36,9 +36,8 @@
 /**********************************************************************//**
  * @file demo_wdt/main.c
  * @author Stephan Nolting
- * @brief Watchdog system reset demo program.
+ * @brief Watchdog demo program.
  **************************************************************************/
-
 #include <neorv32.h>
 
 
@@ -48,90 +47,93 @@
 /**@{*/
 /** UART BAUD rate */
 #define BAUD_RATE 19200
+/** WDT timeout (until system reset) in seconds */
+#define WDT_TIMEOUT_S 4
 /**@}*/
+
+
+/**********************************************************************//**
+ * Watchdog FIRQ handler - executed when the WDT has reached half of
+ * the configured timeout interval.
+ **************************************************************************/
+void wdt_firq_handler(void) {
+
+  neorv32_cpu_csr_write(CSR_MIP, ~(1<<WDT_FIRQ_PENDING)); // clear/ack pending FIRQ
+  neorv32_uart0_puts("WDT IRQ! Timeout imminent!\n");
+}
 
 
 /**********************************************************************//**
  * Main function
  *
- * @note This program requires the WDT and the UART to be synthesized.
+ * @note This program requires the WDT and UART0 to be synthesized.
  *
  * @return 0 if execution was successful
  **************************************************************************/
 int main() {
 
-  // check if WDT unit is implemented at all
-  if (neorv32_wdt_available() == 0) {
-    return 1; // nope, no WDT unit synthesized
-  }
-
-  // check if UART unit is implemented at all
-  if (neorv32_uart0_available() == 0) {
-    return 1; // nope, no UART unit synthesized
-  }
-
-
-  // capture all exceptions and give debug info via UART
-  // this is not required, but keeps us safe
+  // setup NEORV32 runtime environment for capturing all traps
   neorv32_rte_setup();
 
-  // init UART at default baud rate, no parity bits, ho hw flow control
+  // setup UART0 at default baud rate, no parity bits, ho HW flow control
   neorv32_uart0_setup(BAUD_RATE, PARITY_NONE, FLOW_CONTROL_NONE);
 
-  // check available hardware extensions and compare with compiler flags
-  neorv32_rte_check_isa(0); // silent = 0 -> show message if isa mismatch
+  // check if WDT is implemented at all
+  if (neorv32_wdt_available() == 0) {
+    return 1; // WDT not synthesized
+  }
 
-  // simple text output via UART (strings only)
-  neorv32_uart0_puts("\nWatchdog system reset demo program\n\n");
+  // check if UART0 is implemented at all
+  if (neorv32_uart0_available() == 0) {
+    return 1; // UART0 not synthesized
+  }
+
+
+  // intro
+  neorv32_uart0_puts("\n<< Watchdog Demo Program >>\n\n");
 
 
   // show the cause of the last processor reset
   neorv32_uart0_puts("Cause of last processor reset: ");
-  uint8_t wdt_cause = neorv32_wdt_get_cause();
-
-  if (wdt_cause == 0) {
-    neorv32_uart0_puts("External reset\n");
-  }
-  else if (wdt_cause == 1) {
-    neorv32_uart0_puts("Watchdog\n");
+  if (neorv32_wdt_get_cause() == 0) {
+    neorv32_uart0_puts("External reset\n\n");
   }
   else {
-    neorv32_uart0_puts("Undefined\n");
+    neorv32_uart0_puts("Watchdog timeout\n\n");
   }
 
 
-  // the watchdog has a 20-bit counter, which triggers either an interrupt or a system reset
-  // when overflowing
+  // configure and enable WDT interrupt
+  // this IRQ will trigger when half of the configured WDT timeout interval has been reached
+  neorv32_uart0_puts("Configuring WDT interrupt...\n");
+  neorv32_rte_handler_install(WDT_RTE_ID, wdt_firq_handler);
+  neorv32_cpu_irq_enable(WDT_FIRQ_ENABLE);
+  neorv32_cpu_eint(); // enable global interrupt flag
 
-  // init watchdog (watchdog timer increment = cpu_clock/64, trigger reset on overflow, lock
-  // access so nobody can alter the configuration until next reset)
-  neorv32_wdt_setup(CLK_PRSC_64, 1, 1);
 
-
-
-  neorv32_uart0_puts("\n\nWill reset WDT 64 times.\n"
-                    "A system reset will be executed in the following time out.\n"
-                    "Press any key to trigger manual WDT hardware reset by WDT access with wrong password.\n"
-                    "Restart this program after reset to check for the reset cause.\n\n"
-                    "WDT resets: ");
-
-  uint8_t i;
-  for (i=0; i<64; i++) {
-    neorv32_uart0_putc('.');
-    neorv32_wdt_reset(); // reset watchdog
-    neorv32_cpu_delay_ms(80); // wait some time
-
-    // trigger manual reset if key pressed
-    if (neorv32_uart0_char_received()) { // just check, if a char has been received
-      neorv32_wdt_force(); // access wdt with wrong password
-    }
+  // compute WDT timeout value
+  // - the WDT counter increments at f_wdt = f_main / 4096
+  uint32_t timeout = WDT_TIMEOUT_S * (NEORV32_SYSINFO.CLK / 4096)
+  if (timeout & 0xFF000000U) { // check if timeout value fits into 24-bit
+    neorv32_uart0_puts("Timeout value does not fit into 24-bit!\n");
+    return -1;
   }
 
-  while (1) { // wait for the watchdog time-out or trigger manual reset if key pressed
-    if (neorv32_uart0_char_received()) { // just check, if a char has been received
-      neorv32_wdt_force(); // access wdt with wrong password
-    }
+  // setup watchdog: no lock, disable in debug mode, enable in sleep mode
+  neorv32_uart0_puts("Starting WDT...\n");
+  neorv32_wdt_setup(timeout, 0, 0, 1);
+
+
+  // feed the watchdog
+  neorv32_uart0_puts("Resetting WDT...\n");
+  neorv32_wdt_feed(); // reset internal counter to zero
+
+
+  // go to sleep mode and wait for watchdog to kick in
+  neorv32_uart0_puts("Entering sleep mode and waiting for WDT timeout...\n");
+  while(1) {
+    neorv32_cpu_sleep();
   }
 
-  return 0;
+  return 0; // will never be reached
 }

--- a/sw/example/demo_wdt/main.c
+++ b/sw/example/demo_wdt/main.c
@@ -113,7 +113,7 @@ int main() {
 
   // compute WDT timeout value
   // - the WDT counter increments at f_wdt = f_main / 4096
-  uint32_t timeout = WDT_TIMEOUT_S * (NEORV32_SYSINFO.CLK / 4096)
+  uint32_t timeout = WDT_TIMEOUT_S * (NEORV32_SYSINFO.CLK / 4096);
   if (timeout & 0xFF000000U) { // check if timeout value fits into 24-bit
     neorv32_uart0_puts("Timeout value does not fit into 24-bit!\n");
     return -1;

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -1254,7 +1254,7 @@ enum NEORV32_TRNG_CTRL_enum {
 /**@{*/
 /** WDT module prototype */
 typedef struct __attribute__((packed,aligned(4))) {
-  uint32_t CTRL;  /**< offset 0: control register (#NEORV32_WDT_CTRL_enum) */
+  uint32_t CTRL; /**< offset 0: control register (#NEORV32_WDT_CTRL_enum) */
 } neorv32_wdt_t;
 
 /** WDT module base address */
@@ -1263,26 +1263,17 @@ typedef struct __attribute__((packed,aligned(4))) {
 /** WDT module hardware access (#neorv32_wdt_t) */
 #define NEORV32_WDT (*((volatile neorv32_wdt_t*) (NEORV32_WDT_BASE)))
 
-/** WDT access password */
-#define NEORV32_WDT_PWD (0xCA36)
-
 /** WDT control register bits */
 enum NEORV32_WDT_CTRL_enum {
-  WDT_CTRL_EN       =  0, /**< WDT control register(0) (r/w): Watchdog enable */
-  WDT_CTRL_CLK_SEL0 =  1, /**< WDT control register(1) (r/w): Clock prescaler select bit 0 */
-  WDT_CTRL_CLK_SEL1 =  2, /**< WDT control register(2) (r/w): Clock prescaler select bit 1 */
-  WDT_CTRL_CLK_SEL2 =  3, /**< WDT control register(3) (r/w): Clock prescaler select bit 2 */
-  WDT_CTRL_MODE     =  4, /**< WDT control register(4) (r/w): Watchdog mode: 0=timeout causes interrupt, 1=timeout causes processor reset */
-  WDT_CTRL_RCAUSE   =  5, /**< WDT control register(5) (r/-): Cause of last system reset: 0=external reset, 1=watchdog */
-  WDT_CTRL_RESET    =  6, /**< WDT control register(6) (-/w): Reset WDT counter when set, auto-clears */
-  WDT_CTRL_FORCE    =  7, /**< WDT control register(7) (-/w): Force WDT action, auto-clears */
-  WDT_CTRL_LOCK     =  8, /**< WDT control register(8) (r/w): Lock write access to control register, clears on reset (HW or WDT) only */
-  WDT_CTRL_DBEN     =  9, /**< WDT control register(9) (r/w): Allow WDT to continue operation even when in debug mode */
-  WDT_CTRL_HALF     = 10, /**< WDT control register(10) (r/-): Set if at least half of the max. timeout counter value has been reached */
-  WDT_CTRL_PAUSE    = 11, /**< WDT control register(11) (r/w): Pause WDT when CPU is in sleep mode */
+  WDT_CTRL_EN          =  0, /**< WDT control register(0) (r/w): Watchdog enable */
+  WDT_CTRL_LOCK        =  1, /**< WDT control register(1) (r/w): Lock write access to control register, clears on reset only */
+  WDT_CTRL_DBEN        =  2, /**< WDT control register(2) (r/w): Allow WDT to continue operation even when CPU is in debug mode */
+  WDT_CTRL_SEN         =  3, /**< WDT control register(3) (r/w): Allow WDT to continue operation even when CPU is in sleep mode */
+  WDT_CTRL_RESET       =  4, /**< WDT control register(4) (-/w): Reset WDT counter when set, auto-clears */
+  WDT_CTRL_RCAUSE      =  5, /**< WDT control register(5) (r/-): Cause of last system reset: 0=external reset, 1=watchdog */
 
-  WDT_CTRL_PWD_LSB  = 16, /**< WDT control register(16) (-/w): Watchdog access password, LSB ("NEORV32_WDT_PWD") */
-  WDT_CTRL_PWD_MSB  = 31  /**< WDT control register(31) (-/w): Watchdog access password, MSB ("NEORV32_WDT_PWD") */
+  WDT_CTRL_TIMEOUT_LSB =  8, /**< WDT control register(8)  (r/w): Timeout value, LSB */
+  WDT_CTRL_TIMEOUT_MSB = 31  /**< WDT control register(31) (r/w): Timeout value, MSB */
 };
 /**@}*/
 

--- a/sw/lib/include/neorv32_wdt.h
+++ b/sw/lib/include/neorv32_wdt.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2021, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -45,10 +45,9 @@
 
 // prototypes
 int  neorv32_wdt_available(void);
-void neorv32_wdt_setup(uint8_t prsc, uint8_t mode, uint8_t lock);
+void neorv32_wdt_setup(uint32_t timeout, int lock, int debug_en, int sleep_en);
 int  neorv32_wdt_disable(void);
-void neorv32_wdt_reset(void);
+void neorv32_wdt_feed(void);
 int  neorv32_wdt_get_cause(void);
-void neorv32_wdt_force(void);
 
 #endif // neorv32_wdt_h

--- a/sw/lib/source/neorv32_wdt.c
+++ b/sw/lib/source/neorv32_wdt.c
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -63,29 +63,30 @@ int neorv32_wdt_available(void) {
 /**********************************************************************//**
  * Configure and enable watchdog timer. The WDT control register bits are listed in #NEORV32_WDT_CTRL_enum.
  *
- * @warning Once set the watchdog lock can only be removed by an external hardware reset!
+ * @warning Once the lock bit is set it can only be removed by a hardware reset!
  *
- * @param[in] prsc Clock prescaler to select timeout interval. See #NEORV32_CLOCK_PRSC_enum.
- * @param[in] mode Trigger system reset on timeout when 1, trigger interrupt on timeout when 0.
+ * @param[in] timeout 24-bit timeout value. A WDT IRQ is triggered when the internal counter reaches
+ * 'timeout/2'. A system hardware reset is triggered when the internal counter reaches 'timeout'.
  * @param[in] lock Control register will be locked when 1 (until next reset).
+ * @param[in] debug_en Allow watchdog to continue operation even when CPU is in debug mode.
+ * @param[in] sleep_en Allow watchdog to continue operation even when CPU is in sleep mode.
  **************************************************************************/
-void neorv32_wdt_setup(uint8_t prsc, uint8_t mode, uint8_t lock) {
+void neorv32_wdt_setup(uint32_t timeout, int lock, int debug_en, int sleep_en) {
 
-  NEORV32_WDT.CTRL = (NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB) | (1 << WDT_CTRL_RESET); // reset and disable
+  NEORV32_WDT.CTRL = 0; // reset and disable
 
-  uint32_t prsc_int = (uint32_t)(prsc & 0x07);
-  prsc_int = prsc_int << WDT_CTRL_CLK_SEL0;
-
-  uint32_t mode_int = (uint32_t)(mode & 0x01);
-  mode_int = mode_int << WDT_CTRL_MODE;
-
-  uint32_t lock_int = (uint32_t)(lock & 0x01);
-  lock_int = lock_int << WDT_CTRL_LOCK;
-
-  const uint32_t enable = (uint32_t)(1 << WDT_CTRL_EN);
+  uint32_t enable_int   = ((uint32_t)(1))                    << WDT_CTRL_EN;
+  uint32_t timeout_int  = ((uint32_t)(timeout  & 0xffffffU)) << WDT_CTRL_TIMEOUT_LSB;
+  uint32_t debug_en_int = ((uint32_t)(debug_en & 0x1U))      << WDT_CTRL_DBEN;
+  uint32_t sleep_en_int = ((uint32_t)(sleep_en & 0x1U))      << WDT_CTRL_SEN;
 
   // update WDT control register
-  NEORV32_WDT.CTRL = (NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB) | enable | mode_int | prsc_int | lock_int;
+  NEORV32_WDT.CTRL = enable_int | timeout_int | debug_en_int | sleep_en_int;
+
+  // lock configuration?
+  if (lock) {
+    NEORV32_WDT.CTRL |= 1 << WDT_CTRL_LOCK;
+  }
 }
 
 
@@ -96,14 +97,16 @@ void neorv32_wdt_setup(uint8_t prsc, uint8_t mode, uint8_t lock) {
  **************************************************************************/
 int neorv32_wdt_disable(void) {
 
-  NEORV32_WDT.CTRL = (NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB) | (1 << WDT_CTRL_RESET); // reset and disable
+  const uint32_t en_mask_c =  (uint32_t)(1 << WDT_CTRL_EN);
+
+  NEORV32_WDT.CTRL &= en_mask_c; // try to disable
 
   // check if WDT is really off
-  if (NEORV32_WDT.CTRL & (1 << WDT_CTRL_EN)) {
+  if (NEORV32_WDT.CTRL & en_mask_c) {
     return -1; // still active
   }
   else {
-    return 0;
+    return 0; // WDT is disabled
   }
 }
 
@@ -111,9 +114,9 @@ int neorv32_wdt_disable(void) {
 /**********************************************************************//**
  * Feed watchdog (reset timeout counter).
  **************************************************************************/
-void neorv32_wdt_reset(void) {
+void neorv32_wdt_feed(void) {
 
-  NEORV32_WDT.CTRL |= (NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB) | (1 << WDT_CTRL_RESET);
+  NEORV32_WDT.CTRL |= (uint32_t)(1 << WDT_CTRL_RESET);
 }
 
 
@@ -130,13 +133,4 @@ int neorv32_wdt_get_cause(void) {
   else { // reset caused by system (external or OCD)
     return 0;
   }
-}
-
-
-/**********************************************************************//**
- * Force immediate watchdog action (reset/IRQ).
- **************************************************************************/
-void neorv32_wdt_force(void) {
-
-  NEORV32_WDT.CTRL |= (NEORV32_WDT_PWD << WDT_CTRL_PWD_LSB) | (1 << WDT_CTRL_FORCE);
 }


### PR DESCRIPTION
This PR is complete rework of the NEORV32 Watchdog Timer (WDT).

* remove access password and bus exception trigger
* remove clock prescaler select
* add programmable 24-bit timeout value; internal counter increments at f_main/4096
* now using "bite and bark" concept
  * when reaching "timeout/2" an optional CPU interrupt is triggered
  * when reaching "timeout" a system-wide hardware reset is triggered
* change control register layout
* update HAL (SW drivers), example program and documentation