### PR TITLE
GPTMR: Change "variable style" by "pointer style"

### DIFF
--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -852,7 +852,7 @@ enum NEORV32_PWM_CTRL_enum {
  **************************************************************************/
 /**@{*/
 /** GPTMR module prototype */
-typedef struct __attribute__((packed,aligned(4))) {
+typedef volatile struct __attribute__((packed,aligned(4))) {
   uint32_t CTRL;           /**< offset  0: control register (#NEORV32_GPTMR_CTRL_enum) */
   uint32_t THRES;          /**< offset  4: threshold register */
   uint32_t COUNT;          /**< offset  8: counter register */
@@ -863,7 +863,7 @@ typedef struct __attribute__((packed,aligned(4))) {
 #define NEORV32_GPTMR_BASE (0xFFFFFF60U)
 
 /** GPTMR module hardware access (#neorv32_gptmr_t) */
-#define NEORV32_GPTMR (*((volatile neorv32_gptmr_t*) (NEORV32_GPTMR_BASE)))
+#define NEORV32_GPTMR ((neorv32_gptmr_t*) (NEORV32_GPTMR_BASE))
 
 /** GPTMR control/data register bits */
 enum NEORV32_GPTMR_CTRL_enum {

--- a/sw/lib/source/neorv32_gptmr.c
+++ b/sw/lib/source/neorv32_gptmr.c
@@ -69,16 +69,16 @@ int neorv32_gptmr_available(void) {
  **************************************************************************/
 void neorv32_gptmr_setup(int prsc, int mode, uint32_t threshold) {
 
-  NEORV32_GPTMR.CTRL  = 0; // reset
-  NEORV32_GPTMR.THRES = threshold;
-  NEORV32_GPTMR.COUNT = 0; // reset counter
+  NEORV32_GPTMR->CTRL  = 0; // reset
+  NEORV32_GPTMR->THRES = threshold;
+  NEORV32_GPTMR->COUNT = 0; // reset counter
 
   uint32_t tmp = 0;
   tmp |= (uint32_t)(1    & 0x01) << GPTMR_CTRL_EN;
   tmp |= (uint32_t)(prsc & 0x07) << GPTMR_CTRL_PRSC0;
   tmp |= (uint32_t)(mode & 0x01) << GPTMR_CTRL_MODE;
 
-  NEORV32_GPTMR.CTRL = tmp;
+  NEORV32_GPTMR->CTRL = tmp;
 }
 
 
@@ -87,7 +87,7 @@ void neorv32_gptmr_setup(int prsc, int mode, uint32_t threshold) {
  **************************************************************************/
 void neorv32_gptmr_disable(void) {
 
-  NEORV32_GPTMR.CTRL &= ~((uint32_t)(1 << GPTMR_CTRL_EN));
+  NEORV32_GPTMR->CTRL &= ~((uint32_t)(1 << GPTMR_CTRL_EN));
 }
 
 
@@ -96,7 +96,7 @@ void neorv32_gptmr_disable(void) {
  **************************************************************************/
 void neorv32_gptmr_enable(void) {
 
-  NEORV32_GPTMR.CTRL |= ((uint32_t)(1 << GPTMR_CTRL_EN));
+  NEORV32_GPTMR->CTRL |= ((uint32_t)(1 << GPTMR_CTRL_EN));
 }
 
 
@@ -105,5 +105,5 @@ void neorv32_gptmr_enable(void) {
  **************************************************************************/
 void neorv32_gptmr_restart(void) {
 
-  NEORV32_GPTMR.COUNT = 0;
+  NEORV32_GPTMR->COUNT = 0;
 }


### PR DESCRIPTION
Change definition of NEORV32_GPTMR and replace all "NEORV32_GPTMR." by "NEORV32_GPTMR->".
Even make the GPTMR structure volatile.