### PR TITLE
[rtl] move ONEWIRE and TWI tri-state drivers out of core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 09.03.2023 | 1.8.1.10 | :warning: move tri-state drivers (ONEWIRE and TWI) out of the core; [#543](https://github.com/stnolting/neorv32/pull/543) |
 | 08.03.2023 | 1.8.1.9 | reintegrate **UART** RTS/CTS hardware flow-control; [#541](https://github.com/stnolting/neorv32/pull/541) |
 | 07.03.2023 | 1.8.1.8 | update smart LED controller **NEOLED**; [#536](https://github.com/stnolting/neorv32/pull/536) |
 | 05.03.2023 | 1.8.1.7 | :warning: rework and update **UART0 & UART1**; [#533](https://github.com/stnolting/neorv32/pull/533) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -48,8 +48,7 @@ image::neorv32_processor.png[align=center]
 === Processor Top Entity - Signals
 
 The following table shows all interface signals of the processor top entity (`rtl/core/neorv32_top.vhd`).
-The type of all signals is `std_ulogic` or `std_ulogic_vector` (or arrays of those) - the bi-directional signals are of type
-`std_logic`.
+All signals are of type `std_ulogic` or `std_ulogic_vector`, respectively.
 
 .Default Values of Inputs
 [NOTE]
@@ -64,6 +63,10 @@ of PWM channels). The according input/output signals have a fixed sized regardle
 amount of channels. If less than the maximum number of channels is configured, only the LSB-aligned channels are used:
 in case of an _input port_ the remaining bits/channels are left unconnected; in case of an _output port_ the remaining
 bits/channels are hardwired to zero.
+
+.Tri-State Interfaces
+[NOTE]
+Some interfaces (like the TWI and the 1-Wire bus) require tri-state drivers in the designs top module.
 
 [cols="<3,^2,^2,<11"]
 [options="header",grid="rows"]
@@ -122,10 +125,13 @@ bits/channels are hardwired to zero.
 | `sdi_dat_i`      |    1 |    in | serial data input
 | `sdi_csn_i`      |    1 |    in | chip select (low-active)
 4+^| **Two-Wire Interface Controller (<<_two_wire_serial_interface_controller_twi,TWI>>)**
-| `twi_sda_io`     |    1 | inout | serial data line
-| `twi_scl_io`     |    1 | inout | serial clock line
+| `twi_sda_i`      |    1 |    in | serial data line sense input
+| `twi_sda_o`      |    1 |   out | serial data line output (pull low only)
+| `twi_scl_i`      |    1 |    in | serial clock line sense input
+| `twi_scl_o`      |    1 |   out | serial clock line output (pull low only)
 4+^| **1-Wire Interface Controller (<<_one_wire_serial_interface_controller_twi,ONEWIRE>>)**
-| `onewire_io`     |    1 | inout | serial data line
+| `onewire_i`      |    1 |    in | 1-wire bus sense input
+| `onewire_o`      |    1 |   out | 1-wire bus output (pull low only)
 4+^| **Pulse-Width Modulation Channels (<<_pulse_width_modulation_controller_pwm,PWM>>)**
 | `pwm_o`          |   12 |   out | pulse-width modulated channels
 4+^| **Custom Functions Subsystem (<<_custom_functions_subsystem_cfs,CFS>>)**

--- a/docs/datasheet/soc_onewire.adoc
+++ b/docs/datasheet/soc_onewire.adoc
@@ -8,7 +8,8 @@
 | Hardware source file(s): | neorv32_onewire.vhd | 
 | Software driver file(s): | neorv32_onewire.c |
 |                          | neorv32_onewire.h |
-| Top entity port:         | `onewire_io` | 1-bit bi-directional serial data
+| Top entity port:         | `onewire_i` | 1-bit 1-wire bus sense input
+|                          | `onewire_o` | 1-bit 1-wire bus output (pull low only)
 | Configuration generics:  | _IO_ONEWIRE_EN_ | implement ONEWIRE interface controller when _true_
 | CPU interrupts:          | fast IRQ channel 13 | operation done interrupt (see <<_processor_interrupts>>)
 |=======================
@@ -30,6 +31,20 @@ should be added to the `onewire_io` bus line.
 [TIP]
 For more information regarding the 1-Wire bus and the device access mechanism
 see the Application Notes provided by Maxim Integrated.
+
+
+**Tri-State Drivers**
+
+The ONEWIRE module requires a tri-state driver for the 1-wire bus line, which has to be implemented
+in the top module of the setup. A generic VHDL example is given below (`onewire` is the actual 1-wire
+bus signal, which is of type `std_logic`).
+
+.ONEWIRE VHDL tri-state driver example
+[source,VHDL]
+----
+onewire   <= '0' when (onewire_o = '0') else 'Z';
+onewire_i <= std_ulogic(onewire);
+----
 
 
 **Theory of Operation**

--- a/docs/datasheet/soc_twi.adoc
+++ b/docs/datasheet/soc_twi.adoc
@@ -8,8 +8,10 @@
 | Hardware source file(s): | neorv32_twi.vhd | 
 | Software driver file(s): | neorv32_twi.c |
 |                          | neorv32_twi.h |
-| Top entity port:         | `twi_sda_io` | 1-bit bi-directional serial data
-|                          | `twi_scl_io` | 1-bit bi-directional serial clock
+| Top entity port:         | `twi_sda_i` | 1-bit serial data line sense input
+|                          | `twi_sda_o` | 1-bit serial data line output (pull low only)
+|                          | `twi_scl_i` | 1-bit serial clock line sense input
+|                          | `twi_scl_o` | 1-bit serial clock line output (pull low only)
 | Configuration generics:  | _IO_TWI_EN_ | implement TWI controller when _true_
 | CPU interrupts:          | fast IRQ channel 7 | transmission done interrupt (see <<_processor_interrupts>>)
 |=======================
@@ -18,8 +20,8 @@
 **Theory of Operation**
 
 The two wire interface - also called "I²C" - is a quite famous interface for connecting several on-board
-components. Since this interface only needs two signals (the serial data line `twi_sda_io` and the serial
-clock line `twi_scl_io`) for an arbitrarily number of devices it allows easy interconnections of
+components. Since this interface only needs two signals (the serial data line SDA and the serial
+clock line SCL) for an arbitrarily number of devices it allows easy interconnections of
 several peripheral nodes.
 
 The NEORV32 TWI implements a **TWI controller**. Currently, **no multi-controller
@@ -28,6 +30,22 @@ support** is available. Furthermore, the NEORV32 TWI unit cannot operate in peri
 [IMPORTANT]
 The serial clock (SCL) and the serial data (SDA) lines can only be actively driven low by the
 controller. Hence, external pull-up resistors are required for these lines.
+
+
+**Tri-State Drivers**
+
+The TWI module requires two tri-state drivers for the SDA and SCL lines, which have to be implemented
+in the top module of the setup. A generic VHDL example is given below (`sda` and `scl` are the actual TWI
+bus signal, which are of type `std_logic`).
+
+.TWI VHDL tri-state driver example
+[source,VHDL]
+----
+sda       <= '0' when (twi_sda_o = '0') else 'Z';
+scl       <= '0' when (twi_scl_o = '0') else 'Z';
+twi_sda_i <= std_ulogic(sda);
+twi_scl_i <= std_ulogic(scl);
+----
 
 
 **TWI Clock Speed**

--- a/docs/userguide/packaging_vivado.adoc
+++ b/docs/userguide/packaging_vivado.adoc
@@ -22,10 +22,6 @@ according to your needs).
 .Example AXI SoC using Xilinx Vivado
 image::neorv32_axi_soc.png[]
 
-.TWI Tri-State Drivers
-[IMPORTANT]
-Set the synthesis option "global" when generating the block design to maintain the internal TWI tri-state drivers.
-
 .True Random Number Generator
 [IMPORTANT]
 The NEORV32 TRNG peripheral is enabled by default in the `neorv32_top_axi4lite` AXI wrapper. Otherwise, Vivado

--- a/rtl/core/neorv32_onewire.vhd
+++ b/rtl/core/neorv32_onewire.vhd
@@ -12,7 +12,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -260,7 +260,7 @@ begin
   begin
     if rising_edge(clk_i) then
       -- input synchronizer --
-      serial.wire_in <= serial.wire_in(0) & onewire_i; -- synchronize to prevent metastability
+      serial.wire_in <= serial.wire_in(0) & to_stdulogic(to_bit(onewire_i)); -- "to_bit" to avoid hardware-vs-simulation mismatch
 
       -- bus control --
       if (serial.busy = '0') or (serial.wire_hi = '1') then -- disabled/idle or active tristate request

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -65,7 +65,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080109"; -- NEORV32 version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080110"; -- NEORV32 version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -1099,10 +1099,13 @@ package neorv32_package is
       sdi_dat_i      : in  std_ulogic := 'U'; -- controller data in, peripheral data out
       sdi_csn_i      : in  std_ulogic := 'H'; -- chip-select
       -- TWI (available if IO_TWI_EN = true) --
-      twi_sda_io     : inout std_logic; -- twi serial data line
-      twi_scl_io     : inout std_logic; -- twi serial clock line
+      twi_sda_i      : in  std_ulogic := 'H'; -- serial data line sense input
+      twi_sda_o      : out std_ulogic; -- serial data line output (pull low only)
+      twi_scl_i      : in  std_ulogic := 'H'; -- serial clock line sense input
+      twi_scl_o      : out std_ulogic; -- serial clock line output (pull low only)
       -- 1-Wire Interface (available if IO_ONEWIRE_EN = true) --
-      onewire_io     : inout std_logic; -- 1-wire bus
+      onewire_i      : in  std_ulogic := 'H'; -- 1-wire bus sense input
+      onewire_o      : out std_ulogic; -- 1-wire bus output (pull low only)
       -- PWM (available if IO_PWM_NUM_CH > 0) --
       pwm_o          : out std_ulogic_vector(11 downto 0); -- pwm channels
       -- Custom Functions Subsystem IO --

--- a/rtl/core/neorv32_twi.vhd
+++ b/rtl/core/neorv32_twi.vhd
@@ -8,7 +8,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -380,10 +380,10 @@ begin
 
   -- Tri-State Driver Interface -------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  twi_sda_o <= io_con.sda_out; -- NOTE: signal lines can only be actively driven low
-  twi_scl_o <= io_con.scl_out;
-  io_con.sda_in <= twi_sda_i;
-  io_con.scl_in <= twi_scl_i;
+  twi_sda_o     <= io_con.sda_out; -- NOTE: signal lines can only be actively driven low
+  twi_scl_o     <= io_con.scl_out;
+  io_con.sda_in <= to_stdulogic(to_bit(twi_sda_i)); -- "to_bit" to avoid hardware-vs-simulation mismatch
+  io_con.scl_in <= to_stdulogic(to_bit(twi_scl_i)); -- "to_bit" to avoid hardware-vs-simulation mismatch
 
 
 end neorv32_twi_rtl;

--- a/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
@@ -179,11 +179,14 @@ entity neorv32_top_avalonmm is
     spi_csn_o      : out std_ulogic_vector(07 downto 0); -- chip-select
 
     -- TWI (available if IO_TWI_EN = true) --
-    twi_sda_io     : inout std_logic := 'U'; -- twi serial data line
-    twi_scl_io     : inout std_logic := 'U'; -- twi serial clock line
+    twi_sda_i      : in  std_ulogic := 'H'; -- serial data line sense input
+    twi_sda_o      : out std_ulogic; -- serial data line output (pull low only)
+    twi_scl_i      : in  std_ulogic := 'H'; -- serial clock line sense input
+    twi_scl_o      : out std_ulogic; -- serial clock line output (pull low only)
 
     -- 1-Wire Interface (available if IO_ONEWIRE_EN = true) --
-    onewire_io     : inout std_logic; -- 1-wire bus
+    onewire_i      : in  std_ulogic := 'H'; -- 1-wire bus sense input
+    onewire_o      : out std_ulogic; -- 1-wire bus output (pull low only)
 
     -- PWM (available if IO_PWM_NUM_CH > 0) --
     pwm_o          : out std_ulogic_vector(11 downto 0); -- pwm channels
@@ -369,11 +372,14 @@ begin
     spi_csn_o => spi_csn_o,
 
     -- TWI (available if IO_TWI_EN = true) --
-    twi_sda_io => twi_sda_io,
-    twi_scl_io => twi_scl_io,
+    twi_sda_i => twi_sda_i,
+    twi_sda_o => twi_sda_o,
+    twi_scl_i => twi_scl_i,
+    twi_scl_o => twi_scl_o,
 
     -- 1-Wire Interface (available if IO_ONEWIRE_EN = true) --
-    onewire_io => onewire_io,
+    onewire_i => onewire_i,
+    onewire_o => onewire_o,
 
     -- PWM (available if IO_PWM_NUM_CH > 0) --
     pwm_o => pwm_o,

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -183,10 +183,13 @@ entity neorv32_SystemTop_axi4lite is
     spi_dat_i     : in  std_logic := '0'; -- controller data in, peripheral data out
     spi_csn_o     : out std_logic_vector(07 downto 0); -- SPI CS
     -- TWI (available if IO_TWI_EN = true) --
-    twi_sda_io    : inout std_logic; -- twi serial data line
-    twi_scl_io    : inout std_logic; -- twi serial clock line
+    twi_sda_i     : in  std_ulogic := 'H'; -- serial data line sense input
+    twi_sda_o     : out std_ulogic; -- serial data line output (pull low only)
+    twi_scl_i     : in  std_ulogic := 'H'; -- serial clock line sense input
+    twi_scl_o     : out std_ulogic; -- serial clock line output (pull low only)
     -- 1-Wire Interface (available if IO_ONEWIRE_EN = true) --
-    onewire_io     : inout std_logic; -- 1-wire bus
+    onewire_i     : in  std_ulogic := 'H'; -- 1-wire bus sense input
+    onewire_o     : out std_ulogic; -- 1-wire bus output (pull low only)
     -- PWM (available if IO_PWM_NUM_CH > 0) --
     pwm_o         : out std_logic_vector(11 downto 0);  -- pwm channels
     -- Custom Functions Subsystem IO (available if IO_CFS_EN = true) --
@@ -248,6 +251,14 @@ architecture neorv32_SystemTop_axi4lite_rtl of neorv32_SystemTop_axi4lite is
   signal cfs_out_o_int   : std_ulogic_vector(IO_CFS_OUT_SIZE-1 downto 0);
   --
   signal neoled_o_int    : std_ulogic;
+  --
+  signal twi_sda_i_int   : std_ulogic;
+  signal twi_sda_o_int   : std_ulogic;
+  signal twi_scl_i_int   : std_ulogic;
+  signal twi_scl_o_int   : std_ulogic;
+  --
+  signal onewire_i_int   : std_ulogic;
+  signal onewire_o_int   : std_ulogic;
   --
   signal xirq_i_int      : std_ulogic_vector(31 downto 0);
   --
@@ -412,10 +423,13 @@ begin
     spi_dat_i   => spi_dat_i_int,   -- controller data in, peripheral data out
     spi_csn_o   => spi_csn_o_int,   -- SPI CS
     -- TWI (available if IO_TWI_EN = true) --
-    twi_sda_io  => twi_sda_io,      -- twi serial data line
-    twi_scl_io  => twi_scl_io,      -- twi serial clock line
+    twi_sda_i   => twi_sda_i_int,   -- serial data line sense input
+    twi_sda_o   => twi_sda_o_int,   -- serial data line output (pull low only)
+    twi_scl_i   => twi_scl_i_int,   -- serial clock line sense input
+    twi_scl_o   => twi_scl_o_int,   -- serial clock line output (pull low only)
     -- 1-Wire Interface (available if IO_ONEWIRE_EN = true) --
-    onewire_io  => onewire_io,      -- 1-wire bus
+    onewire_i   => onewire_i_int,   -- 1-wire bus sense input
+    onewire_o   => onewire_o_int,   -- 1-wire bus output (pull low only)
     -- PWM available if IO_PWM_NUM_CH > 0) --
     pwm_o       => pwm_o_int,       -- pwm channels
     -- Custom Functions Subsystem IO (available if IO_CFS_EN = true) --
@@ -466,6 +480,14 @@ begin
   cfs_out_o       <= std_logic_vector(cfs_out_o_int);
 
   neoled_o        <= std_logic(neoled_o_int);
+
+  twi_sda_i_int   <= std_ulogic(twi_sda_i);
+  twi_sda_o       <= std_logic(twi_sda_o_int);
+  twi_scl_i_int   <= std_ulogic(twi_scl_i);
+  twi_scl_o       <= std_logic(twi_scl_o_int);
+
+  onewire_i_int   <= std_ulogic(onewire_i);
+  onewire_o       <= std_logic(onewire_o_int);
 
   xirq_i_int      <= std_ulogic_vector(xirq_i);
 

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -110,9 +110,11 @@ architecture neorv32_tb_rtl of neorv32_tb is
 
   -- twi --
   signal twi_scl, twi_sda : std_logic;
+  signal twi_scl_i, twi_scl_o, twi_sda_i, twi_sda_o : std_ulogic;
 
   -- 1-wire --
-  signal one_wire : std_logic;
+  signal onewire : std_logic;
+  signal onewire_i, onewire_o : std_ulogic;
 
   -- spi & sdi --
   signal spi_csn: std_ulogic_vector(7 downto 0);
@@ -344,10 +346,13 @@ begin
     sdi_dat_i      => sdi_di,          -- controller data in, peripheral data out
     sdi_csn_i      => sdi_csn,         -- chip-select
     -- TWI (available if IO_TWI_EN = true) --
-    twi_sda_io     => twi_sda,         -- twi serial data line
-    twi_scl_io     => twi_scl,         -- twi serial clock line
+    twi_sda_i      => twi_sda_i,       -- serial data line sense input
+    twi_sda_o      => twi_sda_o,       -- serial data line output (pull low only)
+    twi_scl_i      => twi_scl_i,       -- serial clock line sense input
+    twi_scl_o      => twi_scl_o,       -- serial clock line output (pull low only)
     -- 1-Wire Interface (available if IO_ONEWIRE_EN = true) --
-    onewire_io     => one_wire,        -- 1-wire bus
+    onewire_i      => onewire_i,       -- 1-wire bus sense input
+    onewire_o      => onewire_o,       -- 1-wire bus output (pull low only)
     -- PWM (available if IO_PWM_NUM_CH > 0) --
     pwm_o          => open,            -- pwm channels
     -- Custom Functions Subsystem IO --
@@ -363,12 +368,22 @@ begin
     mext_irq_i     => mei_ring         -- machine external interrupt
   );
 
+  -- TWI tri-state driver --
+  twi_sda   <= '0' when (twi_sda_o = '0') else 'Z'; -- module can only pull the line low actively
+  twi_scl   <= '0' when (twi_scl_o = '0') else 'Z';
+  twi_sda_i <= std_ulogic(twi_sda);
+  twi_scl_i <= std_ulogic(twi_scl);
+
+  -- 1-Wire tri-state driver --
+  onewire   <= '0' when (onewire_o = '0') else 'Z'; -- module can only pull the line low actively
+  onewire_i <= std_ulogic(onewire);
+
   -- TWI termination (pull-ups) --
   twi_scl <= 'H';
   twi_sda <= 'H';
 
   -- 1-Wire termination (pull-up) --
-  one_wire <= 'H';
+  onewire <= 'H';
 
   -- SPI/SDI echo --
   sdi_clk <= spi_clk;


### PR DESCRIPTION
This PR removes the processor-internal tri-state drivers used by the OENWIRE and TWI modules as discussed in #538.