### PR TITLE
[rtl] CPU: use record as main control bus type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 10.02.2023 | 1.8.0.4 | replace CPU-internal control bus by a VHDL `record` (much cleaner code); minor control optimizations; add 6ht CPU co-processor slot (yet unused); [#489](https://github.com/stnolting/neorv32/pull/489) |
 | 05.02.2023 | 1.8.0.3 | CPU control optimizations; [#487](https://github.com/stnolting/neorv32/pull/487) |
 | 04.02.2023 | 1.8.0.2 | fix RISC-V-incompatible behavior of `mip` CSR; [#486](https://github.com/stnolting/neorv32/pull/486) |
 | 01.02.2023 | 1.8.0.1 | clean-up CPU's interrupt controller; fix race condition in FIRQ trigger/acknowledge; [#484](https://github.com/stnolting/neorv32/pull/484) |

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -31,7 +31,7 @@
 -- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
 -- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
 -- # ********************************************************************************************* #
--- # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+-- # The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32       (c) Stephan Nolting #
 -- #################################################################################################
 
 library ieee;
@@ -58,7 +58,7 @@ entity neorv32_cpu_alu is
     -- global control --
     clk_i       : in  std_ulogic; -- global clock, rising edge
     rstn_i      : in  std_ulogic; -- global reset, low-active, async
-    ctrl_i      : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
+    ctrl_i      : in  ctrl_bus_t; -- main control bus
     -- data input --
     rs1_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
     rs2_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
@@ -72,7 +72,8 @@ entity neorv32_cpu_alu is
     add_o       : out std_ulogic_vector(XLEN-1 downto 0); -- address computation result
     fpu_flags_o : out std_ulogic_vector(4 downto 0); -- FPU exception flags
     -- status --
-    idone_o     : out std_ulogic -- iterative processing units done?
+    exc_o       : out std_ulogic; -- ALU exception
+    cp_done_o   : out std_ulogic  -- co-processor operation done?
   );
 end neorv32_cpu_alu;
 
@@ -100,8 +101,8 @@ begin
 
   -- Comparator Unit (for conditional branches) ---------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  cmp_rs1 <= (rs1_i(rs1_i'left) and (not ctrl_i(ctrl_alu_unsigned_c))) & rs1_i; -- optional sign-extension
-  cmp_rs2 <= (rs2_i(rs2_i'left) and (not ctrl_i(ctrl_alu_unsigned_c))) & rs2_i; -- optional sign-extension
+  cmp_rs1 <= (rs1_i(rs1_i'left) and (not ctrl_i.alu_unsigned)) & rs1_i; -- optional sign-extension
+  cmp_rs2 <= (rs2_i(rs2_i'left) and (not ctrl_i.alu_unsigned)) & rs2_i; -- optional sign-extension
 
   cmp(cmp_equal_c) <= '1' when (rs1_i = rs2_i) else '0';
   cmp(cmp_less_c)  <= '1' when (signed(cmp_rs1) < signed(cmp_rs2)) else '0'; -- signed or unsigned comparison
@@ -110,8 +111,8 @@ begin
 
   -- ALU Input Operand Select ---------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  opa <= pc_i  when (ctrl_i(ctrl_alu_opa_mux_c) = '1') else rs1_i;
-  opb <= imm_i when (ctrl_i(ctrl_alu_opb_mux_c) = '1') else rs2_i;
+  opa <= pc_i  when (ctrl_i.alu_opa_mux = '1') else rs1_i;
+  opb <= imm_i when (ctrl_i.alu_opb_mux = '1') else rs2_i;
 
 
   -- Adder/Subtracter Core ------------------------------------------------------------------
@@ -120,10 +121,10 @@ begin
     variable opa_v, opb_v : std_ulogic_vector(XLEN downto 0);
   begin
     -- operand sign-extension --
-    opa_v := (opa(opa'left) and (not ctrl_i(ctrl_alu_unsigned_c))) & opa;
-    opb_v := (opb(opb'left) and (not ctrl_i(ctrl_alu_unsigned_c))) & opb;
+    opa_v := (opa(opa'left) and (not ctrl_i.alu_unsigned)) & opa;
+    opb_v := (opb(opb'left) and (not ctrl_i.alu_unsigned)) & opb;
     -- add/sub(slt) select --
-    if (ctrl_i(ctrl_alu_op0_c) = '1') then
+    if (ctrl_i.alu_op(0) = '1') then
       addsub_res <= std_ulogic_vector(unsigned(opa_v) - unsigned(opb_v));
     else
       addsub_res <= std_ulogic_vector(unsigned(opa_v) + unsigned(opb_v));
@@ -138,7 +139,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   alu_core: process(ctrl_i, addsub_res, cp_res, rs1_i, opb)
   begin
-    case ctrl_i(ctrl_alu_op2_c downto ctrl_alu_op0_c) is
+    case ctrl_i.alu_op is
       when alu_op_add_c  => res_o <= addsub_res(XLEN-1 downto 0); -- default
       when alu_op_sub_c  => res_o <= addsub_res(XLEN-1 downto 0);
       when alu_op_cp_c   => res_o <= cp_res;
@@ -156,13 +157,18 @@ begin
   -- ALU Co-Processors
   -- **************************************************************************************************************************
 
+  -- Co-Processor Control -------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  -- ALU processing exception --
+  exc_o <= '0'; -- not used yet
+
   -- co-processor select / start trigger --
   -- > "cp_start" is high for one cycle to trigger operation of the according co-processor
-  cp_start(4 downto 0) <= ctrl_i(ctrl_cp_trig4_c downto ctrl_cp_trig0_c);
+  cp_start(4 downto 0) <= ctrl_i.alu_cp_trig;
 
   -- (iterative) co-processor operation done? --
   -- > "cp_valid" signal has to be set (for one cycle) one cycle before CP output data (cp_result) is valid
-  idone_o <= cp_valid(0) or cp_valid(1) or cp_valid(2) or cp_valid(3) or cp_valid(4);
+  cp_done_o <= cp_valid(0) or cp_valid(1) or cp_valid(2) or cp_valid(3) or cp_valid(4);
 
   -- co-processor result --
   -- > "cp_result" data has to be always zero unless the specific co-processor has been actually triggered

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -92,10 +92,10 @@ architecture neorv32_cpu_cpu_rtl of neorv32_cpu_alu is
   signal cp_res     : std_ulogic_vector(XLEN-1 downto 0);
 
   -- co-processor interface --
-  type cp_data_if_t  is array (0 to 4) of std_ulogic_vector(XLEN-1 downto 0);
+  type cp_data_if_t  is array (0 to 5) of std_ulogic_vector(XLEN-1 downto 0);
   signal cp_result : cp_data_if_t; -- co-processor result
-  signal cp_start  : std_ulogic_vector(4 downto 0); -- trigger co-processor
-  signal cp_valid  : std_ulogic_vector(4 downto 0); -- co-processor done
+  signal cp_start  : std_ulogic_vector(5 downto 0); -- trigger co-processor
+  signal cp_valid  : std_ulogic_vector(5 downto 0); -- co-processor done
 
 begin
 
@@ -164,15 +164,15 @@ begin
 
   -- co-processor select / start trigger --
   -- > "cp_start" is high for one cycle to trigger operation of the according co-processor
-  cp_start(4 downto 0) <= ctrl_i.alu_cp_trig;
+  cp_start(5 downto 0) <= ctrl_i.alu_cp_trig;
 
   -- (iterative) co-processor operation done? --
   -- > "cp_valid" signal has to be set (for one cycle) one cycle before CP output data (cp_result) is valid
-  cp_done_o <= cp_valid(0) or cp_valid(1) or cp_valid(2) or cp_valid(3) or cp_valid(4);
+  cp_done_o <= cp_valid(0) or cp_valid(1) or cp_valid(2) or cp_valid(3) or cp_valid(4) or cp_valid(5);
 
   -- co-processor result --
   -- > "cp_result" data has to be always zero unless the specific co-processor has been actually triggered
-  cp_res <= cp_result(0) or cp_result(1) or cp_result(2) or cp_result(3) or cp_result(4);
+  cp_res <= cp_result(0) or cp_result(1) or cp_result(2) or cp_result(3) or cp_result(4) or cp_result(5);
 
 
   -- Co-Processor 0: Shifter Unit ('I'/'E' Base ISA) ----------------------------------------
@@ -326,6 +326,12 @@ begin
     cp_result(4) <= (others => '0');
     cp_valid(4)  <= '0';
   end generate;
+
+
+  -- Co-Processor 5: Reserved ---------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  cp_result(5) <= (others => '0');
+  cp_valid(5)  <= '0';
 
 
 end neorv32_cpu_cpu_rtl;

--- a/rtl/core/neorv32_cpu_cp_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_cp_bitmanip.vhd
@@ -38,7 +38,7 @@
 -- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
 -- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
 -- # ********************************************************************************************* #
--- # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+-- # The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32       (c) Stephan Nolting #
 -- #################################################################################################
 
 library ieee;
@@ -57,7 +57,7 @@ entity neorv32_cpu_cp_bitmanip is
     -- global control --
     clk_i   : in  std_ulogic; -- global clock, rising edge
     rstn_i  : in  std_ulogic; -- global reset, low-active, async
-    ctrl_i  : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
+    ctrl_i  : in  ctrl_bus_t; -- main control bus
     start_i : in  std_ulogic; -- trigger operation
     -- data input --
     cmp_i   : in  std_ulogic_vector(1 downto 0); -- comparator status
@@ -186,40 +186,40 @@ begin
   -- A more precise decoding as well as a valid-instruction-check is performed by the CPU control unit.
 
   -- Zbb - Basic bit-manipulation instructions --
-  cmd(op_andn_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "10") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_1_c downto ctrl_ir_funct3_0_c) = "11") else '0';
-  cmd(op_orn_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "10") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_1_c downto ctrl_ir_funct3_0_c) = "10") else '0';
-  cmd(op_xnor_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "10") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_1_c downto ctrl_ir_funct3_0_c) = "00") else '0';
+  cmd(op_andn_c)   <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(1 downto 0) = "11") else '0';
+  cmd(op_orn_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(1 downto 0) = "10") else '0';
+  cmd(op_xnor_c)   <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(1 downto 0) = "00") else '0';
   --
-  cmd(op_max_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "00") and (ctrl_i(ctrl_ir_funct12_5_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_1_c) = "11") else '0';
-  cmd(op_min_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "00") and (ctrl_i(ctrl_ir_funct12_5_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_1_c) = "10") else '0';
-  cmd(op_zexth_c)  <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "00") and (ctrl_i(ctrl_ir_funct12_5_c) = '0') else '0';
+  cmd(op_max_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '1') and (ctrl_i.ir_funct3(2 downto 1) = "11") else '0';
+  cmd(op_min_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '1') and (ctrl_i.ir_funct3(2 downto 1) = "10") else '0';
+  cmd(op_zexth_c)  <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '0') else '0';
   --
-  cmd(op_orcb_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "01") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_0_c) = "101") else '0';
+  cmd(op_orcb_c)   <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2 downto 0) = "101") else '0';
   --
-  cmd(op_clz_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "000") and (ctrl_i(ctrl_ir_opcode7_5_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') else '0';
-  cmd(op_ctz_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "001") and (ctrl_i(ctrl_ir_opcode7_5_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') else '0';
-  cmd(op_cpop_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "010") and (ctrl_i(ctrl_ir_opcode7_5_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') else '0';
-  cmd(op_sextb_c)  <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "100") and (ctrl_i(ctrl_ir_opcode7_5_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') else '0';
-  cmd(op_sexth_c)  <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct12_2_c downto ctrl_ir_funct12_0_c) = "101") and (ctrl_i(ctrl_ir_opcode7_5_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') else '0';
-  cmd(op_rol_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c  downto ctrl_ir_funct3_0_c)  = "001") and (ctrl_i(ctrl_ir_opcode7_5_c) = '1') else '0';
-  cmd(op_ror_c)    <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c  downto ctrl_ir_funct3_0_c)  = "101") and                                         (ctrl_i(ctrl_ir_funct3_2_c) = '1') else '0';
-  cmd(op_rev8_c)   <= '1' when (zbb_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c  downto ctrl_ir_funct3_0_c)  = "101") else '0';
+  cmd(op_clz_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "000") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_ctz_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "001") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_cpop_c)   <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "010") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_sextb_c)  <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "100") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_sexth_c)  <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "101") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_rol_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(02 downto 0) = "001") and (ctrl_i.ir_opcode(5) = '1') else '0';
+  cmd(op_ror_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(02 downto 0) = "101") and                                 (ctrl_i.ir_funct3(2) = '1') else '0';
+  cmd(op_rev8_c)   <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(02 downto 0) = "101") else '0';
 
   -- Zba - Address generation instructions --
