### PR TITLE
[rtl] rework mip csr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
-| 01.02.2023 | 1.8.0.1 | clean-up CPU's interrupt controller; fix raise condition in FIRQ trigger/acknowledge; [#484](https://github.com/stnolting/neorv32/pull/484) |
+| 04.02.2023 | 1.8.0.2 | fix RISC-V-incompatible behavior of `mip` CSR; [#486](https://github.com/stnolting/neorv32/pull/486) |
+| 01.02.2023 | 1.8.0.1 | clean-up CPU's interrupt controller; fix race condition in FIRQ trigger/acknowledge; [#484](https://github.com/stnolting/neorv32/pull/484) |
 | 25.01.2023 | [**:rocket:1.8.0**](https://github.com/stnolting/neorv32/releases/tag/v1.8.0) | **New release** |
 | 21.01.2023 | 1.7.9.10 | update software framework; :bug: fix bug in constructor calling in `crt0` start-up code; [#478](https://github.com/stnolting/neorv32/pull/478) |
 | 15.01.2023 | 1.7.9.9 | :warning: rework **CPU counters**; remove `mtime_i/o` top entity ports; remove `time[h]` CSRs; [#477](https://github.com/stnolting/neorv32/pull/477) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -72,11 +72,6 @@ test framework is available in a separate repository: https://github.com/stnolti
 
 This list shows the currently identified issues regarding full RISC-V-compatibility.
 
-.Pending Interrupts
-[IMPORTANT]
-An interrupt can only become pending (bit in `mip` becomes set) if the interrupt channel is enabled
-via the according <<_mie>> bit. Clearing a bit in <<_mie>> will also clear the according <<_mip>> bit.
-
 .Physical Memory Protection (PMP)
 [IMPORTANT]
 The RISC-V-compatible NEORV32 <<_machine_physical_memory_protection_csrs>> only implements the **TOR**

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -288,9 +288,6 @@ The `mie` CSR is used to enable/disable individual interrupt sources.
 | 3     | _CSR_MIE_MSIE_ | r/w | **MSIE**: Machine _software_ interrupt enable
 |=======================
 
-[IMPORTANT]
-Clearing a bit in `mie` will also clear the according <<_mip>> bit (if the according interrupt channel was pending).
-
 
 :sectnums!:
 ===== **`mtvec`**
@@ -458,9 +455,11 @@ See section <<_traps_exceptions_and_interrupts>> for more information.
 3+<| Reset value: `0x00000000`
 |=======================
 
-The `mip` CSR shows the currently _pending_ machine-level interrupts.
-The bits for the standard RISC-V interrupts are read-only. Hence, these interrupts cannot be cleared using the
-`mip` register and must be cleared/acknowledged within the according interrupt-generating device.
+The `mip` CSR shows currently _pending_ machine-level interrupt requests. The bits for the standard RISC-V
+machine-level interrupts (`MEIP`, `MTIP`, `MSIP`) are read-only. Hence, these interrupts cannot be
+cleared/set using the `mip` register. These interrupts are cleared/acknowledged by mechanism that are
+specific for the interrupt-causing modules. the according interrupt-generating device.
+
 The upper 16 bits represent the status of the CPU's fast interrupt request lines (FIRQ). Once triggered, these
 bit have to be cleared manually by writing zero to the according `mip` bits (in the interrupt handler routine)
 to clear the current interrupt request.
@@ -474,10 +473,6 @@ to clear the current interrupt request.
 | 7     | _CSR_MIP_MTIP_                       | r/- | **MTIP**: Machine _timer_ interrupt pending; _cleared by platform-defined mechanism_
 | 3     | _CSR_MIP_MSIP_                       | r/- | **MSIP**: Machine _software_ interrupt pending; _cleared by platform-defined mechanism_
 |=======================
-
-[IMPORTANT]
-An interrupt can only become pending (bit in `mip` becomes set) if the interrupt channel is enabled
-via the according <<_mie>> bit.
 
 .FIRQ Channel Mapping
 [TIP]

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080001"; -- NEORV32 version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080002"; -- NEORV32 version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1745,7 +1745,7 @@ void test_ok(void) {
  **************************************************************************/
 void test_fail(void) {
 
-  PRINT_CRITICAL("%c[1m[fail]%c[0m\n", 27, 27);
+  PRINT_CRITICAL("%c[1m[fail (%u)]%c[0m\n", 27, 27, cnt_test);
   cnt_fail++;
 }
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -800,6 +800,7 @@ int main() {
 
   // wait some time for the IRQ to trigger and arrive the CPU
   asm volatile ("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -829,6 +830,7 @@ int main() {
 
   // wait some time for the IRQ to arrive the CPU
   asm volatile ("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
   sim_irq_trigger(0);
@@ -855,6 +857,7 @@ int main() {
   sim_irq_trigger(1 << CSR_MIE_MEIE);
 
   // wait some time for the IRQ to arrive the CPU
+  asm volatile ("nop");
   asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
@@ -908,6 +911,7 @@ int main() {
   neorv32_mtime_set_timecmp(0); // force interrupt
 
   // wait some time for the IRQ to arrive the CPU
+  asm volatile ("nop");
   asm volatile ("nop");
 
   uint32_t was_pending = neorv32_cpu_csr_read(CSR_MIP) & (1 << CSR_MIP_MTIP); // should be pending now
@@ -988,6 +992,7 @@ int main() {
 
   // wait some time for the IRQ to arrive the CPU
   asm volatile ("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1030,6 +1035,7 @@ int main() {
 
   // wait some time for the IRQ to arrive the CPU
   asm volatile ("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1068,6 +1074,7 @@ int main() {
   while(neorv32_uart1_tx_busy());
 
   // wait some time for the IRQ to arrive the CPU
+  asm volatile ("nop");
   asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
@@ -1108,6 +1115,7 @@ int main() {
 
   // wait some time for the IRQ to arrive the CPU
   asm volatile ("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1141,6 +1149,7 @@ int main() {
 
   // wait some time for the IRQ to arrive the CPU
   asm volatile ("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1172,6 +1181,7 @@ int main() {
   neorv32_twi_start_trans(0xA5);
 
   // wait some time for the IRQ to arrive the CPU
+  asm volatile ("nop");
   asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
@@ -1209,6 +1219,7 @@ int main() {
 
   // wait for IRQs to arrive CPU
   asm volatile ("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1242,6 +1253,7 @@ int main() {
   neorv32_neoled_write_nonblocking(0);
 
   // wait some time for the IRQ to arrive the CPU
+  asm volatile ("nop");
   asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
@@ -1278,6 +1290,7 @@ int main() {
   }
 
   // wait some time for the IRQ to arrive the CPU
+  asm volatile ("nop");
   asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
@@ -1323,6 +1336,7 @@ int main() {
 
   // wait some time for the IRQ to arrive the CPU
   asm volatile ("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1360,6 +1374,7 @@ int main() {
 
   // wait some time for the IRQ to arrive the CPU
   asm volatile ("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1392,6 +1407,7 @@ int main() {
   neorv32_onewire_read_bit_blocking();
 
   // wait some time for the IRQ to arrive the CPU
+  asm volatile ("nop");
   asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1745,7 +1745,7 @@ void test_ok(void) {
  **************************************************************************/
 void test_fail(void) {
 
-  PRINT_CRITICAL("%c[1m[fail (%u)]%c[0m\n", 27, 27, cnt_test);
+  PRINT_CRITICAL("%c[1m[fail(%u)]%c[0m\n", 27, cnt_test, 27);
   cnt_fail++;
 }
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -69,7 +69,7 @@
 //** for simulation only! */
 #ifdef SUPPRESS_OPTIONAL_UART_PRINT
 //** print standard output to UART0 */
-#define PRINT_STANDARD(...) 
+#define PRINT_STANDARD(...)
 //** print critical output to UART1 */
 #define PRINT_CRITICAL(...) neorv32_uart1_printf(__VA_ARGS__)
 #else
@@ -129,7 +129,7 @@ int main() {
   uint8_t id;
 
   // disable machine-mode interrupts
-  neorv32_cpu_csr_clr(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE); 
+  neorv32_cpu_csr_clr(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE);
 
   // setup UARTs at default baud rate, no parity bits, no HW flow control
   neorv32_uart0_setup(BAUD_RATE, PARITY_NONE, FLOW_CONTROL_NONE);
@@ -252,7 +252,7 @@ int main() {
 
 
   // ----------------------------------------------------------
-  // Test fence instructions 
+  // Test fence instructions
   // ----------------------------------------------------------
   neorv32_cpu_csr_write(CSR_MCAUSE, mcause_never_c);
   PRINT_STANDARD("[%i] FENCE(.I) ", cnt_test);
@@ -385,7 +385,6 @@ int main() {
 
   // wait some time to have a nice "increment" (there should be NO increment at all!)
   asm volatile ("nop");
-  asm volatile ("nop");
 
   tmp_b = neorv32_cpu_csr_read(CSR_CYCLE);
 
@@ -443,7 +442,7 @@ int main() {
     neorv32_cpu_store_unsigned_word((uint32_t)EXT_MEM_BASE+4, 0x00008067); // ret (32-bit)
 
     // execute program
-    asm volatile("fence.i"); // flush i-cache
+    asm volatile ("fence.i"); // flush i-cache
     tmp_a = (uint32_t)EXT_MEM_BASE; // call the dummy sub program
     asm volatile ("jalr ra, %[input_i]" :  : [input_i] "r" (tmp_a));
 
@@ -506,7 +505,7 @@ int main() {
 
   // cycle CSR is read-only, but no actual write is performed because rs1=r0
   // -> should cause no exception
-  asm volatile("csrrs zero, cycle, zero");
+  asm volatile ("csrrs zero, cycle, zero");
 
   if (neorv32_cpu_csr_read(CSR_MCAUSE) == mcause_never_c) {
     test_ok();
@@ -529,7 +528,7 @@ int main() {
 
     // call unaligned address
     ((void (*)(void))ADDR_UNALIGNED_2)();
-    asm volatile("nop");
+    asm volatile ("nop");
 
     if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_I_MISALIGNED) {
       test_ok();
@@ -558,7 +557,7 @@ int main() {
   // jump to beginning of external memory minus 4 bytes
   // this will cause an instruction access fault as there is no module responding to the fetch request
   // the exception handler will try to resume at the instruction 4 bytes ahead, which is the "ret" we just created
-  asm volatile("fence.i"); // flush i-cache
+  asm volatile ("fence.i"); // flush i-cache
   tmp_a = ((uint32_t)EXT_MEM_BASE) - 4;
   asm volatile ("jalr ra, %[input_i]" :  : [input_i] "r" (tmp_a));
 
@@ -580,10 +579,8 @@ int main() {
   cnt_test++;
 
   // clear mstatus.mie and set mstatus.mpie
-  tmp_a = neorv32_cpu_csr_read(CSR_MSTATUS);
-  tmp_a &= ~(1 << CSR_MSTATUS_MIE);
-  tmp_a |=  (1 << CSR_MSTATUS_MPIE);
-  neorv32_cpu_csr_write(CSR_MSTATUS, tmp_a);
+  neorv32_cpu_csr_clr(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE);
+  neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_MPIE);
 
   // illegal 32-bit instruction (MRET with incorrect opcode)
   asm volatile (".align 4 \n"
@@ -597,6 +594,9 @@ int main() {
   else {
     test_fail();
   }
+
+  // reenable machine-mode interrupts
+  neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE);
 
 
   // ----------------------------------------------------------
@@ -637,7 +637,7 @@ int main() {
   if (NEORV32_SYSINFO.SOC & (1<<SYSINFO_SOC_IS_SIM)) {
     cnt_test++;
 
-    asm volatile("EBREAK");
+    asm volatile ("ebreak");
 
     if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_BREAKPOINT) {
       test_ok();
@@ -754,7 +754,7 @@ int main() {
   PRINT_STANDARD("[%i] ENVCALL M EXC ", cnt_test);
   cnt_test++;
 
-  asm volatile("ecall");
+  asm volatile ("ecall");
 
   if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_MENV_CALL) {
     test_ok();
@@ -774,7 +774,7 @@ int main() {
   // switch to user mode (hart will be back in MACHINE mode when trap handler returns)
   neorv32_cpu_goto_user_mode();
   {
-    asm volatile("ecall");
+    asm volatile ("ecall");
   }
 
   if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_UENV_CALL) {
@@ -799,7 +799,7 @@ int main() {
   neorv32_cpu_csr_write(CSR_MIE, 1 << CSR_MIE_MTIE);
 
   // wait some time for the IRQ to trigger and arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -828,7 +828,7 @@ int main() {
   sim_irq_trigger(1 << CSR_MIE_MSIE);
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
   sim_irq_trigger(0);
@@ -855,7 +855,7 @@ int main() {
   sim_irq_trigger(1 << CSR_MIE_MEIE);
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
   sim_irq_trigger(0);
@@ -901,17 +901,14 @@ int main() {
   PRINT_STANDARD("[%i] Pending IRQ (MTIME) ", cnt_test);
   cnt_test++;
 
-  // disable machine-mode interrupts
-  neorv32_cpu_csr_clr(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE);
-
-  // enable MTIME interrupt source
-  neorv32_cpu_csr_write(CSR_MIE, 1 << CSR_MIE_MTIE);
+  // disable all interrupt setting
+  neorv32_cpu_csr_write(CSR_MIE, 0);
 
   // fire MTIME IRQ
   neorv32_mtime_set_timecmp(0); // force interrupt
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   uint32_t was_pending = neorv32_cpu_csr_read(CSR_MIP) & (1 << CSR_MIP_MTIP); // should be pending now
 
@@ -926,10 +923,6 @@ int main() {
   else {
     test_fail();
   }
-
-  // restore interrupt enable setting
-  neorv32_cpu_csr_write(CSR_MIE, 0);
-  neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE);
 
 
   // ----------------------------------------------------------
@@ -947,7 +940,7 @@ int main() {
   neorv32_wdt_setup(1, 0, 0, 1);
 
   // wait in sleep mode for WDT interrupt
-  asm volatile("wfi");
+  asm volatile ("wfi");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
   NEORV32_WDT.CTRL = 0;
@@ -994,7 +987,7 @@ int main() {
   while(neorv32_uart0_tx_busy());
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1036,7 +1029,7 @@ int main() {
   while(neorv32_uart0_tx_busy());
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1075,7 +1068,7 @@ int main() {
   while(neorv32_uart1_tx_busy());
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1114,7 +1107,7 @@ int main() {
   while(neorv32_uart1_tx_busy());
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1147,7 +1140,7 @@ int main() {
   while(neorv32_spi_busy()); // wait for current transfer to finish
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1179,7 +1172,7 @@ int main() {
   neorv32_twi_start_trans(0xA5);
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1215,7 +1208,7 @@ int main() {
   neorv32_gpio_port_set(3);
 
   // wait for IRQs to arrive CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1249,7 +1242,7 @@ int main() {
   neorv32_neoled_write_nonblocking(0);
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1276,7 +1269,6 @@ int main() {
   neorv32_cpu_csr_write(CSR_MIE, 1 << SLINK_RX_FIRQ_ENABLE);
 
   tmp_b = neorv32_slink_get_fifo_depth(0) + neorv32_slink_get_fifo_depth(1);
-  
   tmp_a = 0; // error counter
 
   // send data words via link 0 to fill TX and RX FIFOs
@@ -1286,7 +1278,7 @@ int main() {
   }
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1330,7 +1322,7 @@ int main() {
   tmp_a += neorv32_slink_tx(0, 0xACCABDDB, 0);
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1367,7 +1359,7 @@ int main() {
   neorv32_gptmr_setup(CLK_PRSC_2, 0, 2);
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1400,7 +1392,7 @@ int main() {
   neorv32_onewire_read_bit_blocking();
 
   // wait some time for the IRQ to arrive the CPU
-  asm volatile("nop");
+  asm volatile ("nop");
 
   neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1438,9 +1430,7 @@ int main() {
 
   // clear mstatus.TW to allow execution of WFI also in user-mode
   // clear mstatus.MIE and mstatus.MPIE to check if IRQ can still trigger in User-mode
-  tmp_a = neorv32_cpu_csr_read(CSR_MSTATUS);
-  tmp_a &= ~((1<<CSR_MSTATUS_TW) | (1<<CSR_MSTATUS_MIE) | (1<<CSR_MSTATUS_MPIE));
-  neorv32_cpu_csr_write(CSR_MSTATUS, tmp_a);
+  neorv32_cpu_csr_clr(CSR_MSTATUS, (1<<CSR_MSTATUS_TW) | (1<<CSR_MSTATUS_MIE) | (1<<CSR_MSTATUS_MPIE));
 
   // put CPU into sleep mode (from user mode)
   neorv32_cpu_goto_user_mode();
@@ -1466,7 +1456,7 @@ int main() {
   cnt_test++;
 
   // set mstatus.TW to disallow execution of WFI in user-mode
-  neorv32_cpu_csr_write(CSR_MSTATUS, neorv32_cpu_csr_read(CSR_MSTATUS) | (1<<CSR_MSTATUS_TW));
+  neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_TW);
 
   // put CPU into sleep mode (from user mode)
   neorv32_cpu_goto_user_mode();
@@ -1610,16 +1600,12 @@ int main() {
     cnt_test++;
 
     // make M-mode load/store accesses use U-mode rights
-    tmp_b = neorv32_cpu_csr_read(CSR_MSTATUS);
-    tmp_b |= 1 << CSR_MSTATUS_MPRV; // set MPRV: M uses U permissions for load/stores
-    tmp_b &= ~(3 << CSR_MSTATUS_MPP_L); // clear MPP: use U as effective privilege mode
-    neorv32_cpu_csr_write(CSR_MSTATUS, tmp_b);
+    neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_MPRV); // set MPRV: M uses U permissions for load/stores
+    neorv32_cpu_csr_clr(CSR_MSTATUS, 3 << CSR_MSTATUS_MPP_L); // clear MPP: use U as effective privilege mode
 
     neorv32_cpu_store_unsigned_word((uint32_t)(&pmp_access_addr), 0); // store access -> should fail
 
-    tmp_b = neorv32_cpu_csr_read(CSR_MSTATUS);
-    tmp_b &= ~(1 << CSR_MSTATUS_MPRV);
-    neorv32_cpu_csr_write(CSR_MSTATUS, tmp_b);
+    neorv32_cpu_csr_clr(CSR_MSTATUS, 1 << CSR_MSTATUS_MPRV);
 
     if ((neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_S_ACCESS) && (pmp_access_addr == 0xcafe1234)) {
       test_ok();
@@ -1722,8 +1708,7 @@ void global_trap_handler(void) {
   }
 
   // hack: always come back in MACHINE MODE
-  uint32_t mask = (1<<CSR_MSTATUS_MPP_H) | (1<<CSR_MSTATUS_MPP_L);
-  asm volatile ("csrrs zero, mstatus, %[input_j]" :  : [input_j] "r" (mask));
+  neorv32_cpu_csr_set(CSR_MSTATUS, (1<<CSR_MSTATUS_MPP_H) | (1<<CSR_MSTATUS_MPP_L));
 }
 
 


### PR DESCRIPTION
* cleanup CPU's trap controller VHDL code
* fix `mip` CSR: bits in this register can now become set when the according interrupt source fire without the according `mie` CSR bit being set (RISC-V compatibility)