### PR TITLE
XIRQ: Change "variable style" by "pointer style"

### DIFF
--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1231,8 +1231,8 @@ int main() {
     test_fail();
   }
 
-  NEORV32_XIRQ.IER = 0;
-  NEORV32_XIRQ.IPR = -1;
+  NEORV32_XIRQ->IER = 0;
+  NEORV32_XIRQ->IPR = -1;
 
 
   // ----------------------------------------------------------

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -951,7 +951,7 @@ enum NEORV32_BUSKEEPER_CTRL_enum {
  **************************************************************************/
 /**@{*/
 /** XIRQ module prototype */
-typedef struct __attribute__((packed,aligned(4))) {
+typedef volatile struct __attribute__((packed,aligned(4))) {
   uint32_t       IER;      /**< offset 0:  IRQ input enable register */
   uint32_t       IPR;      /**< offset 4:  pending IRQ register /ack/clear */
   uint32_t       SCR;      /**< offset 8:  interrupt source register */
@@ -962,7 +962,7 @@ typedef struct __attribute__((packed,aligned(4))) {
 #define NEORV32_XIRQ_BASE (0xFFFFFF80U)
 
 /** XIRQ module hardware access (#neorv32_xirq_t) */
-#define NEORV32_XIRQ (*((volatile neorv32_xirq_t*) (NEORV32_XIRQ_BASE)))
+#define NEORV32_XIRQ ((neorv32_xirq_t*) (NEORV32_XIRQ_BASE))
 /**@}*/
 
 

--- a/sw/lib/source/neorv32_xirq.c
+++ b/sw/lib/source/neorv32_xirq.c
@@ -77,9 +77,9 @@ int neorv32_xirq_available(void) {
  **************************************************************************/
 int neorv32_xirq_setup(void) {
 
-  NEORV32_XIRQ.IER = 0; // disable all input channels
-  NEORV32_XIRQ.IPR = 0; // clear all pending IRQs
-  NEORV32_XIRQ.SCR = 0; // acknowledge (clear) XIRQ interrupt
+  NEORV32_XIRQ->IER = 0; // disable all input channels
+  NEORV32_XIRQ->IPR = 0; // clear all pending IRQs
+  NEORV32_XIRQ->SCR = 0; // acknowledge (clear) XIRQ interrupt
 
   int i;
   for (i=0; i<32; i++) {
@@ -124,8 +124,8 @@ int neorv32_xirq_get_num(void) {
   if (neorv32_xirq_available()) {
 
     neorv32_cpu_csr_clr(CSR_MIE, 1 << XIRQ_FIRQ_ENABLE); // make sure XIRQ cannot fire
-    NEORV32_XIRQ.IER = 0xffffffff; // try to set all enable flags
-    enable = NEORV32_XIRQ.IER; // read back actually set flags
+    NEORV32_XIRQ->IER = 0xffffffff; // try to set all enable flags
+    enable = NEORV32_XIRQ->IER; // read back actually set flags
 
     // count set bits in enable
     cnt = 0;
@@ -151,7 +151,7 @@ int neorv32_xirq_get_num(void) {
 void neorv32_xirq_clear_pending(uint8_t ch) {
 
   if (ch < 32) { // channel valid?
-    NEORV32_XIRQ.IPR = ~(1 << ch);
+    NEORV32_XIRQ->IPR = ~(1 << ch);
   }
 }
 
@@ -164,7 +164,7 @@ void neorv32_xirq_clear_pending(uint8_t ch) {
 void neorv32_xirq_channel_enable(uint8_t ch) {
 
   if (ch < 32) { // channel valid?
-    NEORV32_XIRQ.IER |= 1 << ch;
+    NEORV32_XIRQ->IER |= 1 << ch;
   }
 }
 
@@ -177,7 +177,7 @@ void neorv32_xirq_channel_enable(uint8_t ch) {
 void neorv32_xirq_channel_disable(uint8_t ch) {
 
   if (ch < 32) { // channel valid?
-    NEORV32_XIRQ.IER &= ~(1 << ch);
+    NEORV32_XIRQ->IER &= ~(1 << ch);
   }
 }
 
@@ -197,8 +197,8 @@ int neorv32_xirq_install(uint8_t ch, void (*handler)(void)) {
   if (ch < 32) {
     __neorv32_xirq_vector_lut[ch] = (uint32_t)handler; // install handler
     uint32_t mask = 1 << ch;
-    NEORV32_XIRQ.IPR = ~mask; // clear if pending
-    NEORV32_XIRQ.IER |= mask; // enable channel
+    NEORV32_XIRQ->IPR = ~mask; // clear if pending
+    NEORV32_XIRQ->IER |= mask; // enable channel
     return 0;
   }
   return 1;
@@ -219,8 +219,8 @@ int neorv32_xirq_uninstall(uint8_t ch) {
   if (ch < 32) {
     __neorv32_xirq_vector_lut[ch] = (uint32_t)(&__neorv32_xirq_dummy_handler); // override using dummy handler
     uint32_t mask = 1 << ch;
-    NEORV32_XIRQ.IER &= ~mask; // disable channel
-    NEORV32_XIRQ.IPR = ~mask; // clear if pending
+    NEORV32_XIRQ->IER &= ~mask; // disable channel
+    NEORV32_XIRQ->IPR = ~mask; // clear if pending
     return 0;
   }
   return 1;
@@ -235,7 +235,7 @@ static void __neorv32_xirq_core(void) {
 
   neorv32_cpu_csr_write(CSR_MIP, ~(1 << XIRQ_FIRQ_PENDING)); // acknowledge XIRQ FIRQ
 
-  uint32_t src = NEORV32_XIRQ.SCR; // get IRQ source (with highest priority)
+  uint32_t src = NEORV32_XIRQ->SCR; // get IRQ source (with highest priority)
 
   // execute handler
   uint32_t xirq_handler = __neorv32_xirq_vector_lut[src];
@@ -244,8 +244,8 @@ static void __neorv32_xirq_core(void) {
   (*handler_pnt)();
 
   uint32_t mask = 1 << src;
-  NEORV32_XIRQ.IPR = ~mask; // clear current pending interrupt
-  NEORV32_XIRQ.SCR = 0; // acknowledge current XIRQ interrupt
+  NEORV32_XIRQ->IPR = ~mask; // clear current pending interrupt
+  NEORV32_XIRQ->SCR = 0; // acknowledge current XIRQ interrupt
 }
 
 


### PR DESCRIPTION
Change definition of NEORV32_XIRQ and replace all "NEORV32_XIRQ." by "NEORV32_XIRQ->".
Even make the XIRQ structure volatile.