-  cmd(op_sh1add_c) <= '1' when (zba_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "01") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_1_c) = "01") else '0';
-  cmd(op_sh2add_c) <= '1' when (zba_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "01") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_1_c) = "10") else '0';
-  cmd(op_sh3add_c) <= '1' when (zba_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "01") and (ctrl_i(ctrl_ir_funct12_7_c) = '0') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_1_c) = "11") else '0';
+  cmd(op_sh1add_c) <= '1' when (zba_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(2 downto 1) = "01") else '0';
+  cmd(op_sh2add_c) <= '1' when (zba_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(2 downto 1) = "10") else '0';
+  cmd(op_sh3add_c) <= '1' when (zba_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(2 downto 1) = "11") else '0';
 
   -- Zbs - Single-bit instructions --
-  cmd(op_bclr_c)   <= '1' when (zbs_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "10") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') else '0';
-  cmd(op_bext_c)   <= '1' when (zbs_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "10") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c) = '1') else '0';
-  cmd(op_binv_c)   <= '1' when (zbs_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "11") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') else '0';
-  cmd(op_bset_c)   <= '1' when (zbs_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "01") and (ctrl_i(ctrl_ir_funct12_7_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c) = '0') else '0';
+  cmd(op_bclr_c)   <= '1' when (zbs_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_bext_c)   <= '1' when (zbs_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2) = '1') else '0';
+  cmd(op_binv_c)   <= '1' when (zbs_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_bset_c)   <= '1' when (zbs_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2) = '0') else '0';
 
   -- Zbc - Carry-less multiplication instructions --
