### PR TITLE
[rtl] add co-processor timing monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 10.02.2023 | 1.8.0.5 | :test_tube: add CPU co-processor monitor (to auto-terminate operation if a co-processor operation takes too long); [#490](https://github.com/stnolting/neorv32/pull/490) |
 | 10.02.2023 | 1.8.0.4 | replace CPU-internal control bus by a VHDL `record` (much cleaner code); minor control optimizations; add 6ht CPU co-processor slot (yet unused); [#489](https://github.com/stnolting/neorv32/pull/489) |
 | 05.02.2023 | 1.8.0.3 | CPU control optimizations; [#487](https://github.com/stnolting/neorv32/pull/487) |
 | 04.02.2023 | 1.8.0.2 | fix RISC-V-incompatible behavior of `mip` CSR; [#486](https://github.com/stnolting/neorv32/pull/486) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -146,6 +146,9 @@ The co-processors are implemented as iterative units that require several cycles
 the co-processors are used to implement all further processing-based ISA extensions (e.g. <<_m_integer_multiplication_and_division>> and
 <<_b_bit_manipulation_operations>>). Custom RISC-V instructions (<<_custom_functions_unit_cfu>>) are also implemented as ALU co-processor.
 
+Once triggered, the selected co-processor is required to complete processing within a bound time window. Otherwise, the co-processor
+operation is terminated by the hardware and an illegal instruction exception is raised. The time window is 2^T^ clock cycles
+wide; _T_ is defined by the `cp_timeout_c` VHDL package constant (default = 7 -> 128 cycles).
 
 :sectnums:
 ==== CPU Bus Unit

--- a/docs/datasheet/cpu_cfu.adoc
+++ b/docs/datasheet/cpu_cfu.adoc
@@ -218,7 +218,7 @@ The default CFU hardware module already implement some exemplary instructions th
 by the CFU example program. See the CFU's VHDL source file (`rtl/core/neorv32_cpu_cp_cfu.vhd`), which
 is highly commented to explain the available signals and the handshake with the CPU pipeline.
 
-.CFU hardware resource requirements
+.CFU Hardware Resource Requirements
 [WARNING]
 Enabling the CFU and actually implementing R4-type and/or R5-type instructions (or more precisely, using
 the according operands for the CFU hardware) will add one or two additional read ports to the core's
@@ -226,11 +226,11 @@ register file increasing resource requirements.
 
 CFU operations can be entirely combinatorial (like bit-reversal) so the result is available at the end of
 the current clock cycle. Operations can also take several clock cycles to complete (like multiplications)
-and may also include internal states and memories. The CFU's internal controller unit takes care of
-interfacing the custom user logic to the CPU's pipeline.
+and may also include internal states and memories. The CFU's internal control/proxy unit takes care of
+interfacing the custom user logic to the CPU pipeline.
 
 .CFU Execution Time
 [NOTE]
-The CFU is not required to finish processing within a bound time. However, you should keep in mind that the
-CPU is _stalled_ until the CFU has finished processing. This also means the CPU cannot react to pending
-interrupts during this time affecting real-time behavior (interrupt requests will still be queued).
+The CFU has to complete computation within a **bound time window**. Otherwise, the CFU operation is terminated
+by the hardware and an illegal instruction exception is raised. See section <<_cpu_arithmetic_logic_unit>>
+for more information.

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1014,27 +1014,27 @@ begin
             end case;
 
             -- co-processor MULDIV operation (multi-cycle) --
-            if ((CPU_EXTENSION_RISCV_M = true) and (execute_engine.i_reg(instr_opcode_lsb_c+5) = opcode_alu_c(5)) and 
+            if ((CPU_EXTENSION_RISCV_M = true) and (execute_engine.i_reg(instr_opcode_lsb_c+5) = opcode_alu_c(5)) and
                 ((decode_aux.is_m_mul = '1') or (decode_aux.is_m_div = '1'))) or -- MUL/DIV
                ((CPU_EXTENSION_RISCV_Zmmul = true) and (execute_engine.i_reg(instr_opcode_lsb_c+5) = opcode_alu_c(5)) and
                 (decode_aux.is_m_mul = '1')) then -- MUL
               ctrl_nxt.alu_cp_trig(cp_sel_muldiv_c) <= '1'; -- trigger MULDIV CP
-              execute_engine.state_nxt <= ALU_WAIT;
+              execute_engine.state_nxt              <= ALU_WAIT;
             -- co-processor BIT-MANIPULATION operation (multi-cycle) --
             elsif (CPU_EXTENSION_RISCV_B = true) and
                   (((execute_engine.i_reg(instr_opcode_lsb_c+5) = opcode_alu_c(5))  and (decode_aux.is_b_reg = '1')) or -- register operation
                    ((execute_engine.i_reg(instr_opcode_lsb_c+5) = opcode_alui_c(5)) and (decode_aux.is_b_imm = '1'))) then -- immediate operation
               ctrl_nxt.alu_cp_trig(cp_sel_bitmanip_c) <= '1'; -- trigger BITMANIP CP
-              execute_engine.state_nxt <= ALU_WAIT;
+              execute_engine.state_nxt                <= ALU_WAIT;
             -- co-processor SHIFT operation (multi-cycle) --
             elsif (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_sll_c) or
                   (execute_engine.i_reg(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_sr_c) then
               ctrl_nxt.alu_cp_trig(cp_sel_shifter_c) <= '1'; -- trigger SHIFTER CP
-              execute_engine.state_nxt <= ALU_WAIT;
+              execute_engine.state_nxt               <= ALU_WAIT;
             -- ALU CORE operation (single-cycle) --
             else
-              ctrl_nxt.rf_wb_en <= '1'; -- valid RF write-back
-              execute_engine.state_nxt  <= DISPATCH;
+              ctrl_nxt.rf_wb_en        <= '1'; -- valid RF write-back
+              execute_engine.state_nxt <= DISPATCH;
             end if;
 
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -55,6 +55,9 @@ package neorv32_package is
   -- = cycles after which an *unacknowledged* internal bus access will timeout and trigger a bus fault exception
   constant max_proc_int_response_time_c : natural := 15; -- min 2
 
+  -- log2 of co-processor timeout cycles --
+  constant cp_timeout_c : natural := 7; -- default = 7
+
   -- JTAG tap - identifier --
   constant jtag_tap_idcode_version_c : std_ulogic_vector(03 downto 0) := x"0"; -- version
   constant jtag_tap_idcode_partid_c  : std_ulogic_vector(15 downto 0) := x"cafe"; -- part number
@@ -62,7 +65,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080004"; -- NEORV32 version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080005"; -- NEORV32 version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
 
   -- Check if we're inside the Matrix -------------------------------------------------------


### PR DESCRIPTION
If a CPU co-processor operation (e.g. FPU or CFU) takes too long (default: max 128 clock cycles) the operation is automatically terminated by the hardware an an illegal instruction exception is raised.