### PR TITLE
Changed proposal for default ICACHE_NUM_BLOCKS.

### DIFF
--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -92,7 +92,7 @@ entity neorv32_top is
 
     -- Internal Instruction Cache (iCACHE) --
     ICACHE_EN                    : boolean := false;  -- implement instruction cache
-    ICACHE_NUM_BLOCKS            : natural := 4;      -- i-cache: number of blocks (min 1), has to be a power of 2
+    ICACHE_NUM_BLOCKS            : natural := 32;     -- i-cache: number of blocks (min 1), has to be a power of 2
     ICACHE_BLOCK_SIZE            : natural := 64;     -- i-cache: block size in bytes (min 4), has to be a power of 2
     ICACHE_ASSOCIATIVITY         : natural := 1;      -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
 


### PR DESCRIPTION
Testing with Dhrystone and CoreMark has shown that 32x64 is the optimal size for the ICACHE if the code is executed from the SDRAM of the DE0-Nano, for example. This gives a total size of 2K for the cache. Greater values than 2K no longer had a big impact on Dhrystone and CoreMark.