### PR TITLE
:warning: Rework CPU counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
-| 14.01.2023 | 1.7.9.8 | minor CPU control edits, optimizations and fixes ;[#476](https://github.com/stnolting/neorv32/pull/476) |
+| 15.01.2023 | 1.7.9.9 | :warning: rework **CPU counters**; remove `mtime_i/o` top entity ports; remove `time[h]` CSRs; [#477](https://github.com/stnolting/neorv32/pull/477) |
+| 14.01.2023 | 1.7.9.8 | minor CPU control edits, optimizations and fixes; [#476](https://github.com/stnolting/neorv32/pull/476) |
 | 10.01.2023 | 1.7.9.7 | :warning: rework **watchdog timer (WDT)**; [#474](https://github.com/stnolting/neorv32/pull/474) |
 | 06.01.2023 | 1.7.9.6 | update [neoTRNG v2](https://github.com/stnolting/neoTRNG); [#472](https://github.com/stnolting/neorv32/pull/472) |
 | 06.01.2023 | 1.7.9.5 | CPU control: logic optimization and fix minor bug in trigger module; [#470](https://github.com/stnolting/neorv32/pull/470) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -668,12 +668,8 @@ The actual number of implemented HPM counters is defined by the <<_hpm_num_cnts>
 Additional CSRs:
 
 * <<_mhpmevent>> 3..31 (depending on <<_hpm_num_cnts>>) - event configuration CSRs
-* <<_mhpmcounterh>> 3..31 (depending on <<_hpm_num_cnts>>) - counter CSRs
-
-[IMPORTANT]
-The HPM counter CSRs can only be accessed in machine-mode. Hence, the according <<_mcounteren>> CSR bits
-are always zero and read-only. Any access from less-privileged modes will raise an illegal instruction
-exception.
+* <<_mhpmcounterh>> 3..31 (depending on <<_hpm_num_cnts>>) - machine-level counter CSRs
+* <<_hpmcounterh>> 3..31 (depending on <<_hpm_num_cnts>>) - user-level counter CSRs
 
 [TIP]
 Auto-increment of the HPMs can be deactivated individually via the <<_mcountinhibit>> CSR.

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -229,8 +229,7 @@ ISA extension. When the CPU is in sleep mode, all CPU-internal operations are st
 Note that this does _not affect_ the operation of any peripheral/IO modules like interfaces and timers. Furthermore,
 the CPU will continue to buffer/enqueue all incoming interrupt requests.
 
-The CPU will leave sleep mode as soon as any interrupt source becomes _pending_. This requires that interrupts are globally
-enabled by setting `<<_mstatus>>.mie` and that at least one interrupt source is enabled in <<_mie>>.
+The CPU will leave sleep mode as soon as any interrupt source becomes _pending_.
 
 [IMPORTANT]
 If sleep mode is entered without at least one enabled interrupt source the CPU will be _permanently_ halted.
@@ -866,7 +865,7 @@ the second highest priority will get serviced and so on until no further interru
 
 .Interrupts when in User-Mode
 [IMPORTANT]
-IF the core is currently operating in less privileged user-mode, (machine-mode) interrupts are globally enabled
+If the core is currently operating in less privileged user-mode, (machine-mode) interrupts are globally enabled
 even if <<_mstatus>>`.mie` is cleared.
 
 .Interrupt Signal Requirements - Standard RISC-V Interrupts

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -304,8 +304,6 @@ direction seen from the CPU.
 | `d_bus_err_i`    |     1 | in  | bus transfer terminate from accessed peripheral
 | `d_bus_fence_o`  |     1 | out | indicates an executed `fence` instruction
 | `d_bus_priv_o`   |     1 | out | current _effective_ CPU privilege level (`0` = user, `1` = machine)
-4+^| **System Time (for <<_timeh>> CSR)**
-| `time_i`         |    64 | in  | system time input from <<_machine_system_timer_mtime>>
 4+^| **Interrupts, RISC-V-compatible (<<_traps_exceptions_and_interrupts>>)**
 | `msw_irq_i`      |     1 | in  | RISC-V machine software interrupt
 | `mext_irq_i`     |     1 | in  | RISC-V machine external interrupt
@@ -639,8 +637,8 @@ will raise an illegal instruction exception if <<_mstatus>>`.TW` is set.
 
 ==== **`Zicntr`** CPU Base Counters
 
-The `Zicntr` ISA extension adds the basic cycle `[m]cycle[h]`), instruction-retired (`[m]instret[h]`) and time (`time[h]`)
-counters. This extensions is stated as _mandatory_ by the RISC-V spec. However, area-constrained setups may remove support for
+The `Zicntr` ISA extension adds the basic cycle `[m]cycle[h]`) and instruction-retired (`[m]instret[h]`) counters.
+This extensions is stated as _mandatory_ by the RISC-V spec. However, area-constrained setups may remove support for
 these counters. Section <<_machine_counter_and_timer_csrs>> shows a list of all `Zicntr`-related CSRs.
 These are available if the `Zicntr` ISA extensions is enabled via the <<_cpu_extension_riscv_zicntr>> generic.
 
@@ -648,10 +646,9 @@ Additional CSRs:
 
 * <<_cycleh>>, <<_mcycleh>> - cycle counter
 * <<_instreth>>, <<_minstreth>> - instructions-retired counter
-* <<_timeh>> - system _wall-clock_ time (driven by the <<_machine_system_timer_mtime>>)
 
-[NOTE]
-Disabling the `Zicntr` extension does not remove the `time[h]`-driving <<_machine_system_timer_mtime>>.
+[IMPORTANT]
+The `Zicntr` ISA extension does not include the `time[h]` CSRs.
 
 If the `Zicntr` ISA extension is disabled, all accesses to the according counter CSRs will raise an illegal instruction exception.
 

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -746,9 +746,9 @@ The `mcountinhibit` CSR can be used to halt specific counter CSRs.
 [options="header",grid="rows"]
 |=======================
 | Bit  | Name [C] | R/W | Event
-| 3:31 | _CSR_MCOUNTINHIBIT_HPM3_ : _CSR_MCOUNTINHIBIT_HPM31_ | r/w | **HPMx**: `0` = The `[m]hpmcount*[h]` CSRs will auto-increment according to the configured `mhpmevent*` selector
-| 2    | _CSR_MCOUNTINHIBIT_CY_ | r/w | **CY**: `0` = The `[m]cycle[h]` CSRs will auto-increment with each clock cycle (if CPU is not in sleep state) when set
-| 0    | _CSR_MCOUNTINHIBIT_IR_ | r/w | **IR**: `0` = The `[m]instret[h]` CSRs will auto-increment with each committed instruction when set
+| 3:31 | _CSR_MCOUNTINHIBIT_HPM3_ : _CSR_MCOUNTINHIBIT_HPM31_ | r/w | **HPMx**: Set to `1` to halt `[m]hpmcount*[h]`; hardwired to zero if `Zihpm` ISA extension is disabled
+| 2    | _CSR_MCOUNTINHIBIT_CY_ | r/w | **CY**: Set to `1` to halt `[m]cycle[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
+| 0    | _CSR_MCOUNTINHIBIT_IR_ | r/w | **IR**: Set to `1` to halt `[m]instret[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
 |=======================
 
 

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -28,14 +28,14 @@ just read-only).
 | 0x002   | <<_frm>>                            | _CSR_FRM_            | r/w | Floating-point dynamic rounding mode
 | 0x003   | <<_fcsr>>                           | _CSR_FCSR_           | r/w | Floating-point control and status (`frm` + `fflags`)
 5+^| **<<_machine_configuration_csrs>>**
-| 0x30a   | <<_menvcfg>>                        | _CSR_MENVCFG_        | r/- | Machine environment configuration register - low word
-| 0x31a   | <<_menvcfgh>>                       | _CSR_MENVCFGH_       | r/- | Machine environment configuration register - low word
+| 0x30A   | <<_menvcfg>>                        | _CSR_MENVCFG_        | r/- | Machine environment configuration register - low word
+| 0x31A   | <<_menvcfgh>>                       | _CSR_MENVCFGH_       | r/- | Machine environment configuration register - low word
 5+^| **<<_machine_trap_setup_csrs>>**
 | 0x300   | <<_mstatus>>                        | _CSR_MSTATUS_        | r/w | Machine status register - low word
 | 0x301   | <<_misa>>                           | _CSR_MISA_           | r/- | Machine CPU ISA and extensions
 | 0x304   | <<_mie>>                            | _CSR_MIE_            | r/w | Machine interrupt enable register
 | 0x305   | <<_mtvec>>                          | _CSR_MTVEC_          | r/w | Machine trap-handler base address for ALL traps
-| 0x306   | <<_mcounteren>>                     | _CSR_MCOUNTEREN_     | r/w | Machine counter-enable register
+| 0x306   | <<_mcounteren>>                     | _CSR_MCOUNTEREN_     | r/- | Machine counter-enable register
 | 0x310   | <<_mstatush>>                       | _CSR_MSTATUSH_       | r/- | Machine status register - high word
 5+^| **<<_machine_trap_handling_csrs>>**
 | 0x340   | <<_mscratch>>                       | _CSR_MSCRATCH_       | r/w | Machine scratch register
@@ -44,46 +44,46 @@ just read-only).
 | 0x343   | <<_mtval>>                          | _CSR_MTVAL_          | r/w | Machine bad address or instruction
 | 0x344   | <<_mip>>                            | _CSR_MIP_            | r/w | Machine interrupt pending register
 5+^| **<<_machine_physical_memory_protection_csrs>>**
-| 0x3a0   | <<_pmpcfg, `pmpcfg0`>>   .. <<_pmpcfg, `pmpcfg3`>>    | _CSR_PMPCFG0_  .. _CSR_PMPCFG3_   | r/w | Physical memory protection configuration for region 0..15
-| 0x3b0   | <<_pmpaddr, `pmpaddr0`>> .. <<_pmpaddr, `pmpaddr15`>> | _CSR_PMPADDR0_ .. _CSR_PMPADDR15_ | r/w | Physical memory protection address register region 0..15
+| 0x3A0 .. 0x3A3 | <<_pmpcfg, `pmpcfg0`>> .. <<_pmpcfg, `pmpcfg3`>>      | _CSR_PMPCFG0_ .. _CSR_PMPCFG3_    | r/w | Physical memory protection configuration for region 0..15
+| 0x3B0 .. 0x3BF | <<_pmpaddr, `pmpaddr0`>> .. <<_pmpaddr, `pmpaddr15`>> | _CSR_PMPADDR0_ .. _CSR_PMPADDR15_ | r/w | Physical memory protection address register region 0..15
 5+^| **<<_trigger_module_csrs>>**
-| 0x7a0   | <<_tselect>>                        | _CSR_TSELECT_        | r/w | Trigger select register
-| 0x7a1   | <<_tdata1>>                         | _CSR_TDATA1_         | r/w | Trigger data register 1
-| 0x7a2   | <<_tdata2>>                         | _CSR_TDATA2_         | r/w | Trigger data register 2
-| 0x7a3   | <<_tdata3>>                         | _CSR_TDATA3_         | r/w | Trigger data register 3
-| 0x7a4   | <<_tinfo>>                          | _CSR_TINFO_          | r/w | Trigger information register
-| 0x7a5   | <<_tcontrol>>                       | _CSR_TCONTROL_       | r/w | Trigger control register
-| 0x7a8   | <<_mcontext>>                       | _CSR_MCONTEXT_       | r/w | Machine context register
-| 0x7aa   | <<_scontext>>                       | _CSR_SCONTEXT_       | r/w | Supervisor context register
+| 0x7A0   | <<_tselect>>                        | _CSR_TSELECT_        | r/w | Trigger select register
+| 0x7A1   | <<_tdata1>>                         | _CSR_TDATA1_         | r/w | Trigger data register 1
+| 0x7A2   | <<_tdata2>>                         | _CSR_TDATA2_         | r/w | Trigger data register 2
+| 0x7A3   | <<_tdata3>>                         | _CSR_TDATA3_         | r/w | Trigger data register 3
+| 0x7A4   | <<_tinfo>>                          | _CSR_TINFO_          | r/w | Trigger information register
+| 0x7A5   | <<_tcontrol>>                       | _CSR_TCONTROL_       | r/w | Trigger control register
+| 0x7A8   | <<_mcontext>>                       | _CSR_MCONTEXT_       | r/w | Machine context register
+| 0x7AA   | <<_scontext>>                       | _CSR_SCONTEXT_       | r/w | Supervisor context register
 5+^| **<<_cpu_debug_mode_csrs>>**
-| 0x7b0   | <<_dcsr>>                           | -                    | r/w | Debug control and status register
-| 0x7b1   | <<_dpc>>                            | -                    | r/w | Debug program counter
-| 0x7b2   | <<_dscratch0>>                      | -                    | r/w | Debug scratch register 0
+| 0x7B0   | <<_dcsr>>                           | -                    | r/w | Debug control and status register
+| 0x7B1   | <<_dpc>>                            | -                    | r/w | Debug program counter
+| 0x7B2   | <<_dscratch0>>                      | -                    | r/w | Debug scratch register 0
 5+^| **<<_machine_counter_and_timer_csrs>>**
-| 0xb00   | <<_mcycleh, `mcycle`>>              | _CSR_MCYCLE_         | r/w | Machine cycle counter low word
-| 0xb02   | <<_minstreth, `minstret`>>          | _CSR_MINSTRET_       | r/w | Machine instruction-retired counter low word
-| 0xb80   | <<_mcycleh, `mcycleh`>>             | _CSR_MCYCLEH_        | r/w | Machine cycle counter high word
-| 0xb82   | <<_minstreth, `minstreth`>>         | _CSR_MINSTRETH_      | r/w | Machine instruction-retired counter high word
-| 0xc00   | <<_cycleh, `cycle`>>                | _CSR_CYCLE_          | r/- | Cycle counter low word
-| 0xc01   | <<_timeh, `time`>>                  | _CSR_TIME_           | r/- | System time (from MTIME) low word
-| 0xc02   | <<_instreth, `instret`>>            | _CSR_INSTRET_        | r/- | Instruction-retired counter low word
-| 0xc80   | <<_cycleh, `cycleh`>>               | _CSR_CYCLEH_         | r/- | Cycle counter high word
-| 0xc81   | <<_timeh, `timeh`>>                 | _CSR_TIMEH_          | r/- | System time (from MTIME) high word
-| 0xc82   | <<_instreth, `instreth`>>           | _CSR_INSTRETH_       | r/- | Instruction-retired counter high word
+| 0xB00   | <<_mcycleh, `mcycle`>>              | _CSR_MCYCLE_         | r/w | Machine cycle counter low word
+| 0xB02   | <<_minstreth, `minstret`>>          | _CSR_MINSTRET_       | r/w | Machine instruction-retired counter low word
+| 0xB80   | <<_mcycleh, `mcycleh`>>             | _CSR_MCYCLEH_        | r/w | Machine cycle counter high word
+| 0xB82   | <<_minstreth, `minstreth`>>         | _CSR_MINSTRETH_      | r/w | Machine instruction-retired counter high word
+| 0xC00   | <<_cycleh, `cycle`>>                | _CSR_CYCLE_          | r/- | Cycle counter low word
+| 0xC02   | <<_instreth, `instret`>>            | _CSR_INSTRET_        | r/- | Instruction-retired counter low word
+| 0xC80   | <<_cycleh, `cycleh`>>               | _CSR_CYCLEH_         | r/- | Cycle counter high word
+| 0xC82   | <<_instreth, `instreth`>>           | _CSR_INSTRETH_       | r/- | Instruction-retired counter high word
 5+^| **<<_hardware_performance_monitors_hpm_csrs>>**
-| 0x323   | <<_mhpmevent, `mhpmevent3`>>       ,, <<_mhpmevent, `mhpmevent31`>>       | _CSR_MHPMEVENT3_    .. _CSR_MHPMEVENT31_   | r/w | Machine performance-monitoring event select for counter 3..31
-| 0xb03   | <<_mhpmcounterh, `mhpmcounter3`>>  ,, <<_mhpmcounterh, `mhpmcounter31`>>  | _CSR_MHPMCOUNTER3_  .. _CSR_MHPMCOUNTER3H_ | r/w | Machine performance-monitoring counter 3..31 low word
-| 0xb83   | <<_mhpmcounterh, `mhpmcounter3h`>> ,, <<_mhpmcounterh, `mhpmcounter31h`>> | _CSR_MHPMCOUNTER3H_ .. _CSR_MHPMCOUNTER31H_| r/w | Machine performance-monitoring counter 3..31 high word
+| 0x323 .. 0x33F | <<_mhpmevent, `mhpmevent3`>> .. <<_mhpmevent, `mhpmevent31`>>             | _CSR_MHPMEVENT3_ .. _CSR_MHPMEVENT31_      | r/w | Machine performance-monitoring event select for counter 3..31
+| 0xB03 .. 0xB1F | <<_mhpmcounterh, `mhpmcounter3`>> .. <<_mhpmcounterh, `mhpmcounter31`>>   | _CSR_MHPMCOUNTER3_ .. _CSR_MHPMCOUNTER3H_  | r/w | Machine performance-monitoring counter 3..31 low word
+| 0xB83 .. 0xB9F | <<_mhpmcounterh, `mhpmcounter3h`>> .. <<_mhpmcounterh, `mhpmcounter31h`>> | _CSR_MHPMCOUNTER3H_ .. _CSR_MHPMCOUNTER31H_| r/w | Machine performance-monitoring counter 3..31 high word
+| 0xC03 .. 0xC1F | <<_hpmcounterh, `hpmcounter3`>> .. <<_hpmcounterh, `hpmcounter31`>>       | _CSR_HPMCOUNTER3_  .. _CSR_HPMCOUNTER3H_   | r/- | User performance-monitoring counter 3..31 low word
+| 0xC83 .. 0xC9F | <<_hpmcounterh, `hpmcounter3h`>> .. <<_hpmcounterh, `hpmcounter31h`>>     | _CSR_HPMCOUNTER3H_ .. _CSR_HPMCOUNTER31H_  | r/- | User performance-monitoring counter 3..31 high word
 5+^| **<<_machine_counter_setup_csrs>>**
 | 0x320   | <<_mcountinhibit>>                  | _CSR_MCOUNTINHIBIT_  | r/w | Machine counter-enable register
 5+^| **<<_machine_information_csrs>>**
-| 0xf11   | <<_mvendorid>>                      | _CSR_MVENDORID_      | r/- | Vendor ID
-| 0xf12   | <<_marchid>>                        | _CSR_MARCHID_        | r/- | Architecture ID
-| 0xf13   | <<_mimpid>>                         | _CSR_MIMPID_         | r/- | Machine implementation ID / version
-| 0xf14   | <<_mhartid>>                        | _CSR_MHARTID_        | r/- | Machine thread ID
-| 0xf15   | <<_mconfigptr>>                     | _CSR_MCONFIGPTR_     | r/- | Machine configuration pointer register
+| 0xF11   | <<_mvendorid>>                      | _CSR_MVENDORID_      | r/- | Machine vendor ID
+| 0xF12   | <<_marchid>>                        | _CSR_MARCHID_        | r/- | Machine architecture ID
+| 0xF13   | <<_mimpid>>                         | _CSR_MIMPID_         | r/- | Machine implementation ID / version
+| 0xF14   | <<_mhartid>>                        | _CSR_MHARTID_        | r/- | Machine thread ID
+| 0xF15   | <<_mconfigptr>>                     | _CSR_MCONFIGPTR_     | r/- | Machine configuration pointer register
 5+^| **<<_neorv32_specific_csrs>>**
-| 0xfc0   | <<_mxisa>>                          | _CSR_MXISA_          | r/- | NEORV32-specific "extended" machine CPU ISA and extensions
+| 0xFC0   | <<_mxisa>>                          | _CSR_MXISA_          | r/- | NEORV32-specific "extended" machine CPU ISA and extensions
 |=======================
 
 [NOTE]
@@ -106,6 +106,8 @@ a short description, the reset value and all ISA extension(s) that are required 
 | 0x001 | `fflags` - **Floating-point accrued exceptions** | `Zicsr` + `Zfinx`
 3+<| Reset value: `0x00000000`
 |=======================
+
+The `fflags` CSR gives access to the FPU status flags.
 
 [cols="^1,^1,<10"]
 [options="header",grid="rows"]
@@ -130,6 +132,8 @@ a short description, the reset value and all ISA extension(s) that are required 
 3+<| Reset value: `0x00000000`
 |=======================
 
+The `frm` CSR is used to configure the rounding mode of the FPU.
+
 [cols="^1,^1,<10"]
 [options="header",grid="rows"]
 |=======================
@@ -148,6 +152,8 @@ a short description, the reset value and all ISA extension(s) that are required 
 | 0x003 | `fcsr` - **Floating-point control and status register** | `Zicsr` + `Zfinx`
 3+<| Reset value: `0x00000000`
 |=======================
+
+The `fcsr` provides combined access to the <<_fflags>> and <<_frm>> flags.
 
 [cols="^1,^1,<10"]
 [options="header",grid="rows"]
@@ -207,6 +213,8 @@ The features of this CSR are not implemented yet. The register is read-only and 
 3+<| Reset value: `0x00000000`
 |=======================
 
+The `mstatus` is used to configure general machine environment parameters.
+
 [cols="^1,^3,^1,<9"]
 [options="header",grid="rows"]
 |=======================
@@ -232,6 +240,8 @@ bit for the higher-privilege mode." - RISC-V ISA Spec.
 | 0x301 | `misa` - **ISA and extensions** | `Zicsr`
 3+<| Reset value: `DEFINED`
 |=======================
+
+The `misa` CSR provides information regarding the availability of baic RISC-V ISa extensions.
 
 [NOTE]
 The NEORV32 `misa` CSR is read-only. Hence, active CPU extensions are entirely defined by pre-synthesis configurations
@@ -266,6 +276,8 @@ Machine-mode software can discover available `Z*` _sub-extensions_ (like `Zicsr`
 3+<| Reset value: `0x00000000`
 |=======================
 
+The `mie` CSR is used to enable/disable individual interrupt sources.
+
 [cols="^1,^3,^1,<9"]
 [options="header",grid="rows"]
 |=======================
@@ -287,6 +299,9 @@ Machine-mode software can discover available `Z*` _sub-extensions_ (like `Zicsr`
 3+<| Reset value: `0x00000000`
 |=======================
 
+The `mtvec` CSR contain the address of the primary trap handler, which gets executed whenever an
+interrupt is triggered or an exception is raised.
+
 [cols="^1,^1,<10"]
 [options="header",grid="rows"]
 |=======================
@@ -303,26 +318,27 @@ Machine-mode software can discover available `Z*` _sub-extensions_ (like `Zicsr`
 [frame="topbot",grid="none"]
 |=======================
 | 0x306 | `mcounteren` - **Machine counter enable** | `Zicsr` + `U`
-3+<| Reset value: `0x00000000`
+3+<| Reset value: _see below_
 |=======================
 
-[cols="^1,^3,^1,<9"]
+The `mcounteren` CSR is used to constrain user-level access to the CPU's counter CSRs.
+
+[cols="^1,^1,<9"]
 [options="header",grid="rows"]
 |=======================
-| Bit   | Name [C] | R/W | Function
-| 31:3  | -                   | r/- | Always zero: user-level code is **not** allowed to read HPM counters
-| 2     | _CSR_MCOUNTEREN_IR_ | r/w | **IR**: User-level code is allowed to read `cycle[h]` CSRs when set
-| 1     | _CSR_MCOUNTEREN_TM_ | r/w | **TM**: User-level code is allowed to read `time[h]` CSRs when set
-| 0     | _CSR_MCOUNTEREN_CY_ | r/w | **CY**: User-level code is allowed to read `instret[h]` CSRs when set
+| Bit  | R/W | Function
+| 31:3 | r/- | **HPM** = all `1`: user-level code is **not** allowed to read HPM counters <<_hpm_num_cnts>>
+| 2    | r/- | **IR** = `1`: User-level code is allowed to read `cycle[h]` CSRs when set
+| 1    | r/- | **TM** = `0`: `time` CSRs not implemented, always zero
+| 0    | r/- | **CY** = `1`: User-level code is allowed to read `instret[h]` CSRs when set
 |=======================
 
+[NOTE]
 If User mode is not implemented this register is read-only and always return zero when read.
 
-.HPM Access
 [NOTE]
-Bits 3 to 31 are used to control user-level access to the <<_hardware_performance_monitors_hpm_csrs>>. In the NEORV32
-CPU these bits are hardwired to zero. Hence, user-level software cannot access the HPMs. Accordingly, the
-`hpmcounter*[h]` CSRs are **not** implemented and any access will raise an illegal instruction exception.
+This CSR is read-only. Any write access will be ignored and will not raise an illegal
+instruction exception.
 
 
 :sectnums!:
@@ -354,6 +370,8 @@ The features of this CSR are not implemented yet. The register is read-only and 
 3+<| Reset value: `DEFINED`
 |=======================
 
+The `mscratch` is a general machine-mode scratch register.
+
 
 :sectnums!:
 ===== **`mepc`**
@@ -364,6 +382,12 @@ The features of this CSR are not implemented yet. The register is read-only and 
 | 0x341 | `mepc` - **Machine exception program counter** | `Zicsr`
 3+<| Reset value: `0x00000000`
 |=======================
+
+The `mepc` CSR provides the instruction address where execution has stopped/failed when
+an instruction is triggered / an exception is raised.
+
+[TIP]
+See section <<_traps_exceptions_and_interrupts>> for more information.
 
 
 :sectnums!:
@@ -376,6 +400,11 @@ The features of this CSR are not implemented yet. The register is read-only and 
 3+<| Reset value: `0x00000000`
 |=======================
 
+The `mcause` CSRs shows the exact cause of a trap.
+
+[TIP]
+See section <<_traps_exceptions_and_interrupts>> for more information.
+
 [cols="^1,^1,<10"]
 [options="header",grid="rows"]
 |=======================
@@ -384,9 +413,6 @@ The features of this CSR are not implemented yet. The register is read-only and 
 | 30:5 | r/- | _Reserved_, read as zero
 | 4:0  | r/w | **Exception code**: see <<_neorv32_trap_listing>>
 |=======================
-
-[TIP]
-See section <<_traps_exceptions_and_interrupts>> for more information.
 
 
 :sectnums!:
@@ -398,6 +424,8 @@ See section <<_traps_exceptions_and_interrupts>> for more information.
 | 0x343 | `mtval` - **Machine trap value register** | `Zicsr`
 3+<| Reset value: `0x00000000`
 |=======================
+
+The `mtval` CSR provides additional information why a trap was entered.
 
 [cols="^5,^5"]
 [options="header",grid="rows"]
@@ -427,11 +455,12 @@ See section <<_traps_exceptions_and_interrupts>> for more information.
 3+<| Reset value: `0x00000000`
 |=======================
 
-The `mip` CSR shows the currently _pending_ interrupts.
-The bits for the standard RISC-V interrupts are read-only. Hence, these interrupts cannot be cleared using the `mip` register and must
-be cleared/acknowledged within the according interrupt-generating device.
-The upper 16 bits represent the status of the CPU's fast interrupt request lines (FIRQ). Once triggered, these bit have to be cleared manually by
-writing zero to the according `mip` bits (in the interrupt handler routine) to clear the current interrupt request.
+The `mip` CSR shows the currently _pending_ machine-level interrupts.
+The bits for the standard RISC-V interrupts are read-only. Hence, these interrupts cannot be cleared using the
+`mip` register and must be cleared/acknowledged within the according interrupt-generating device.
+The upper 16 bits represent the status of the CPU's fast interrupt request lines (FIRQ). Once triggered, these
+bit have to be cleared manually by writing zero to the according `mip` bits (in the interrupt handler routine)
+to clear the current interrupt request.
 
 [cols="^1,^3,^1,<9"]
 [options="header",grid="rows"]
@@ -484,6 +513,9 @@ However, any access beyond `pmpcfg3` or `pmpaddr15`, which are the last physical
 3+<| Reset value: all `0x00000000`
 |=======================
 
+The `pmpcfg*` CSRs are used to configure the different PMP regions. Each region features an independent 8-bit array
+in these CSRs.
+
 [cols="^1,^2,^1,<11"]
 [options="header",grid="rows"]
 |=======================
@@ -505,6 +537,8 @@ See the RISC-V specs. for more information.
 
 :sectnums!:
 ===== **`pmpaddr`**
+
+The `pmpaddr*` CSRs are used to configure the region's address boundaries.
 
 [cols="1,8,>3"]
 [frame="topbot",grid="none"]
@@ -532,7 +566,7 @@ When implemented (by enabling the `Zicntr` ISA extension) the standard CPU count
 .Instruction Retired Counter Increment
 [NOTE]
 The `[m]instret[h]` counter always increments when a instruction enters the pipeline's execute stage no matter
-if this instruction is meant to retire or if it causes an exception.
+if this instruction is actually going to retire or if it causes an exception.
 
 
 :sectnums!:
@@ -546,17 +580,8 @@ if this instruction is meant to retire or if it causes an exception.
 3+<| Reset value: all `0x00000000`
 |=======================
 
-
-:sectnums!:
-===== **`time[h]`**
-
-[cols="1,8,>3"]
-[frame="topbot",grid="none"]
-|=======================
-| 0xc01 | `time` - **System time - low word** | `Zicsr` + `Zicntr`
-| 0xc81 | `timeh` - **System time - high word** | `Zicsr` + `Zicntr`
-3+<| Reset value: all `0x00000000`
-|=======================
+The `cycle[h]` are user-mode shadow copies of the according <<_mcycleh>> CSRs. The user-level
+counter are read-only. Any write access will raise an illegal instruction exception.
 
 
 :sectnums!:
@@ -570,6 +595,9 @@ if this instruction is meant to retire or if it causes an exception.
 3+<| Reset value: all `0x00000000`
 |=======================
 
+The `instret[h]` are user-mode shadow copies of the according <<_minstreth>> CSRs. The user-level
+counter are read-only. Any write access will raise an illegal instruction exception.
+
 
 :sectnums!:
 ===== **`mcycle[h]`**
@@ -582,6 +610,9 @@ if this instruction is meant to retire or if it causes an exception.
 3+<| Reset value: all `0x00000000`
 |=======================
 
+If not halted via the <<_mcountinhibit>> CSR the `cycle[h]` CSR will increment with every active CPU clock
+cycle (CPU not in sleep mode). These registers are read/write only for machine-mode software.
+
 
 :sectnums!:
 ===== **`minstret[h]`**
@@ -593,6 +624,9 @@ if this instruction is meant to retire or if it causes an exception.
 | 0xb82 | `minstreth` - **Machine instructions-retired counter - high word** | `Zicsr` + `Zicntr`
 3+<| Reset value: all `0x00000000`
 |=======================
+
+If not halted via the <<_mcountinhibit>> CSR the `minstret[h]` CSRs will increment with every retired instruction.
+These registers are read/write only for machine-mode software.
 
 
 
@@ -607,12 +641,6 @@ only the actually configured ones are implemented as "real" physical registers -
 
 If trying to access an HPM-related CSR beyond <<_hpm_num_cnts>> **no illegal instruction exception is
 triggered**. These CSRs are read-only (writes are ignored) and always return zero.
-
-.Access Privilege
-[NOTE]
-The HPM system only allows machine-mode access. Hence, `hpmcounter*[h]` CSR are not implemented and any access (even
-from machine mode) will raise an illegal instruction exception. Furthermore, the according bits of <<_mcounteren>>
-used to configure user-mode access to `hpmcounter*[h]` are hardwired to zero.
 
 The total counter width of the HPMs can be configured before synthesis via the <<_hpm_cnt_width>> generic (0..64-bit).
 If <<_hpm_num_cnts>> is less than 64, all remaining MSB-aligned bits are hardwired to zero.
@@ -673,6 +701,29 @@ cycle even if more than one trigger event is observed.
 3+<| Reset value: all `0x00000000`
 |=======================
 
+If not halted via the <<_mcountinhibit>> CSR the `mhpmcounter*[h]` counter CSR increment whenever a configured
+event from the according <<_mhpmevent>> CSR occurs. The counter registers are read/write for machine mode and
+are not accessible for lower-privileged software.
+
+
+:sectnums!:
+===== **`hpmcounter[h]`**
+
+[cols="1,9,>2"]
+[frame="topbot",grid="none"]
+|=======================
+| 0xc03 | `hpmcounter3` - **User hardware performance monitor - counter 3 low** | `Zicsr` + `Zihpm`
+3+<| ...
+| 0xc1f | `hpmcounter31` - **User hardware performance monitor - counter 31 low** | `Zicsr` + `Zihpm`
+| 0xc83 | `hpmcounter3h` - **User hardware performance monitor - counter 3 high** | `Zicsr` + `Zihpm`
+3+<| ...
+| 0xc9f | `hpmcounter31h` - **User hardware performance monitor - counter 31 high** | `Zicsr` + `Zihpm`
+3+<| Reset value: all `0x00000000`
+|=======================
+
+The `hpmcounter*[h]` are user-level shadow copies of the according <<_mhpmcounterh>> CSRs. The user level
+counter CSRs are read-only. Any write access will raise an illegal instruction exception.
+
 
 <<<
 // ####################################################################################################################
@@ -681,6 +732,8 @@ cycle even if more than one trigger event is observed.
 
 :sectnums!:
 ===== **`mcountinhibit`**
+
+The `mcountinhibit` CSR can be used to halt specific counter CSRs.
 
 [cols="1,8,>3"]
 [frame="topbot",grid="none"]
@@ -693,9 +746,9 @@ cycle even if more than one trigger event is observed.
 [options="header",grid="rows"]
 |=======================
 | Bit  | Name [C] | R/W | Event
-| 3:31 | _CSR_MCOUNTINHIBIT_HPM3_ : _CSR_MCOUNTINHIBIT_HPM31_ | r/w | **HPMx**: The `mhpmcount*[h]` CSRs will auto-increment according to the configured `mhpmevent*` selector
-| 2    | _CSR_MCOUNTINHIBIT_CY_ | r/w | **CY**: The `[m]cycle[h]` CSRs will auto-increment with each clock cycle (if CPU is not in sleep state) when set
-| 0    | _CSR_MCOUNTINHIBIT_IR_ | r/w | **IR**: The `[m]instret[h]` CSRs will auto-increment with each committed instruction when set
+| 3:31 | _CSR_MCOUNTINHIBIT_HPM3_ : _CSR_MCOUNTINHIBIT_HPM31_ | r/w | **HPMx**: `0` = The `[m]hpmcount*[h]` CSRs will auto-increment according to the configured `mhpmevent*` selector
+| 2    | _CSR_MCOUNTINHIBIT_CY_ | r/w | **CY**: `0` = The `[m]cycle[h]` CSRs will auto-increment with each clock cycle (if CPU is not in sleep state) when set
+| 0    | _CSR_MCOUNTINHIBIT_IR_ | r/w | **IR**: `0` = The `[m]instret[h]` CSRs will auto-increment with each committed instruction when set
 |=======================
 
 
@@ -717,6 +770,7 @@ All machine information registers can only be accessed in machine mode and are r
 3+<| Reset value: `0x00000000`
 |=======================
 
+[NOTE]
 The features of this CSR are not implemented yet. The register is read-only and always returns zero.
 
 
@@ -730,7 +784,7 @@ The features of this CSR are not implemented yet. The register is read-only and 
 3+<| Reset value: `0x00000013`
 |=======================
 
-The `marchid` CSR is read-only and shows the NEORV32 official RISC-V open-source architecture ID
+The `marchid` CSR is read-only and provides the NEORV32 official RISC-V open-source architecture ID
 (decimal: 19, 32-bit hexadecimal: 0x00000013).
 
 
@@ -744,7 +798,7 @@ The `marchid` CSR is read-only and shows the NEORV32 official RISC-V open-source
 3+<| Reset value: `DEFINED`
 |=======================
 
-The `mimpid` CSR is read-only and shows the version of the
+The `mimpid` CSR is read-only and provides the version of the
 NEORV32 as BCD-coded number (example: `mimpid` = _0x01020312_ → 01.02.03.12 → version 1.2.3.12).
 
 
@@ -758,7 +812,8 @@ NEORV32 as BCD-coded number (example: `mimpid` = _0x01020312_ → 01.02.03.12 �
 3+<| Reset value: `DEFINED`
 |=======================
 
-The `mhartid` CSR is read-only and shows the core's hart ID, which is assigned via the <<_hw_thread_id>> top generic.
+The `mhartid` CSR is read-only and provides the core's hart ID,
+which is assigned via the <<_hw_thread_id>> top generic.
 
 
 :sectnums!:
@@ -771,6 +826,7 @@ The `mhartid` CSR is read-only and shows the core's hart ID, which is assigned v
 3+<| Reset value: `0x00000000`
 |=======================
 
+[NOTE]
 The features of this CSR are not implemented yet. The register is read-only and always returns zero.
 
 
@@ -794,7 +850,8 @@ outside of machine-mode will raise an illegal instruction exception.
 3+<| Reset value: `DEFINED`
 |=======================
 
-NEORV32-specific read-only CSR that helps machine-mode software to discover `Z*` sub-extensions and CPU options.
+The `mxisa` CSRs is a NEORV32-specific read-only CSR that helps machine-mode software to
+discover ISA sub-extensions and CPU configuration options.
 
 [cols="^1,^3,^1,<9"]
 [options="header",grid="rows"]
@@ -809,7 +866,7 @@ NEORV32-specific read-only CSR that helps machine-mode software to discover `Z*`
 | 10    | _CSR_MXISA_SDEXT_     | r/- | `Sdext` extension (debug mode) available when set (via top's <<_cpu_extension_riscv_sdext>> generic)
 |  9    | _CSR_MXISA_ZIHPM_     | r/- | `Zihpm` (hardware performance monitors) extension available when set (via top's <<_cpu_extension_riscv_zihpm>> generic)
 |  8    | _CSR_MXISA_PMP_       | r/- | `PMP` (physical memory protection) extension available when set (via top's <<_pmp_num_regions>> generic)
-|  7    | _CSR_MXISA_ZICNTR_    | r/- | `Zicntr` extension (`I` sub-extension) available when set - `[m]cycle`, `[m]instret` and `[m]time` CSRs available when set (via top's <<_cpu_extension_riscv_zicntr>> generic)
+|  7    | _CSR_MXISA_ZICNTR_    | r/- | `Zicntr` extension (`I` sub-extension) available when set - `[m]cycle` and `[m]instret` CSRs available when set (via top's <<_cpu_extension_riscv_zicntr>> generic)
 |  6    | -                     | r/- | _reserved_, read as zero
 |  5    | _CSR_MXISA_ZFINX_     | r/- | `Zfinx` extension (`F` sub-/alternative-extension: FPU using `x` registers) available when set (via top's <<_cpu_extension_riscv_zfinx>> generic)
 |  4    | -                     | r/- | _reserved_, read as zero

--- a/docs/datasheet/overview.adoc
+++ b/docs/datasheet/overview.adoc
@@ -274,13 +274,6 @@ just _exemplary_. If not otherwise mentioned all implementations use the default
 | `rv32imcbu_Zicsr_Zicntr_Zifencei_Zfinx_DebugMode` | 4825 | 2018 |     1024 |    7 | 123 MHz
 |=======================
 
-.**RISC-V Compliance**
-[NOTE]
-The `Zicsr` ISA extension implements the privileged machine architecture
-(see <<_zicsr_control_and_status_register_access_privileged_architecture>>). The `Zicntr` ISA
-extension implements the basic counters and timers (see <<_zicntr_cpu_base_counters>>). Both
-extensions are _mandatory_ in order to comply with the RISC-V architecture specifications.
-
 [NOTE]
 The table above does not show _all_ CPU ISA extensions. More sophisticated and application-specific
 options like PMP and HMP are not included in this overview.

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -136,9 +136,6 @@ bits/channels are hardwired to zero.
 | `cfs_out_o`      |   32 |   out | custom CFS output signal conduit
 4+^| **Smart LED Interface - NeoPixel(TM) compatible (<<_smart_led_interface_neoled,NEOLED>>)**
 | `neoled_o`       |    1 |   out | asynchronous serial data output
-4+^| **System time (<<_machine_system_timer_mtime,MTIME>>)**
-| `mtime_i`        |   64 |    in | machine timer time from _external MTIME_ unit if the processor-internal _MTIME_ unit is not implemented
-| `mtime_o`        |   64 |   out | machine timer time from _internal MTIME_ unit if the processor-internal _MTIME_ unit is implemented
 4+^| **External Interrupts (<<_processor_interrupts, XIRQ>>)**
 | `xirq_i`         |   32 |    in | external interrupt requests
 4+^| **RISC-V Machine-Level <<_processor_interrupts, CPU Interrupts>>**

--- a/docs/datasheet/soc_mtime.adoc
+++ b/docs/datasheet/soc_mtime.adoc
@@ -8,35 +8,22 @@
 | Hardware source file(s): | neorv32_mtime.vhd | 
 | Software driver file(s): | neorv32_mtime.c |
 |                          | neorv32_mtime.h |
-| Top entity port:         | `mtime_i`     | System time input from external MTIME
-|                          | `mtime_o`     | System time output (64-bit) for SoC
-|                          | `mtime_irq_i` | RISC-V machine time IRQ if MTIME is **not** implemented
+| Top entity port:         | `mtime_irq_i` | RISC-V machine timer IRQ if internal MTIME is **not** implemented
 | Configuration generics:  | _IO_MTIME_EN_ | implement MTIME when _true_
 | CPU interrupts:          | `MTI` | machine timer interrupt (see <<_processor_interrupts>>)
 |=======================
 
-The MTIME module implements the memory-mapped MTIME machine timer from the official RISC-V
-specifications. This module features a 64-bit system timer incrementing with the primary processor clock.
-Besides accessing the MTIME register via memory operation the current system time can also be obtained using
-the `time[h]` CSRs. Furthermore, the current system time is made available for processor-external
-usage via the top's `mtime_o` signal.
-
-The 64-bit system time can be accessed via the `TIME_LO` and `TIME_HI` memory-mapped registers (read/write) and also via
-the CPU's `time[h]` CSRs (read-only). A 64-bit time compare register - accessible via the memory-mapped `TIMECMP_LO` and `TIMECMP_HI`
-registers - is used to configure the CPU's MTI (machine timer interrupt). The interrupt is triggered
-whenever `TIME` (high & low part) is greater than or equal to `TIMECMP` (high & low part).
-The interrupt remain active (=pending) until `TIME` becomes less `TIMECMP` again (either by modifying `TIME` or `TIMECMP`).
+The MTIME module implements a memory-mapped MTIME machine system timer that is compatible to the RISC-V
+privileged specifications. The 64-bit system time is accessed via the  memory-mapped `TIME_LO` and
+`TIME_HI`registers. A 64-bit time compare register, which is accessible via the memory-mapped `TIMECMP_LO`
+and `TIMECMP_HI` registers, can be used to configure the CPU's MTI (machine timer interrupt). The interrupt
+is triggered whenever `TIME` (high & low part) is greater than or equal to `TIMECMP` (high & low part).
+The interrupt remains active (=pending) until `TIME` becomes less `TIMECMP` again (either by modifying
+`TIME` or `TIMECMP`).
 
 .Reset
 [NOTE]
-After a hardware reset the `TIME` register is reset to **all-zero** and the `TIMECMP` register is reset to **all-one**
-to prevent accidental interrupt requests during early boot phase.
-
-.External MTIME Input
-[NOTE]
-If the processor-internal **MTIME module is NOT implemented**, the top's `mtime_i` input signal is used to update the `time[h]` CSRs
-and the `MTI` machine timer CPU interrupt (`MTI`) is directly connected to the top's `mtime_irq_i` input. The `mtime_o` signal
-is hardwired to zero in this case.
+After a hardware reset the `TIME` and `TIMECMP` register are reset to all-zero.
 
 .External MTIME Interrupt
 [IMPORTANT]

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -8,7 +8,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -102,8 +102,6 @@ entity neorv32_cpu is
     d_bus_err_i   : in  std_ulogic; -- bus transfer error
     d_bus_fence_o : out std_ulogic; -- executed FENCE operation
     d_bus_priv_o  : out std_ulogic; -- current effective privilege level
-    -- system time input from MTIME --
-    time_i        : in  std_ulogic_vector(63 downto 0); -- current system time
     -- interrupts (risc-v compliant) --
     msw_irq_i     : in  std_ulogic;-- machine software interrupt
     mext_irq_i    : in  std_ulogic;-- machine external interrupt
@@ -327,8 +325,6 @@ begin
     mtime_irq_i   => mtime_irq_i,   -- machine timer interrupt
     -- fast interrupts (custom) --
     firq_i        => firq_i,        -- fast interrupt trigger
-    -- system time input from MTIME --
-    time_i        => time_i,        -- current system time
     -- physical memory protection --
     pmp_addr_o    => pmp_addr,      -- addresses
     pmp_ctrl_o    => pmp_ctrl,      -- configs

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -307,22 +307,22 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
     minstreth         : std_ulogic_vector(XLEN-1 downto 0); -- minstreth (R/W)
     --
     mhpmcounter       : mhpmcnt_t; -- mhpmcounter* (R/W), plus carry bit
-    mhpmcounter_nxt   : mhpmcnt_nxt_t;
+    mhpmcounter_nxt   : mhpmcnt_nxt_t; -- low-word to high-word counter overflow
     mhpmcounter_ovfl  : mhpmcnt_ovfl_t; -- counter low-to-high-word overflow
     mhpmcounterh      : mhpmcnt_t; -- mhpmcounter*h (R/W)
-    mhpmcounter_rd    : mhpmcnt_rd_t; -- mhpmcounter* (R/W): actual read data
-    mhpmcounterh_rd   : mhpmcnt_rd_t; -- mhpmcounter*h (R/W): actual read data
+    mhpmcounter_rd    : mhpmcnt_rd_t; -- counter low read-back
+    mhpmcounterh_rd   : mhpmcnt_rd_t; --  counter high read-back
     --
-    pmpcfg            : pmpcfg_t; -- physical memory protection - configuration registers
-    pmpcfg_rd         : pmpcfg_rd_t; -- physical memory protection - configuration read-back
-    pmpaddr           : pmpaddr_t; -- physical memory protection - address registers (bits 33:2 of PHYSICAL address)
-    pmpaddr_rd        : pmpaddr_rd_t; -- physical memory protection - address read-back
+    pmpcfg            : pmpcfg_t; -- PMP configuration registers
+    pmpcfg_rd         : pmpcfg_rd_t; -- PMP configuration read-back
+    pmpaddr           : pmpaddr_t; -- PMP address registers (bits 33:2 of PHYSICAL address)
+    pmpaddr_rd        : pmpaddr_rd_t; -- PMP address read-back
     --
     frm               : std_ulogic_vector(2 downto 0); -- frm (R/W): FPU rounding mode
     fflags            : std_ulogic_vector(4 downto 0); -- fflags (R/W): FPU exception flags
     --
-    dcsr_ebreakm      : std_ulogic; -- dcsr.ebreakm (R/W): behavior of ebreak instruction on m-mode
-    dcsr_ebreaku      : std_ulogic; -- dcsr.ebreaku (R/W): behavior of ebreak instruction on u-mode
+    dcsr_ebreakm      : std_ulogic; -- dcsr.ebreakm (R/W): behavior of ebreak instruction in m-mode
+    dcsr_ebreaku      : std_ulogic; -- dcsr.ebreaku (R/W): behavior of ebreak instruction in u-mode
     dcsr_step         : std_ulogic; -- dcsr.step (R/W): single-step mode
     dcsr_prv          : std_ulogic; -- dcsr.prv (R/W): current privilege level when entering debug mode
     dcsr_cause        : std_ulogic_vector(2 downto 0); -- dcsr.cause (R/-): why was debug mode entered

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1533,7 +1533,7 @@ begin
         -- interrupt queue: NEORV32-specific fast interrupts (FIRQ) --
         -- > require manual ACK/clear via mip CSR
         for i in 0 to 15 loop
-          trap_ctrl.irq_buf(irq_firq_0_c + i) <= (trap_ctrl.irq_buf(irq_firq_0_c + i) or firq_i(i)) and csr.mip_firq_nclr(i);
+          trap_ctrl.irq_buf(irq_firq_0_c + i) <= (trap_ctrl.irq_buf(irq_firq_0_c + i) or firq_i(i)) and csr.mie_firq(i) and csr.mip_firq_nclr(i);
         end loop;
 
 

--- a/rtl/core/neorv32_fifo.vhd
+++ b/rtl/core/neorv32_fifo.vhd
@@ -135,8 +135,9 @@ begin
   end generate; -- /check_large
   check_small:
   if (FIFO_DEPTH <= 1) generate
-    fifo.full  <= '1' when (fifo.r_pnt(0) /= fifo.w_pnt(0)) else '0';
-    fifo.empty <= '1' when (fifo.r_pnt(0)  = fifo.w_pnt(0)) else '0';
+    fifo.match <= '1' when (fifo.r_pnt(0) = fifo.w_pnt(0)) else '0';
+    fifo.full  <= not fifo.match;
+    fifo.empty <= fifo.match;
   end generate; -- /check_small
 
   fifo.free  <= not fifo.full;

--- a/rtl/core/neorv32_mtime.vhd
+++ b/rtl/core/neorv32_mtime.vhd
@@ -103,8 +103,8 @@ begin
   write_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      mtimecmp_lo   <= (others => '1'); -- all-one to prevent accidental interrupt after reset
-      mtimecmp_hi   <= (others => '1');
+      mtimecmp_lo   <= (others => '0');
+      mtimecmp_hi   <= (others => '0');
       mtime_lo_we   <= '0';
       mtime_hi_we   <= '0';
       mtime_lo      <= (others => '0');

--- a/rtl/core/neorv32_mtime.vhd
+++ b/rtl/core/neorv32_mtime.vhd
@@ -53,8 +53,6 @@ entity neorv32_mtime is
     data_i : in  std_ulogic_vector(31 downto 0); -- data in
     data_o : out std_ulogic_vector(31 downto 0); -- data out
     ack_o  : out std_ulogic; -- transfer acknowledge
-    -- system time --
-    time_o : out std_ulogic_vector(63 downto 0); -- current system time
     -- interrupt --
     irq_o  : out std_ulogic  -- interrupt request
   );
@@ -172,9 +170,6 @@ begin
       end if;
     end if;
   end process read_access;
-
-  -- system time output for cpu --
-  time_o <= mtime_hi & mtime_lo; -- NOTE: low and high words are not in-sync here!
 
 
   -- Comparator -----------------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -52,18 +52,18 @@ package neorv32_package is
   constant reset_x0_c : boolean := true; -- has to be 'true' for the default register file rtl description (BRAM-based)
 
   -- "response time window" for processor-internal modules --
-  -- = cycles after which an *unacknowledged* internal bus access will timeout and trigger a bus fault exception (min 2)
-  constant max_proc_int_response_time_c : natural := 15;
+  -- = cycles after which an *unacknowledged* internal bus access will timeout and trigger a bus fault exception
+  constant max_proc_int_response_time_c : natural := 15; -- min 2
 
-  -- jtag tap - identifier --
+  -- JTAG tap - identifier --
   constant jtag_tap_idcode_version_c : std_ulogic_vector(03 downto 0) := x"0"; -- version
   constant jtag_tap_idcode_partid_c  : std_ulogic_vector(15 downto 0) := x"cafe"; -- part number
   constant jtag_tap_idcode_manid_c   : std_ulogic_vector(10 downto 0) := "00000000000"; -- manufacturer id
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070909"; -- NEORV32 version - no touchy!
-  constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070909"; -- NEORV32 version
+  constant archid_c     : natural := 19; -- official RISC-V architecture ID
 
   -- Check if we're inside the Matrix -------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070908"; -- NEORV32 version - no touchy!
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01070909"; -- NEORV32 version - no touchy!
   constant archid_c     : natural := 19; -- official RISC-V architecture ID - hands off!
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -517,8 +517,6 @@ package neorv32_package is
   -- machine counter setup --
   constant csr_cnt_setup_c      : std_ulogic_vector(06 downto 0) := x"3" & "001"; -- counter setup
   constant csr_mcountinhibit_c  : std_ulogic_vector(11 downto 0) := x"320";
-  constant csr_mcnt_hwdummy0_c  : std_ulogic_vector(11 downto 0) := x"321"; -- dummy register (only for decoding; not accessible)
-  constant csr_mcnt_hwdummy1_c  : std_ulogic_vector(11 downto 0) := x"322"; -- dummy register (only for decoding; not accessible)
   constant csr_mhpmevent3_c     : std_ulogic_vector(11 downto 0) := x"323";
   constant csr_mhpmevent4_c     : std_ulogic_vector(11 downto 0) := x"324";
   constant csr_mhpmevent5_c     : std_ulogic_vector(11 downto 0) := x"325";
@@ -598,7 +596,6 @@ package neorv32_package is
   constant csr_class_mcnt_c     : std_ulogic_vector(03 downto 0) := x"b"; -- machine-mode counters
   constant csr_mcycle_c         : std_ulogic_vector(11 downto 0) := x"b00";
   constant csr_minstret_c       : std_ulogic_vector(11 downto 0) := x"b02";
-  --
   constant csr_mhpmcounter3_c   : std_ulogic_vector(11 downto 0) := x"b03";
   constant csr_mhpmcounter4_c   : std_ulogic_vector(11 downto 0) := x"b04";
   constant csr_mhpmcounter5_c   : std_ulogic_vector(11 downto 0) := x"b05";
@@ -631,7 +628,6 @@ package neorv32_package is
   --
   constant csr_mcycleh_c        : std_ulogic_vector(11 downto 0) := x"b80";
   constant csr_minstreth_c      : std_ulogic_vector(11 downto 0) := x"b82";
-  --
   constant csr_mhpmcounter3h_c  : std_ulogic_vector(11 downto 0) := x"b83";
   constant csr_mhpmcounter4h_c  : std_ulogic_vector(11 downto 0) := x"b84";
   constant csr_mhpmcounter5h_c  : std_ulogic_vector(11 downto 0) := x"b85";
@@ -665,9 +661,7 @@ package neorv32_package is
   -- user counters/timers --
   constant csr_class_ucnt_c     : std_ulogic_vector(03 downto 0) := x"c"; -- user-mode counters
   constant csr_cycle_c          : std_ulogic_vector(11 downto 0) := x"c00";
-  constant csr_time_c           : std_ulogic_vector(11 downto 0) := x"c01";
   constant csr_instret_c        : std_ulogic_vector(11 downto 0) := x"c02";
-  --
   constant csr_hpmcounter3_c    : std_ulogic_vector(11 downto 0) := x"c03";
   constant csr_hpmcounter4_c    : std_ulogic_vector(11 downto 0) := x"c04";
   constant csr_hpmcounter5_c    : std_ulogic_vector(11 downto 0) := x"c05";
@@ -699,9 +693,7 @@ package neorv32_package is
   constant csr_hpmcounter31_c   : std_ulogic_vector(11 downto 0) := x"c1f";
   --
   constant csr_cycleh_c         : std_ulogic_vector(11 downto 0) := x"c80";
-  constant csr_timeh_c          : std_ulogic_vector(11 downto 0) := x"c81";
   constant csr_instreth_c       : std_ulogic_vector(11 downto 0) := x"c82";
-  --
   constant csr_hpmcounter3h_c   : std_ulogic_vector(11 downto 0) := x"c83";
   constant csr_hpmcounter4h_c   : std_ulogic_vector(11 downto 0) := x"c84";
   constant csr_hpmcounter5h_c   : std_ulogic_vector(11 downto 0) := x"c85";
@@ -1142,9 +1134,6 @@ package neorv32_package is
       cfs_out_o      : out std_ulogic_vector(IO_CFS_OUT_SIZE-1 downto 0); -- custom CFS outputs conduit
       -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
       neoled_o       : out std_ulogic; -- async serial data line
-      -- System time --
-      mtime_i        : in  std_ulogic_vector(63 downto 0) := (others => 'U'); -- current system time from ext. MTIME (if IO_MTIME_EN = false)
-      mtime_o        : out std_ulogic_vector(63 downto 0); -- current system time from int. MTIME (if IO_MTIME_EN = true)
       -- External platform interrupts (available if XIRQ_NUM_CH > 0) --
       xirq_i         : in  std_ulogic_vector(31 downto 0) := (others => 'L'); -- IRQ channels
       -- CPU Interrupts --
@@ -1214,8 +1203,6 @@ package neorv32_package is
       d_bus_err_i   : in  std_ulogic; -- bus transfer error
       d_bus_fence_o : out std_ulogic; -- executed FENCE operation
       d_bus_priv_o  : out std_ulogic; -- current effective privilege level
-      -- system time input from MTIME --
-      time_i        : in  std_ulogic_vector(63 downto 0); -- current system time
       -- interrupts (risc-v compliant) --
       msw_irq_i     : in  std_ulogic; -- machine software interrupt
       mext_irq_i    : in  std_ulogic; -- machine external interrupt
@@ -1297,8 +1284,6 @@ package neorv32_package is
       mtime_irq_i   : in  std_ulogic; -- machine timer interrupt
       -- fast interrupts (custom) --
       firq_i        : in  std_ulogic_vector(15 downto 0);
-      -- system time input from MTIME --
-      time_i        : in  std_ulogic_vector(63 downto 0); -- current system time
       -- physical memory protection --
       pmp_addr_o    : out pmp_addr_if_t; -- addresses
       pmp_ctrl_o    : out pmp_ctrl_if_t; -- configs
@@ -1722,8 +1707,6 @@ package neorv32_package is
       data_i : in  std_ulogic_vector(31 downto 0); -- data in
       data_o : out std_ulogic_vector(31 downto 0); -- data out
       ack_o  : out std_ulogic; -- transfer acknowledge
-      -- system time --
-      time_o : out std_ulogic_vector(63 downto 0); -- current system time
       -- interrupt --
       irq_o  : out std_ulogic  -- interrupt request
     );

--- a/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
@@ -3,7 +3,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -154,98 +154,19 @@ begin
     ICACHE_BLOCK_SIZE            => ICACHE_BLOCK_SIZE,     -- i-cache: block size in bytes (min 4), has to be a power of 2
     ICACHE_ASSOCIATIVITY         => ICACHE_ASSOCIATIVITY,  -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
 
-    -- External memory interface --
-    MEM_EXT_EN                   => false,       -- implement external memory bus interface?
-    MEM_EXT_TIMEOUT              => 0,           -- cycles after a pending bus access auto-terminates (0 = disabled)
-
     -- Processor peripherals --
-    IO_GPIO_EN                   => false,         -- implement general purpose input/output port unit (GPIO)?
     IO_MTIME_EN                  => IO_MTIME_EN,   -- implement machine system timer (MTIME)?
-    IO_UART0_EN                  => false,         -- implement primary universal asynchronous receiver/transmitter (UART0)?
-    IO_UART1_EN                  => false,         -- implement secondary universal asynchronous receiver/transmitter (UART1)?
-    IO_SPI_EN                    => false,         -- implement serial peripheral interface (SPI)?
-    IO_TWI_EN                    => false,         -- implement two-wire interface (TWI)?
     IO_PWM_NUM_CH                => IO_PWM_NUM_CH, -- number of PWM channels to implement (0..60); 0 = disabled
-    IO_WDT_EN                    => IO_WDT_EN,     -- implement watch dog timer (WDT)?
-    IO_TRNG_EN                   => false,         -- implement true random number generator (TRNG)?
-    IO_CFS_EN                    => false,         -- implement custom functions subsystem (CFS)?
-    IO_CFS_CONFIG                => x"00000000",   -- custom CFS configuration generic
-    IO_CFS_IN_SIZE               => 32,            -- size of CFS input conduit in bits
-    IO_CFS_OUT_SIZE              => 32,            -- size of CFS output conduit in bits
-    IO_NEOLED_EN                 => false          -- implement NeoPixel-compatible smart LED interface (NEOLED)?
+    IO_WDT_EN                    => IO_WDT_EN      -- implement watch dog timer (WDT)?
+
   )
   port map (
     -- Global control --
     clk_i       => clk_i,                        -- global clock, rising edge
     rstn_i      => rstn_i,                       -- global reset, low-active, async
 
-    -- JTAG on-chip debugger interface (available if ON_CHIP_DEBUGGER_EN = true) --
-    jtag_trst_i => '0',                          -- low-active TAP reset (optional)
-    jtag_tck_i  => '0',                          -- serial clock
-    jtag_tdi_i  => '0',                          -- serial data input
-    jtag_tdo_o  => open,                         -- serial data output
-    jtag_tms_i  => '0',                          -- mode select
-
-    -- Wishbone bus interface (available if MEM_EXT_EN = true) --
-    wb_tag_o    => open,                         -- request tag
-    wb_adr_o    => open,                         -- address
-    wb_dat_i    => (others => '0'),              -- read data
-    wb_dat_o    => open,                         -- write data
-    wb_we_o     => open,                         -- read/write
-    wb_sel_o    => open,                         -- byte enable
-    wb_stb_o    => open,                         -- strobe
-    wb_cyc_o    => open,                         -- valid cycle
-    wb_ack_i    => '0',                          -- transfer acknowledge
-    wb_err_i    => '0',                          -- transfer error
-
-    -- Advanced memory control signals (available if MEM_EXT_EN = true) --
-    fence_o     => open,                         -- indicates an executed FENCE operation
-    fencei_o    => open,                         -- indicates an executed FENCEI operation
-
-    -- GPIO (available if IO_GPIO_EN = true) --
-    gpio_o      => open,                         -- parallel output
-    gpio_i      => (others => '0'),              -- parallel input
-
-    -- primary UART0 (available if IO_UART0_EN = true) --
-    uart0_txd_o => open,                         -- UART0 send data
-    uart0_rxd_i => '0',                          -- UART0 receive data
-    uart0_rts_o => open,                         -- hw flow control: UART0.RX ready to receive ("RTR"), low-active, optional
-    uart0_cts_i => '0',                          -- hw flow control: UART0.TX allowed to transmit, low-active, optional
-
-    -- secondary UART1 (available if IO_UART1_EN = true) --
-    uart1_txd_o => open,                         -- UART1 send data
-    uart1_rxd_i => '0',                          -- UART1 receive data
-    uart1_rts_o => open,                         -- hw flow control: UART1.RX ready to receive ("RTR"), low-active, optional
-    uart1_cts_i => '0',                          -- hw flow control: UART1.TX allowed to transmit, low-active, optional
-
-    -- SPI (available if IO_SPI_EN = true) --
-    spi_sck_o   => open,                         -- SPI serial clock
-    spi_sdo_o   => open,                         -- controller data out, peripheral data in
-    spi_sdi_i   => '0',                          -- controller data in, peripheral data out
-    spi_csn_o   => open,                         -- SPI CS
-
-    -- TWI (available if IO_TWI_EN = true) --
-    twi_sda_io  => open,                         -- twi serial data line
-    twi_scl_io  => open,                         -- twi serial clock line
-
     -- PWM (available if IO_PWM_NUM_CH > 0) --
-    pwm_o       => con_pwm_o,                    -- pwm channels
-
-    -- Custom Functions Subsystem IO --
-    cfs_in_i    => (others => '0'),              -- custom CFS inputs conduit
-    cfs_out_o   => open,                         -- custom CFS outputs conduit
-
-    -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
-    neoled_o    => open,                         -- async serial data line
-
-    -- System time --
-    mtime_i     => (others => '0'),              -- current system time from ext. MTIME (if IO_MTIME_EN = false)
-    mtime_o     => open,                         -- current system time from int. MTIME (if IO_MTIME_EN = true)
-
-    -- Interrupts --
-    mtime_irq_i => '0',                          -- machine timer interrupt, available if IO_MTIME_EN = false
-    msw_irq_i   => '0',                          -- machine software interrupt
-    mext_irq_i  => '0'                           -- machine external interrupt
+    pwm_o       => con_pwm_o                     -- pwm channels
   );
 
 end architecture;

--- a/rtl/processor_templates/neorv32_ProcessorTop_MinimalBoot.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_MinimalBoot.vhd
@@ -3,7 +3,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -170,53 +170,17 @@ begin
     ICACHE_BLOCK_SIZE            => ICACHE_BLOCK_SIZE,     -- i-cache: block size in bytes (min 4), has to be a power of 2
     ICACHE_ASSOCIATIVITY         => ICACHE_ASSOCIATIVITY,  -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
 
-    -- External memory interface --
-    MEM_EXT_EN                   => false,       -- implement external memory bus interface?
-    MEM_EXT_TIMEOUT              => 0,           -- cycles after a pending bus access auto-terminates (0 = disabled)
-
     -- Processor peripherals --
     IO_GPIO_EN                   => IO_GPIO_EN,    -- implement general purpose input/output port unit (GPIO)?
     IO_MTIME_EN                  => IO_MTIME_EN,   -- implement machine system timer (MTIME)?
     IO_UART0_EN                  => IO_UART0_EN,   -- implement primary universal asynchronous receiver/transmitter (UART0)?
-    IO_UART1_EN                  => false,         -- implement secondary universal asynchronous receiver/transmitter (UART1)?
-    IO_SPI_EN                    => false,         -- implement serial peripheral interface (SPI)?
-    IO_TWI_EN                    => false,         -- implement two-wire interface (TWI)?
     IO_PWM_NUM_CH                => IO_PWM_NUM_CH, -- number of PWM channels to implement (0..60); 0 = disabled
-    IO_WDT_EN                    => IO_WDT_EN,     -- implement watch dog timer (WDT)?
-    IO_TRNG_EN                   => false,         -- implement true random number generator (TRNG)?
-    IO_CFS_EN                    => false,         -- implement custom functions subsystem (CFS)?
-    IO_CFS_CONFIG                => x"00000000",   -- custom CFS configuration generic
-    IO_CFS_IN_SIZE               => 32,            -- size of CFS input conduit in bits
-    IO_CFS_OUT_SIZE              => 32,            -- size of CFS output conduit in bits
-    IO_NEOLED_EN                 => false          -- implement NeoPixel-compatible smart LED interface (NEOLED)?
+    IO_WDT_EN                    => IO_WDT_EN      -- implement watch dog timer (WDT)?
   )
   port map (
     -- Global control --
     clk_i       => clk_i,                        -- global clock, rising edge
     rstn_i      => rstn_i,                       -- global reset, low-active, async
-
-    -- JTAG on-chip debugger interface (available if ON_CHIP_DEBUGGER_EN = true) --
-    jtag_trst_i => '0',                          -- low-active TAP reset (optional)
-    jtag_tck_i  => '0',                          -- serial clock
-    jtag_tdi_i  => '0',                          -- serial data input
-    jtag_tdo_o  => open,                         -- serial data output
-    jtag_tms_i  => '0',                          -- mode select
-
-    -- Wishbone bus interface (available if MEM_EXT_EN = true) --
-    wb_tag_o    => open,                         -- request tag
-    wb_adr_o    => open,                         -- address
-    wb_dat_i    => (others => '0'),              -- read data
-    wb_dat_o    => open,                         -- write data
-    wb_we_o     => open,                         -- read/write
-    wb_sel_o    => open,                         -- byte enable
-    wb_stb_o    => open,                         -- strobe
-    wb_cyc_o    => open,                         -- valid cycle
-    wb_ack_i    => '0',                          -- transfer acknowledge
-    wb_err_i    => '0',                          -- transfer error
-
-    -- Advanced memory control signals (available if MEM_EXT_EN = true) --
-    fence_o     => open,                         -- indicates an executed FENCE operation
-    fencei_o    => open,                         -- indicates an executed FENCEI operation
 
     -- GPIO (available if IO_GPIO_EN = true) --
     gpio_o      => con_gpio_o,                   -- parallel output
@@ -228,40 +192,8 @@ begin
     uart0_rts_o => uart_rts_o,                   -- hw flow control: UART0.RX ready to receive ("RTR"), low-active, optional
     uart0_cts_i => uart_cts_i,                   -- hw flow control: UART0.TX allowed to transmit, low-active, optional
 
-    -- secondary UART1 (available if IO_UART1_EN = true) --
-    uart1_txd_o => open,                         -- UART1 send data
-    uart1_rxd_i => '0',                          -- UART1 receive data
-    uart1_rts_o => open,                         -- hw flow control: UART1.RX ready to receive ("RTR"), low-active, optional
-    uart1_cts_i => '0',                          -- hw flow control: UART1.TX allowed to transmit, low-active, optional
-
-    -- SPI (available if IO_SPI_EN = true) --
-    spi_sck_o   => open,                         -- SPI serial clock
-    spi_sdo_o   => open,                         -- controller data out, peripheral data in
-    spi_sdi_i   => '0',                          -- controller data in, peripheral data out
-    spi_csn_o   => open,                         -- SPI CS
-
-    -- TWI (available if IO_TWI_EN = true) --
-    twi_sda_io  => open,                         -- twi serial data line
-    twi_scl_io  => open,                         -- twi serial clock line
-
     -- PWM (available if IO_PWM_NUM_CH > 0) --
-    pwm_o       => con_pwm_o,                    -- pwm channels
-
-    -- Custom Functions Subsystem IO --
-    cfs_in_i    => (others => '0'),              -- custom CFS inputs conduit
-    cfs_out_o   => open,                         -- custom CFS outputs conduit
-
-    -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
-    neoled_o    => open,                         -- async serial data line
-
-    -- System time --
-    mtime_i     => (others => '0'),              -- current system time from ext. MTIME (if IO_MTIME_EN = false)
-    mtime_o     => open,                         -- current system time from int. MTIME (if IO_MTIME_EN = true)
-
-    -- Interrupts --
-    mtime_irq_i => '0',                          -- machine timer interrupt, available if IO_MTIME_EN = false
-    msw_irq_i   => '0',                          -- machine software interrupt
-    mext_irq_i  => '0'                           -- machine external interrupt
+    pwm_o       => con_pwm_o                     -- pwm channels
   );
 
 end architecture;

--- a/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
@@ -3,7 +3,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -210,53 +210,19 @@ begin
     ICACHE_BLOCK_SIZE            => ICACHE_BLOCK_SIZE,     -- i-cache: block size in bytes (min 4), has to be a power of 2
     ICACHE_ASSOCIATIVITY         => ICACHE_ASSOCIATIVITY,  -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
 
-    -- External memory interface --
-    MEM_EXT_EN                   => false,  -- implement external memory bus interface?
-    MEM_EXT_TIMEOUT              => 0,      -- cycles after a pending bus access auto-terminates (0 = disabled)
-
     -- Processor peripherals --
     IO_GPIO_EN                   => IO_GPIO_EN,     -- implement general purpose input/output port unit (GPIO)?
     IO_MTIME_EN                  => IO_MTIME_EN,    -- implement machine system timer (MTIME)?
     IO_UART0_EN                  => IO_UART0_EN,    -- implement primary universal asynchronous receiver/transmitter (UART0)?
-    IO_UART1_EN                  => false,          -- implement secondary universal asynchronous receiver/transmitter (UART1)?
     IO_SPI_EN                    => IO_SPI_EN,      -- implement serial peripheral interface (SPI)?
     IO_TWI_EN                    => IO_TWI_EN,      -- implement two-wire interface (TWI)?
     IO_PWM_NUM_CH                => IO_PWM_NUM_CH,  -- number of PWM channels to implement (0..60); 0 = disabled
-    IO_WDT_EN                    => IO_WDT_EN,      -- implement watch dog timer (WDT)?
-    IO_TRNG_EN                   => false,          -- implement true random number generator (TRNG)?
-    IO_CFS_EN                    => false,          -- implement custom functions subsystem (CFS)?
-    IO_CFS_CONFIG                => x"00000000",    -- custom CFS configuration generic
-    IO_CFS_IN_SIZE               => 32,             -- size of CFS input conduit in bits
-    IO_CFS_OUT_SIZE              => 32,             -- size of CFS output conduit in bits
-    IO_NEOLED_EN                 => false           -- implement NeoPixel-compatible smart LED interface (NEOLED)?
+    IO_WDT_EN                    => IO_WDT_EN       -- implement watch dog timer (WDT)??
   )
   port map (
     -- Global control --
     clk_i       => clk_i,                        -- global clock, rising edge
     rstn_i      => rstn_i,                       -- global reset, low-active, async
-
-    -- JTAG on-chip debugger interface (available if ON_CHIP_DEBUGGER_EN = true) --
-    jtag_trst_i => '0',                          -- low-active TAP reset (optional)
-    jtag_tck_i  => '0',                          -- serial clock
-    jtag_tdi_i  => '0',                          -- serial data input
-    jtag_tdo_o  => open,                         -- serial data output
-    jtag_tms_i  => '0',                          -- mode select
-
-    -- Wishbone bus interface (available if MEM_EXT_EN = true) --
-    wb_tag_o    => open,                         -- request tag
-    wb_adr_o    => open,                         -- address
-    wb_dat_i    => (others => '0'),              -- read data
-    wb_dat_o    => open,                         -- write data
-    wb_we_o     => open,                         -- read/write
-    wb_sel_o    => open,                         -- byte enable
-    wb_stb_o    => open,                         -- strobe
-    wb_cyc_o    => open,                         -- valid cycle
-    wb_ack_i    => '0',                          -- transfer acknowledge
-    wb_err_i    => '0',                          -- transfer error
-
-    -- Advanced memory control signals (available if MEM_EXT_EN = true) --
-    fence_o     => open,                         -- indicates an executed FENCE operation
-    fencei_o    => open,                         -- indicates an executed FENCEI operation
 
     -- GPIO (available if IO_GPIO_EN = true) --
     gpio_o      => con_gpio_o,                   -- parallel output
@@ -267,12 +233,6 @@ begin
     uart0_rxd_i => uart_rxd_i,                   -- UART0 receive data
     uart0_rts_o => uart_rts_o,                   -- hw flow control: UART0.RX ready to receive ("RTR"), low-active, optional
     uart0_cts_i => uart_cts_i,                   -- hw flow control: UART0.TX allowed to transmit, low-active, optional
-
-    -- secondary UART1 (available if IO_UART1_EN = true) --
-    uart1_txd_o => open,                         -- UART1 send data
-    uart1_rxd_i => '0',                          -- UART1 receive data
-    uart1_rts_o => open,                         -- hw flow control: UART1.RX ready to receive ("RTR"), low-active, optional
-    uart1_cts_i => '0',                          -- hw flow control: UART1.TX allowed to transmit, low-active, optional
 
     -- SPI (available if IO_SPI_EN = true) --
     spi_sck_o   => con_spi_sck,                  -- SPI serial clock
@@ -285,23 +245,7 @@ begin
     twi_scl_io  => twi_scl_io,                   -- twi serial clock line
 
     -- PWM (available if IO_PWM_NUM_CH > 0) --
-    pwm_o       => con_pwm_o,                    -- pwm channels
-
-    -- Custom Functions Subsystem IO --
-    cfs_in_i    => (others => '0'),              -- custom CFS inputs conduit
-    cfs_out_o   => open,                         -- custom CFS outputs conduit
-
-    -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
-    neoled_o    => open,                         -- async serial data line
-
-    -- System time --
-    mtime_i     => (others => '0'),              -- current system time from ext. MTIME (if IO_MTIME_EN = false)
-    mtime_o     => open,                         -- current system time from int. MTIME (if IO_MTIME_EN = true)
-
-    -- Interrupts --
-    mtime_irq_i => '0',                          -- machine timer interrupt, available if IO_MTIME_EN = false
-    msw_irq_i   => '0',                          -- machine software interrupt
-    mext_irq_i  => '0'                           -- machine external interrupt
+    pwm_o       => con_pwm_o                     -- pwm channels
   );
 
 end architecture;

--- a/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
+++ b/rtl/system_integration/neorv32_ProcessorTop_stdlogic.vhd
@@ -3,7 +3,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -191,10 +191,7 @@ entity neorv32_ProcessorTop_stdlogic is
     cfs_in_i       : in  std_logic_vector(IO_CFS_IN_SIZE-1  downto 0); -- custom inputs
     cfs_out_o      : out std_logic_vector(IO_CFS_OUT_SIZE-1 downto 0); -- custom outputs
     -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
-    neoled_o       : out std_logic; -- async serial data line
-    -- System time --
-    mtime_i        : in  std_logic_vector(63 downto 0) := (others => '0'); -- current system time from ext. MTIME (if IO_MTIME_EN = false)
-    mtime_o        : out std_logic_vector(63 downto 0); -- current system time from int. MTIME (if IO_MTIME_EN = true)
+    neoled_o       : out std_logic; -- async serial data line´
     -- External platform interrupts (available if XIRQ_NUM_CH > 0) --
     xirq_i         : in  std_logic_vector(31 downto 0) := (others => '0'); -- IRQ channels
     -- CPU Interrupts --
@@ -273,9 +270,6 @@ architecture neorv32_ProcessorTop_stdlogic_rtl of neorv32_ProcessorTop_stdlogic 
   signal cfs_out_o_int   : std_ulogic_vector(IO_CFS_OUT_SIZE-1 downto 0);
   --
   signal neoled_o_int    : std_ulogic;
-  --
-  signal mtime_i_int     : std_ulogic_vector(63 downto 0);
-  signal mtime_o_int     : std_ulogic_vector(63 downto 0);
   --
   signal xirq_i_int      : std_ulogic_vector(31 downto 0);
   --
@@ -440,9 +434,6 @@ begin
     cfs_out_o      => cfs_out_o_int,   -- custom outputs
     -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
     neoled_o       => neoled_o_int,    -- async serial data line
-    -- System time --
-    mtime_i        => mtime_i_int,     -- current system time from ext. MTIME (if IO_MTIME_EN = false)
-    mtime_o        => mtime_o_int,     -- current system time from int. MTIME (if IO_MTIME_EN = true)
     -- External platform interrupts (available if XIRQ_NUM_CH > 0) --
     xirq_i         => xirq_i_int,      -- IRQ channels
     -- CPU Interrupts --
@@ -516,9 +507,6 @@ begin
   cfs_out_o       <= std_logic_vector(cfs_out_o_int);
 
   neoled_o        <= std_logic(neoled_o_int);
-
-  mtime_i_int     <= std_ulogic_vector(mtime_i);
-  mtime_o         <= std_logic_vector(mtime_o_int);
 
   xirq_i_int      <= std_ulogic_vector(xirq_i);
 

--- a/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
@@ -6,7 +6,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -212,10 +212,6 @@ entity neorv32_top_avalonmm is
 
     -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
     neoled_o       : out std_ulogic; -- async serial data line
-
-    -- System time --
-    mtime_i        : in  std_ulogic_vector(63 downto 0) := (others => 'U'); -- current system time from ext. MTIME (if IO_MTIME_EN = false)
-    mtime_o        : out std_ulogic_vector(63 downto 0); -- current system time from int. MTIME (if IO_MTIME_EN = true)
 
     -- External platform interrupts (available if XIRQ_NUM_CH > 0) --
     xirq_i         : in  std_ulogic_vector(31 downto 0) := (others => 'L'); -- IRQ channels
@@ -424,10 +420,6 @@ begin
 
     -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
     neoled_o => neoled_o,
-
-    -- System time --
-    mtime_i => mtime_i,
-    mtime_o => mtime_o,
 
     -- External platform interrupts (available if XIRQ_NUM_CH > 0) --
     xirq_i => xirq_i,

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -6,7 +6,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -423,9 +423,6 @@ begin
     cfs_out_o   => cfs_out_o_int,   -- custom outputs
     -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
     neoled_o    => neoled_o_int,    -- async serial data line
-    -- System time --
-    mtime_i     => (others => '0'), -- current system time from ext. MTIME (if IO_MTIME_EN = false)
-    mtime_o     => open,            -- current system time from int. MTIME (if IO_MTIME_EN = true)
     -- External platform interrupts (available if XIRQ_NUM_CH > 0) --
     xirq_i      => xirq_i_int,      -- IRQ channels
     -- CPU Interrupts --

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -221,7 +221,7 @@ begin
     if ci_mode then
       -- No need to send the full expectation in one big chunk
       check_uart(net, uart1_rx_handle, nul & nul);
-      check_uart(net, uart1_rx_handle, "0/49" & cr & lf);
+      check_uart(net, uart1_rx_handle, "0/48" & cr & lf);
     end if;
 
     -- Apply some random data on each SLINK inputs and expect it to

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -7,7 +7,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -430,9 +430,6 @@ begin
     cfs_out_o      => open,            -- custom CFS outputs
     -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
     neoled_o       => open,            -- async serial data line
-    -- System time --
-    mtime_i        => (others => '0'), -- current system time from ext. MTIME (if IO_MTIME_EN = false)
-    mtime_o        => open,            -- current system time from int. MTIME (if IO_MTIME_EN = true)
     -- External platform interrupts (available if XIRQ_NUM_CH > 0) --
     xirq_i         => gpio(31 downto 0), -- IRQ channels
     -- CPU Interrupts --

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -7,7 +7,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -321,9 +321,6 @@ begin
     cfs_out_o      => open,            -- custom CFS outputs
     -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
     neoled_o       => open,            -- async serial data line
-    -- System time --
-    mtime_i        => (others => '0'), -- current system time from ext. MTIME (if IO_MTIME_EN = false)
-    mtime_o        => open,            -- current system time from int. MTIME (if IO_MTIME_EN = true)
     -- External platform interrupts (available if XIRQ_NUM_CH > 0) --
     xirq_i         => gpio(31 downto 0), -- IRQ channels
     -- CPU Interrupts --

--- a/sw/lib/include/legacy.h
+++ b/sw/lib/include/legacy.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -121,6 +121,22 @@ inline int __attribute__((deprecated("Use 'neorv32_rte_handler_uninstall()' inst
 /** R3-type CFU custom instruction 7 (funct3 = 111) */
 #define neorv32_cfu_cmd7(funct7, rs1, rs2) neorv32_cfu_r3_instr(funct7, 7, rs1, rs2)
 /**@}*/
+
+
+// ================================================================================================
+// CPU Core
+// ================================================================================================
+
+/**********************************************************************//**
+ * Get current system time from time[h] CSR.
+ *
+ * @note This function requires the MTIME system timer to be implemented.
+ *
+ * @return Current system time (64 bit).
+ **************************************************************************/
+inline uint64_t __attribute__((deprecated("Use 'neorv32_mtime_get_time()' instead."))) neorv32_cpu_get_systime(void) {
+  return neorv32_mtime_get_time();
+}
 
 
 

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -73,7 +73,7 @@ enum NEORV32_CSR_enum {
   CSR_MISA           = 0x301, /**< 0x301 - misa       (r/-): CPU ISA and extensions (read-only in NEORV32) */
   CSR_MIE            = 0x304, /**< 0x304 - mie        (r/w): Machine interrupt-enable register */
   CSR_MTVEC          = 0x305, /**< 0x305 - mtvec      (r/w): Machine trap-handler base address (for ALL traps) */
-  CSR_MCOUNTEREN     = 0x306, /**< 0x305 - mcounteren (r/w): Machine counter enable register (controls access rights from U-mode) */
+  CSR_MCOUNTEREN     = 0x306, /**< 0x305 - mcounteren (r/-): Machine counter enable register (controls access rights from U-mode) */
 
   CSR_MENVCFG        = 0x30a, /**< 0x30a - menvcfg (r/-): Machine environment configuration register */
 
@@ -159,7 +159,7 @@ enum NEORV32_CSR_enum {
   CSR_DPC            = 0x7b1, /**< 0x7b1 - dpc       (-/-): Debug program counter */
   CSR_DSCRATCH0      = 0x7b2, /**< 0x7b2 - dscratch0 (-/-): Debug scratch register */
 
-  /* counter and timers - low word */
+  /* machine counters and timers */
   CSR_MCYCLE         = 0xb00, /**< 0xb00 - mcycle   (r/w): Machine cycle counter low word */
   CSR_MINSTRET       = 0xb02, /**< 0xb02 - minstret (r/w): Machine instructions-retired counter low word */
 
@@ -226,77 +226,72 @@ enum NEORV32_CSR_enum {
   CSR_MHPMCOUNTER30H = 0xb9e, /**< 0xb9e - mhpmcounter30h (r/w): Machine hardware performance monitor 30 counter high word */
   CSR_MHPMCOUNTER31H = 0xb9f, /**< 0xb9f - mhpmcounter31h (r/w): Machine hardware performance monitor 31 counter high word */
 
+  /* user counters and timers */
   CSR_CYCLE          = 0xc00, /**< 0xc00 - cycle   (r/-): Cycle counter low word (from MCYCLE) */
-  CSR_TIME           = 0xc01, /**< 0xc01 - time    (r/-): Timer low word (from MTIME.TIME_LO) */
   CSR_INSTRET        = 0xc02, /**< 0xc02 - instret (r/-): Instructions-retired counter low word (from MINSTRET) */
 
-  /* not implemented */
-//CSR_HPMCOUNTER3    = 0xc03, /**< 0xc03 - hpmcounter3  (r/-): User hardware performance monitor 3  counter low word */
-//CSR_HPMCOUNTER4    = 0xc04, /**< 0xc04 - hpmcounter4  (r/-): User hardware performance monitor 4  counter low word */
-//CSR_HPMCOUNTER5    = 0xc05, /**< 0xc05 - hpmcounter5  (r/-): User hardware performance monitor 5  counter low word */
-//CSR_HPMCOUNTER6    = 0xc06, /**< 0xc06 - hpmcounter6  (r/-): User hardware performance monitor 6  counter low word */
-//CSR_HPMCOUNTER7    = 0xc07, /**< 0xc07 - hpmcounter7  (r/-): User hardware performance monitor 7  counter low word */
-//CSR_HPMCOUNTER8    = 0xc08, /**< 0xc08 - hpmcounter8  (r/-): User hardware performance monitor 8  counter low word */
-//CSR_HPMCOUNTER9    = 0xc09, /**< 0xc09 - hpmcounter9  (r/-): User hardware performance monitor 9  counter low word */
-//CSR_HPMCOUNTER10   = 0xc0a, /**< 0xc0a - hpmcounter10 (r/-): User hardware performance monitor 10 counter low word */
-//CSR_HPMCOUNTER11   = 0xc0b, /**< 0xc0b - hpmcounter11 (r/-): User hardware performance monitor 11 counter low word */
-//CSR_HPMCOUNTER12   = 0xc0c, /**< 0xc0c - hpmcounter12 (r/-): User hardware performance monitor 12 counter low word */
-//CSR_HPMCOUNTER13   = 0xc0d, /**< 0xc0d - hpmcounter13 (r/-): User hardware performance monitor 13 counter low word */
-//CSR_HPMCOUNTER14   = 0xc0e, /**< 0xc0e - hpmcounter14 (r/-): User hardware performance monitor 14 counter low word */
-//CSR_HPMCOUNTER15   = 0xc0f, /**< 0xc0f - hpmcounter15 (r/-): User hardware performance monitor 15 counter low word */
-//CSR_HPMCOUNTER16   = 0xc10, /**< 0xc10 - hpmcounter16 (r/-): User hardware performance monitor 16 counter low word */
-//CSR_HPMCOUNTER17   = 0xc11, /**< 0xc11 - hpmcounter17 (r/-): User hardware performance monitor 17 counter low word */
-//CSR_HPMCOUNTER18   = 0xc12, /**< 0xc12 - hpmcounter18 (r/-): User hardware performance monitor 18 counter low word */
-//CSR_HPMCOUNTER19   = 0xc13, /**< 0xc13 - hpmcounter19 (r/-): User hardware performance monitor 19 counter low word */
-//CSR_HPMCOUNTER20   = 0xc14, /**< 0xc14 - hpmcounter20 (r/-): User hardware performance monitor 20 counter low word */
-//CSR_HPMCOUNTER21   = 0xc15, /**< 0xc15 - hpmcounter21 (r/-): User hardware performance monitor 21 counter low word */
-//CSR_HPMCOUNTER22   = 0xc16, /**< 0xc16 - hpmcounter22 (r/-): User hardware performance monitor 22 counter low word */
-//CSR_HPMCOUNTER23   = 0xc17, /**< 0xc17 - hpmcounter23 (r/-): User hardware performance monitor 23 counter low word */
-//CSR_HPMCOUNTER24   = 0xc18, /**< 0xc18 - hpmcounter24 (r/-): User hardware performance monitor 24 counter low word */
-//CSR_HPMCOUNTER25   = 0xc19, /**< 0xc19 - hpmcounter25 (r/-): User hardware performance monitor 25 counter low word */
-//CSR_HPMCOUNTER26   = 0xc1a, /**< 0xc1a - hpmcounter26 (r/-): User hardware performance monitor 26 counter low word */
-//CSR_HPMCOUNTER27   = 0xc1b, /**< 0xc1b - hpmcounter27 (r/-): User hardware performance monitor 27 counter low word */
-//CSR_HPMCOUNTER28   = 0xc1c, /**< 0xc1c - hpmcounter28 (r/-): User hardware performance monitor 28 counter low word */
-//CSR_HPMCOUNTER29   = 0xc1d, /**< 0xc1d - hpmcounter29 (r/-): User hardware performance monitor 29 counter low word */
-//CSR_HPMCOUNTER30   = 0xc1e, /**< 0xc1e - hpmcounter30 (r/-): User hardware performance monitor 30 counter low word */
-//CSR_HPMCOUNTER31   = 0xc1f, /**< 0xc1f - hpmcounter31 (r/-): User hardware performance monitor 31 counter low word */
+  CSR_HPMCOUNTER3    = 0xc03, /**< 0xc03 - hpmcounter3  (r/-): User hardware performance monitor 3  counter low word */
+  CSR_HPMCOUNTER4    = 0xc04, /**< 0xc04 - hpmcounter4  (r/-): User hardware performance monitor 4  counter low word */
+  CSR_HPMCOUNTER5    = 0xc05, /**< 0xc05 - hpmcounter5  (r/-): User hardware performance monitor 5  counter low word */
+  CSR_HPMCOUNTER6    = 0xc06, /**< 0xc06 - hpmcounter6  (r/-): User hardware performance monitor 6  counter low word */
+  CSR_HPMCOUNTER7    = 0xc07, /**< 0xc07 - hpmcounter7  (r/-): User hardware performance monitor 7  counter low word */
+  CSR_HPMCOUNTER8    = 0xc08, /**< 0xc08 - hpmcounter8  (r/-): User hardware performance monitor 8  counter low word */
+  CSR_HPMCOUNTER9    = 0xc09, /**< 0xc09 - hpmcounter9  (r/-): User hardware performance monitor 9  counter low word */
+  CSR_HPMCOUNTER10   = 0xc0a, /**< 0xc0a - hpmcounter10 (r/-): User hardware performance monitor 10 counter low word */
+  CSR_HPMCOUNTER11   = 0xc0b, /**< 0xc0b - hpmcounter11 (r/-): User hardware performance monitor 11 counter low word */
+  CSR_HPMCOUNTER12   = 0xc0c, /**< 0xc0c - hpmcounter12 (r/-): User hardware performance monitor 12 counter low word */
+  CSR_HPMCOUNTER13   = 0xc0d, /**< 0xc0d - hpmcounter13 (r/-): User hardware performance monitor 13 counter low word */
+  CSR_HPMCOUNTER14   = 0xc0e, /**< 0xc0e - hpmcounter14 (r/-): User hardware performance monitor 14 counter low word */
+  CSR_HPMCOUNTER15   = 0xc0f, /**< 0xc0f - hpmcounter15 (r/-): User hardware performance monitor 15 counter low word */
+  CSR_HPMCOUNTER16   = 0xc10, /**< 0xc10 - hpmcounter16 (r/-): User hardware performance monitor 16 counter low word */
+  CSR_HPMCOUNTER17   = 0xc11, /**< 0xc11 - hpmcounter17 (r/-): User hardware performance monitor 17 counter low word */
+  CSR_HPMCOUNTER18   = 0xc12, /**< 0xc12 - hpmcounter18 (r/-): User hardware performance monitor 18 counter low word */
+  CSR_HPMCOUNTER19   = 0xc13, /**< 0xc13 - hpmcounter19 (r/-): User hardware performance monitor 19 counter low word */
+  CSR_HPMCOUNTER20   = 0xc14, /**< 0xc14 - hpmcounter20 (r/-): User hardware performance monitor 20 counter low word */
+  CSR_HPMCOUNTER21   = 0xc15, /**< 0xc15 - hpmcounter21 (r/-): User hardware performance monitor 21 counter low word */
+  CSR_HPMCOUNTER22   = 0xc16, /**< 0xc16 - hpmcounter22 (r/-): User hardware performance monitor 22 counter low word */
+  CSR_HPMCOUNTER23   = 0xc17, /**< 0xc17 - hpmcounter23 (r/-): User hardware performance monitor 23 counter low word */
+  CSR_HPMCOUNTER24   = 0xc18, /**< 0xc18 - hpmcounter24 (r/-): User hardware performance monitor 24 counter low word */
+  CSR_HPMCOUNTER25   = 0xc19, /**< 0xc19 - hpmcounter25 (r/-): User hardware performance monitor 25 counter low word */
+  CSR_HPMCOUNTER26   = 0xc1a, /**< 0xc1a - hpmcounter26 (r/-): User hardware performance monitor 26 counter low word */
+  CSR_HPMCOUNTER27   = 0xc1b, /**< 0xc1b - hpmcounter27 (r/-): User hardware performance monitor 27 counter low word */
+  CSR_HPMCOUNTER28   = 0xc1c, /**< 0xc1c - hpmcounter28 (r/-): User hardware performance monitor 28 counter low word */
+  CSR_HPMCOUNTER29   = 0xc1d, /**< 0xc1d - hpmcounter29 (r/-): User hardware performance monitor 29 counter low word */
+  CSR_HPMCOUNTER30   = 0xc1e, /**< 0xc1e - hpmcounter30 (r/-): User hardware performance monitor 30 counter low word */
+  CSR_HPMCOUNTER31   = 0xc1f, /**< 0xc1f - hpmcounter31 (r/-): User hardware performance monitor 31 counter low word */
 
-
-  /* counter and timers - high word */
   CSR_CYCLEH         = 0xc80, /**< 0xc80 - cycleh   (r/-): Cycle counter high word (from MCYCLEH) */
-  CSR_TIMEH          = 0xc81, /**< 0xc81 - timeh    (r/-): Timer high word (from MTIME.TIME_HI) */
   CSR_INSTRETH       = 0xc82, /**< 0xc82 - instreth (r/-): Instructions-retired counter high word (from MINSTRETH) */
 
-  /* not implemented */
-//CSR_HPMCOUNTER3H   = 0xc83, /**< 0xc83 - hpmcounter3h  (r/-): User hardware performance monitor 3  counter high word */
-//CSR_HPMCOUNTER4H   = 0xc84, /**< 0xc84 - hpmcounter4h  (r/-): User hardware performance monitor 4  counter high word */
-//CSR_HPMCOUNTER5H   = 0xc85, /**< 0xc85 - hpmcounter5h  (r/-): User hardware performance monitor 5  counter high word */
-//CSR_HPMCOUNTER6H   = 0xc86, /**< 0xc86 - hpmcounter6h  (r/-): User hardware performance monitor 6  counter high word */
-//CSR_HPMCOUNTER7H   = 0xc87, /**< 0xc87 - hpmcounter7h  (r/-): User hardware performance monitor 7  counter high word */
-//CSR_HPMCOUNTER8H   = 0xc88, /**< 0xc88 - hpmcounter8h  (r/-): User hardware performance monitor 8  counter high word */
-//CSR_HPMCOUNTER9H   = 0xc89, /**< 0xc89 - hpmcounter9h  (r/-): User hardware performance monitor 9  counter high word */
-//CSR_HPMCOUNTER10H  = 0xc8a, /**< 0xc8a - hpmcounter10h (r/-): User hardware performance monitor 10 counter high word */
-//CSR_HPMCOUNTER11H  = 0xc8b, /**< 0xc8b - hpmcounter11h (r/-): User hardware performance monitor 11 counter high word */
-//CSR_HPMCOUNTER12H  = 0xc8c, /**< 0xc8c - hpmcounter12h (r/-): User hardware performance monitor 12 counter high word */
-//CSR_HPMCOUNTER13H  = 0xc8d, /**< 0xc8d - hpmcounter13h (r/-): User hardware performance monitor 13 counter high word */
-//CSR_HPMCOUNTER14H  = 0xc8e, /**< 0xc8e - hpmcounter14h (r/-): User hardware performance monitor 14 counter high word */
-//CSR_HPMCOUNTER15H  = 0xc8f, /**< 0xc8f - hpmcounter15h (r/-): User hardware performance monitor 15 counter high word */
-//CSR_HPMCOUNTER16H  = 0xc90, /**< 0xc90 - hpmcounter16h (r/-): User hardware performance monitor 16 counter high word */
-//CSR_HPMCOUNTER17H  = 0xc91, /**< 0xc91 - hpmcounter17h (r/-): User hardware performance monitor 17 counter high word */
-//CSR_HPMCOUNTER18H  = 0xc92, /**< 0xc92 - hpmcounter18h (r/-): User hardware performance monitor 18 counter high word */
-//CSR_HPMCOUNTER19H  = 0xc93, /**< 0xc93 - hpmcounter19h (r/-): User hardware performance monitor 19 counter high word */
-//CSR_HPMCOUNTER20H  = 0xc94, /**< 0xc94 - hpmcounter20h (r/-): User hardware performance monitor 20 counter high word */
-//CSR_HPMCOUNTER21H  = 0xc95, /**< 0xc95 - hpmcounter21h (r/-): User hardware performance monitor 21 counter high word */
-//CSR_HPMCOUNTER22H  = 0xc96, /**< 0xc96 - hpmcounter22h (r/-): User hardware performance monitor 22 counter high word */
-//CSR_HPMCOUNTER23H  = 0xc97, /**< 0xc97 - hpmcounter23h (r/-): User hardware performance monitor 23 counter high word */
-//CSR_HPMCOUNTER24H  = 0xc98, /**< 0xc98 - hpmcounter24h (r/-): User hardware performance monitor 24 counter high word */
-//CSR_HPMCOUNTER25H  = 0xc99, /**< 0xc99 - hpmcounter25h (r/-): User hardware performance monitor 25 counter high word */
-//CSR_HPMCOUNTER26H  = 0xc9a, /**< 0xc9a - hpmcounter26h (r/-): User hardware performance monitor 26 counter high word */
-//CSR_HPMCOUNTER27H  = 0xc9b, /**< 0xc9b - hpmcounter27h (r/-): User hardware performance monitor 27 counter high word */
-//CSR_HPMCOUNTER28H  = 0xc9c, /**< 0xc9c - hpmcounter28h (r/-): User hardware performance monitor 28 counter high word */
-//CSR_HPMCOUNTER29H  = 0xc9d, /**< 0xc9d - hpmcounter29h (r/-): User hardware performance monitor 29 counter high word */
-//CSR_HPMCOUNTER30H  = 0xc9e, /**< 0xc9e - hpmcounter30h (r/-): User hardware performance monitor 30 counter high word */
-//CSR_HPMCOUNTER31H  = 0xc9f, /**< 0xc9f - hpmcounter31h (r/-): User hardware performance monitor 31 counter high word */
+  CSR_HPMCOUNTER3H   = 0xc83, /**< 0xc83 - hpmcounter3h  (r/-): User hardware performance monitor 3  counter high word */
+  CSR_HPMCOUNTER4H   = 0xc84, /**< 0xc84 - hpmcounter4h  (r/-): User hardware performance monitor 4  counter high word */
+  CSR_HPMCOUNTER5H   = 0xc85, /**< 0xc85 - hpmcounter5h  (r/-): User hardware performance monitor 5  counter high word */
+  CSR_HPMCOUNTER6H   = 0xc86, /**< 0xc86 - hpmcounter6h  (r/-): User hardware performance monitor 6  counter high word */
+  CSR_HPMCOUNTER7H   = 0xc87, /**< 0xc87 - hpmcounter7h  (r/-): User hardware performance monitor 7  counter high word */
+  CSR_HPMCOUNTER8H   = 0xc88, /**< 0xc88 - hpmcounter8h  (r/-): User hardware performance monitor 8  counter high word */
+  CSR_HPMCOUNTER9H   = 0xc89, /**< 0xc89 - hpmcounter9h  (r/-): User hardware performance monitor 9  counter high word */
+  CSR_HPMCOUNTER10H  = 0xc8a, /**< 0xc8a - hpmcounter10h (r/-): User hardware performance monitor 10 counter high word */
+  CSR_HPMCOUNTER11H  = 0xc8b, /**< 0xc8b - hpmcounter11h (r/-): User hardware performance monitor 11 counter high word */
+  CSR_HPMCOUNTER12H  = 0xc8c, /**< 0xc8c - hpmcounter12h (r/-): User hardware performance monitor 12 counter high word */
+  CSR_HPMCOUNTER13H  = 0xc8d, /**< 0xc8d - hpmcounter13h (r/-): User hardware performance monitor 13 counter high word */
+  CSR_HPMCOUNTER14H  = 0xc8e, /**< 0xc8e - hpmcounter14h (r/-): User hardware performance monitor 14 counter high word */
+  CSR_HPMCOUNTER15H  = 0xc8f, /**< 0xc8f - hpmcounter15h (r/-): User hardware performance monitor 15 counter high word */
+  CSR_HPMCOUNTER16H  = 0xc90, /**< 0xc90 - hpmcounter16h (r/-): User hardware performance monitor 16 counter high word */
+  CSR_HPMCOUNTER17H  = 0xc91, /**< 0xc91 - hpmcounter17h (r/-): User hardware performance monitor 17 counter high word */
+  CSR_HPMCOUNTER18H  = 0xc92, /**< 0xc92 - hpmcounter18h (r/-): User hardware performance monitor 18 counter high word */
+  CSR_HPMCOUNTER19H  = 0xc93, /**< 0xc93 - hpmcounter19h (r/-): User hardware performance monitor 19 counter high word */
+  CSR_HPMCOUNTER20H  = 0xc94, /**< 0xc94 - hpmcounter20h (r/-): User hardware performance monitor 20 counter high word */
+  CSR_HPMCOUNTER21H  = 0xc95, /**< 0xc95 - hpmcounter21h (r/-): User hardware performance monitor 21 counter high word */
+  CSR_HPMCOUNTER22H  = 0xc96, /**< 0xc96 - hpmcounter22h (r/-): User hardware performance monitor 22 counter high word */
+  CSR_HPMCOUNTER23H  = 0xc97, /**< 0xc97 - hpmcounter23h (r/-): User hardware performance monitor 23 counter high word */
+  CSR_HPMCOUNTER24H  = 0xc98, /**< 0xc98 - hpmcounter24h (r/-): User hardware performance monitor 24 counter high word */
+  CSR_HPMCOUNTER25H  = 0xc99, /**< 0xc99 - hpmcounter25h (r/-): User hardware performance monitor 25 counter high word */
+  CSR_HPMCOUNTER26H  = 0xc9a, /**< 0xc9a - hpmcounter26h (r/-): User hardware performance monitor 26 counter high word */
+  CSR_HPMCOUNTER27H  = 0xc9b, /**< 0xc9b - hpmcounter27h (r/-): User hardware performance monitor 27 counter high word */
+  CSR_HPMCOUNTER28H  = 0xc9c, /**< 0xc9c - hpmcounter28h (r/-): User hardware performance monitor 28 counter high word */
+  CSR_HPMCOUNTER29H  = 0xc9d, /**< 0xc9d - hpmcounter29h (r/-): User hardware performance monitor 29 counter high word */
+  CSR_HPMCOUNTER30H  = 0xc9e, /**< 0xc9e - hpmcounter30h (r/-): User hardware performance monitor 30 counter high word */
+  CSR_HPMCOUNTER31H  = 0xc9f, /**< 0xc9f - hpmcounter31h (r/-): User hardware performance monitor 31 counter high word */
 
   /* machine information registers */
   CSR_MVENDORID      = 0xf11, /**< 0xf11 - mvendorid  (r/-): Vendor ID */
@@ -319,16 +314,6 @@ enum NEORV32_CSR_MSTATUS_enum {
   CSR_MSTATUS_MPP_H = 12, /**< CPU mstatus CSR (12): MPP_H - Machine previous privilege mode bit high (r/w) */
   CSR_MSTATUS_MPRV  = 17, /**< CPU mstatus CSR (17): MPRV - Use MPP as effective privilege for M-mode load/stores when set (r/w) */
   CSR_MSTATUS_TW    = 21  /**< CPU mstatus CSR (21): TW - Disallow execution of wfi instruction in user mode when set (r/w) */
-};
-
-
-/**********************************************************************//**
- * CPU <b>mcounteren</b> CSR (r/w): Machine counter enable
- **************************************************************************/
-enum NEORV32_CSR_MCOUNTEREN_enum {
-  CSR_MCOUNTEREN_CY    = 0, /**< CPU mcounteren CSR (0): CY - Allow access to cycle[h]   CSRs from U-mode when set (r/w) */
-  CSR_MCOUNTEREN_TM    = 1, /**< CPU mcounteren CSR (1): TM - Allow access to time[h]    CSRs from U-mode when set (r/w) */
-  CSR_MCOUNTEREN_IR    = 2  /**< CPU mcounteren CSR (2): IR - Allow access to instret[h] CSRs from U-mode when set (r/w) */
 };
 
 

--- a/sw/lib/include/neorv32_cpu.h
+++ b/sw/lib/include/neorv32_cpu.h
@@ -48,7 +48,6 @@ uint64_t neorv32_cpu_get_cycle(void);
 void     neorv32_cpu_set_mcycle(uint64_t value);
 uint64_t neorv32_cpu_get_instret(void);
 void     neorv32_cpu_set_minstret(uint64_t value);
-uint64_t neorv32_cpu_get_systime(void);
 void     neorv32_cpu_delay_ms(uint32_t time_ms);
 uint32_t neorv32_cpu_get_clk_from_prsc(int prsc);
 uint32_t neorv32_cpu_pmp_get_num_regions(void);

--- a/sw/lib/source/neorv32_cpu.c
+++ b/sw/lib/source/neorv32_cpu.c
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -231,37 +231,6 @@ void neorv32_cpu_set_minstret(uint64_t value) {
   neorv32_cpu_csr_write(CSR_MINSTRET,  cycles.uint32[0]);
 
   asm volatile("nop"); // delay due to CPU-internal instret write buffer
-}
-
-
-/**********************************************************************//**
- * Get current system time from time[h] CSR.
- *
- * @note This function requires the MTIME system timer to be implemented.
- *
- * @return Current system time (64 bit).
- **************************************************************************/
-uint64_t neorv32_cpu_get_systime(void) {
-
-  union {
-    uint64_t uint64;
-    uint32_t uint32[sizeof(uint64_t)/sizeof(uint32_t)];
-  } cycles;
-
-  uint32_t tmp1, tmp2, tmp3;
-  while(1) {
-    tmp1 = neorv32_cpu_csr_read(CSR_TIMEH);
-    tmp2 = neorv32_cpu_csr_read(CSR_TIME);
-    tmp3 = neorv32_cpu_csr_read(CSR_TIMEH);
-    if (tmp1 == tmp3) {
-      break;
-    }
-  }
-
-  cycles.uint32[0] = tmp2;
-  cycles.uint32[1] = tmp3;
-
-  return cycles.uint64;
 }
 
 


### PR DESCRIPTION
* ⚠️ remove `mtime_i` and `mtime_o` top entity ports
* ⚠️ remove `time` and `timeh` CSRs
* ⚠️ hardwire `mcounteren` CSR to all-one - user-level software is always allowed to access the user-level counter CSRs
* add user-level HPM counters `hpmcounter3[h]` to `hpmcounter31[h]`
* simplify CSR access check logic
* ⚠️ clearing `mie` CSR (enabled interrupts) will not clear `mip` CSR (pending interrupts)