-  cmd(op_clmul_c)  <= '1' when (zbc_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "00") and (ctrl_i(ctrl_ir_funct12_5_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_0_c) = "001") else '0';
-  cmd(op_clmulh_c) <= '1' when (zbc_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "00") and (ctrl_i(ctrl_ir_funct12_5_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_0_c) = "011") else '0';
-  cmd(op_clmulr_c) <= '1' when (zbc_en_c = true) and (ctrl_i(ctrl_ir_funct12_10_c downto ctrl_ir_funct12_9_c) = "00") and (ctrl_i(ctrl_ir_funct12_5_c) = '1') and (ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_0_c) = "010") else '0';
+  cmd(op_clmul_c)  <= '1' when (zbc_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '1') and (ctrl_i.ir_funct3(2 downto 0) = "001") else '0';
+  cmd(op_clmulh_c) <= '1' when (zbc_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '1') and (ctrl_i.ir_funct3(2 downto 0) = "011") else '0';
+  cmd(op_clmulr_c) <= '1' when (zbc_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '1') and (ctrl_i.ir_funct3(2 downto 0) = "010") else '0';
 
 
   -- Co-Processor Controller ----------------------------------------------------------------
@@ -275,7 +275,7 @@ begin
 
         when S_BUSY_SHIFT => -- wait for multi-cycle shift operation to finish
         -- ------------------------------------------------------------
