### PR TITLE
SYSINFO: Change "variable style" by "pointer style"

### DIFF
--- a/sw/bootloader/bootloader.c
+++ b/sw/bootloader/bootloader.c
@@ -307,7 +307,7 @@ int main(void) {
   if (neorv32_mtime_available()) {
     NEORV32_MTIME.TIME_LO = 0;
     NEORV32_MTIME.TIME_HI = 0;
-    NEORV32_MTIME.TIMECMP_LO = NEORV32_SYSINFO.CLK/4;
+    NEORV32_MTIME.TIMECMP_LO = NEORV32_SYSINFO->CLK/4;
     NEORV32_MTIME.TIMECMP_HI = 0;
     neorv32_cpu_csr_write(CSR_MIE, 1 << CSR_MIE_MTIE); // activate MTIME IRQ source
     neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE); // enable machine-mode interrupts
@@ -321,22 +321,22 @@ int main(void) {
                      "BLDV: "__DATE__"\nHWV:  ");
   PRINT_XNUM(neorv32_cpu_csr_read(CSR_MIMPID));
   PRINT_TEXT("\nCID:  ");
-  PRINT_XNUM(NEORV32_SYSINFO.CUSTOM_ID);
+  PRINT_XNUM(NEORV32_SYSINFO->CUSTOM_ID);
   PRINT_TEXT("\nCLK:  ");
-  PRINT_XNUM(NEORV32_SYSINFO.CLK);
+  PRINT_XNUM(NEORV32_SYSINFO->CLK);
   PRINT_TEXT("\nISA:  ");
   PRINT_XNUM(neorv32_cpu_csr_read(CSR_MISA));
   PRINT_TEXT(" + ");
   PRINT_XNUM(neorv32_cpu_csr_read(CSR_MXISA));
   PRINT_TEXT("\nSOC:  ");
-  PRINT_XNUM(NEORV32_SYSINFO.SOC);
+  PRINT_XNUM(NEORV32_SYSINFO->SOC);
   PRINT_TEXT("\nIMEM: ");
-  PRINT_XNUM(NEORV32_SYSINFO.IMEM_SIZE); PRINT_TEXT(" bytes @");
-  PRINT_XNUM(NEORV32_SYSINFO.ISPACE_BASE);
+  PRINT_XNUM(NEORV32_SYSINFO->IMEM_SIZE); PRINT_TEXT(" bytes @");
+  PRINT_XNUM(NEORV32_SYSINFO->ISPACE_BASE);
   PRINT_TEXT("\nDMEM: ");
-  PRINT_XNUM(NEORV32_SYSINFO.DMEM_SIZE);
+  PRINT_XNUM(NEORV32_SYSINFO->DMEM_SIZE);
   PRINT_TEXT(" bytes @");
-  PRINT_XNUM(NEORV32_SYSINFO.DSPACE_BASE);
+  PRINT_XNUM(NEORV32_SYSINFO->DSPACE_BASE);
 
 
   // ------------------------------------------------
@@ -347,7 +347,7 @@ int main(void) {
   if (neorv32_mtime_available()) {
 
     PRINT_TEXT("\n\nAutoboot in "xstr(AUTO_BOOT_TIMEOUT)"s. Press any key to abort.\n");
-    uint64_t timeout_time = neorv32_mtime_get_time() + (uint64_t)(AUTO_BOOT_TIMEOUT * NEORV32_SYSINFO.CLK);
+    uint64_t timeout_time = neorv32_mtime_get_time() + (uint64_t)(AUTO_BOOT_TIMEOUT * NEORV32_SYSINFO->CLK);
 
     while(1){
 
@@ -462,7 +462,7 @@ void start_app(int boot_xip) {
   // deactivate global IRQs
   neorv32_cpu_csr_clr(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE);
 
-  register uint32_t app_base = NEORV32_SYSINFO.ISPACE_BASE; // default = start at beginning of IMEM
+  register uint32_t app_base = NEORV32_SYSINFO->ISPACE_BASE; // default = start at beginning of IMEM
 #if (XIP_EN != 0)
   if (boot_xip) {
     app_base = (uint32_t)(XIP_PAGE_BASE_ADDR + SPI_BOOT_BASE_ADDR); // start from XIP mapped address
@@ -502,7 +502,7 @@ void __attribute__((__interrupt__)) bootloader_trap_handler(void) {
 #endif
     // set time for next IRQ
     if (neorv32_mtime_available()) {
-      neorv32_mtime_set_timecmp(neorv32_mtime_get_time() + (NEORV32_SYSINFO.CLK/4));
+      neorv32_mtime_set_timecmp(neorv32_mtime_get_time() + (NEORV32_SYSINFO->CLK/4));
     }
   }
 
@@ -553,7 +553,7 @@ void get_exe(int src) {
     PRINT_TEXT(")...\n");
 
     // flash checks
-    if (((NEORV32_SYSINFO.SOC & (1<<SYSINFO_SOC_IO_SPI)) == 0) || // SPI module not implemented?
+    if (((NEORV32_SYSINFO->SOC & (1<<SYSINFO_SOC_IO_SPI)) == 0) || // SPI module not implemented?
        (spi_flash_check() != 0)) { // check if flash ready (or available at all)
       system_error(ERROR_FLASH);
     }
@@ -571,7 +571,7 @@ void get_exe(int src) {
   uint32_t check = get_exe_word(src, addr + EXE_OFFSET_CHECKSUM); // complement sum checksum
 
   // transfer program data
-  uint32_t *pnt = (uint32_t*)NEORV32_SYSINFO.ISPACE_BASE;
+  uint32_t *pnt = (uint32_t*)NEORV32_SYSINFO->ISPACE_BASE;
   uint32_t checksum = 0;
   uint32_t d = 0, i = 0;
   addr = addr + EXE_OFFSET_DATA;
@@ -641,7 +641,7 @@ void save_exe(void) {
 
   // store data from instruction memory and update checksum
   uint32_t checksum = 0;
-  uint32_t *pnt = (uint32_t*)NEORV32_SYSINFO.ISPACE_BASE;
+  uint32_t *pnt = (uint32_t*)NEORV32_SYSINFO->ISPACE_BASE;
   addr = addr + EXE_OFFSET_DATA;
   uint32_t i = 0;
   while (i < size) { // in chunks of 4 bytes

--- a/sw/bootloader/bootloader.c
+++ b/sw/bootloader/bootloader.c
@@ -307,7 +307,7 @@ int main(void) {
   if (neorv32_mtime_available()) {
     NEORV32_MTIME->TIME_LO = 0;
     NEORV32_MTIME->TIME_HI = 0;
-    NEORV32_MTIME->TIMECMP_LO = NEORV32_SYSINFO>CLK/4;
+    NEORV32_MTIME->TIMECMP_LO = NEORV32_SYSINFO->CLK/4;
     NEORV32_MTIME->TIMECMP_HI = 0;
     neorv32_cpu_csr_write(CSR_MIE, 1 << CSR_MIE_MTIE); // activate MTIME IRQ source
     neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE); // enable machine-mode interrupts

--- a/sw/bootloader/bootloader.c
+++ b/sw/bootloader/bootloader.c
@@ -307,7 +307,7 @@ int main(void) {
   if (neorv32_mtime_available()) {
     NEORV32_MTIME->TIME_LO = 0;
     NEORV32_MTIME->TIME_HI = 0;
-    NEORV32_MTIME->TIMECMP_LO = NEORV32_SYSINFO.CLK/4;
+    NEORV32_MTIME->TIMECMP_LO = NEORV32_SYSINFO>CLK/4;
     NEORV32_MTIME->TIMECMP_HI = 0;
     neorv32_cpu_csr_write(CSR_MIE, 1 << CSR_MIE_MTIE); // activate MTIME IRQ source
     neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE); // enable machine-mode interrupts

--- a/sw/example/coremark/core_portme.c
+++ b/sw/example/coremark/core_portme.c
@@ -125,7 +125,7 @@ secs_ret
 time_in_secs(CORE_TICKS ticks)
 {
     /* NEORV32-specific */
-    secs_ret retval = (secs_ret)(((CORE_TICKS)ticks) / ((CORE_TICKS)NEORV32_SYSINFO.CLK));
+    secs_ret retval = (secs_ret)(((CORE_TICKS)ticks) / ((CORE_TICKS)NEORV32_SYSINFO->CLK));
     return retval;
 }
 
@@ -183,7 +183,7 @@ portable_init(core_portable *p, int *argc, char *argv[])
   neorv32_cpu_csr_write(CSR_MHPMCOUNTER13, 0); neorv32_cpu_csr_write(CSR_MHPMEVENT13, 1 << HPMCNT_EVENT_TRAP);
   neorv32_cpu_csr_write(CSR_MHPMCOUNTER14, 0); neorv32_cpu_csr_write(CSR_MHPMEVENT14, 1 << HPMCNT_EVENT_ILLEGAL);
 
-  neorv32_uart0_printf("NEORV32: Processor running at %u Hz\n", (uint32_t)NEORV32_SYSINFO.CLK);
+  neorv32_uart0_printf("NEORV32: Processor running at %u Hz\n", (uint32_t)NEORV32_SYSINFO->CLK);
   neorv32_uart0_printf("NEORV32: Executing coremark (%u iterations). This may take some time...\n\n", (uint32_t)ITERATIONS);
 
   // clear cycle counter

--- a/sw/example/demo_freeRTOS/main.c
+++ b/sw/example/demo_freeRTOS/main.c
@@ -152,9 +152,9 @@ static void prvSetupHardware( void )
   neorv32_uart0_setup(BAUD_RATE, PARITY_NONE, FLOW_CONTROL_NONE);
 
   // check clock tick configuration
-  if (NEORV32_SYSINFO.CLK != (uint32_t)configCPU_CLOCK_HZ) {
+  if (NEORV32_SYSINFO->CLK != (uint32_t)configCPU_CLOCK_HZ) {
     neorv32_uart0_printf("Warning! Incorrect 'configCPU_CLOCK_HZ' configuration!\n"
-                         "Is %u Hz but should be %u Hz.\n\n", (uint32_t)configCPU_CLOCK_HZ, NEORV32_SYSINFO.CLK);
+                         "Is %u Hz but should be %u Hz.\n\n", (uint32_t)configCPU_CLOCK_HZ, NEORV32_SYSINFO->CLK);
   }
 
   // check available hardware ISA extensions and compare with compiler flags

--- a/sw/example/demo_gptmr/main.c
+++ b/sw/example/demo_gptmr/main.c
@@ -90,7 +90,7 @@ int main() {
   neorv32_rte_handler_install(GPTMR_RTE_ID, gptmr_firq_handler);
 
   // configure timer for 1Hz ticks in continuous mode (with clock divisor = 8)
-  neorv32_gptmr_setup(CLK_PRSC_8, 1, NEORV32_SYSINFO.CLK / (8 * 2));
+  neorv32_gptmr_setup(CLK_PRSC_8, 1, NEORV32_SYSINFO->CLK / (8 * 2));
 
   // enable interrupt
   neorv32_cpu_csr_set(CSR_MIE, 1 << GPTMR_FIRQ_ENABLE); // enable GPTMR FIRQ channel

--- a/sw/example/demo_mtime/main.c
+++ b/sw/example/demo_mtime/main.c
@@ -91,7 +91,7 @@ int main() {
 
   // configure MTIME timer's first interrupt to appear after SYSTEM_CLOCK / 2 cycles (toggle at 2Hz)
   // starting from _now_
-  neorv32_mtime_set_timecmp(neorv32_mtime_get_time() + (NEORV32_SYSINFO.CLK / 2));
+  neorv32_mtime_set_timecmp(neorv32_mtime_get_time() + (NEORV32_SYSINFO->CLK / 2));
 
   // enable interrupt
   neorv32_cpu_csr_set(CSR_MIE, 1 << CSR_MIE_MTIE); // enable MTIME interrupt
@@ -116,7 +116,7 @@ void mtime_irq_handler(void) {
 
   // update MTIMECMP value for next IRQ (in SYSTEM_CLOCK / 2 cycles)
   // this will also ack/clear the current MTIME interrupt request
-  neorv32_mtime_set_timecmp(neorv32_mtime_get_timecmp() + (NEORV32_SYSINFO.CLK / 2));
+  neorv32_mtime_set_timecmp(neorv32_mtime_get_timecmp() + (NEORV32_SYSINFO->CLK / 2));
 
 
   neorv32_uart0_putc('.'); // send tick symbol via UART

--- a/sw/example/demo_newlib/main.c
+++ b/sw/example/demo_newlib/main.c
@@ -113,7 +113,7 @@ int main() {
   char_buffer = (char *) malloc(4 * sizeof(char)); // 4 bytes
 
   // do not test read & write in simulation as there would be no UART RX input
-  if (NEORV32_SYSINFO.SOC & (1<<SYSINFO_SOC_IS_SIM)) {
+  if (NEORV32_SYSINFO->SOC & (1<<SYSINFO_SOC_IS_SIM)) {
     neorv32_uart0_printf("Skipping <read> & <write> tests as this seems to be a simulation.\n");
   }
   else {

--- a/sw/example/demo_spi/main.c
+++ b/sw/example/demo_spi/main.c
@@ -267,7 +267,7 @@ void spi_setup(void) {
   neorv32_uart0_scan(terminal_buffer, 2, 1);
   clk_div = (uint8_t)hexstr_to_uint(terminal_buffer, strlen(terminal_buffer));
 
-  uint32_t clock = NEORV32_SYSINFO.CLK / (2 * PRSC_LUT[spi_prsc] * (1 + clk_div));
+  uint32_t clock = NEORV32_SYSINFO->CLK / (2 * PRSC_LUT[spi_prsc] * (1 + clk_div));
   neorv32_uart0_printf("\n+ New SPI clock speed = %u Hz\n", clock);
 
   // ---- SPI clock mode ----

--- a/sw/example/demo_twi/main.c
+++ b/sw/example/demo_twi/main.c
@@ -212,7 +212,7 @@ void set_clock(void) {
   bus_claimed = 0;
 
   // print new clock frequency
-  uint32_t clock = NEORV32_SYSINFO.CLK / (4 * PRSC_LUT[prsc] * (1 + cdiv));
+  uint32_t clock = NEORV32_SYSINFO->CLK / (4 * PRSC_LUT[prsc] * (1 + cdiv));
   neorv32_uart0_printf("\nNew I2C clock: %u Hz\n", clock);
 }
 

--- a/sw/example/demo_wdt/main.c
+++ b/sw/example/demo_wdt/main.c
@@ -113,7 +113,7 @@ int main() {
 
   // compute WDT timeout value
   // - the WDT counter increments at f_wdt = f_main / 4096
-  uint32_t timeout = WDT_TIMEOUT_S * (NEORV32_SYSINFO.CLK / 4096);
+  uint32_t timeout = WDT_TIMEOUT_S * (NEORV32_SYSINFO->CLK / 4096);
   if (timeout & 0xFF000000U) { // check if timeout value fits into 24-bit
     neorv32_uart0_puts("Timeout value does not fit into 24-bit!\n");
     return -1;

--- a/sw/example/demo_xip/main.c
+++ b/sw/example/demo_xip/main.c
@@ -388,7 +388,7 @@ int main() {
 
 
   // warning if i-cache is not implemented
-  if ((NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_ICACHE)) == 0) {
+  if ((NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_ICACHE)) == 0) {
     neorv32_uart0_printf("WARNING! No instruction cache implemented! The XIP program might run very slow...\n");
   }
 

--- a/sw/example/dhrystone/dhry_1.c
+++ b/sw/example/dhrystone/dhry_1.c
@@ -108,7 +108,7 @@ int main (void)
     // check available hardware extensions and compare with compiler flags
     neorv32_rte_check_isa(0); // silent = 0 -> show message if isa mismatch
 
-    neorv32_uart0_printf("NEORV32: Processor running at %u Hz\n", (uint32_t)NEORV32_SYSINFO.CLK);
+    neorv32_uart0_printf("NEORV32: Processor running at %u Hz\n", (uint32_t)NEORV32_SYSINFO->CLK);
     neorv32_uart0_printf("NEORV32: Executing Dhrystone (%u iterations). This may take some time...\n\n", (uint32_t)DHRY_ITERS);
 
     // clear cycle counter
@@ -342,24 +342,24 @@ int main (void)
 #endif
 */
     { /* *****  NEORV32-SPECIFIC ***** */
-      neorv32_uart0_printf ("Microseconds for one run through Dhrystone: %u \n", (uint32_t)((User_Time * (Mic_secs_Per_Second / Number_Of_Runs)) / NEORV32_SYSINFO.CLK));
+      neorv32_uart0_printf ("Microseconds for one run through Dhrystone: %u \n", (uint32_t)((User_Time * (Mic_secs_Per_Second / Number_Of_Runs)) / NEORV32_SYSINFO->CLK));
 
-      uint32_t dhry_per_sec = (uint32_t)(NEORV32_SYSINFO.CLK / (User_Time / Number_Of_Runs));
+      uint32_t dhry_per_sec = (uint32_t)(NEORV32_SYSINFO->CLK / (User_Time / Number_Of_Runs));
 
       neorv32_uart0_printf ("Dhrystones per Second:                      %u \n\n", (uint32_t)dhry_per_sec);
 
       neorv32_uart0_printf("NEORV32: << DETAILED RESULTS (integer parts only) >>\n");
       neorv32_uart0_printf("NEORV32: Total cycles:      %u\n", (uint32_t)User_Time);
-      neorv32_uart0_printf("NEORV32: Cycles per second: %u\n", (uint32_t)NEORV32_SYSINFO.CLK);
+      neorv32_uart0_printf("NEORV32: Cycles per second: %u\n", (uint32_t)NEORV32_SYSINFO->CLK);
       neorv32_uart0_printf("NEORV32: Total runs:        %u\n", (uint32_t)Number_Of_Runs);
 
       neorv32_uart0_printf("\n");
       neorv32_uart0_printf("NEORV32: DMIPS/s:           %u\n", (uint32_t)dhry_per_sec);
-      neorv32_uart0_printf("NEORV32: DMIPS/s/MHz:       %u\n", (uint32_t)(dhry_per_sec / (NEORV32_SYSINFO.CLK / 1000000)));
+      neorv32_uart0_printf("NEORV32: DMIPS/s/MHz:       %u\n", (uint32_t)(dhry_per_sec / (NEORV32_SYSINFO->CLK / 1000000)));
 
       neorv32_uart0_printf("\n");
       neorv32_uart0_printf("NEORV32: VAX DMIPS/s:       %u\n", (uint32_t)dhry_per_sec/1757);
-      neorv32_uart0_printf("NEORV32: VAX DMIPS/s/MHz:   %u/1757\n", (uint32_t)(dhry_per_sec / (NEORV32_SYSINFO.CLK / 1000000)));
+      neorv32_uart0_printf("NEORV32: VAX DMIPS/s/MHz:   %u/1757\n", (uint32_t)(dhry_per_sec / (NEORV32_SYSINFO->CLK / 1000000)));
     } /* ***** /NEORV32-SPECIFIC ***** */
     /*
       neorv32_uart0_printf ("Microseconds for one run through Dhrystone: ");

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -56,7 +56,7 @@
 //** Unreachable word-aligned address */
 #define ADDR_UNREACHABLE    (IO_BASE_ADDRESS-4)
 //**Read-only word-aligned address */
-#define ADDR_READONLY       ((uint32_t)&NEORV32_SYSINFO.CLK)
+#define ADDR_READONLY       ((uint32_t)&NEORV32_SYSINFO->CLK)
 //** external memory base address */
 #define EXT_MEM_BASE        (0xF0000000)
 /**@}*/
@@ -431,7 +431,7 @@ int main() {
   neorv32_cpu_csr_write(CSR_MCAUSE, mcause_never_c);
   PRINT_STANDARD("[%i] Ext. memory access (@0x%x) ", cnt_test, (uint32_t)EXT_MEM_BASE);
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_MEM_EXT)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_MEM_EXT)) {
     cnt_test++;
 
     // clear scratch CSR
@@ -634,7 +634,7 @@ int main() {
   PRINT_STANDARD("[%i] BREAK EXC ", cnt_test);
 
   // skip on real hardware since ebreak will make problems when running this test program via gdb
-  if (NEORV32_SYSINFO.SOC & (1<<SYSINFO_SOC_IS_SIM)) {
+  if (NEORV32_SYSINFO->SOC & (1<<SYSINFO_SOC_IS_SIM)) {
     cnt_test++;
 
     asm volatile ("ebreak");

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -1304,7 +1304,7 @@ enum NEORV32_NEOLED_CTRL_enum {
  **************************************************************************/
 /**@{*/
 /** SYSINFO module prototype - whole module is read-only */
-typedef struct __attribute__((packed,aligned(4))) {
+typedef volatile struct __attribute__((packed,aligned(4))) {
   const uint32_t CLK;         /**< offset 0:  clock speed in Hz */
   const uint32_t CUSTOM_ID;   /**< offset 4:  custom user-defined ID (via top generic) */
   const uint32_t SOC;         /**< offset 8:  SoC features (#NEORV32_SYSINFO_SOC_enum) */
@@ -1319,9 +1319,9 @@ typedef struct __attribute__((packed,aligned(4))) {
 #define NEORV32_SYSINFO_BASE (0xFFFFFFE0U)
 
 /** SYSINFO module hardware access (#neorv32_sysinfo_t) */
-#define NEORV32_SYSINFO (*((volatile neorv32_sysinfo_t*) (NEORV32_SYSINFO_BASE)))
+#define NEORV32_SYSINFO ((neorv32_sysinfo_t*) (NEORV32_SYSINFO_BASE))
 
-/** NEORV32_SYSINFO.SOC (r/-): Implemented processor devices/features */
+/** NEORV32_SYSINFO->SOC (r/-): Implemented processor devices/features */
 enum NEORV32_SYSINFO_SOC_enum {
   SYSINFO_SOC_BOOTLOADER     =  0, /**< SYSINFO_FEATURES  (0) (r/-): Bootloader implemented when 1 (via INT_BOOTLOADER_EN generic) */
   SYSINFO_SOC_MEM_EXT        =  1, /**< SYSINFO_FEATURES  (1) (r/-): External bus interface implemented when 1 (via MEM_EXT_EN generic) */
@@ -1351,7 +1351,7 @@ enum NEORV32_SYSINFO_SOC_enum {
   SYSINFO_SOC_IO_ONEWIRE     = 31  /**< SYSINFO_FEATURES (31) (r/-): 1-wire interface controller implemented when 1 (via IO_ONEWIRE_EN generic) */
 };
 
-/** NEORV32_SYSINFO.CACHE (r/-): Cache configuration */
+/** NEORV32_SYSINFO->CACHE (r/-): Cache configuration */
  enum NEORV32_SYSINFO_CACHE_enum {
   SYSINFO_CACHE_IC_BLOCK_SIZE_0    =  0, /**< SYSINFO_CACHE  (0) (r/-): i-cache: log2(Block size in bytes), bit 0 (via ICACHE_BLOCK_SIZE generic) */
   SYSINFO_CACHE_IC_BLOCK_SIZE_1    =  1, /**< SYSINFO_CACHE  (1) (r/-): i-cache: log2(Block size in bytes), bit 1 (via ICACHE_BLOCK_SIZE generic) */

--- a/sw/lib/source/neorv32_cfs.c
+++ b/sw/lib/source/neorv32_cfs.c
@@ -54,7 +54,7 @@
  **************************************************************************/
 int neorv32_cfs_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_CFS)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_CFS)) {
     return 1;
   }
   else {

--- a/sw/lib/source/neorv32_cpu.c
+++ b/sw/lib/source/neorv32_cpu.c
@@ -184,7 +184,7 @@ void neorv32_cpu_set_minstret(uint64_t value) {
  **************************************************************************/
 void neorv32_cpu_delay_ms(uint32_t time_ms) {
 
-  uint32_t clock = NEORV32_SYSINFO.CLK; // clock ticks per second
+  uint32_t clock = NEORV32_SYSINFO->CLK; // clock ticks per second
   clock = clock / 1000; // clock ticks per ms
   uint64_t wait_cycles = ((uint64_t)clock) * ((uint64_t)time_ms);
   uint64_t tmp = 0;
@@ -200,7 +200,7 @@ void neorv32_cpu_delay_ms(uint32_t time_ms) {
 
   // use MTIME machine timer
   // -------------------------------------------
-  else if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_MTIME)) { // MTIME timer available?
+  else if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_MTIME)) { // MTIME timer available?
 
     tmp = neorv32_mtime_get_time() + wait_cycles;
     while (neorv32_mtime_get_time() < tmp);
@@ -239,7 +239,7 @@ uint32_t neorv32_cpu_get_clk_from_prsc(int prsc) {
   }
 
   uint32_t res = 0;
-  uint32_t clock = NEORV32_SYSINFO.CLK; // SoC main clock in Hz
+  uint32_t clock = NEORV32_SYSINFO->CLK; // SoC main clock in Hz
 
   switch(prsc & 7) {
     case CLK_PRSC_2    : res = clock/2    ; break;

--- a/sw/lib/source/neorv32_gpio.c
+++ b/sw/lib/source/neorv32_gpio.c
@@ -51,7 +51,7 @@
  **************************************************************************/
 int neorv32_gpio_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_GPIO)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_GPIO)) {
     return 1;
   }
   else {

--- a/sw/lib/source/neorv32_gptmr.c
+++ b/sw/lib/source/neorv32_gptmr.c
@@ -51,7 +51,7 @@
  **************************************************************************/
 int neorv32_gptmr_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_GPTMR)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_GPTMR)) {
     return 1;
   }
   else {

--- a/sw/lib/source/neorv32_mtime.c
+++ b/sw/lib/source/neorv32_mtime.c
@@ -51,7 +51,7 @@
  **************************************************************************/
 int neorv32_mtime_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_MTIME)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_MTIME)) {
     return 1;
   }
   else {

--- a/sw/lib/source/neorv32_neoled.c
+++ b/sw/lib/source/neorv32_neoled.c
@@ -51,7 +51,7 @@
  **************************************************************************/
 int neorv32_neoled_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_NEOLED)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_NEOLED)) {
     return 1;
   }
   else {
@@ -111,7 +111,7 @@ void neorv32_neoled_setup_ws2812(void) {
   const uint32_t CLK_PRSC_FACTOR_LUT[8] = {2, 4, 8, 64, 128, 1024, 2048, 4096};
 
   // get base clock period in multiples of 0.5ns
-  uint32_t t_clock_x500ps = (2 * 1000 * 1000 * 1000) / NEORV32_SYSINFO.CLK;
+  uint32_t t_clock_x500ps = (2 * 1000 * 1000 * 1000) / NEORV32_SYSINFO->CLK;
 
   // compute LED interface timing parameters
   uint32_t t_base         = 0;

--- a/sw/lib/source/neorv32_onewire.c
+++ b/sw/lib/source/neorv32_onewire.c
@@ -51,7 +51,7 @@
  **************************************************************************/
 int neorv32_onewire_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_ONEWIRE)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_ONEWIRE)) {
     return 1;
   }
   else {
@@ -77,7 +77,7 @@ int neorv32_onewire_setup(uint32_t t_base) {
   uint32_t t_tick;
   uint32_t clkdiv;
   uint32_t clk_prsc_sel   = 0; // initial prsc = CLK/2
-  uint32_t t_clock_x250ps = (4 * 1000 * 1000 * 1000U) / NEORV32_SYSINFO.CLK; // t_clock in multiples of 0.25 ns
+  uint32_t t_clock_x250ps = (4 * 1000 * 1000 * 1000U) / NEORV32_SYSINFO->CLK; // t_clock in multiples of 0.25 ns
 
   // find best base tick configuration
   while (1) {

--- a/sw/lib/source/neorv32_pwm.c
+++ b/sw/lib/source/neorv32_pwm.c
@@ -51,7 +51,7 @@
  **************************************************************************/
 int neorv32_pwm_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_PWM)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_PWM)) {
     return 1;
   }
   else {

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -306,8 +306,8 @@ void neorv32_rte_print_hw_config(void) {
 
   // general
   neorv32_uart0_printf("Is simulation:     "); __neorv32_rte_print_true_false(neorv32_cpu_csr_read(CSR_MXISA) & (1 << CSR_MXISA_IS_SIM));
-  neorv32_uart0_printf("Clock speed:       %u Hz\n", NEORV32_SYSINFO.CLK);
-  neorv32_uart0_printf("On-chip debugger:  "); __neorv32_rte_print_true_false(NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_OCD));
+  neorv32_uart0_printf("Clock speed:       %u Hz\n", NEORV32_SYSINFO->CLK);
+  neorv32_uart0_printf("On-chip debugger:  "); __neorv32_rte_print_true_false(NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_OCD));
 
   // IDs
   neorv32_uart0_printf("Custom ID:         0x%x\n"
@@ -315,7 +315,7 @@ void neorv32_rte_print_hw_config(void) {
                        "Vendor ID:         0x%x\n"
                        "Architecture ID:   0x%x\n"
                        "Implementation ID: 0x%x",
-                       NEORV32_SYSINFO.CUSTOM_ID,
+                       NEORV32_SYSINFO->CUSTOM_ID,
                        neorv32_cpu_csr_read(CSR_MHARTID),
                        neorv32_cpu_csr_read(CSR_MVENDORID),
                        neorv32_cpu_csr_read(CSR_MARCHID),
@@ -411,29 +411,29 @@ void neorv32_rte_print_hw_config(void) {
   neorv32_uart0_printf("\n\n====== Memory ======\n");
 
   neorv32_uart0_printf("Boot configuration:  Boot ");
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_BOOTLOADER)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_BOOTLOADER)) {
     neorv32_uart0_printf("via Bootloader\n");
   }
   else {
-    neorv32_uart0_printf("from memory (@ 0x%x)\n", NEORV32_SYSINFO.ISPACE_BASE);
+    neorv32_uart0_printf("from memory (@ 0x%x)\n", NEORV32_SYSINFO->ISPACE_BASE);
   }
 
-  neorv32_uart0_printf("Instr. base address: 0x%x\n", NEORV32_SYSINFO.ISPACE_BASE);
+  neorv32_uart0_printf("Instr. base address: 0x%x\n", NEORV32_SYSINFO->ISPACE_BASE);
 
   // IMEM
   neorv32_uart0_printf("Internal IMEM:       ");
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_MEM_INT_IMEM)) {
-    neorv32_uart0_printf("yes, %u bytes\n", NEORV32_SYSINFO.IMEM_SIZE);
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_MEM_INT_IMEM)) {
+    neorv32_uart0_printf("yes, %u bytes\n", NEORV32_SYSINFO->IMEM_SIZE);
   }
   else {
     neorv32_uart0_printf("no\n");
   }
 
   // DMEM
-  neorv32_uart0_printf("Data base address:   0x%x\n", NEORV32_SYSINFO.DSPACE_BASE);
+  neorv32_uart0_printf("Data base address:   0x%x\n", NEORV32_SYSINFO->DSPACE_BASE);
   neorv32_uart0_printf("Internal DMEM:       ");
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_MEM_INT_DMEM)) {
-    neorv32_uart0_printf("yes, %u bytes\n", NEORV32_SYSINFO.DMEM_SIZE);
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_MEM_INT_DMEM)) {
+    neorv32_uart0_printf("yes, %u bytes\n", NEORV32_SYSINFO->DMEM_SIZE);
   }
   else {
     neorv32_uart0_printf("no\n");
@@ -441,10 +441,10 @@ void neorv32_rte_print_hw_config(void) {
 
   // i-cache
   neorv32_uart0_printf("Internal i-cache:    ");
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_ICACHE)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_ICACHE)) {
     neorv32_uart0_printf("yes, ");
 
-    uint32_t ic_block_size = (NEORV32_SYSINFO.CACHE >> SYSINFO_CACHE_IC_BLOCK_SIZE_0) & 0x0F;
+    uint32_t ic_block_size = (NEORV32_SYSINFO->CACHE >> SYSINFO_CACHE_IC_BLOCK_SIZE_0) & 0x0F;
     if (ic_block_size) {
       ic_block_size = 1 << ic_block_size;
     }
@@ -452,7 +452,7 @@ void neorv32_rte_print_hw_config(void) {
       ic_block_size = 0;
     }
 
-    uint32_t ic_num_blocks = (NEORV32_SYSINFO.CACHE >> SYSINFO_CACHE_IC_NUM_BLOCKS_0) & 0x0F;
+    uint32_t ic_num_blocks = (NEORV32_SYSINFO->CACHE >> SYSINFO_CACHE_IC_NUM_BLOCKS_0) & 0x0F;
     if (ic_num_blocks) {
       ic_num_blocks = 1 << ic_num_blocks;
     }
@@ -460,14 +460,14 @@ void neorv32_rte_print_hw_config(void) {
       ic_num_blocks = 0;
     }
 
-    uint32_t ic_associativity = (NEORV32_SYSINFO.CACHE >> SYSINFO_CACHE_IC_ASSOCIATIVITY_0) & 0x0F;
+    uint32_t ic_associativity = (NEORV32_SYSINFO->CACHE >> SYSINFO_CACHE_IC_ASSOCIATIVITY_0) & 0x0F;
     ic_associativity = 1 << ic_associativity;
 
     neorv32_uart0_printf("%u bytes, %u set(s), %u block(s) per set, %u bytes per block", ic_associativity*ic_num_blocks*ic_block_size, ic_associativity, ic_num_blocks, ic_block_size);
     if (ic_associativity == 1) {
       neorv32_uart0_printf(" (direct-mapped)\n");
     }
-    else if (((NEORV32_SYSINFO.CACHE >> SYSINFO_CACHE_IC_REPLACEMENT_0) & 0x0F) == 1) {
+    else if (((NEORV32_SYSINFO->CACHE >> SYSINFO_CACHE_IC_REPLACEMENT_0) & 0x0F) == 1) {
       neorv32_uart0_printf(" (LRU replacement policy)\n");
     }
     else {
@@ -479,9 +479,9 @@ void neorv32_rte_print_hw_config(void) {
   }
 
   neorv32_uart0_printf("Ext. bus interface:  ");
-  __neorv32_rte_print_true_false(NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_MEM_EXT));
+  __neorv32_rte_print_true_false(NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_MEM_EXT));
   neorv32_uart0_printf("Ext. bus endianness: ");
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_MEM_EXT_ENDIAN)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_MEM_EXT_ENDIAN)) {
     neorv32_uart0_printf("big\n");
   }
   else {
@@ -491,7 +491,7 @@ void neorv32_rte_print_hw_config(void) {
   // peripherals
   neorv32_uart0_printf("\n====== Peripherals ======\n");
 
-  tmp = NEORV32_SYSINFO.SOC;
+  tmp = NEORV32_SYSINFO->SOC;
   __neorv32_rte_print_checkbox(tmp & (1 << SYSINFO_SOC_IO_GPIO));    neorv32_uart0_printf(" GPIO\n");
   __neorv32_rte_print_checkbox(tmp & (1 << SYSINFO_SOC_IO_MTIME));   neorv32_uart0_printf(" MTIME\n");
   __neorv32_rte_print_checkbox(tmp & (1 << SYSINFO_SOC_IO_UART0));   neorv32_uart0_printf(" UART0\n");

--- a/sw/lib/source/neorv32_sdi.c
+++ b/sw/lib/source/neorv32_sdi.c
@@ -51,7 +51,7 @@
  **************************************************************************/
 int neorv32_sdi_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_SDI)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_SDI)) {
     return 1;
   }
   else {

--- a/sw/lib/source/neorv32_spi.c
+++ b/sw/lib/source/neorv32_spi.c
@@ -51,7 +51,7 @@
  **************************************************************************/
 int neorv32_spi_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_SPI)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_SPI)) {
     return 1;
   }
   else {
@@ -101,7 +101,7 @@ uint32_t neorv32_spi_get_clock_speed(void) {
   uint32_t clock_div = (ctrl >> SPI_CTRL_CDIV0) & 0xf;
 
   uint32_t tmp = 2 * PRSC_LUT[prsc_sel] * clock_div;
-  return NEORV32_SYSINFO.CLK / tmp;
+  return NEORV32_SYSINFO->CLK / tmp;
 }
 
 

--- a/sw/lib/source/neorv32_trng.c
+++ b/sw/lib/source/neorv32_trng.c
@@ -51,7 +51,7 @@
  **************************************************************************/
 int neorv32_trng_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_TRNG)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_TRNG)) {
     return 1;
   }
   else {

--- a/sw/lib/source/neorv32_twi.c
+++ b/sw/lib/source/neorv32_twi.c
@@ -51,7 +51,7 @@
  **************************************************************************/
 int neorv32_twi_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_TWI)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_TWI)) {
     return 1;
   }
   else {

--- a/sw/lib/source/neorv32_uart.c
+++ b/sw/lib/source/neorv32_uart.c
@@ -94,7 +94,7 @@ int getchar(void) {
  **************************************************************************/
 int neorv32_uart0_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_UART0)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_UART0)) {
     return 1;
   }
   else {
@@ -119,7 +119,7 @@ void neorv32_uart0_setup(uint32_t baudrate, uint8_t parity, uint8_t flow_con) {
 
   NEORV32_UART0.CTRL = 0; // reset
 
-  uint32_t clock = NEORV32_SYSINFO.CLK;
+  uint32_t clock = NEORV32_SYSINFO->CLK;
   uint16_t i = 0; // BAUD rate divisor
   uint8_t p = 0; // initial prsc = CLK/2
 
@@ -472,7 +472,7 @@ int neorv32_uart0_scan(char *buffer, int max_size, int echo) {
  **************************************************************************/
 int neorv32_uart1_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_UART1)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_UART1)) {
     return 1;
   }
   else {
@@ -497,7 +497,7 @@ void neorv32_uart1_setup(uint32_t baudrate, uint8_t parity, uint8_t flow_con) {
 
   NEORV32_UART1.CTRL = 0; // reset
 
-  uint32_t clock = NEORV32_SYSINFO.CLK;
+  uint32_t clock = NEORV32_SYSINFO->CLK;
   uint16_t i = 0; // BAUD rate divisor
   uint8_t p = 0; // initial prsc = CLK/2
 

--- a/sw/lib/source/neorv32_wdt.c
+++ b/sw/lib/source/neorv32_wdt.c
@@ -51,7 +51,7 @@
  **************************************************************************/
 int neorv32_wdt_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_WDT)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_WDT)) {
     return 1;
   }
   else {

--- a/sw/lib/source/neorv32_xip.c
+++ b/sw/lib/source/neorv32_xip.c
@@ -51,7 +51,7 @@
  **************************************************************************/
 int neorv32_xip_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_XIP)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_XIP)) {
     return 1;
   }
   else {

--- a/sw/lib/source/neorv32_xirq.c
+++ b/sw/lib/source/neorv32_xirq.c
@@ -59,7 +59,7 @@ static void __neorv32_xirq_dummy_handler(void);
  **************************************************************************/
 int neorv32_xirq_available(void) {
 
-  if (NEORV32_SYSINFO.SOC & (1 << SYSINFO_SOC_IO_XIRQ)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_XIRQ)) {
     return 1;
   }
   else {


### PR DESCRIPTION
Change definition of NEORV32_SYSINFO and replace all "NEORV32_SYSINFO." by "NEORV32_SYSINFO->".
Even make the SYSINFO structure volatile.