### PR TITLE
PWM: Change "variable style" by "pointer style"

### DIFF
--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -826,7 +826,7 @@ enum NEORV32_XIP_CTRL_enum {
  **************************************************************************/
 /**@{*/
 /** PWM module prototype */
-typedef struct __attribute__((packed,aligned(4))) {
+typedef volatile struct __attribute__((packed,aligned(4))) {
   uint32_t CTRL;  /**< offset 0: control register (#NEORV32_PWM_CTRL_enum) */
   uint32_t DC[3]; /**< offset 4..12: duty cycle register 0..2 */
 } neorv32_pwm_t;
@@ -835,7 +835,7 @@ typedef struct __attribute__((packed,aligned(4))) {
 #define NEORV32_PWM_BASE (0xFFFFFF50U)
 
 /** PWM module hardware access (#neorv32_pwm_t) */
-#define NEORV32_PWM (*((volatile neorv32_pwm_t*) (NEORV32_PWM_BASE)))
+#define NEORV32_PWM ((neorv32_pwm_t*) (NEORV32_PWM_BASE))
 
 /** PWM control register bits */
 enum NEORV32_PWM_CTRL_enum {

--- a/sw/lib/source/neorv32_pwm.c
+++ b/sw/lib/source/neorv32_pwm.c
@@ -68,7 +68,7 @@ int neorv32_pwm_available(void) {
  **************************************************************************/
 void neorv32_pwm_setup(int prsc) {
 
-  NEORV32_PWM.CTRL = 0; // reset
+  NEORV32_PWM->CTRL = 0; // reset
 
   uint32_t ct_enable = 1;
   ct_enable = ct_enable << PWM_CTRL_EN;
@@ -76,7 +76,7 @@ void neorv32_pwm_setup(int prsc) {
   uint32_t ct_prsc = (uint32_t)(prsc & 0x07);
   ct_prsc = ct_prsc << PWM_CTRL_PRSC0;
 
-  NEORV32_PWM.CTRL = ct_enable | ct_prsc;
+  NEORV32_PWM->CTRL = ct_enable | ct_prsc;
 }
 
 
@@ -85,7 +85,7 @@ void neorv32_pwm_setup(int prsc) {
  **************************************************************************/
 void neorv32_pwm_disable(void) {
 
-  NEORV32_PWM.CTRL &= ~((uint32_t)(1 << PWM_CTRL_EN));
+  NEORV32_PWM->CTRL &= ~((uint32_t)(1 << PWM_CTRL_EN));
 }
 
 
@@ -94,7 +94,7 @@ void neorv32_pwm_disable(void) {
  **************************************************************************/
 void neorv32_pwm_enable(void) {
 
-  NEORV32_PWM.CTRL |= ((uint32_t)(1 << PWM_CTRL_EN));
+  NEORV32_PWM->CTRL |= ((uint32_t)(1 << PWM_CTRL_EN));
 }
 
 
@@ -135,12 +135,12 @@ void neorv32_pwm_set(int channel, uint8_t dc) {
   const uint32_t dc_mask = 0xff;
   uint32_t dc_new  = (uint32_t)dc;
 
-  uint32_t tmp = NEORV32_PWM.DC[channel/4];
+  uint32_t tmp = NEORV32_PWM->DC[channel/4];
 
   tmp &= ~(dc_mask << ((channel % 4) * 8)); // clear previous duty cycle
   tmp |=   dc_new  << ((channel % 4) * 8);  // set new duty cycle
 
-  NEORV32_PWM.DC[channel/4] = tmp;
+  NEORV32_PWM->DC[channel/4] = tmp;
 }
 
 
@@ -156,7 +156,7 @@ uint8_t neorv32_pwm_get(int channel) {
     return 0; // out of range
   }
 
-  uint32_t rd = NEORV32_PWM.DC[channel/4] >> (((channel % 4) * 8));
+  uint32_t rd = NEORV32_PWM->DC[channel/4] >> (((channel % 4) * 8));
 
   return (uint8_t)rd;
 }


### PR DESCRIPTION
Change definition of NEORV32_PWM and replace all "NEORV32_PWM." by "NEORV32_PWM->".
Even make the PWM structure volatile.