### PR TITLE
[rtl] Cleanup CPU interrupt controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 01.02.2023 | 1.8.0.1 | clean-up CPU's interrupt controller; fix raise condition in FIRQ trigger/acknowledge; [#484](https://github.com/stnolting/neorv32/pull/484) |
 | 25.01.2023 | [**:rocket:1.8.0**](https://github.com/stnolting/neorv32/releases/tag/v1.8.0) | **New release** |
 | 21.01.2023 | 1.7.9.10 | update software framework; :bug: fix bug in constructor calling in `crt0` start-up code; [#478](https://github.com/stnolting/neorv32/pull/478) |
 | 15.01.2023 | 1.7.9.9 | :warning: rework **CPU counters**; remove `mtime_i/o` top entity ports; remove `time[h]` CSRs; [#477](https://github.com/stnolting/neorv32/pull/477) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -72,11 +72,10 @@ test framework is available in a separate repository: https://github.com/stnolti
 
 This list shows the currently identified issues regarding full RISC-V-compatibility.
 
-.Read-Only "Read-Write" CSRs
+.Pending Interrupts
 [IMPORTANT]
-The NEORV32 <<_misa>> CSR is _read-only_. Hence, ISA capabilities are fixed at synthesis time and cannot be
-enabled/disabled dynamically at runtime. Any machine-mode write access to this CSR is ignored and will _not_
-cause any exceptions or side-effects to maintain RISC-V compatibility.
+An interrupt can only become pending (bit in `mip` becomes set) if the interrupt channel is enabled
+via the according <<_mie>> bit. Clearing a bit in <<_mie>> will also clear the according <<_mip>> bit.
 
 .Physical Memory Protection (PMP)
 [IMPORTANT]

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -288,6 +288,9 @@ The `mie` CSR is used to enable/disable individual interrupt sources.
 | 3     | _CSR_MIE_MSIE_ | r/w | **MSIE**: Machine _software_ interrupt enable
 |=======================
 
+[IMPORTANT]
+Clearing a bit in `mie` will also clear the according <<_mip>> bit (if the according interrupt channel was pending).
+
 
 :sectnums!:
 ===== **`mtvec`**
@@ -472,12 +475,9 @@ to clear the current interrupt request.
 | 3     | _CSR_MIP_MSIP_                       | r/- | **MSIP**: Machine _software_ interrupt pending; _cleared by platform-defined mechanism_
 |=======================
 
-.RISC-V Standard Interrupts
 [IMPORTANT]
-Pending RISC-V standard machine interrupts (MEI, MTI, MSI) **cannot** be acknowledged/cleared by clearing the according
-`mip` bit. The interrupt source has to keep the interrupt request signal high until explicitly acknowledged (e.g. by writing
-to a specific memory-mapped register). However, the RISC-V standard interrupts can be cleared at any time by clearing the
-according <<_mip>> bit(s).
+An interrupt can only become pending (bit in `mip` becomes set) if the interrupt channel is enabled
+via the according <<_mie>> bit.
 
 .FIRQ Channel Mapping
 [TIP]

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080000"; -- NEORV32 version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080001"; -- NEORV32 version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
 
   -- Check if we're inside the Matrix -------------------------------------------------------


### PR DESCRIPTION
This PR also fixes a race condition: when a FIRQ is triggered in the same moment as the according FIRQ channel is cleared/acknowledged using the `mip` CSR the actual interrupt request got lost.