### PR TITLE
[sw/uart] allow for escaped percent sign

### DIFF
--- a/sw/lib/source/neorv32_uart.c
+++ b/sw/lib/source/neorv32_uart.c
@@ -432,6 +432,9 @@ void neorv32_uart_printf(neorv32_uart_t *UARTx, const char *format, ...) {
           }
           neorv32_uart_puts(UARTx, string_buf);
           break;
+        case '%': // escaped percent sign
+          neorv32_uart_putc(UARTx, '%');
+          break;
         default: // unsupported format
           neorv32_uart_putc(UARTx, '%');
           neorv32_uart_putc(UARTx, c);


### PR DESCRIPTION
Hi there!

The current `printf` implementation did not allow me to print a single `%` by escaping it with an additional percent sign in front `%%`. This is [supported](https://cplusplus.com/reference/cstdio/printf/#:~:text=A%20%25%20followed%20by%20another%20%25%20character%20will%20write%20a%20single%20%25%20to%20the%20stream.) in the standard implementation.

If I put two, it printed out two. If I put only one, it printed `%<break>` with _cutecom_ (Maybe misconfiguration on my end? PuTTY correctly showed only `%`.)

Anyway this small pr adds support for it.

I assume that the custom implementation of `printf` is deliberately kept small and need not be compliant with all the quirks of the official rules (for example floats are left out). So feel free to decline this pr if it would add to much _bloat_.

Cheers, Nik