### PR TITLE
[sw/lib/include/neorv32.h]: remove redundant uart typedef

### DIFF
--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -1025,29 +1025,23 @@ typedef struct __attribute__((packed,aligned(4))) {
  * @name IO Device: Primary/Secondary Universal Asynchronous Receiver and Transmitter (UART0 / UART1)
  **************************************************************************/
 /**@{*/
-/** UART0 module prototype */
+/** UART module prototype */
 typedef struct __attribute__((packed,aligned(4))) {
   uint32_t CTRL;  /**< offset 0: control register (#NEORV32_UART_CTRL_enum) */
   uint32_t DATA;  /**< offset 4: data register (#NEORV32_UART_DATA_enum) */
-} neorv32_uart0_t;
+} neorv32_uart_t;
 
 /** UART0 module base address */
 #define NEORV32_UART0_BASE (0xFFFFFFA0U)
 
-/** UART0 module hardware access (#neorv32_uart0_t) */
-#define NEORV32_UART0 (*((volatile neorv32_uart0_t*) (NEORV32_UART0_BASE)))
-
-/** UART1 module prototype */
-typedef struct __attribute__((packed,aligned(4))) {
-  uint32_t CTRL;  /**< offset 0: control register (#NEORV32_UART_CTRL_enum) */
-  uint32_t DATA;  /**< offset 4: data register (#NEORV32_UART_DATA_enum) */
-} neorv32_uart1_t;
+/** UART0 module hardware access (#neorv32_uart_t) */
+#define NEORV32_UART0 (*((volatile neorv32_uart_t*) (NEORV32_UART0_BASE)))
 
 /** UART1 module base address */
 #define NEORV32_UART1_BASE (0xFFFFFFD0U)
 
-/** UART1 module hardware access (#neorv32_uart1_t) */
-#define NEORV32_UART1 (*((volatile neorv32_uart1_t*) (NEORV32_UART1_BASE)))
+/** UART1 module hardware access (#neorv32_uart_t) */
+#define NEORV32_UART1 (*((volatile neorv32_uart_t*) (NEORV32_UART1_BASE)))
 
 /** UART0/UART1 control register bits */
 enum NEORV32_UART_CTRL_enum {


### PR DESCRIPTION
As discussed in #492 is for UART0 and UART1 the same register layout definition used.