-          if (shifter.run = '0') or (ctrl_i(ctrl_trap_c) = '1') then -- abort on trap
+          if (shifter.run = '0') or (ctrl_i.cpu_trap = '1') then -- abort on trap
             valid      <= '1';
             ctrl_state <= S_IDLE;
           end if;
@@ -286,7 +286,7 @@ begin
 
         when S_BUSY_CLMUL => -- wait for multi-cycle clmul operation to finish
         -- ------------------------------------------------------------
-          if (clmul.busy = '0') or (ctrl_i(ctrl_trap_c) = '1') then -- abort on trap
+          if (clmul.busy = '0') or (ctrl_i.cpu_trap = '1') then -- abort on trap
             valid      <= '1';
             ctrl_state <= S_IDLE;
           end if;
@@ -399,7 +399,7 @@ begin
   shift_adder: process(rs1_reg, rs2_reg, ctrl_i)
     variable opb_v : std_ulogic_vector(XLEN-1 downto 0);
   begin
-    case ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_1_c) is
+    case ctrl_i.ir_funct3(2 downto 1) is
       when "01"   => opb_v := rs1_reg(rs1_reg'left-1 downto 0) & '0';   -- << 1
       when "10"   => opb_v := rs1_reg(rs1_reg'left-2 downto 0) & "00";  -- << 2
       when others => opb_v := rs1_reg(rs1_reg'left-3 downto 0) & "000"; -- << 3

--- a/rtl/core/neorv32_cpu_cp_cfu.vhd
+++ b/rtl/core/neorv32_cpu_cp_cfu.vhd
@@ -34,7 +34,7 @@
 -- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
 -- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
 -- # ********************************************************************************************* #
--- # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+-- # The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32       (c) Stephan Nolting #
 -- #################################################################################################
 
 library ieee;
@@ -52,7 +52,7 @@ entity neorv32_cpu_cp_cfu is
     -- global control --
     clk_i   : in  std_ulogic; -- global clock, rising edge
     rstn_i  : in  std_ulogic; -- global reset, low-active, async
-    ctrl_i  : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
+    ctrl_i  : in  ctrl_bus_t; -- main control bus
     start_i : in  std_ulogic; -- trigger operation
     -- data input --
     rs1_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
@@ -122,7 +122,7 @@ begin
           control.busy <= '1';
         end if;
       else -- busy
-        if (control.done = '1') or (ctrl_i(ctrl_trap_c) = '1') then -- processing done? abort if trap (exception)
+        if (control.done = '1') or (ctrl_i.cpu_trap = '1') then -- processing done? abort if trap (exception)
           res_o        <= control.result; -- output result for just one cycle, CFU output has to be all-zero otherwise
           control.busy <= '0';
         end if;
@@ -134,9 +134,9 @@ begin
   valid_o <= control.busy and control.done; -- set one cycle before result data
 
   -- pack user-defined instruction type/function bits --
-  control.rtype  <= ctrl_i(ctrl_ir_opcode7_6_c  downto ctrl_ir_opcode7_5_c);
-  control.funct3 <= ctrl_i(ctrl_ir_funct3_2_c   downto ctrl_ir_funct3_0_c);
-  control.funct7 <= ctrl_i(ctrl_ir_funct12_11_c downto ctrl_ir_funct12_5_c);
+  control.rtype  <= ctrl_i.ir_opcode(6 downto 5);
+  control.funct3 <= ctrl_i.ir_funct3;
+  control.funct7 <= ctrl_i.ir_funct12(11 downto 5);
 
 
 -- ****************************************************************************************************************************

--- a/rtl/core/neorv32_cpu_cp_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_cp_muldiv.vhd
@@ -7,7 +7,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -33,7 +33,7 @@
 -- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
 -- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
 -- # ********************************************************************************************* #
--- # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+-- # The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32       (c) Stephan Nolting #
 -- #################################################################################################
 
 library ieee;
@@ -53,7 +53,7 @@ entity neorv32_cpu_cp_muldiv is
     -- global control --
     clk_i   : in  std_ulogic; -- global clock, rising edge
     rstn_i  : in  std_ulogic; -- global reset, low-active, async
-    ctrl_i  : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
+    ctrl_i  : in  ctrl_bus_t; -- main control bus
     start_i : in  std_ulogic; -- trigger operation
     -- data input --
     rs1_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
@@ -166,7 +166,7 @@ begin
 
         when S_BUSY => -- processing
           ctrl.cnt <= std_ulogic_vector(unsigned(ctrl.cnt) - 1);
-          if (or_reduce_f(ctrl.cnt) = '0') or (ctrl_i(ctrl_trap_c) = '1') then -- abort on trap
+          if (or_reduce_f(ctrl.cnt) = '0') or (ctrl_i.cpu_trap = '1') then -- abort on trap
             ctrl.state <= S_DONE;
           end if;
 
@@ -184,8 +184,8 @@ begin
   valid_o <= '1' when (ctrl.state = S_DONE) else '0';
 
   -- co-processor operation --
-  ctrl.cp_op <= ctrl_i(ctrl_ir_funct3_2_c downto ctrl_ir_funct3_0_c);
-  ctrl.op    <= '1' when (ctrl_i(ctrl_ir_funct3_2_c) = '1') else '0';
+  ctrl.cp_op <= ctrl_i.ir_funct3;
+  ctrl.op    <= '1' when (ctrl_i.ir_funct3(2) = '1') else '0';
 
   -- input operands treated as signed? --
   ctrl.rs1_is_signed <= '1' when (ctrl.cp_op = cp_op_mulh_c) or (ctrl.cp_op = cp_op_mulhsu_c) or

--- a/rtl/core/neorv32_cpu_decompressor.vhd
+++ b/rtl/core/neorv32_cpu_decompressor.vhd
@@ -29,7 +29,7 @@
 -- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
 -- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
 -- # ********************************************************************************************* #
--- # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+-- # The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32       (c) Stephan Nolting #
 -- #################################################################################################
 
 library ieee;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -761,7 +761,7 @@ package neorv32_package is
     alu_opb_mux   : std_ulogic;                     -- operand B select (0=rs2, 1=IMM)
     alu_unsigned  : std_ulogic;                     -- is unsigned ALU operation
     alu_frm       : std_ulogic_vector(02 downto 0); -- FPU rounding mode
-    alu_cp_trig   : std_ulogic_vector(04 downto 0); -- trigger CP (one-hot)
+    alu_cp_trig   : std_ulogic_vector(05 downto 0); -- trigger CP (one-hot)
     -- bus interface --
     bus_req       : std_ulogic;                     -- trigger memory request
     bus_mo_we     : std_ulogic;                     -- memory address and data output register write enable
@@ -819,6 +819,7 @@ package neorv32_package is
   constant cp_sel_bitmanip_c : natural := 2; -- CP2: bit manipulation ('B' extensions)
   constant cp_sel_fpu_c      : natural := 3; -- CP3: floating-point unit ('Zfinx' extension)
   constant cp_sel_cfu_c      : natural := 4; -- CP4: custom instructions CFU ('Zxcfu' extension)
+--constant cp_sel_???_c      : natural := 5; -- CP5: reserved
 
   -- ALU Function Codes [DO NOT CHANGE ENCODING!] -------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@
 -- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
 -- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
 -- # ********************************************************************************************* #
--- # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
+-- # The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32       (c) Stephan Nolting #
 -- #################################################################################################
 
 library ieee;
@@ -62,7 +62,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080003"; -- NEORV32 version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080004"; -- NEORV32 version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -746,83 +746,66 @@ package neorv32_package is
 
   -- Main CPU Control Bus -------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  -- register file --
-  constant ctrl_rf_wb_en_c      : natural :=  0; -- write back enable
-  constant ctrl_rf_rs1_adr0_c   : natural :=  1; -- source register 1 address bit 0
-  constant ctrl_rf_rs1_adr1_c   : natural :=  2; -- source register 1 address bit 1
-  constant ctrl_rf_rs1_adr2_c   : natural :=  3; -- source register 1 address bit 2
-  constant ctrl_rf_rs1_adr3_c   : natural :=  4; -- source register 1 address bit 3
-  constant ctrl_rf_rs1_adr4_c   : natural :=  5; -- source register 1 address bit 4
-  constant ctrl_rf_rs2_adr0_c   : natural :=  6; -- source register 2 address bit 0
-  constant ctrl_rf_rs2_adr1_c   : natural :=  7; -- source register 2 address bit 1
-  constant ctrl_rf_rs2_adr2_c   : natural :=  8; -- source register 2 address bit 2
-  constant ctrl_rf_rs2_adr3_c   : natural :=  9; -- source register 2 address bit 3
-  constant ctrl_rf_rs2_adr4_c   : natural := 10; -- source register 2 address bit 4
-  constant ctrl_rf_rs3_adr0_c   : natural := 11; -- source register 3 address bit 0
-  constant ctrl_rf_rs3_adr1_c   : natural := 12; -- source register 3 address bit 1
-  constant ctrl_rf_rs3_adr2_c   : natural := 13; -- source register 3 address bit 2
-  constant ctrl_rf_rs3_adr3_c   : natural := 14; -- source register 3 address bit 3
-  constant ctrl_rf_rs3_adr4_c   : natural := 15; -- source register 3 address bit 4
-  constant ctrl_rf_rd_adr0_c    : natural := 16; -- destination register address bit 0
-  constant ctrl_rf_rd_adr1_c    : natural := 17; -- destination register address bit 1
-  constant ctrl_rf_rd_adr2_c    : natural := 18; -- destination register address bit 2
-  constant ctrl_rf_rd_adr3_c    : natural := 19; -- destination register address bit 3
-  constant ctrl_rf_rd_adr4_c    : natural := 20; -- destination register address bit 4
-  constant ctrl_rf_mux0_c       : natural := 21; -- input source select lsb
-  constant ctrl_rf_mux1_c       : natural := 22; -- input source select msb
-  constant ctrl_rf_zero_we_c    : natural := 23; -- allow/force write access to x0
-  -- alu --
-  constant ctrl_alu_op0_c       : natural := 24; -- ALU operation select bit 0
-  constant ctrl_alu_op1_c       : natural := 25; -- ALU operation select bit 1
-  constant ctrl_alu_op2_c       : natural := 26; -- ALU operation select bit 2
-  constant ctrl_alu_opa_mux_c   : natural := 27; -- operand A select (0=rs1, 1=PC)
-  constant ctrl_alu_opb_mux_c   : natural := 28; -- operand B select (0=rs2, 1=IMM)
-  constant ctrl_alu_unsigned_c  : natural := 29; -- is unsigned ALU operation
-  constant ctrl_alu_frm0_c      : natural := 30; -- FPU rounding mode bit 0
-  constant ctrl_alu_frm1_c      : natural := 31; -- FPU rounding mode bit 1
-  constant ctrl_alu_frm2_c      : natural := 32; -- FPU rounding mode bit 2
-  -- alu co-processor trigger (one-hot selection) --
-  constant ctrl_cp_trig0_c      : natural := 33; -- trigger CP0
-  constant ctrl_cp_trig1_c      : natural := 34; -- trigger CP1
-  constant ctrl_cp_trig2_c      : natural := 35; -- trigger CP2
-  constant ctrl_cp_trig3_c      : natural := 36; -- trigger CP3
-  constant ctrl_cp_trig4_c      : natural := 37; -- trigger CP4
-  -- bus interface --
-  constant ctrl_bus_req_c       : natural := 38; -- trigger memory request
-  constant ctrl_bus_mo_we_c     : natural := 39; -- memory address and data output register write enable
-  constant ctrl_bus_fence_c     : natural := 40; -- fence operation
-  constant ctrl_bus_fencei_c    : natural := 41; -- fence.i operation
-  constant ctrl_bus_priv_c      : natural := 42; -- effective privilege level for load/store
-  -- instruction word control blocks --
-  constant ctrl_ir_funct3_0_c   : natural := 43; -- funct3 bit 0
-  constant ctrl_ir_funct3_1_c   : natural := 44; -- funct3 bit 1
-  constant ctrl_ir_funct3_2_c   : natural := 45; -- funct3 bit 2
-  constant ctrl_ir_funct12_0_c  : natural := 46; -- funct12 bit 0
-  constant ctrl_ir_funct12_1_c  : natural := 47; -- funct12 bit 1
-  constant ctrl_ir_funct12_2_c  : natural := 48; -- funct12 bit 2
-  constant ctrl_ir_funct12_3_c  : natural := 49; -- funct12 bit 3
-  constant ctrl_ir_funct12_4_c  : natural := 50; -- funct12 bit 4
-  constant ctrl_ir_funct12_5_c  : natural := 51; -- funct12 bit 5
-  constant ctrl_ir_funct12_6_c  : natural := 52; -- funct12 bit 6
-  constant ctrl_ir_funct12_7_c  : natural := 53; -- funct12 bit 7
-  constant ctrl_ir_funct12_8_c  : natural := 54; -- funct12 bit 8
-  constant ctrl_ir_funct12_9_c  : natural := 55; -- funct12 bit 9
-  constant ctrl_ir_funct12_10_c : natural := 56; -- funct12 bit 10
-  constant ctrl_ir_funct12_11_c : natural := 57; -- funct12 bit 11
-  constant ctrl_ir_opcode7_0_c  : natural := 58; -- opcode7 bit 0
-  constant ctrl_ir_opcode7_1_c  : natural := 59; -- opcode7 bit 1
-  constant ctrl_ir_opcode7_2_c  : natural := 60; -- opcode7 bit 2
-  constant ctrl_ir_opcode7_3_c  : natural := 61; -- opcode7 bit 3
-  constant ctrl_ir_opcode7_4_c  : natural := 62; -- opcode7 bit 4
-  constant ctrl_ir_opcode7_5_c  : natural := 63; -- opcode7 bit 5
-  constant ctrl_ir_opcode7_6_c  : natural := 64; -- opcode7 bit 6
-  -- cpu status --
-  constant ctrl_priv_mode_c     : natural := 65; -- effective privilege mode
-  constant ctrl_sleep_c         : natural := 66; -- set when CPU is in sleep mode
-  constant ctrl_trap_c          : natural := 67; -- set when CPU is entering trap execution
-  constant ctrl_debug_running_c : natural := 68; -- set when CPU is in debug mode
-  -- control bus size --
-  constant ctrl_width_c         : natural := 69; -- control bus size
+  type ctrl_bus_t is record
+    -- register file --
+    rf_wb_en      : std_ulogic; -- write back enable
+    rf_rs1        : std_ulogic_vector(04 downto 0); -- source register 1 address
+    rf_rs2        : std_ulogic_vector(04 downto 0); -- source register 2 address
+    rf_rs3        : std_ulogic_vector(04 downto 0); -- source register 3 address
+    rf_rd         : std_ulogic_vector(04 downto 0); -- destination register address
+    rf_mux        : std_ulogic_vector(01 downto 0); -- input source select
+    rf_zero_we    : std_ulogic;                     -- allow/force write access to x0
+    -- alu --
+    alu_op        : std_ulogic_vector(02 downto 0); -- ALU operation select
+    alu_opa_mux   : std_ulogic;                     -- operand A select (0=rs1, 1=PC)
+    alu_opb_mux   : std_ulogic;                     -- operand B select (0=rs2, 1=IMM)
+    alu_unsigned  : std_ulogic;                     -- is unsigned ALU operation
+    alu_frm       : std_ulogic_vector(02 downto 0); -- FPU rounding mode
+    alu_cp_trig   : std_ulogic_vector(04 downto 0); -- trigger CP (one-hot)
+    -- bus interface --
+    bus_req       : std_ulogic;                     -- trigger memory request
+    bus_mo_we     : std_ulogic;                     -- memory address and data output register write enable
+    bus_fence     : std_ulogic;                     -- fence operation
+    bus_fencei    : std_ulogic;                     -- fence.i operation
+    bus_priv      : std_ulogic;                     -- effective privilege level for load/store
+    -- instruction word bit fields --
+    ir_funct3     : std_ulogic_vector(02 downto 0); -- funct3 bit-field
+    ir_funct12    : std_ulogic_vector(11 downto 0); -- funct12 bit-field
+    ir_opcode     : std_ulogic_vector(06 downto 0); -- opcode bit-field
+    -- cpu status --
+    cpu_priv      : std_ulogic;                     -- effective privilege mode
+    cpu_sleep     : std_ulogic;                     -- set when CPU is in sleep mode
+    cpu_trap      : std_ulogic;                     -- set when CPU is entering trap exec
+    cpu_debug     : std_ulogic;                     -- set when CPU is in debug mode
+  end record;
+
+  constant ctrl_bus_zero_c : ctrl_bus_t := (
+    rf_wb_en      => '0',
+    rf_rs1        => (others => '0'),
+    rf_rs2        => (others => '0'),
+    rf_rs3        => (others => '0'),
+    rf_rd         => (others => '0'),
+    rf_mux        => (others => '0'),
+    rf_zero_we    => '0',
+    alu_op        => (others => '0'),
+    alu_opa_mux   => '0',
+    alu_opb_mux   => '0',
+    alu_unsigned  => '0',
+    alu_frm       => (others => '0'),
+    alu_cp_trig   => (others => '0'),
+    bus_req       => '0',
+    bus_mo_we     => '0',
+    bus_fence     => '0',
+    bus_fencei    => '0',
+    bus_priv      => '0',
+    ir_funct3     => (others => '0'),
+    ir_funct12    => (others => '0'),
+    ir_opcode     => (others => '0'),
+    cpu_priv      => '0',
+    cpu_sleep     => '0',
+    cpu_trap      => '0',
+    cpu_debug     => '0'
+  );
 
   -- Comparator Bus -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -1254,7 +1237,7 @@ package neorv32_package is
       -- global control --
       clk_i         : in  std_ulogic; -- global clock, rising edge
       rstn_i        : in  std_ulogic; -- global reset, low-active, async
-      ctrl_o        : out std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
+      ctrl_o        : out ctrl_bus_t; -- main control bus
       -- instruction fetch interface --
       i_bus_addr_o  : out std_ulogic_vector(XLEN-1 downto 0); -- bus access address
       i_bus_rdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- bus read data
@@ -1263,7 +1246,8 @@ package neorv32_package is
       i_bus_err_i   : in  std_ulogic; -- bus transfer error
       i_pmp_fault_i : in  std_ulogic; -- instruction fetch pmp fault
       -- status input --
-      alu_idone_i   : in  std_ulogic; -- ALU iterative operation done
+      alu_cp_done_i : in  std_ulogic; -- ALU iterative operation done
+      alu_exc_i     : in  std_ulogic; -- ALU exception
       bus_d_wait_i  : in  std_ulogic; -- wait for bus
       -- data input --
       cmp_i         : in  std_ulogic_vector(1 downto 0); -- comparator status
@@ -1308,7 +1292,7 @@ package neorv32_package is
     port (
       -- global control --
       clk_i  : in  std_ulogic; -- global clock, rising edge
-      ctrl_i : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
+      ctrl_i : in  ctrl_bus_t; -- main control bus
       -- data input --
       alu_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- ALU result
       mem_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- memory read data
@@ -1341,7 +1325,7 @@ package neorv32_package is
       -- global control --
       clk_i       : in  std_ulogic; -- global clock, rising edge
       rstn_i      : in  std_ulogic; -- global reset, low-active, async
-      ctrl_i      : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
+      ctrl_i      : in  ctrl_bus_t; -- main control bus
       -- data input --
       rs1_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
       rs2_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
@@ -1355,7 +1339,8 @@ package neorv32_package is
       add_o       : out std_ulogic_vector(XLEN-1 downto 0); -- address computation result
       fpu_flags_o : out std_ulogic_vector(4 downto 0); -- FPU exception flags
       -- status --
-      idone_o     : out std_ulogic -- iterative processing units done?
+      exc_o       : out std_ulogic; -- ALU exception
+      cp_done_o   : out std_ulogic -- co-processor operation done?
     );
   end component;
 
@@ -1370,7 +1355,7 @@ package neorv32_package is
       -- global control --
       clk_i   : in  std_ulogic; -- global clock, rising edge
       rstn_i  : in  std_ulogic; -- global reset, low-active, async
-      ctrl_i  : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
+      ctrl_i  : in  ctrl_bus_t; -- main control bus
       start_i : in  std_ulogic; -- trigger operation
       -- data input --
       rs1_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
@@ -1393,7 +1378,7 @@ package neorv32_package is
       -- global control --
       clk_i   : in  std_ulogic; -- global clock, rising edge
       rstn_i  : in  std_ulogic; -- global reset, low-active, async
-      ctrl_i  : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
+      ctrl_i  : in  ctrl_bus_t; -- main control bus
       start_i : in  std_ulogic; -- trigger operation
       -- data input --
       rs1_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
@@ -1415,7 +1400,7 @@ package neorv32_package is
       -- global control --
       clk_i   : in  std_ulogic; -- global clock, rising edge
       rstn_i  : in  std_ulogic; -- global reset, low-active, async
-      ctrl_i  : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
+      ctrl_i  : in  ctrl_bus_t; -- main control bus
       start_i : in  std_ulogic; -- trigger operation
       -- data input --
       cmp_i   : in  std_ulogic_vector(1 downto 0); -- comparator status
@@ -1438,7 +1423,7 @@ package neorv32_package is
       -- global control --
       clk_i    : in  std_ulogic; -- global clock, rising edge
       rstn_i   : in  std_ulogic; -- global reset, low-active, async
-      ctrl_i   : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
+      ctrl_i   : in  ctrl_bus_t; -- main control bus
       start_i  : in  std_ulogic; -- trigger operation
       -- data input --
       cmp_i    : in  std_ulogic_vector(1 downto 0); -- comparator status
@@ -1462,7 +1447,7 @@ package neorv32_package is
       -- global control --
       clk_i   : in  std_ulogic; -- global clock, rising edge
       rstn_i  : in  std_ulogic; -- global reset, low-active, async
-      ctrl_i  : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
+      ctrl_i  : in  ctrl_bus_t; -- main control bus
       start_i : in  std_ulogic; -- trigger operation
       -- data input --
       rs1_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
@@ -1487,7 +1472,7 @@ package neorv32_package is
       -- global control --
       clk_i         : in  std_ulogic; -- global clock, rising edge
       rstn_i        : in  std_ulogic := '0'; -- global reset, low-active, async
-      ctrl_i        : in  std_ulogic_vector(ctrl_width_c-1 downto 0); -- main control bus
+      ctrl_i        : in  ctrl_bus_t; -- main control bus
       -- cpu instruction fetch interface --
       fetch_pc_i    : in  std_ulogic_vector(XLEN-1 downto 0); -- PC for instruction fetch
       i_pmp_fault_o : out std_ulogic; -- instruction fetch pmp fault


### PR DESCRIPTION
* control bus now using `record` type: cleaner code and easier to analyze in logic waveform
* minor instruction decoding optimization (`M` ISA extension)
* add 6th CPU co-processor slot (yet unused)