### PR TITLE
XIP: Change "variable style" by "pointer style"

### DIFF
--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -781,7 +781,7 @@ enum NEORV32_SDI_CTRL_enum {
  **************************************************************************/
 /**@{*/
 /** XIP module prototype */
-typedef struct __attribute__((packed,aligned(4))) {
+typedef volatile struct __attribute__((packed,aligned(4))) {
   uint32_t CTRL;           /**< offset  0: control register (#NEORV32_XIP_CTRL_enum) */
   const uint32_t reserved; /**< offset  4: reserved */
   uint32_t DATA_LO;        /**< offset  8: SPI data register low */
@@ -792,7 +792,7 @@ typedef struct __attribute__((packed,aligned(4))) {
 #define NEORV32_XIP_BASE (0xFFFFFF40U)
 
 /** XIP module hardware access (#neorv32_xip_t) */
-#define NEORV32_XIP (*((volatile neorv32_xip_t*) (NEORV32_XIP_BASE)))
+#define NEORV32_XIP ((neorv32_xip_t*) (NEORV32_XIP_BASE))
 
 /** XIP control/data register bits */
 enum NEORV32_XIP_CTRL_enum {

--- a/sw/lib/source/neorv32_xip.c
+++ b/sw/lib/source/neorv32_xip.c
@@ -80,11 +80,11 @@ int neorv32_xip_setup(uint8_t prsc, uint8_t cpol, uint8_t cpha, uint8_t rd_cmd) 
   }
 
   // reset and disable module
-  NEORV32_XIP.CTRL = 0;
+  NEORV32_XIP->CTRL = 0;
 
   // clear data registers
-  NEORV32_XIP.DATA_LO = 0;
-  NEORV32_XIP.DATA_HI = 0; // will not trigger SPI transfer since module is disabled
+  NEORV32_XIP->DATA_LO = 0;
+  NEORV32_XIP->DATA_HI = 0; // will not trigger SPI transfer since module is disabled
 
   uint32_t ctrl = 0;
   ctrl |= ((uint32_t)(1            )) << XIP_CTRL_EN; // enable module
@@ -94,16 +94,16 @@ int neorv32_xip_setup(uint8_t prsc, uint8_t cpol, uint8_t cpha, uint8_t rd_cmd) 
   ctrl |= ((uint32_t)(8            )) << XIP_CTRL_SPI_NBYTES_LSB; // set 8 bytes transfer size as default
   ctrl |= ((uint32_t)(rd_cmd & 0xff)) << XIP_CTRL_RD_CMD_LSB;
 
-  NEORV32_XIP.CTRL = ctrl;
+  NEORV32_XIP->CTRL = ctrl;
 
   // send 64 SPI dummy clocks but without an active CS
-  NEORV32_XIP.DATA_LO = 0;
-  NEORV32_XIP.DATA_HI = 0; // trigger SPI transfer
+  NEORV32_XIP->DATA_LO = 0;
+  NEORV32_XIP->DATA_HI = 0; // trigger SPI transfer
 
   // wait for transfer to complete
-  while (NEORV32_XIP.CTRL & (1 << XIP_CTRL_PHY_BUSY)); // direct SPI mode -> check PHY status
+  while (NEORV32_XIP->CTRL & (1 << XIP_CTRL_PHY_BUSY)); // direct SPI mode -> check PHY status
 
-  NEORV32_XIP.CTRL |= 1 << XIP_CTRL_SPI_CSEN; // finally enable automatic SPI chip-select
+  NEORV32_XIP->CTRL |= 1 << XIP_CTRL_SPI_CSEN; // finally enable automatic SPI chip-select
 
   return 0;
 }
@@ -127,7 +127,7 @@ int neorv32_xip_start(uint8_t abytes, uint32_t page_base) {
   }
   page_base >>= 28;
 
-  uint32_t ctrl = NEORV32_XIP.CTRL;
+  uint32_t ctrl = NEORV32_XIP->CTRL;
 
   // address bytes send to SPI flash
   ctrl &= ~(3 << XIP_CTRL_XIP_ABYTES_LSB); // clear old configuration
@@ -144,7 +144,7 @@ int neorv32_xip_start(uint8_t abytes, uint32_t page_base) {
 
   ctrl |= 1 << XIP_CTRL_XIP_EN; // enable XIP mode
 
-  NEORV32_XIP.CTRL = ctrl;
+  NEORV32_XIP->CTRL = ctrl;
 
   return 0;
 }
@@ -157,7 +157,7 @@ int neorv32_xip_start(uint8_t abytes, uint32_t page_base) {
  **************************************************************************/
 void neorv32_xip_highspeed_enable(void) {
 
-  NEORV32_XIP.CTRL |= 1 << XIP_CTRL_HIGHSPEED;
+  NEORV32_XIP->CTRL |= 1 << XIP_CTRL_HIGHSPEED;
 }
 
 
@@ -166,7 +166,7 @@ void neorv32_xip_highspeed_enable(void) {
  **************************************************************************/
 void neorv32_xip_highspeed_disable(void) {
 
-  NEORV32_XIP.CTRL &= ~(1 << XIP_CTRL_HIGHSPEED);
+  NEORV32_XIP->CTRL &= ~(1 << XIP_CTRL_HIGHSPEED);
 }
 
 
@@ -177,7 +177,7 @@ void neorv32_xip_highspeed_disable(void) {
  **************************************************************************/
 void neorv32_xip_burst_mode_enable(void) {
 
-  NEORV32_XIP.CTRL |= 1 << XIP_CTRL_BURST_EN;
+  NEORV32_XIP->CTRL |= 1 << XIP_CTRL_BURST_EN;
 }
 
 
@@ -186,7 +186,7 @@ void neorv32_xip_burst_mode_enable(void) {
  **************************************************************************/
 void neorv32_xip_burst_mode_disable(void) {
 
-  NEORV32_XIP.CTRL &= ~(1 << XIP_CTRL_BURST_EN);
+  NEORV32_XIP->CTRL &= ~(1 << XIP_CTRL_BURST_EN);
 }
 
 
@@ -207,10 +207,10 @@ int neorv32_xip_spi_trans(uint8_t nbytes, uint64_t *rtx_data) {
   }
 
   // configure number of bytes to transfer
-  uint32_t ctrl = NEORV32_XIP.CTRL;
+  uint32_t ctrl = NEORV32_XIP->CTRL;
   ctrl &= ~(0xF << XIP_CTRL_SPI_NBYTES_LSB); // clear old configuration
   ctrl |= nbytes << XIP_CTRL_SPI_NBYTES_LSB; // set new configuration
-  NEORV32_XIP.CTRL = ctrl;
+  NEORV32_XIP->CTRL = ctrl;
 
   union {
     uint64_t uint64;
@@ -218,13 +218,13 @@ int neorv32_xip_spi_trans(uint8_t nbytes, uint64_t *rtx_data) {
   } data;
 
   data.uint64 = *rtx_data;
-  NEORV32_XIP.DATA_LO = data.uint32[0];
-  NEORV32_XIP.DATA_HI = data.uint32[1]; // trigger SPI transfer
+  NEORV32_XIP->DATA_LO = data.uint32[0];
+  NEORV32_XIP->DATA_HI = data.uint32[1]; // trigger SPI transfer
 
   // wait for transfer to complete
-  while (NEORV32_XIP.CTRL & (1 << XIP_CTRL_PHY_BUSY)); // direct SPI mode -> check PHY status
+  while (NEORV32_XIP->CTRL & (1 << XIP_CTRL_PHY_BUSY)); // direct SPI mode -> check PHY status
 
-  data.uint32[0] = NEORV32_XIP.DATA_LO; // RX data is always 32-bit and LSB-aligned
+  data.uint32[0] = NEORV32_XIP->DATA_LO; // RX data is always 32-bit and LSB-aligned
   data.uint32[1] = 0;
   *rtx_data = data.uint64;
 


### PR DESCRIPTION
Change definition of NEORV32_XIP and replace all "NEORV32_XIP." by "NEORV32_XIP->".
Even make the XIP structure volatile.