### PR TITLE
MTIME: Change "variable style" by "pointer style"

### DIFF
--- a/sw/bootloader/bootloader.c
+++ b/sw/bootloader/bootloader.c
@@ -305,10 +305,10 @@ int main(void) {
 
   // Configure machine system timer interrupt
   if (neorv32_mtime_available()) {
-    NEORV32_MTIME.TIME_LO = 0;
-    NEORV32_MTIME.TIME_HI = 0;
-    NEORV32_MTIME.TIMECMP_LO = NEORV32_SYSINFO.CLK/4;
-    NEORV32_MTIME.TIMECMP_HI = 0;
+    NEORV32_MTIME->TIME_LO = 0;
+    NEORV32_MTIME->TIME_HI = 0;
+    NEORV32_MTIME->TIMECMP_LO = NEORV32_SYSINFO.CLK/4;
+    NEORV32_MTIME->TIMECMP_HI = 0;
     neorv32_cpu_csr_write(CSR_MIE, 1 << CSR_MIE_MTIE); // activate MTIME IRQ source
     neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE); // enable machine-mode interrupts
   }

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -971,7 +971,7 @@ typedef struct __attribute__((packed,aligned(4))) {
  **************************************************************************/
 /**@{*/
 /** MTIME module prototype */
-typedef struct __attribute__((packed,aligned(4))) {
+typedef volatile struct __attribute__((packed,aligned(4))) {
   uint32_t TIME_LO;    /**< offset 0:  time register low word */
   uint32_t TIME_HI;    /**< offset 4:  time register high word */
   uint32_t TIMECMP_LO; /**< offset 8:  compare register low word */
@@ -982,7 +982,7 @@ typedef struct __attribute__((packed,aligned(4))) {
 #define NEORV32_MTIME_BASE (0xFFFFFF90U)
 
 /** MTIME module hardware access (#neorv32_mtime_t) */
-#define NEORV32_MTIME (*((volatile neorv32_mtime_t*) (NEORV32_MTIME_BASE)))
+#define NEORV32_MTIME ((neorv32_mtime_t*) (NEORV32_MTIME_BASE))
 /**@}*/
 
 

--- a/sw/lib/source/neorv32_mtime.c
+++ b/sw/lib/source/neorv32_mtime.c
@@ -76,9 +76,9 @@ void neorv32_mtime_set_time(uint64_t time) {
 
   cycles.uint64 = time;
 
-  NEORV32_MTIME.TIME_LO = 0;
-  NEORV32_MTIME.TIME_HI = cycles.uint32[1];
-  NEORV32_MTIME.TIME_LO = cycles.uint32[0];
+  NEORV32_MTIME->TIME_LO = 0;
+  NEORV32_MTIME->TIME_HI = cycles.uint32[1];
+  NEORV32_MTIME->TIME_LO = cycles.uint32[0];
 
   asm volatile("nop"); // delay due to write buffer
 }
@@ -100,9 +100,9 @@ uint64_t neorv32_mtime_get_time(void) {
 
   uint32_t tmp1, tmp2, tmp3;
   while(1) {
-    tmp1 = NEORV32_MTIME.TIME_HI;
-    tmp2 = NEORV32_MTIME.TIME_LO;
-    tmp3 = NEORV32_MTIME.TIME_HI;
+    tmp1 = NEORV32_MTIME->TIME_HI;
+    tmp2 = NEORV32_MTIME->TIME_LO;
+    tmp3 = NEORV32_MTIME->TIME_HI;
     if (tmp1 == tmp3) {
       break;
     }
@@ -132,9 +132,9 @@ void neorv32_mtime_set_timecmp(uint64_t timecmp) {
 
   cycles.uint64 = timecmp;
 
-  NEORV32_MTIME.TIMECMP_LO = -1; // prevent MTIMECMP from temporarily becoming smaller than the lesser of the old and new values
-  NEORV32_MTIME.TIMECMP_HI = cycles.uint32[1];
-  NEORV32_MTIME.TIMECMP_LO = cycles.uint32[0];
+  NEORV32_MTIME->TIMECMP_LO = -1; // prevent MTIMECMP from temporarily becoming smaller than the lesser of the old and new values
+  NEORV32_MTIME->TIMECMP_HI = cycles.uint32[1];
+  NEORV32_MTIME->TIMECMP_LO = cycles.uint32[0];
 
   asm volatile("nop"); // delay due to write buffer
 }
@@ -152,8 +152,8 @@ uint64_t neorv32_mtime_get_timecmp(void) {
     uint32_t uint32[sizeof(uint64_t)/sizeof(uint32_t)];
   } cycles;
 
-  cycles.uint32[0] = NEORV32_MTIME.TIMECMP_LO;
-  cycles.uint32[1] = NEORV32_MTIME.TIMECMP_HI;
+  cycles.uint32[0] = NEORV32_MTIME->TIMECMP_LO;
+  cycles.uint32[1] = NEORV32_MTIME->TIMECMP_HI;
 
   return cycles.uint64;
 }


### PR DESCRIPTION
Change definition of NEORV32_MTIME and replace all "NEORV32_MTIME." by "NEORV32_MTIME->".
Even make the MTIME structure volatile.