### PR TITLE
DM: Change "variable style" by "pointer style"

### DIFF
--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -675,7 +675,7 @@ enum NEORV32_CLOCK_PRSC_enum {
 // ############################################################################################################################
 /**@{*/
 /** on-chip debugger - debug module prototype */
-typedef struct __attribute__((packed,aligned(4))) {
+typedef volatile struct __attribute__((packed,aligned(4))) {
   const uint32_t CODE[16];      /**< offset 0: park loop code ROM (r/-) */
   const uint32_t PBUF[4];       /**< offset 64: program buffer (r/-) */
   const uint32_t reserved1[12]; /**< reserved */
@@ -689,7 +689,7 @@ typedef struct __attribute__((packed,aligned(4))) {
 #define NEORV32_DM_BASE (0XFFFFF800U)
 
 /** on-chip debugger debug module hardware access (#neorv32_dm_t) */
-#define NEORV32_DM (*((volatile neorv32_dm_t*) (NEORV32_DM_BASE)))
+#define NEORV32_DM ((neorv32_dm_t*) (NEORV32_DM_BASE))
 /**@}*/
 
 


### PR DESCRIPTION
Change definition of NEORV32_DM and replace all "NEORV32_DM." by "NEORV32_DM->".
Even make the DM structure volatile.