### PR TITLE
CFS: Change "variable style" by "pointer style"

### DIFF
--- a/sw/example/demo_cfs/main.c
+++ b/sw/example/demo_cfs/main.c
@@ -93,10 +93,10 @@ int main() {
                        "      simple data conversion functions using four memory-mapped registers.\n\n");
 
   neorv32_uart0_printf("Default CFS memory-mapped registers:\n"
-                       " * NEORV32_CFS.REG[0] (r/w): convert binary to gray code\n"
-                       " * NEORV32_CFS.REG[1] (r/w): convert gray to binary code\n"
-                       " * NEORV32_CFS.REG[2] (r/w): bit reversal\n"
-                       " * NEORV32_CFS.REG[3] (r/w): byte swap\n"
+                       " * NEORV32_CFS->REG[0] (r/w): convert binary to gray code\n"
+                       " * NEORV32_CFS->REG[1] (r/w): convert gray to binary code\n"
+                       " * NEORV32_CFS->REG[2] (r/w): bit reversal\n"
+                       " * NEORV32_CFS->REG[3] (r/w): byte swap\n"
                        "The remaining 60 CFS registers are unused and will return 0 when read.\n");
 
 
@@ -104,29 +104,29 @@ int main() {
   neorv32_uart0_printf("\n--- CFS 'binary to gray' function ---\n");
   for (i=0; i<TESTCASES; i++) {
     tmp = xorshift32(); // get random test data
-    NEORV32_CFS.REG[0] = tmp; // write to CFS memory-mapped register 0
-    neorv32_uart0_printf("%u: IN = 0x%x, OUT = 0x%x\n", i, tmp, NEORV32_CFS.REG[0]); // read from CFS memory-mapped register 0
+    NEORV32_CFS->REG[0] = tmp; // write to CFS memory-mapped register 0
+    neorv32_uart0_printf("%u: IN = 0x%x, OUT = 0x%x\n", i, tmp, NEORV32_CFS->REG[0]); // read from CFS memory-mapped register 0
   }
 
   neorv32_uart0_printf("\n--- CFS 'gray to binary' function ---\n");
   for (i=0; i<TESTCASES; i++) {
     tmp = xorshift32(); // get random test data
-    NEORV32_CFS.REG[1] = tmp; // write to CFS memory-mapped register 1
-    neorv32_uart0_printf("%u: IN = 0x%x, OUT = 0x%x\n", i, tmp, NEORV32_CFS.REG[1]); // read from CFS memory-mapped register 1
+    NEORV32_CFS->REG[1] = tmp; // write to CFS memory-mapped register 1
+    neorv32_uart0_printf("%u: IN = 0x%x, OUT = 0x%x\n", i, tmp, NEORV32_CFS->REG[1]); // read from CFS memory-mapped register 1
   }
 
   neorv32_uart0_printf("\n--- CFS 'bit reversal' function ---\n");
   for (i=0; i<TESTCASES; i++) {
     tmp = xorshift32(); // get random test data
-    NEORV32_CFS.REG[2] = tmp; // write to CFS memory-mapped register 2
-    neorv32_uart0_printf("%u: IN = 0x%x, OUT = 0x%x\n", i, tmp, NEORV32_CFS.REG[2]); // read from CFS memory-mapped register 2
+    NEORV32_CFS->REG[2] = tmp; // write to CFS memory-mapped register 2
+    neorv32_uart0_printf("%u: IN = 0x%x, OUT = 0x%x\n", i, tmp, NEORV32_CFS->REG[2]); // read from CFS memory-mapped register 2
   }
 
   neorv32_uart0_printf("\n--- CFS 'byte swap' function ---\n");
   for (i=0; i<TESTCASES; i++) {
     tmp = xorshift32(); // get random test data
-    NEORV32_CFS.REG[3] = tmp; // write to CFS memory-mapped register 3
-    neorv32_uart0_printf("%u: IN = 0x%x, OUT = 0x%x\n", i, tmp, NEORV32_CFS.REG[3]); // read from CFS memory-mapped register 3
+    NEORV32_CFS->REG[3] = tmp; // write to CFS memory-mapped register 3
+    neorv32_uart0_printf("%u: IN = 0x%x, OUT = 0x%x\n", i, tmp, NEORV32_CFS->REG[3]); // read from CFS memory-mapped register 3
   }
 
 

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -726,7 +726,7 @@ typedef struct __attribute__((packed,aligned(4))) {
  **************************************************************************/
 /**@{*/
 /** CFS module prototype */
-typedef struct __attribute__((packed,aligned(4))) {
+typedef volatile struct __attribute__((packed,aligned(4))) {
   uint32_t REG[64]; /**< offset 4*0..4*63: CFS register 0..63, user-defined */
 } neorv32_cfs_t;
 
@@ -734,7 +734,7 @@ typedef struct __attribute__((packed,aligned(4))) {
 #define NEORV32_CFS_BASE (0xFFFFFE00U)
 
 /** CFS module hardware access (#neorv32_cfs_t) */
-#define NEORV32_CFS (*((volatile neorv32_cfs_t*) (NEORV32_CFS_BASE)))
+#define NEORV32_CFS ((neorv32_cfs_t*) (NEORV32_CFS_BASE))
 /**@}*/
 
 


### PR DESCRIPTION
Change definition of NEORV32_CFS and replace all "NEORV32_CFS." by "NEORV32_CFS->".
Even make the CFS structure volatile.