### PR TITLE
[CFS] add another 64 interface registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 23.02.2023 | 1.8.1.1 | CFS: add another 32 interface register (now having 64 memory-mapped registers for custom usage); [#503](https://github.com/stnolting/neorv32/pull/503) |
 | 23.02.2023 | [**:rocket:1.8.1**](https://github.com/stnolting/neorv32/releases/tag/v1.8.1) | **New release** |
 | 22.02.2023 | 1.8.0.10 | :warning: **remove stream link interface (SLINK)**; [#502](https://github.com/stnolting/neorv32/pull/502) |
 | 19.02.2023 | 1.8.0.9 | :warning: constrain number of **PWM** channels to 12 (was 60); change base address of PWM module; [#501](https://github.com/stnolting/neorv32/pull/501) |

--- a/docs/datasheet/soc_cfs.adoc
+++ b/docs/datasheet/soc_cfs.adoc
@@ -11,9 +11,9 @@
 | Top entity port:         | `cfs_in_i`  | custom input conduit
 |                          | `cfs_out_o` | custom output conduit
 | Configuration generics:  | _IO_CFS_EN_ | implement CFS when _true_
-|                          | _IO_CFS_CONFIG_ | custom generic conduit
-|                          | _IO_CFS_IN_SIZE_ | size of `cfs_in_i`
-|                          | _IO_CFS_OUT_SIZE_ | size of `cfs_out_o`
+|                          | _IO_CFS_CONFIG_    | custom generic conduit
+|                          | _IO_CFS_IN_SIZE_   | size of `cfs_in_i`
+|                          | _IO_CFS_OUT_SIZE_  | size of `cfs_out_o`
 | CPU interrupts:          | fast IRQ channel 1 | CFS interrupt (see <<_processor_interrupts>>)
 |=======================
 
@@ -21,7 +21,7 @@
 **Theory of Operation**
 
 The custom functions subsystem is meant for implementing custom and application-specific logic.
-The CFS provides up to 32x 32-bit memory-mapped read/write
+The CFS provides up to 64 32-bit memory-mapped read/write
 registers (`REG`, see register map below) that can be accessed by the CPU via normal load/store operations.
 The actual functionality of these register has to be defined by the hardware designer. Furthermore, the CFS
 provides two IO conduits to implement custom on-chip or off-chip interfaces.
@@ -100,9 +100,9 @@ _IO_CFS_OUT_SIZE_ configuration generic (default = 32-bit). If the custom functi
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s) | R/W | Function
-| `0xfffffe00` | `NEORV32_CFS.REG[0]`  |`31:0` | (r)/(w) | custom CFS interface register 0
-| `0xfffffe04` | `NEORV32_CFS.REG[1]`  |`31:0` | (r)/(w) | custom CFS interface register 1
+| `0xfffffe00` | `NEORV32_CFS.REG[0]`  |`31:0` | (r)/(w) | custom CFS register 0
+| `0xfffffe04` | `NEORV32_CFS.REG[1]`  |`31:0` | (r)/(w) | custom CFS register 1
 | ...          | ...                   |`31:0` | (r)/(w) | ...
-| `0xfffffe78` | `NEORV32_CFS.REG[30]` |`31:0` | (r)/(w) | custom CFS interface register 30
-| `0xfffffe7c` | `NEORV32_CFS.REG[31]` |`31:0` | (r)/(w) | custom CFS interface register 31
+| `0xfffffef8` | `NEORV32_CFS.REG[62]` |`31:0` | (r)/(w) | custom CFS register 62
+| `0xfffffefc` | `NEORV32_CFS.REG[63]` |`31:0` | (r)/(w) | custom CFS register 63
 |=======================

--- a/rtl/core/neorv32_cfs.vhd
+++ b/rtl/core/neorv32_cfs.vhd
@@ -2,7 +2,7 @@
 -- # << NEORV32 - Custom Functions Subsystem (CFS) >>                                              #
 -- # ********************************************************************************************* #
 -- # Intended for tightly-coupled, application-specific custom co-processors. This module provides #
--- # 32x 32-bit memory-mapped interface registers, one interrupt request signal and custom IO      #
+-- # 64x 32-bit memory-mapped interface registers, one interrupt request signal and custom IO      #
 -- # conduits for processor-external or chip-external interface.                                   #
 -- #                                                                                               #
 -- # NOTE: This is just an example/illustration template. Modify/replace this file to implement    #
@@ -182,7 +182,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   -- Here we are reading/writing from/to the interface registers of the module and generate the CPU access handshake (bus response).
   --
-  -- The CFS provides up to 32 memory-mapped 32-bit interface registers. For instance, these could be used to provide a
+  -- The CFS provides up to 64 memory-mapped 32-bit interface registers. For instance, these could be used to provide a
   -- <control register> for global control of the unit, a <data register> for reading/writing from/to a data FIFO, a
   -- <command register> for issuing commands and a <status register> for status information.
   --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -65,7 +65,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080100"; -- NEORV32 version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080101"; -- NEORV32 version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -156,7 +156,7 @@ package neorv32_package is
 
   -- Custom Functions Subsystem (CFS) --
   constant cfs_base_c           : std_ulogic_vector(31 downto 0) := x"fffffe00"; -- base address
-  constant cfs_size_c           : natural := 32*4; -- module's address space in bytes
+  constant cfs_size_c           : natural := 64*4; -- module's address space in bytes
   constant cfs_reg0_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe00";
   constant cfs_reg1_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe04";
   constant cfs_reg2_addr_c      : std_ulogic_vector(31 downto 0) := x"fffffe08";
@@ -189,14 +189,38 @@ package neorv32_package is
   constant cfs_reg29_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe74";
   constant cfs_reg30_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe78";
   constant cfs_reg31_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe7c";
-
-  -- reserved --
---constant reserved_base_c      : std_ulogic_vector(31 downto 0) := x"fffffe80"; -- base address
---constant reserved_size_c      : natural := 16*4; -- module's address space size in bytes
-
-  -- reserved --
---constant reserved_base_c      : std_ulogic_vector(31 downto 0) := x"fffffec0"; -- base address
---constant reserved_size_c      : natural := 16*4; -- module's address space size in bytes
+  constant cfs_reg32_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe80";
+  constant cfs_reg33_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe84";
+  constant cfs_reg34_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe88";
+  constant cfs_reg35_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe8c";
+  constant cfs_reg36_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe90";
+  constant cfs_reg37_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe94";
+  constant cfs_reg38_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe98";
+  constant cfs_reg39_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffe9c";
+  constant cfs_reg40_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffea0";
+  constant cfs_reg41_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffea4";
+  constant cfs_reg42_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffea8";
+  constant cfs_reg43_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffeac";
+  constant cfs_reg44_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffeb0";
+  constant cfs_reg45_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffeb4";
+  constant cfs_reg46_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffeb8";
+  constant cfs_reg47_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffebc";
+  constant cfs_reg48_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffec0";
+  constant cfs_reg49_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffec4";
+  constant cfs_reg50_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffec8";
+  constant cfs_reg51_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffecc";
+  constant cfs_reg52_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffed0";
+  constant cfs_reg53_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffed4";
+  constant cfs_reg54_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffed8";
+  constant cfs_reg55_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffedc";
+  constant cfs_reg56_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffee0";
+  constant cfs_reg57_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffee4";
+  constant cfs_reg58_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffee8";
+  constant cfs_reg59_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffeec";
+  constant cfs_reg60_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffef0";
+  constant cfs_reg61_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffef4";
+  constant cfs_reg62_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffef8";
+  constant cfs_reg63_addr_c     : std_ulogic_vector(31 downto 0) := x"fffffefc";
 
   -- reserved --
 --constant reserved_base_c      : std_ulogic_vector(31 downto 0) := x"ffffff00"; -- base address

--- a/sw/example/demo_cfs/main.c
+++ b/sw/example/demo_cfs/main.c
@@ -1,9 +1,9 @@
 // #################################################################################################
-// # << NEORV32 - CFS Demo Program >>                                                              #
+// # << NEORV32 - Custom Functions Subsystem (CFS) Demo Program >>                                 #
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -97,7 +97,7 @@ int main() {
                        " * NEORV32_CFS.REG[1] (r/w): convert gray to binary code\n"
                        " * NEORV32_CFS.REG[2] (r/w): bit reversal\n"
                        " * NEORV32_CFS.REG[3] (r/w): byte swap\n"
-                       "The remaining 28 CFS registers are unused and will return 0 when read.\n");
+                       "The remaining 60 CFS registers are unused and will return 0 when read.\n");
 
 
   // function examples

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -720,7 +720,7 @@ typedef struct __attribute__((packed,aligned(4))) {
 /**@{*/
 /** CFS module prototype */
 typedef struct __attribute__((packed,aligned(4))) {
-  uint32_t REG[32]; /**< offset 4*0..4*31: CFS register 0..31, user-defined */
+  uint32_t REG[64]; /**< offset 4*0..4*63: CFS register 0..63, user-defined */
 } neorv32_cfs_t;
 
 /** CFS base address */


### PR DESCRIPTION
The _custom functions subsystem_ (CFS) now provides up to 64 memory-mapped 32-bit registers for custom use.