### PR TITLE
[rtl] cleanup top's generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 18.03.2023 | 1.8.2.6 | add new generic `JEDEC_ID` (official JEDEC identifier; used for the `mvendorid`); further generics cleanups; [#557](https://github.com/stnolting/neorv32/pull/557)
 | 17.03.2023 | 1.8.2.5 | add RISC-V `time[h]` CSRs (part of the `Zicntr` ISA extension); [#556](https://github.com/stnolting/neorv32/pull/556) |
 | 17.03.2023 | 1.8.2.4 | re-add VHDL process names; [#555](https://github.com/stnolting/neorv32/pull/555) |
 | 15.03.2023 | 1.8.2.3 | rtl reworks, cleanups and optimizations; [#550](https://github.com/stnolting/neorv32/pull/550) |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -82,7 +82,7 @@ should always read back a CSR after writing to check if the targeted bits can ac
 | 0xF11   | <<_mvendorid>>                      | `CSR_MVENDORID`      | r/- | Machine vendor ID
 | 0xF12   | <<_marchid>>                        | `CSR_MARCHID`        | r/- | Machine architecture ID
 | 0xF13   | <<_mimpid>>                         | `CSR_MIMPID`         | r/- | Machine implementation ID / version
-| 0xF14   | <<_mhartid>>                        | `CSR_MHARTID`        | r/- | Machine thread ID
+| 0xF14   | <<_mhartid>>                        | `CSR_MHARTID`        | r/- | Machine hardware thread ID
 | 0xF15   | <<_mconfigptr>>                     | `CSR_MCONFIGPTR`     | r/- | Machine configuration pointer register
 5+^| **<<_neorv32_specific_csrs>>**
 | 0xFC0   | <<_mxisa>>                          | `CSR_MXISA`          | r/- | NEORV32-specific "extended" machine CPU ISA and extensions
@@ -785,9 +785,9 @@ counter CSRs are read-only. Any write access will raise an illegal instruction e
 |=======================
 | Name        | Machine vendor ID
 | Address     | `0xf11`
-| Reset value | `0x00000000`
+| Reset value | `DEFINED`
 | ISA         | `Zicsr`
-| Description | The features of this CSR are not implemented yet. The register is read-only and always returns zero.
+| Description | Vendor ID (JEDEC identifier), assigned via the `VENDOR_ID` top generic (<<_processor_top_entity_generics>>).
 |=======================
 
 
@@ -835,7 +835,7 @@ NEORV32 as BCD-coded number (example: `mimpid` = _0x01020312_ â†’ 01.02.03.12 â†
 | Reset value | `DEFINED`
 | ISA         | `Zicsr`
 | Description | The `mhartid` CSR is read-only and provides the core's hart ID,
-which is assigned via the `HW_THREAD_ID` top generic.
+which is assigned via the `HW_THREAD_ID` top generic (<<_processor_top_entity_generics>>).
 |=======================
 
 

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -107,7 +107,7 @@ register. The following table shows the available data registers and their addre
 [options="header",grid="rows"]
 |=======================
 | Address (via `IR`) | Name     | Size [bits] | Description
-| `00001`            | `IDCODE` | 32          | identifier, default: `0x0CAFE001` (configurable via package's `jtag_tap_idcode_*` constants)
+| `00001`            | `IDCODE` | 32          | identifier, hardwired to `0x00000001`
 | `10000`            | `DTMCS`  | 32          | debug transport module control and status register
 | `10001`            | `DMI`    | 40          | debug module interface (_dmi_); 6-bit address, 32-bit read/write data, 2-bit operation (`00` = NOP; `10` = write; `01` = read)
 | others             | `BYPASS` | 1           | default JTAG bypass register

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -191,8 +191,9 @@ The generic type "suv(x:y)" defines a `std_ulogic_vector(x downto y)`.
 4+^| **General**
 | `CLOCK_FREQUENCY`       | natural   | -          | The clock frequency of the processor's `clk_i` input port in Hertz (Hz).
 | `INT_BOOTLOADER_EN`     | boolean   | false      | Implement the processor-internal <<_bootloader_rom_bootrom>>, pre-initialized with the default <<_bootloader>> image.
-| `HW_THREAD_ID`          | natural   | 0          | The hart ID of the CPU.
-| `CUSTOM_ID`             | suv(31:0) | 0x00000000 | User-defined identifier to identify a certain setup or to pass user-defined flags to software.
+| `HART_ID`               | suv(31:0) | 0x00000000 | The hart thread ID of the CPU (passed to <<_mhartid>> CSRs).
+| `VENDOR_ID`             | suv(31:0) | 0x00000000 | JEDEC ID (passed to <<_mvendorid>> CSRs).
+| `CUSTOM_ID`             | suv(31:0) | 0x00000000 | User-defined identifier to identify a certain setup or to pass user-defined flags to software (via the <<_system_configuration_information_memory_sysinfo>>).
 | `ON_CHIP_DEBUGGER_EN`   | boolean   | false      | Implement the on-chip debugger <<_on_chip_debugger_ocd>> and the CPU debug mode.
 4+^| **CPU <<_instruction_sets_and_extensions>>**
 | `CPU_EXTENSION_RISCV_B`        | boolean | false | Enable <<_b_isa_extension>> (bit-manipulation).
@@ -260,8 +261,8 @@ The generic type "suv(x:y)" defines a `std_ulogic_vector(x downto y)`.
 | `IO_TRNG_FIFO`          | natural   | 1          | Depth of the TRNG data FIFO. Has to be a power of two, min 1, max 32768.
 | `IO_CFS_EN`             | boolean   | false      | Implement the <<_custom_functions_subsystem_cfs>>.
 | `IO_CFS_CONFIG`         | suv(31:0) | 0x00000000 | "Conduit" generic to pass user-defined flags to the <<_custom_functions_subsystem_cfs>>.
-| `IO_CFS_IN_SIZE`        | positive  | 32         | Size of the <<_custom_functions_subsystem_cfs>> input signal conduit (`cfs_in_i`).
-| `IO_CFS_OUT_SIZE`       | positive  | 32         | Size of the <<_custom_functions_subsystem_cfs>> output signal conduit (`cfs_out_o`).
+| `IO_CFS_IN_SIZE`        | natural   | 32         | Size of the <<_custom_functions_subsystem_cfs>> input signal conduit (`cfs_in_i`).
+| `IO_CFS_OUT_SIZE`       | natural   | 32         | Size of the <<_custom_functions_subsystem_cfs>> output signal conduit (`cfs_out_o`).
 | `IO_NEOLED_EN`          | boolean   | false      | Implement the <<_smart_led_interface_neoled>>.
 | `IO_NEOLED_TX_FIFO`     | natural   | 1          | TX FIFO depth of the the <<_smart_led_interface_neoled>>. Has to be a power of two, min 1, max 32768.
 | `IO_GPTMR_EN`           | boolean   | false      | Implement the <<_general_purpose_timer_gptmr>>.

--- a/docs/userguide/debugging_with_ocd.adoc
+++ b/docs/userguide/debugging_with_ocd.adoc
@@ -74,7 +74,7 @@ libusb1 09e75e98b4d9ea7909e8837b7a3f00dda4589dc3
 For bug reports, read
         http://openocd.org/doc/doxygen/bugs.html
 Info : clock speed 1000 kHz
-Info : JTAG tap: neorv32.cpu tap/device found: 0x0cafe001 (mfg: 0x000 (<invalid>), part: 0xcafe, ver: 0x0)
+Info : JTAG tap: neorv32.cpu tap/device found: 0x00000000 (mfg: 0x000 (<invalid>), part: 0x0000, ver: 0x0)
 Info : datacount=1 progbufsize=2
 Info : Disabling abstract command reads from CSRs.
 Info : Examined RISC-V core; found 1 harts

--- a/rtl/core/neorv32_cfs.vhd
+++ b/rtl/core/neorv32_cfs.vhd
@@ -49,8 +49,8 @@ use neorv32.neorv32_package.all;
 entity neorv32_cfs is
   generic (
     CFS_CONFIG   : std_ulogic_vector(31 downto 0); -- custom CFS configuration generic
-    CFS_IN_SIZE  : positive; -- size of CFS input conduit in bits
-    CFS_OUT_SIZE : positive  -- size of CFS output conduit in bits
+    CFS_IN_SIZE  : natural; -- size of CFS input conduit in bits
+    CFS_OUT_SIZE : natural  -- size of CFS output conduit in bits
   );
   port (
     -- host access --

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -42,7 +42,8 @@ use neorv32.neorv32_package.all;
 entity neorv32_cpu is
   generic (
     -- General --
-    HW_THREAD_ID                 : natural; -- hardware thread id (32-bit)
+    HART_ID                      : std_ulogic_vector(31 downto 0); -- hardware thread ID
+    VENDOR_ID                    : std_ulogic_vector(31 downto 0); -- vendor's JEDEC ID
     CPU_BOOT_ADDR                : std_ulogic_vector(31 downto 0); -- cpu boot address
     CPU_DEBUG_PARK_ADDR          : std_ulogic_vector(31 downto 0); -- cpu debug mode parking loop entry address
     CPU_DEBUG_EXC_ADDR           : std_ulogic_vector(31 downto 0); -- cpu debug mode exception entry address
@@ -260,7 +261,8 @@ begin
   generic map (
     -- General --
     XLEN                         => XLEN,                         -- data path width
-    HW_THREAD_ID                 => HW_THREAD_ID,                 -- hardware thread id
+    HART_ID                      => HART_ID,                      -- hardware thread ID
+    VENDOR_ID                    => VENDOR_ID,                    -- vendor's JEDEC ID
     CPU_BOOT_ADDR                => CPU_BOOT_ADDR,                -- cpu boot address
     CPU_DEBUG_PARK_ADDR          => CPU_DEBUG_PARK_ADDR,          -- cpu debug mode parking loop entry address
     CPU_DEBUG_EXC_ADDR           => CPU_DEBUG_EXC_ADDR,           -- cpu debug mode exception entry address

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -58,14 +58,9 @@ package neorv32_package is
   -- log2 of co-processor timeout cycles --
   constant cp_timeout_c : natural := 7; -- default = 7 (= 128 cycles)
 
-  -- JTAG tap - identifier --
-  constant jtag_tap_idcode_version_c : std_ulogic_vector(03 downto 0) := x"0"; -- version
-  constant jtag_tap_idcode_partid_c  : std_ulogic_vector(15 downto 0) := x"cafe"; -- part number
-  constant jtag_tap_idcode_manid_c   : std_ulogic_vector(10 downto 0) := "00000000000"; -- manufacturer id
-
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080205"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080206"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -972,7 +967,8 @@ package neorv32_package is
     generic (
       -- General --
       CLOCK_FREQUENCY              : natural;           -- clock frequency of clk_i in Hz
-      HW_THREAD_ID                 : natural := 0;      -- hardware thread id (32-bit)
+      HART_ID                      : std_ulogic_vector(31 downto 0) := x"00000000"; -- hardware thread ID
+      VENDOR_ID                    : std_ulogic_vector(31 downto 0) := x"00000000"; -- vendor's JEDEC ID
       CUSTOM_ID                    : std_ulogic_vector(31 downto 0) := x"00000000"; -- custom user-defined ID
       INT_BOOTLOADER_EN            : boolean := false;  -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
       -- On-Chip Debugger (OCD) --
@@ -1043,8 +1039,8 @@ package neorv32_package is
       IO_TRNG_FIFO                 : natural := 1;      -- TRNG fifo depth, has to be a power of two, min 1
       IO_CFS_EN                    : boolean := false;  -- implement custom functions subsystem (CFS)?
       IO_CFS_CONFIG                : std_ulogic_vector(31 downto 0) := x"00000000"; -- custom CFS configuration generic
-      IO_CFS_IN_SIZE               : positive := 32;    -- size of CFS input conduit in bits
-      IO_CFS_OUT_SIZE              : positive := 32;    -- size of CFS output conduit in bits
+      IO_CFS_IN_SIZE               : natural := 32;     -- size of CFS input conduit in bits
+      IO_CFS_OUT_SIZE              : natural := 32;     -- size of CFS output conduit in bits
       IO_NEOLED_EN                 : boolean := false;  -- implement NeoPixel-compatible smart LED interface (NEOLED)?
       IO_NEOLED_TX_FIFO            : natural := 1;      -- NEOLED FIFO depth, has to be a power of two, min 1
       IO_GPTMR_EN                  : boolean := false;  -- implement general purpose timer (GPTMR)?
@@ -1132,7 +1128,8 @@ package neorv32_package is
   component neorv32_cpu
     generic (
       -- General --
-      HW_THREAD_ID                 : natural; -- hardware thread id (32-bit)
+      HART_ID                      : std_ulogic_vector(31 downto 0); -- hardware thread ID
+      VENDOR_ID                    : std_ulogic_vector(31 downto 0); -- vendor's JEDEC ID
       CPU_BOOT_ADDR                : std_ulogic_vector(31 downto 0); -- cpu boot address
       CPU_DEBUG_PARK_ADDR          : std_ulogic_vector(31 downto 0); -- cpu debug mode parking loop entry address
       CPU_DEBUG_EXC_ADDR           : std_ulogic_vector(31 downto 0); -- cpu debug mode exception entry address
@@ -1205,7 +1202,8 @@ package neorv32_package is
     generic (
       -- General --
       XLEN                         : natural; -- data path width
-      HW_THREAD_ID                 : natural; -- hardware thread id (32-bit)
+      HART_ID                      : std_ulogic_vector(31 downto 0); -- hardware thread ID
+      VENDOR_ID                    : std_ulogic_vector(31 downto 0); -- vendor's JEDEC ID
       CPU_BOOT_ADDR                : std_ulogic_vector(31 downto 0); -- cpu boot address
       CPU_DEBUG_PARK_ADDR          : std_ulogic_vector(31 downto 0); -- cpu debug mode parking loop entry address
       CPU_DEBUG_EXC_ADDR           : std_ulogic_vector(31 downto 0); -- cpu debug mode exception entry address
@@ -1956,8 +1954,8 @@ package neorv32_package is
   component neorv32_cfs
     generic (
       CFS_CONFIG   : std_ulogic_vector(31 downto 0); -- custom CFS configuration generic
-      CFS_IN_SIZE  : positive; -- size of CFS input conduit in bits
-      CFS_OUT_SIZE : positive  -- size of CFS output conduit in bits
+      CFS_IN_SIZE  : natural; -- size of CFS input conduit in bits
+      CFS_OUT_SIZE : natural  -- size of CFS output conduit in bits
     );
     port (
       -- host access --

--- a/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
@@ -113,7 +113,7 @@ begin
     -- General --
     CLOCK_FREQUENCY              => CLOCK_FREQUENCY,  -- clock frequency of clk_i in Hz
     INT_BOOTLOADER_EN            => false,            -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
-    HW_THREAD_ID                 => HW_THREAD_ID,     -- hardware thread id (32-bit)
+    HART_ID                      => HW_THREAD_ID,     -- hardware thread id (32-bit)
 
     -- On-Chip Debugger (OCD) --
     ON_CHIP_DEBUGGER_EN          => false,  -- implement on-chip debugger?

--- a/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
@@ -41,7 +41,7 @@ library neorv32;
 entity neorv32_ProcessorTop_Minimal is
   generic (
     CLOCK_FREQUENCY              : natural := 0;      -- clock frequency of clk_i in Hz
-    HW_THREAD_ID                 : natural := 0;      -- hardware thread id (32-bit)
+    HW_THREAD_ID                 : natural := 0;      -- hardware thread id (32-bit) - unused
 
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_C        : boolean := false;  -- implement compressed extension?
@@ -113,7 +113,6 @@ begin
     -- General --
     CLOCK_FREQUENCY              => CLOCK_FREQUENCY,  -- clock frequency of clk_i in Hz
     INT_BOOTLOADER_EN            => false,            -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
-    HART_ID                      => HW_THREAD_ID,     -- hardware thread id (32-bit)
 
     -- On-Chip Debugger (OCD) --
     ON_CHIP_DEBUGGER_EN          => false,  -- implement on-chip debugger?

--- a/rtl/processor_templates/neorv32_ProcessorTop_MinimalBoot.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_MinimalBoot.vhd
@@ -42,7 +42,7 @@ entity neorv32_ProcessorTop_MinimalBoot is
   generic (
     CLOCK_FREQUENCY              : natural := 0;      -- clock frequency of clk_i in Hz
     INT_BOOTLOADER_EN            : boolean := true;   -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
-    HW_THREAD_ID                 : natural := 0;      -- hardware thread id (32-bit)
+    HW_THREAD_ID                 : natural := 0;      -- hardware thread id (32-bit) - unused
 
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_C        : boolean := true;   -- implement compressed extension?
@@ -127,7 +127,6 @@ begin
     -- General --
     CLOCK_FREQUENCY              => CLOCK_FREQUENCY,  -- clock frequency of clk_i in Hz
     INT_BOOTLOADER_EN            => INT_BOOTLOADER_EN,-- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
-    HART_ID                      => HW_THREAD_ID,     -- hardware thread id (32-bit)
 
     -- On-Chip Debugger (OCD) --
     ON_CHIP_DEBUGGER_EN          => false,  -- implement on-chip debugger?

--- a/rtl/processor_templates/neorv32_ProcessorTop_MinimalBoot.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_MinimalBoot.vhd
@@ -127,7 +127,7 @@ begin
     -- General --
     CLOCK_FREQUENCY              => CLOCK_FREQUENCY,  -- clock frequency of clk_i in Hz
     INT_BOOTLOADER_EN            => INT_BOOTLOADER_EN,-- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
-    HW_THREAD_ID                 => HW_THREAD_ID,     -- hardware thread id (32-bit)
+    HART_ID                      => HW_THREAD_ID,     -- hardware thread id (32-bit)
 
     -- On-Chip Debugger (OCD) --
     ON_CHIP_DEBUGGER_EN          => false,  -- implement on-chip debugger?

--- a/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
@@ -41,7 +41,7 @@ library neorv32;
 entity neorv32_ProcessorTop_UP5KDemo is
   generic (
     CLOCK_FREQUENCY              : natural := 0;      -- clock frequency of clk_i in Hz
-    HW_THREAD_ID                 : natural := 0;      -- hardware thread id (32-bit)
+    HW_THREAD_ID                 : natural := 0;      -- hardware thread id (32-bit) - unused
 
     -- On-Chip Debugger (OCD) --
     ON_CHIP_DEBUGGER_EN          : boolean := false;  -- implement on-chip debugger?
@@ -177,7 +177,6 @@ begin
     -- General --
     CLOCK_FREQUENCY              => CLOCK_FREQUENCY,  -- clock frequency of clk_i in Hz
     INT_BOOTLOADER_EN            => true,             -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
-    HART_ID                      => HW_THREAD_ID,     -- hardware thread id (32-bit)
 
     -- On-Chip Debugger (OCD) --
     ON_CHIP_DEBUGGER_EN          => ON_CHIP_DEBUGGER_EN,  -- implement on-chip debugger?

--- a/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
@@ -177,7 +177,7 @@ begin
     -- General --
     CLOCK_FREQUENCY              => CLOCK_FREQUENCY,  -- clock frequency of clk_i in Hz
     INT_BOOTLOADER_EN            => true,             -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
-    HW_THREAD_ID                 => HW_THREAD_ID,     -- hardware thread id (32-bit)
+    HART_ID                      => HW_THREAD_ID,     -- hardware thread id (32-bit)
 
     -- On-Chip Debugger (OCD) --
     ON_CHIP_DEBUGGER_EN          => ON_CHIP_DEBUGGER_EN,  -- implement on-chip debugger?

--- a/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
@@ -46,7 +46,8 @@ entity neorv32_top_avalonmm is
   generic (
     -- General --
     CLOCK_FREQUENCY              : natural;           -- clock frequency of clk_i in Hz
-    HW_THREAD_ID                 : natural := 0;      -- hardware thread id (32-bit)
+    HART_ID                      : std_ulogic_vector(31 downto 0) := x"00000000"; -- hardware thread ID
+    VENDOR_ID                    : std_ulogic_vector(31 downto 0) := x"00000000"; -- vendor's JEDEC ID
     CUSTOM_ID                    : std_ulogic_vector(31 downto 0) := x"00000000"; -- custom user-defined ID
     INT_BOOTLOADER_EN            : boolean := false;  -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
 
@@ -228,9 +229,9 @@ begin
   generic map (
     -- General --
     CLOCK_FREQUENCY => CLOCK_FREQUENCY,
-    HW_THREAD_ID => HW_THREAD_ID,
+    HART_ID => HART_ID,
+    VENDOR_ID => VENDOR_ID,
     CUSTOM_ID => CUSTOM_ID,
-    INT_BOOTLOADER_EN => INT_BOOTLOADER_EN,
 
     -- On-Chip Debugger (OCD) --
     ON_CHIP_DEBUGGER_EN => ON_CHIP_DEBUGGER_EN,

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -49,8 +49,9 @@ entity neorv32_SystemTop_axi4lite is
     -- ------------------------------------------------------------
     -- General --
     CLOCK_FREQUENCY              : natural := 0;      -- clock frequency of clk_i in Hz
-    HW_THREAD_ID                 : natural := 0;      -- hardware thread id (32-bit)
-    CUSTOM_ID                    : std_logic_vector(31 downto 0) := x"00000000"; -- custom user-defined ID
+    HART_ID                      : std_ulogic_vector(31 downto 0) := x"00000000"; -- hardware thread ID
+    VENDOR_ID                    : std_ulogic_vector(31 downto 0) := x"00000000"; -- vendor's JEDEC ID
+    CUSTOM_ID                    : std_ulogic_vector(31 downto 0) := x"00000000"; -- custom user-defined ID
     INT_BOOTLOADER_EN            : boolean := true;   -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
     -- On-Chip Debugger (OCD) --
     ON_CHIP_DEBUGGER_EN          : boolean := false;  -- implement on-chip debugger
@@ -299,8 +300,9 @@ begin
   generic map (
     -- General --
     CLOCK_FREQUENCY              => CLOCK_FREQUENCY,    -- clock frequency of clk_i in Hz
-    HW_THREAD_ID                 => HW_THREAD_ID,       -- hardware thread id (hartid)
-    CUSTOM_ID                    => CUSTOM_ID_INT,      -- custom user-defined ID
+    HART_ID                      => HART_ID,            -- hardware thread ID
+    VENDOR_ID                    => VENDOR_ID,          -- vendor's JEDEC ID
+    CUSTOM_ID                    => CUSTOM_ID,          -- custom user-defined ID
     INT_BOOTLOADER_EN            => INT_BOOTLOADER_EN,  -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
     -- On-Chip Debugger (OCD) --
     ON_CHIP_DEBUGGER_EN          => ON_CHIP_DEBUGGER_EN,          -- implement on-chip debugger

--- a/rtl/system_integration/neorv32_litex_core_complex.vhd
+++ b/rtl/system_integration/neorv32_litex_core_complex.vhd
@@ -37,7 +37,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -108,7 +108,12 @@ end neorv32_litex_core_complex;
 
 architecture neorv32_litex_core_complex_rtl of neorv32_litex_core_complex is
 
-  -- advance configuration --
+  -- identifiers --
+  constant hart_id_c  : std_ulogic_vector(31 downto 0) := x"00000000"; -- hardware thread ID ("core ID")
+  constant jedec_id_c : std_ulogic_vector(31 downto 0) := x"00000000"; -- vendor's JEDEC manufacturer ID
+  constant user_id_c  : std_ulogic_vector(31 downto 0) := x"00000000"; -- custom user ID
+
+  -- advanced configuration --
   constant num_configs_c : natural := 4;     -- number of pre-defined configurations
   constant wb_timeout_c  : natural := 4096;  -- external bus interface timeout cycles
   constant big_endian_c  : boolean := false; -- external bus interface endianness; default is little-endian
@@ -160,6 +165,9 @@ begin
   generic map (
     -- General --
     CLOCK_FREQUENCY              => 0,                              -- clock frequency of clk_i in Hz [not required by the core complex]
+    HART_ID                      => hart_id_c,                      -- hardware thread ID
+    VENDOR_ID                    => jedec_id_c,                     -- vendor's JEDEC ID
+    CUSTOM_ID                    => user_id_c,                      -- custom user-defined ID
     -- On-Chip Debugger (OCD) --
     ON_CHIP_DEBUGGER_EN          => DEBUG,                          -- implement on-chip debugger
     -- RISC-V CPU Extensions --

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -215,8 +215,9 @@ begin
   generic map (
     -- General --
     CLOCK_FREQUENCY              => f_clock_c,     -- clock frequency of clk_i in Hz
-    HW_THREAD_ID                 => 0,             -- hardware thread id (hartid) (32-bit)
-    CUSTOM_ID                    => x"12345678",  -- custom user-defined ID
+    HART_ID                      => x"00000000",   -- hardware thread ID
+    VENDOR_ID                    => x"00000000",   -- vendor's JEDEC ID
+    CUSTOM_ID                    => x"12345678",   -- custom user-defined ID
     INT_BOOTLOADER_EN            => false,         -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
     -- On-Chip Debugger (OCD) --
     ON_CHIP_DEBUGGER_EN          => true,          -- implement on-chip debugger

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -167,7 +167,8 @@ begin
   generic map (
     -- General --
     CLOCK_FREQUENCY              => f_clock_c,     -- clock frequency of clk_i in Hz
-    HW_THREAD_ID                 => 0,             -- hardware thread id (hartid) (32-bit)
+    HART_ID                      => x"00000000",   -- hardware thread ID
+    VENDOR_ID                    => x"00000000",   -- vendor's JEDEC ID
     CUSTOM_ID                    => x"12345678",   -- custom user-defined ID
     INT_BOOTLOADER_EN            => false,         -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
     -- On-Chip Debugger (OCD) --

--- a/sw/openocd/openocd_neorv32.cfg
+++ b/sw/openocd/openocd_neorv32.cfg
@@ -24,8 +24,7 @@ transport select jtag
 # Target configuration
 # ----------------------------------------------
 set _CHIPNAME neorv32
-set _JTAGID 0x0cafe001
-jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id $_JTAGID
+jtag newtap $_CHIPNAME cpu -irlen 5
 
 set _TARGETNAME $_CHIPNAME.cpu
 


### PR DESCRIPTION
* rename `HW_THREAD_ID` to `HART_ID` and change from `natural` to `std_ulogic_vector(31 downto 0)`
* add `VENDOR_ID` generic, type `std_ulogic_vector(31 downto 0)`, used to set content of `mvendorid` CSR (vendor's JEDEC manufacturer ID)
* hardwire JTAG tap's IDCODE identifier to all-zero