### PR TITLE
Corrected the PWM address which was a typo.

### DIFF
--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -89,7 +89,7 @@
       <name>PWM</name>
       <description>Pulse-width modulation controller</description>
       <groupName>PWM</groupName>
-      <baseAddress>0xFFFFFF%0</baseAddress>
+      <baseAddress>0xFFFFFF50</baseAddress>
 
       <addressBlock>
         <offset>0</offset>


### PR DESCRIPTION
This also crashes SEGGER Embedded Studio for RISC-V.