### PR TITLE
GPIO: Change "variable style" by "pointer style"

### DIFF
--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -1227,7 +1227,7 @@ enum NEORV32_WDT_CTRL_enum {
  **************************************************************************/
 /**@{*/
 /** GPIO module prototype */
-typedef struct __attribute__((packed,aligned(4))) {
+typedef volatile struct __attribute__((packed,aligned(4))) {
   const uint32_t INPUT_LO;  /**< offset 0:  parallel input port lower 32-bit, read-only */
   const uint32_t INPUT_HI;  /**< offset 4:  parallel input port upper 32-bit, read-only */
   uint32_t       OUTPUT_LO; /**< offset 8:  parallel output port lower 32-bit */
@@ -1238,7 +1238,7 @@ typedef struct __attribute__((packed,aligned(4))) {
 #define NEORV32_GPIO_BASE (0xFFFFFFC0U)
 
 /** GPIO module hardware access (#neorv32_gpio_t) */
-#define NEORV32_GPIO (*((volatile neorv32_gpio_t*) (NEORV32_GPIO_BASE)))
+#define NEORV32_GPIO ((volatile neorv32_gpio_t*) (NEORV32_GPIO_BASE))
 /**@}*/
 
 

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -1238,7 +1238,7 @@ typedef volatile struct __attribute__((packed,aligned(4))) {
 #define NEORV32_GPIO_BASE (0xFFFFFFC0U)
 
 /** GPIO module hardware access (#neorv32_gpio_t) */
-#define NEORV32_GPIO ((volatile neorv32_gpio_t*) (NEORV32_GPIO_BASE))
+#define NEORV32_GPIO ((neorv32_gpio_t*) (NEORV32_GPIO_BASE))
 /**@}*/
 
 

--- a/sw/lib/source/neorv32_gpio.c
+++ b/sw/lib/source/neorv32_gpio.c
@@ -70,10 +70,10 @@ void neorv32_gpio_pin_set(int pin) {
   uint32_t mask = (uint32_t)(1 << (pin & 0x1f));
 
   if (pin < 32) {
-    NEORV32_GPIO.OUTPUT_LO |= mask;
+    NEORV32_GPIO->OUTPUT_LO |= mask;
   }
   else {
-    NEORV32_GPIO.OUTPUT_HI |= mask;
+    NEORV32_GPIO->OUTPUT_HI |= mask;
   }
 }
 
@@ -88,10 +88,10 @@ void neorv32_gpio_pin_clr(int pin) {
   uint32_t mask = (uint32_t)(1 << (pin & 0x1f));
 
   if (pin < 32) {
-    NEORV32_GPIO.OUTPUT_LO &= ~mask;
+    NEORV32_GPIO->OUTPUT_LO &= ~mask;
   }
   else {
-    NEORV32_GPIO.OUTPUT_HI &= ~mask;
+    NEORV32_GPIO->OUTPUT_HI &= ~mask;
   }
 }
 
@@ -106,10 +106,10 @@ void neorv32_gpio_pin_toggle(int pin) {
   uint32_t mask = (uint32_t)(1 << (pin & 0x1f));
 
   if (pin < 32) {
-    NEORV32_GPIO.OUTPUT_LO ^= mask;
+    NEORV32_GPIO->OUTPUT_LO ^= mask;
   }
   else {
-    NEORV32_GPIO.OUTPUT_HI ^= mask;
+    NEORV32_GPIO->OUTPUT_HI ^= mask;
   }
 }
 
@@ -125,10 +125,10 @@ uint32_t neorv32_gpio_pin_get(int pin) {
   uint32_t mask = (uint32_t)(1 << (pin & 0x1f));
 
   if (pin < 32) {
-    return NEORV32_GPIO.INPUT_LO & mask;
+    return NEORV32_GPIO->INPUT_LO & mask;
   }
   else {
-    return NEORV32_GPIO.INPUT_HI & mask;
+    return NEORV32_GPIO->INPUT_HI & mask;
   }
 }
 
@@ -146,8 +146,8 @@ void neorv32_gpio_port_set(uint64_t port_data) {
   } data;
 
   data.uint64 = port_data;
-  NEORV32_GPIO.OUTPUT_LO = data.uint32[0];
-  NEORV32_GPIO.OUTPUT_HI = data.uint32[1];
+  NEORV32_GPIO->OUTPUT_LO = data.uint32[0];
+  NEORV32_GPIO->OUTPUT_HI = data.uint32[1];
 }
 
 
@@ -163,8 +163,8 @@ uint64_t neorv32_gpio_port_get(void) {
     uint32_t uint32[sizeof(uint64_t)/sizeof(uint32_t)];
   } data;
 
-  data.uint32[0] = NEORV32_GPIO.INPUT_LO;
-  data.uint32[1] = NEORV32_GPIO.INPUT_HI;
+  data.uint32[0] = NEORV32_GPIO->INPUT_LO;
+  data.uint32[1] = NEORV32_GPIO->INPUT_HI;
 
   return data.uint64;
 }


### PR DESCRIPTION
Change definition of NEORV32_GPIO and replace all "NEORV32_GPIO." by "NEORV32_GPIO->".
Even make the GPIO structure volatile.