### PR TITLE
⚠️ [rtl] remove Zicsr generic, cleanups and optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 29.03.2023 | 1.8.2.9 | :warning: remove `CPU_EXTENSION_RISCV_Zicsr` generic - `Zicsr` ISA extension is always enabled; optimize bus switch; VHDL code cleanups; [#562](https://github.com/stnolting/neorv32/pull/562) |
 | 25.03.2023 | 1.8.2.8 | :test_tube: add configurable data cache (**dCACHE**); [#560](https://github.com/stnolting/neorv32/pull/560) |
 | 24.03.2023 | 1.8.2.7 | :sparkles: add full support of `mcounteren` CSR; cleanup counter and PMP CSRs; i-cache optimization; [#559](https://github.com/stnolting/neorv32/pull/559) |
 | 18.03.2023 | 1.8.2.6 | add new generic `JEDEC_ID` (official JEDEC identifier; used for `mvendorid` CSR); further generics cleanups; [#557](https://github.com/stnolting/neorv32/pull/557)

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -76,7 +76,7 @@ caused by speculative execution (like Spectre or Meltdown).
 :sectnums:
 ==== CPU Register File
 
-The data register file contains the general purpose "`x`" architecture registers. For `rv32i` ISA there are 32 32-bit registers
+The data register file contains the general purpose "`x`" architecture registers. For the `rv32i` ISA there are 32 32-bit registers
 and for the `rv32e` ISA there are 16 32-bit registers. Register zero (`x0`/`zero`) always read as zero and any write access to it
 is discarded.
 
@@ -162,7 +162,7 @@ includes the <<_control_and_status_registers_csrs>> as well as the trap controll
 === Sleep Mode
 
 The NEORV32 CPU provides a single sleep mode that can be entered to power-down the core reducing dynamic
-power consumption. Sleep mode in entered by executing the `wfi` instruction from the <<_zicsr_isa_extension>>.
+power consumption. Sleep mode in entered by executing the `wfi` instruction.
 When the CPU is in sleep mode, all CPU-internal operations are stopped (execution, instruction fetch, ...).
 However, this does not affect the operation of any peripheral/IO modules like interfaces and timers. Furthermore,
 the CPU will continue to buffer/enqueue incoming interrupt requests. The CPU will leave sleep mode as soon as
@@ -496,7 +496,8 @@ conditional operations from C-language code (see `sw/example/zicond_test`).
 ==== `Zicsr` ISA Extension
 
 This ISA extensions provides instructions for accessing the <<_control_and_status_registers_csrs>> as well as further
-privileged-architecture extensions. This extension is mandatory and cannot be disabled.
+privileged-architecture extensions. This extension is mandatory and cannot be disabled. Hence, there is no generic
+for enabling/disabling this ISa extension.
 
 [NOTE]
 If `rd=x0` for the `csrrw[i]` instructions there will be no actual read access to the according CSR.

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -203,7 +203,6 @@ The generic type "suv(x:y)" defines a `std_ulogic_vector(x downto y)`.
 | `CPU_EXTENSION_RISCV_M`        | boolean | false | Enable <<_m_isa_extension>> (hardware-based integer multiplication and division).
 | `CPU_EXTENSION_RISCV_U`        | boolean | false | Enable <<_u_isa_extension>> (less-privileged user mode).
 | `CPU_EXTENSION_RISCV_Zfinx`    | boolean | false | Enable <<_zfinx_isa_extension>> (single-precision floating-point unit).
-| `CPU_EXTENSION_RISCV_Zicsr`    | boolean | true  | Enable <<_zicsr_isa_extension>> (control and status register access).
 | `CPU_EXTENSION_RISCV_Zicntr`   | boolean | true  | Enable <<_zicntr_isa_extension>> (CPU base counters).
 | `CPU_EXTENSION_RISCV_Zicond`   | boolean | false | Enable <<_zicond_isa_extension>> (conditional operations).
 | `CPU_EXTENSION_RISCV_Zihpm`    | boolean | false | Enable <<_zihpm_isa_extension>> (hardware performance monitors).

--- a/rtl/core/neorv32_busswitch.vhd
+++ b/rtl/core/neorv32_busswitch.vhd
@@ -156,7 +156,7 @@ begin
     -- state machine --
     case arbiter.state is
 
-      when IDLE => -- port A or B access
+      when IDLE => -- wait for requests
       -- ------------------------------------------------------------
         if (ca_req_current = '1') then -- current request from port A?
           arbiter.bus_sel   <= '0';
@@ -176,7 +176,11 @@ begin
       -- ------------------------------------------------------------
         arbiter.bus_sel <= '0'; -- access from port A
         if (p_bus_err_i = '1') or (p_bus_ack_i = '1') then
-          arbiter.state_nxt <= IDLE;
+          if (cb_req_pending = '1') or (cb_req_current = '1') then -- any request from B?
+            arbiter.state_nxt <= B_RETIRE;
+          else
+            arbiter.state_nxt <= IDLE;
+          end if;
         end if;
 
       when A_RETIRE => -- retire port A pending access

--- a/rtl/core/neorv32_dcache.vhd
+++ b/rtl/core/neorv32_dcache.vhd
@@ -53,7 +53,6 @@ entity neorv32_dcache is
     clk_i        : in  std_ulogic; -- global clock, rising edge
     rstn_i       : in  std_ulogic; -- global reset, low-active, async
     clear_i      : in  std_ulogic; -- cache clear
-    miss_o       : out std_ulogic; -- cache miss
     -- host controller interface --
     host_addr_i  : in  std_ulogic_vector(31 downto 0); -- bus access address
     host_rdata_o : out std_ulogic_vector(31 downto 0); -- bus read data
@@ -327,9 +326,6 @@ begin
 
   -- cached access? --
   bus_cached_o <= '1' when (ctrl.state = S_DOWNLOAD_REQ) or (ctrl.state = S_DOWNLOAD_WAIT) else '1';
-
-  -- miss access? --
-  miss_o <= '1' when (ctrl.state = S_CHECK) and (cache.hit = '0') else '0';
 
 
 	-- Cache Memory ---------------------------------------------------------------------------

--- a/rtl/core/neorv32_icache.vhd
+++ b/rtl/core/neorv32_icache.vhd
@@ -53,7 +53,6 @@ entity neorv32_icache is
     clk_i        : in  std_ulogic; -- global clock, rising edge
     rstn_i       : in  std_ulogic; -- global reset, low-active, async
     clear_i      : in  std_ulogic; -- cache clear
-    miss_o       : out std_ulogic; -- cache miss
     -- host controller interface --
     host_addr_i  : in  std_ulogic_vector(31 downto 0); -- bus access address
     host_rdata_o : out std_ulogic_vector(31 downto 0); -- bus read data
@@ -262,9 +261,6 @@ begin
 
   -- cached access? --
   bus_cached_o <= '1' when (ctrl.state = S_DOWNLOAD_REQ) or (ctrl.state = S_DOWNLOAD_GET) else '0';
-
-  -- miss access? --
-  miss_o <= '1' when (ctrl.state = S_CHECK) and (cache.hit = '0') else '0';
 
 
   -- Cache Memory ---------------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -60,7 +60,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080208"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080209"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -980,7 +980,6 @@ package neorv32_package is
       CPU_EXTENSION_RISCV_M        : boolean := false;  -- implement mul/div extension?
       CPU_EXTENSION_RISCV_U        : boolean := false;  -- implement user mode extension?
       CPU_EXTENSION_RISCV_Zfinx    : boolean := false;  -- implement 32-bit floating-point extension (using INT regs!)
-      CPU_EXTENSION_RISCV_Zicsr    : boolean := true;   -- implement CSR system?
       CPU_EXTENSION_RISCV_Zicntr   : boolean := true;   -- implement base counters?
       CPU_EXTENSION_RISCV_Zicond   : boolean := false;  -- implement conditional operations extension?
       CPU_EXTENSION_RISCV_Zihpm    : boolean := false;  -- implement hardware performance monitors?
@@ -1144,7 +1143,6 @@ package neorv32_package is
       CPU_EXTENSION_RISCV_M        : boolean; -- implement mul/div extension?
       CPU_EXTENSION_RISCV_U        : boolean; -- implement user mode extension?
       CPU_EXTENSION_RISCV_Zfinx    : boolean; -- implement 32-bit floating-point extension (using INT reg!)
-      CPU_EXTENSION_RISCV_Zicsr    : boolean; -- implement CSR system?
       CPU_EXTENSION_RISCV_Zicntr   : boolean; -- implement base counters?
       CPU_EXTENSION_RISCV_Zicond   : boolean; -- implement conditional operations extension?
       CPU_EXTENSION_RISCV_Zihpm    : boolean; -- implement hardware performance monitors?
@@ -1218,7 +1216,6 @@ package neorv32_package is
       CPU_EXTENSION_RISCV_M        : boolean; -- implement mul/div extension?
       CPU_EXTENSION_RISCV_U        : boolean; -- implement user mode extension?
       CPU_EXTENSION_RISCV_Zfinx    : boolean; -- implement 32-bit floating-point extension (using INT reg!)
-      CPU_EXTENSION_RISCV_Zicsr    : boolean; -- implement CSR system?
       CPU_EXTENSION_RISCV_Zicntr   : boolean; -- implement base counters?
       CPU_EXTENSION_RISCV_Zicond   : boolean; -- implement conditional operations extension?
       CPU_EXTENSION_RISCV_Zihpm    : boolean; -- implement hardware performance monitors?
@@ -1568,7 +1565,6 @@ package neorv32_package is
       clk_i        : in  std_ulogic; -- global clock, rising edge
       rstn_i       : in  std_ulogic; -- global reset, low-active, async
       clear_i      : in  std_ulogic; -- cache clear
-      miss_o       : out std_ulogic; -- cache miss
       -- host controller interface --
       host_addr_i  : in  std_ulogic_vector(31 downto 0); -- bus access address
       host_rdata_o : out std_ulogic_vector(31 downto 0); -- bus read data
@@ -1598,7 +1594,6 @@ package neorv32_package is
       clk_i        : in  std_ulogic; -- global clock, rising edge
       rstn_i       : in  std_ulogic; -- global reset, low-active, async
       clear_i      : in  std_ulogic; -- cache clear
-      miss_o       : out std_ulogic; -- cache miss
       -- host controller interface --
       host_addr_i  : in  std_ulogic_vector(31 downto 0); -- bus access address
       host_rdata_o : out std_ulogic_vector(31 downto 0); -- bus read data

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -63,7 +63,6 @@ entity neorv32_top is
     CPU_EXTENSION_RISCV_M        : boolean := false;  -- implement mul/div extension?
     CPU_EXTENSION_RISCV_U        : boolean := false;  -- implement user mode extension?
     CPU_EXTENSION_RISCV_Zfinx    : boolean := false;  -- implement 32-bit floating-point extension (using INT regs!)
-    CPU_EXTENSION_RISCV_Zicsr    : boolean := true;   -- implement CSR system?
     CPU_EXTENSION_RISCV_Zicntr   : boolean := true;   -- implement base counters?
     CPU_EXTENSION_RISCV_Zicond   : boolean := false;  -- implement conditional operations extension?
     CPU_EXTENSION_RISCV_Zihpm    : boolean := false;  -- implement hardware performance monitors?
@@ -527,7 +526,6 @@ begin
     CPU_EXTENSION_RISCV_M        => CPU_EXTENSION_RISCV_M,        -- implement mul/div extension?
     CPU_EXTENSION_RISCV_U        => CPU_EXTENSION_RISCV_U,        -- implement user mode extension?
     CPU_EXTENSION_RISCV_Zfinx    => CPU_EXTENSION_RISCV_Zfinx,    -- implement 32-bit floating-point extension (using INT reg!)
-    CPU_EXTENSION_RISCV_Zicsr    => CPU_EXTENSION_RISCV_Zicsr,    -- implement CSR system?
     CPU_EXTENSION_RISCV_Zicntr   => CPU_EXTENSION_RISCV_Zicntr,   -- implement base counters?
     CPU_EXTENSION_RISCV_Zicond   => CPU_EXTENSION_RISCV_Zicond,   -- implement conditional operations extension?
     CPU_EXTENSION_RISCV_Zihpm    => CPU_EXTENSION_RISCV_Zihpm,    -- implement hardware performance monitors?
@@ -626,7 +624,6 @@ begin
       clk_i        => clk_i,          -- global clock, rising edge
       rstn_i       => rstn_int,       -- global reset, low-active, async
       clear_i      => cpu_i.fence,    -- cache clear
-      miss_o       => open,           -- cache miss
       -- host controller interface --
       host_addr_i  => cpu_i.addr,     -- bus access address
       host_rdata_o => cpu_i.rdata,    -- bus read data
@@ -673,7 +670,6 @@ begin
       clk_i        => clk_i,          -- global clock, rising edge
       rstn_i       => rstn_int,       -- global reset, low-active, async
       clear_i      => cpu_d.fence,    -- cache clear
-      miss_o       => open,           -- cache miss
       -- host controller interface --
       host_addr_i  => cpu_d.addr,     -- bus access address
       host_rdata_o => cpu_d.rdata,    -- bus read data

--- a/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
@@ -40,55 +40,23 @@ library neorv32;
 
 entity neorv32_ProcessorTop_Minimal is
   generic (
-    CLOCK_FREQUENCY              : natural := 0;      -- clock frequency of clk_i in Hz
-    HW_THREAD_ID                 : natural := 0;      -- hardware thread id (32-bit) - unused
-
-    -- RISC-V CPU Extensions --
-    CPU_EXTENSION_RISCV_C        : boolean := false;  -- implement compressed extension?
-    CPU_EXTENSION_RISCV_E        : boolean := false;  -- implement embedded RF extension?
-    CPU_EXTENSION_RISCV_M        : boolean := false;  -- implement mul/div extension?
-    CPU_EXTENSION_RISCV_U        : boolean := false;  -- implement user mode extension?
-    CPU_EXTENSION_RISCV_Zfinx    : boolean := false;  -- implement 32-bit floating-point extension (using INT regs!)
-    CPU_EXTENSION_RISCV_Zicsr    : boolean := true;   -- implement CSR system?
-    CPU_EXTENSION_RISCV_Zifencei : boolean := false;  -- implement instruction stream sync.?
-
-    -- Extension Options --
-    FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
-    FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
-
-    -- Physical Memory Protection (PMP) --
-    PMP_NUM_REGIONS              : natural := 0;       -- number of regions (0..16)
-    PMP_MIN_GRANULARITY          : natural := 4;       -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
-
-    -- Hardware Performance Monitors (HPM) --
-    HPM_NUM_CNTS                 : natural := 0;       -- number of implemented HPM counters (0..29)
-    HPM_CNT_WIDTH                : natural := 40;      -- total size of HPM counters (0..64)
-
+    -- General --
+    CLOCK_FREQUENCY   : natural := 0;       -- clock frequency of clk_i in Hz
     -- Internal Instruction memory --
-    MEM_INT_IMEM_EN              : boolean := true;    -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE            : natural := 8*1024;  -- size of processor-internal instruction memory in bytes
-
+    MEM_INT_IMEM_EN   : boolean := true;    -- implement processor-internal instruction memory
+    MEM_INT_IMEM_SIZE : natural := 8*1024;  -- size of processor-internal instruction memory in bytes
     -- Internal Data memory --
-    MEM_INT_DMEM_EN              : boolean := true;    -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE            : natural := 64*1024; -- size of processor-internal data memory in bytes
-
-    -- Internal Cache memory --
-    ICACHE_EN                    : boolean := false;  -- implement instruction cache
-    ICACHE_NUM_BLOCKS            : natural := 4;      -- i-cache: number of blocks (min 1), has to be a power of 2
-    ICACHE_BLOCK_SIZE            : natural := 64;     -- i-cache: block size in bytes (min 4), has to be a power of 2
-    ICACHE_ASSOCIATIVITY         : natural := 1;      -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
-
+    MEM_INT_DMEM_EN   : boolean := true;    -- implement processor-internal data memory
+    MEM_INT_DMEM_SIZE : natural := 64*1024; -- size of processor-internal data memory in bytes
     -- Processor peripherals --
-    IO_MTIME_EN                  : boolean := false;  -- implement machine system timer (MTIME)?
-    IO_PWM_NUM_CH                : natural := 3;      -- number of PWM channels to implement (0..12); 0 = disabled
-    IO_WDT_EN                    : boolean := false   -- implement watch dog timer (WDT)?
+    IO_PWM_NUM_CH     : natural := 3        -- number of PWM channels to implement (0..12); 0 = disabled
   );
   port (
-    clk_i      : in  std_logic;
-    rstn_i     : in  std_logic;
-
+    -- Global control --
+    clk_i  : in  std_logic;
+    rstn_i : in  std_logic;
     -- PWM (available if IO_PWM_NUM_CH > 0) --
-    pwm_o      : out std_ulogic_vector(IO_PWM_NUM_CH-1 downto 0)
+    pwm_o  : out std_ulogic_vector(IO_PWM_NUM_CH-1 downto 0)
   );
 end entity;
 
@@ -99,72 +67,33 @@ architecture neorv32_ProcessorTop_Minimal_rtl of neorv32_ProcessorTop_Minimal is
 
 begin
 
-  -- IO Connection --------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-
-  -- PWM --
-  pwm_o <= con_pwm_o(IO_PWM_NUM_CH-1 downto 0);
-
-
   -- The core of the problem ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   neorv32_inst: entity neorv32.neorv32_top
   generic map (
     -- General --
-    CLOCK_FREQUENCY              => CLOCK_FREQUENCY,  -- clock frequency of clk_i in Hz
-    INT_BOOTLOADER_EN            => false,            -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
-
-    -- On-Chip Debugger (OCD) --
-    ON_CHIP_DEBUGGER_EN          => false,  -- implement on-chip debugger?
-
-    -- RISC-V CPU Extensions --
-    CPU_EXTENSION_RISCV_C        => CPU_EXTENSION_RISCV_C,         -- implement compressed extension?
-    CPU_EXTENSION_RISCV_E        => CPU_EXTENSION_RISCV_E,         -- implement embedded RF extension?
-    CPU_EXTENSION_RISCV_M        => CPU_EXTENSION_RISCV_M,         -- implement mul/div extension?
-    CPU_EXTENSION_RISCV_U        => CPU_EXTENSION_RISCV_U,         -- implement user mode extension?
-    CPU_EXTENSION_RISCV_Zfinx    => CPU_EXTENSION_RISCV_Zfinx,     -- implement 32-bit floating-point extension (using INT regs!)
-    CPU_EXTENSION_RISCV_Zicsr    => CPU_EXTENSION_RISCV_Zicsr,     -- implement CSR system?
-    CPU_EXTENSION_RISCV_Zicntr   => true,                          -- implement base counters?
-    CPU_EXTENSION_RISCV_Zifencei => CPU_EXTENSION_RISCV_Zifencei,  -- implement instruction stream sync.?
-
-    -- Extension Options --
-    FAST_MUL_EN                  => FAST_MUL_EN,    -- use DSPs for M extension's multiplier
-    FAST_SHIFT_EN                => FAST_SHIFT_EN,  -- use barrel shifter for shift operations
-
-    -- Physical Memory Protection (PMP) --
-    PMP_NUM_REGIONS              => PMP_NUM_REGIONS,       -- number of regions (0..16)
-    PMP_MIN_GRANULARITY          => PMP_MIN_GRANULARITY,   -- minimal region granularity in bytes, has to be a power of 2, min 8 bytes
-
-    -- Hardware Performance Monitors (HPM) --
-    HPM_NUM_CNTS                 => HPM_NUM_CNTS,          -- number of implemented HPM counters (0..29)
-    HPM_CNT_WIDTH                => HPM_CNT_WIDTH,         -- total size of HPM counters (1..64)
-
+    CLOCK_FREQUENCY              => CLOCK_FREQUENCY,   -- clock frequency of clk_i in Hz
+    INT_BOOTLOADER_EN            => false,             -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
     -- Internal Instruction memory --
-    MEM_INT_IMEM_EN              => MEM_INT_IMEM_EN,       -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE            => MEM_INT_IMEM_SIZE,     -- size of processor-internal instruction memory in bytes
-
+    MEM_INT_IMEM_EN              => MEM_INT_IMEM_EN,   -- implement processor-internal instruction memory
+    MEM_INT_IMEM_SIZE            => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes
     -- Internal Data memory --
-    MEM_INT_DMEM_EN              => MEM_INT_DMEM_EN,       -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE            => MEM_INT_DMEM_SIZE,     -- size of processor-internal data memory in bytes
-
-    -- Internal Cache memory --
-    ICACHE_EN                    => ICACHE_EN,             -- implement instruction cache
-    ICACHE_NUM_BLOCKS            => ICACHE_NUM_BLOCKS,     -- i-cache: number of blocks (min 1), has to be a power of 2
-    ICACHE_BLOCK_SIZE            => ICACHE_BLOCK_SIZE,     -- i-cache: block size in bytes (min 4), has to be a power of 2
-    ICACHE_ASSOCIATIVITY         => ICACHE_ASSOCIATIVITY,  -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
-
+    MEM_INT_DMEM_EN              => MEM_INT_DMEM_EN,   -- implement processor-internal data memory
+    MEM_INT_DMEM_SIZE            => MEM_INT_DMEM_SIZE, -- size of processor-internal data memory in bytes
     -- Processor peripherals --
-    IO_MTIME_EN                  => IO_MTIME_EN,   -- implement machine system timer (MTIME)?
-    IO_PWM_NUM_CH                => IO_PWM_NUM_CH, -- number of PWM channels to implement (0..12); 0 = disabled
-    IO_WDT_EN                    => IO_WDT_EN      -- implement watch dog timer (WDT)?
+    IO_MTIME_EN                  => true,              -- implement machine system timer (MTIME)?
+    IO_PWM_NUM_CH                => IO_PWM_NUM_CH      -- number of PWM channels to implement (0..12); 0 = disabled
   )
   port map (
     -- Global control --
-    clk_i       => clk_i,                        -- global clock, rising edge
-    rstn_i      => rstn_i,                       -- global reset, low-active, async
-
+    clk_i  => clk_i,    -- global clock, rising edge
+    rstn_i => rstn_i,   -- global reset, low-active, async
     -- PWM (available if IO_PWM_NUM_CH > 0) --
-    pwm_o       => con_pwm_o                     -- pwm channels
+    pwm_o  => con_pwm_o -- pwm channels
   );
+
+  -- PWM --
+  pwm_o <= con_pwm_o(IO_PWM_NUM_CH-1 downto 0);
+
 
 end architecture;

--- a/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
@@ -40,84 +40,41 @@ library neorv32;
 
 entity neorv32_ProcessorTop_UP5KDemo is
   generic (
-    CLOCK_FREQUENCY              : natural := 0;      -- clock frequency of clk_i in Hz
-    HW_THREAD_ID                 : natural := 0;      -- hardware thread id (32-bit) - unused
-
-    -- On-Chip Debugger (OCD) --
-    ON_CHIP_DEBUGGER_EN          : boolean := false;  -- implement on-chip debugger?
-
-    -- RISC-V CPU Extensions --
-    CPU_EXTENSION_RISCV_C        : boolean := true;   -- implement compressed extension?
-    CPU_EXTENSION_RISCV_E        : boolean := false;  -- implement embedded RF extension?
-    CPU_EXTENSION_RISCV_M        : boolean := true;   -- implement mul/div extension?
-    CPU_EXTENSION_RISCV_U        : boolean := false;  -- implement user mode extension?
-    CPU_EXTENSION_RISCV_Zfinx    : boolean := false;  -- implement 32-bit floating-point extension (using INT regs!)
-    CPU_EXTENSION_RISCV_Zicsr    : boolean := true;   -- implement CSR system?
-    CPU_EXTENSION_RISCV_Zifencei : boolean := false;  -- implement instruction stream sync.?
-
-    -- Extension Options --
-    FAST_MUL_EN                  : boolean := false;  -- use DSPs for M extension's multiplier
-    FAST_SHIFT_EN                : boolean := false;  -- use barrel shifter for shift operations
-
-    -- Physical Memory Protection (PMP) --
-    PMP_NUM_REGIONS              : natural := 0;       -- number of regions (0..16)
-    PMP_MIN_GRANULARITY          : natural := 4;       -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
-
-    -- Hardware Performance Monitors (HPM) --
-    HPM_NUM_CNTS                 : natural := 0;       -- number of implemented HPM counters (0..29)
-    HPM_CNT_WIDTH                : natural := 40;      -- total size of HPM counters (0..64)
-
+    -- General --
+    CLOCK_FREQUENCY   : natural := 0;       -- clock frequency of clk_i in Hz
     -- Internal Instruction memory --
-    MEM_INT_IMEM_EN              : boolean := true;    -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE            : natural := 64*1024; -- size of processor-internal instruction memory in bytes
-
+    MEM_INT_IMEM_EN   : boolean := true;    -- implement processor-internal instruction memory
+    MEM_INT_IMEM_SIZE : natural := 64*1024; -- size of processor-internal instruction memory in bytes
     -- Internal Data memory --
-    MEM_INT_DMEM_EN              : boolean := true;    -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE            : natural := 64*1024; -- size of processor-internal data memory in bytes
-
-    -- Internal Cache memory --
-    ICACHE_EN                    : boolean := false;  -- implement instruction cache
-    ICACHE_NUM_BLOCKS            : natural := 4;      -- i-cache: number of blocks (min 1), has to be a power of 2
-    ICACHE_BLOCK_SIZE            : natural := 64;     -- i-cache: block size in bytes (min 4), has to be a power of 2
-    ICACHE_ASSOCIATIVITY         : natural := 1;      -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
-
+    MEM_INT_DMEM_EN   : boolean := true;    -- implement processor-internal data memory
+    MEM_INT_DMEM_SIZE : natural := 64*1024; -- size of processor-internal data memory in bytes
     -- Processor peripherals --
-    IO_GPIO_NUM                  : natural := 64;     -- number of GPIO input/output pairs (0..64)
-    IO_MTIME_EN                  : boolean := true;   -- implement machine system timer (MTIME)?
-    IO_UART0_EN                  : boolean := true;   -- implement primary universal asynchronous receiver/transmitter (UART0)?
-    IO_SPI_EN                    : boolean := true;   -- implement serial peripheral interface (SPI)?
-    IO_TWI_EN                    : boolean := true;   -- implement two-wire interface (TWI)?
-    IO_PWM_NUM_CH                : natural := 3;      -- number of PWM channels to implement (0..12); 0 = disabled
-    IO_WDT_EN                    : boolean := true    -- implement watch dog timer (WDT)?
+    IO_GPIO_NUM       : natural := 64;      -- number of GPIO input/output pairs (0..64)
+    IO_PWM_NUM_CH     : natural := 3        -- number of PWM channels to implement (0..12); 0 = disabled
   );
   port (
+    -- Global control --
     clk_i       : in  std_logic;
     rstn_i      : in  std_logic;
-
     -- GPIO (available if IO_GPIO_NUM > 0) --
     gpio_i      : in  std_ulogic_vector(3 downto 0);
     gpio_o      : out std_ulogic_vector(3 downto 0);
-
     -- primary UART0 (available if IO_UART0_EN = true) --
     uart_txd_o  : out std_ulogic; -- UART0 send data
     uart_rxd_i  : in  std_ulogic := '0'; -- UART0 receive data
-
     -- SPI to on-board flash --
     flash_sck_o : out std_ulogic;
     flash_sdo_o : out std_ulogic;
     flash_sdi_i : in  std_ulogic;
     flash_csn_o : out std_ulogic; -- NEORV32.SPI_CS(0)
-
     -- SPI (available if IO_SPI_EN = true) --
     spi_sck_o   : out std_ulogic;
     spi_sdo_o   : out std_ulogic;
     spi_sdi_i   : in  std_ulogic;
     spi_csn_o   : out std_ulogic; -- NEORV32.SPI_CS(1)
-
     -- TWI (available if IO_TWI_EN = true) --
     twi_sda_io  : inout std_logic;
     twi_scl_io  : inout std_logic;
-
     -- PWM (available if IO_PWM_NUM_CH > 0) --
     pwm_o       : out std_ulogic_vector(IO_PWM_NUM_CH-1 downto 0)
   );
@@ -140,8 +97,50 @@ architecture neorv32_ProcessorTop_UP5KDemo_rtl of neorv32_ProcessorTop_UP5KDemo 
 
 begin
 
-  -- IO Connection --------------------------------------------------------------------------
+  -- The core of the problem ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
+  neorv32_inst: entity neorv32.neorv32_top
+  generic map (
+    -- General --
+    CLOCK_FREQUENCY              => CLOCK_FREQUENCY,   -- clock frequency of clk_i in Hz
+    INT_BOOTLOADER_EN            => true,              -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
+    -- RISC-V CPU Extensions --
+    CPU_EXTENSION_RISCV_M        => true,              -- implement mul/div extension?
+    CPU_EXTENSION_RISCV_U        => true,              -- implement user mode extension?
+    CPU_EXTENSION_RISCV_Zicntr   => true,                          -- implement base counters?
+    CPU_EXTENSION_RISCV_Zifencei => true,              -- implement instruction stream sync.?
+    -- Internal Instruction memory --
+    MEM_INT_IMEM_EN              => MEM_INT_IMEM_EN,   -- implement processor-internal instruction memory
+    MEM_INT_IMEM_SIZE            => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes
+    -- Internal Data memory --
+    MEM_INT_DMEM_EN              => MEM_INT_DMEM_EN,   -- implement processor-internal data memory
+    MEM_INT_DMEM_SIZE            => MEM_INT_DMEM_SIZE, -- size of processor-internal data memory in bytes
+    -- Processor peripherals --
+    IO_GPIO_NUM                  => IO_GPIO_NUM,       -- number of GPIO input/output pairs (0..64)
+    IO_MTIME_EN                  => true,              -- implement machine system timer (MTIME)?
+    IO_UART0_EN                  => true,              -- implement primary universal asynchronous receiver/transmitter (UART0)?
+    IO_SPI_EN                    => true,              -- implement serial peripheral interface (SPI)?
+    IO_TWI_EN                    => true,              -- implement two-wire interface (TWI)?
+    IO_PWM_NUM_CH                => IO_PWM_NUM_CH      -- number of PWM channels to implement (0..12); 0 = disabled
+  )
+  port map (
+    -- Global control --
+    clk_i       => clk_i,         -- global clock, rising edge
+    rstn_i      => rstn_i,        -- global reset, low-active, async
+    -- GPIO (available if IO_GPIO_NUM > 0) --
+    gpio_o      => con_gpio_o,    -- parallel output
+    gpio_i      => con_gpio_i,    -- parallel input
+    -- primary UART0 (available if IO_UART0_EN = true) --
+    uart0_txd_o => uart_txd_o,    -- UART0 send data
+    uart0_rxd_i => uart_rxd_i,    -- UART0 receive data
+    -- TWI (available if IO_TWI_EN = true) --
+    twi_sda_i   => con_twi_sda_i, -- serial data line sense input
+    twi_sda_o   => con_twi_sda_o, -- serial data line output (pull low only)
+    twi_scl_i   => con_twi_scl_i, -- serial clock line sense input
+    twi_scl_o   => con_twi_scl_o, -- serial clock line output (pull low only)
+    -- PWM (available if IO_PWM_NUM_CH > 0) --
+    pwm_o       => con_pwm_o      -- pwm channels
+  );
 
   -- SPI: on-board flash --
   flash_sck_o <= con_spi_sck;
@@ -168,86 +167,6 @@ begin
   twi_scl_io    <= '0' when (con_twi_scl_o = '0') else 'Z';
   con_twi_sda_i <= std_ulogic(twi_sda_io);
   con_twi_scl_i <= std_ulogic(twi_scl_io);
-
-
-  -- The core of the problem ----------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  neorv32_inst: entity neorv32.neorv32_top
-  generic map (
-    -- General --
-    CLOCK_FREQUENCY              => CLOCK_FREQUENCY,  -- clock frequency of clk_i in Hz
-    INT_BOOTLOADER_EN            => true,             -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
-
-    -- On-Chip Debugger (OCD) --
-    ON_CHIP_DEBUGGER_EN          => ON_CHIP_DEBUGGER_EN,  -- implement on-chip debugger?
-
-    -- RISC-V CPU Extensions --
-    CPU_EXTENSION_RISCV_C        => CPU_EXTENSION_RISCV_C,         -- implement compressed extension?
-    CPU_EXTENSION_RISCV_E        => CPU_EXTENSION_RISCV_E,         -- implement embedded RF extension?
-    CPU_EXTENSION_RISCV_M        => CPU_EXTENSION_RISCV_M,         -- implement mul/div extension?
-    CPU_EXTENSION_RISCV_U        => CPU_EXTENSION_RISCV_U,         -- implement user mode extension?
-    CPU_EXTENSION_RISCV_Zfinx    => CPU_EXTENSION_RISCV_Zfinx,     -- implement 32-bit floating-point extension (using INT regs!)
-    CPU_EXTENSION_RISCV_Zicsr    => CPU_EXTENSION_RISCV_Zicsr,     -- implement CSR system?
-    CPU_EXTENSION_RISCV_Zicntr   => true,                          -- implement base counters?
-    CPU_EXTENSION_RISCV_Zifencei => CPU_EXTENSION_RISCV_Zifencei,  -- implement instruction stream sync.?
-
-    -- Extension Options --
-    FAST_MUL_EN                  => FAST_MUL_EN,    -- use DSPs for M extension's multiplier
-    FAST_SHIFT_EN                => FAST_SHIFT_EN,  -- use barrel shifter for shift operations
-
-    -- Physical Memory Protection (PMP) --
-    PMP_NUM_REGIONS              => PMP_NUM_REGIONS,       -- number of regions (0..16)
-    PMP_MIN_GRANULARITY          => PMP_MIN_GRANULARITY,   -- minimal region granularity in bytes, has to be a power of 2, min 8 bytes
-
-    -- Hardware Performance Monitors (HPM) --
-    HPM_NUM_CNTS                 => HPM_NUM_CNTS,          -- number of implemented HPM counters (0..29)
-    HPM_CNT_WIDTH                => HPM_CNT_WIDTH,         -- total size of HPM counters (1..64)
-
-    -- Internal Instruction memory --
-    MEM_INT_IMEM_EN              => MEM_INT_IMEM_EN,       -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE            => MEM_INT_IMEM_SIZE,     -- size of processor-internal instruction memory in bytes
-
-    -- Internal Data memory --
-    MEM_INT_DMEM_EN              => MEM_INT_DMEM_EN,       -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE            => MEM_INT_DMEM_SIZE,     -- size of processor-internal data memory in bytes
-
-    -- Internal Cache memory --
-    ICACHE_EN                    => ICACHE_EN,             -- implement instruction cache
-    ICACHE_NUM_BLOCKS            => ICACHE_NUM_BLOCKS,     -- i-cache: number of blocks (min 1), has to be a power of 2
-    ICACHE_BLOCK_SIZE            => ICACHE_BLOCK_SIZE,     -- i-cache: block size in bytes (min 4), has to be a power of 2
-    ICACHE_ASSOCIATIVITY         => ICACHE_ASSOCIATIVITY,  -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
-
-    -- Processor peripherals --
-    IO_GPIO_NUM                  => IO_GPIO_NUM,    -- number of GPIO input/output pairs (0..64)
-    IO_MTIME_EN                  => IO_MTIME_EN,    -- implement machine system timer (MTIME)?
-    IO_UART0_EN                  => IO_UART0_EN,    -- implement primary universal asynchronous receiver/transmitter (UART0)?
-    IO_SPI_EN                    => IO_SPI_EN,      -- implement serial peripheral interface (SPI)?
-    IO_TWI_EN                    => IO_TWI_EN,      -- implement two-wire interface (TWI)?
-    IO_PWM_NUM_CH                => IO_PWM_NUM_CH,  -- number of PWM channels to implement (0..12); 0 = disabled
-    IO_WDT_EN                    => IO_WDT_EN       -- implement watch dog timer (WDT)??
-  )
-  port map (
-    -- Global control --
-    clk_i       => clk_i,                        -- global clock, rising edge
-    rstn_i      => rstn_i,                       -- global reset, low-active, async
-
-    -- GPIO (available if IO_GPIO_NUM > 0) --
-    gpio_o      => con_gpio_o,                   -- parallel output
-    gpio_i      => con_gpio_i,                   -- parallel input
-
-    -- primary UART0 (available if IO_UART0_EN = true) --
-    uart0_txd_o => uart_txd_o,                   -- UART0 send data
-    uart0_rxd_i => uart_rxd_i,                   -- UART0 receive data
-
-    -- TWI (available if IO_TWI_EN = true) --
-    twi_sda_i      => con_twi_sda_i,             -- serial data line sense input
-    twi_sda_o      => con_twi_sda_o,             -- serial data line output (pull low only)
-    twi_scl_i      => con_twi_scl_i,             -- serial clock line sense input
-    twi_scl_o      => con_twi_scl_o,             -- serial clock line output (pull low only)
-
-    -- PWM (available if IO_PWM_NUM_CH > 0) --
-    pwm_o       => con_pwm_o                     -- pwm channels
-  );
 
 
 end architecture;

--- a/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
@@ -61,7 +61,6 @@ entity neorv32_top_avalonmm is
     CPU_EXTENSION_RISCV_M        : boolean := false;  -- implement mul/div extension?
     CPU_EXTENSION_RISCV_U        : boolean := false;  -- implement user mode extension?
     CPU_EXTENSION_RISCV_Zfinx    : boolean := false;  -- implement 32-bit floating-point extension (using INT regs!)
-    CPU_EXTENSION_RISCV_Zicsr    : boolean := true;   -- implement CSR system?
     CPU_EXTENSION_RISCV_Zicntr   : boolean := true;   -- implement base counters?
     CPU_EXTENSION_RISCV_Zihpm    : boolean := false;  -- implement hardware performance monitors?
     CPU_EXTENSION_RISCV_Zifencei : boolean := false;  -- implement instruction stream sync.?
@@ -248,7 +247,6 @@ begin
     CPU_EXTENSION_RISCV_M => CPU_EXTENSION_RISCV_M,
     CPU_EXTENSION_RISCV_U => CPU_EXTENSION_RISCV_U,
     CPU_EXTENSION_RISCV_Zfinx => CPU_EXTENSION_RISCV_Zfinx,
-    CPU_EXTENSION_RISCV_Zicsr => CPU_EXTENSION_RISCV_Zicsr,
     CPU_EXTENSION_RISCV_Zicntr => CPU_EXTENSION_RISCV_Zicntr,
     CPU_EXTENSION_RISCV_Zihpm => CPU_EXTENSION_RISCV_Zihpm,
     CPU_EXTENSION_RISCV_Zifencei => CPU_EXTENSION_RISCV_Zifencei,

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -62,7 +62,6 @@ entity neorv32_SystemTop_axi4lite is
     CPU_EXTENSION_RISCV_M        : boolean := false;  -- implement muld/div extension?
     CPU_EXTENSION_RISCV_U        : boolean := false;  -- implement user mode extension?
     CPU_EXTENSION_RISCV_Zfinx    : boolean := false;  -- implement 32-bit floating-point extension (using INT reg!)
-    CPU_EXTENSION_RISCV_Zicsr    : boolean := true;   -- implement CSR system?
     CPU_EXTENSION_RISCV_Zicntr   : boolean := true;   -- implement base counters?
     CPU_EXTENSION_RISCV_Zihpm    : boolean := false;  -- implement hardware performance monitors?
     CPU_EXTENSION_RISCV_Zifencei : boolean := false;  -- implement instruction stream sync.?
@@ -317,7 +316,6 @@ begin
     CPU_EXTENSION_RISCV_M        => CPU_EXTENSION_RISCV_M,        -- implement mul/div extension?
     CPU_EXTENSION_RISCV_U        => CPU_EXTENSION_RISCV_U,        -- implement user mode extension?
     CPU_EXTENSION_RISCV_Zfinx    => CPU_EXTENSION_RISCV_Zfinx,    -- implement 32-bit floating-point extension (using INT reg!)
-    CPU_EXTENSION_RISCV_Zicsr    => CPU_EXTENSION_RISCV_Zicsr,    -- implement CSR system?
     CPU_EXTENSION_RISCV_Zicntr   => CPU_EXTENSION_RISCV_Zicntr,   -- implement base counters?
     CPU_EXTENSION_RISCV_Zihpm    => CPU_EXTENSION_RISCV_Zihpm,    -- implement hardware performance monitors?
     CPU_EXTENSION_RISCV_Zifencei => CPU_EXTENSION_RISCV_Zifencei, -- implement instruction stream sync.?

--- a/rtl/system_integration/neorv32_litex_core_complex.vhd
+++ b/rtl/system_integration/neorv32_litex_core_complex.vhd
@@ -180,7 +180,6 @@ begin
     CPU_EXTENSION_RISCV_C        => configs_c.riscv_c(CONFIG),      -- implement compressed extension?
     CPU_EXTENSION_RISCV_M        => configs_c.riscv_m(CONFIG),      -- implement mul/div extension?
     CPU_EXTENSION_RISCV_U        => configs_c.riscv_u(CONFIG),      -- implement user mode extension?
-    CPU_EXTENSION_RISCV_Zicsr    => true,                           -- implement CSR system?
     CPU_EXTENSION_RISCV_Zicntr   => configs_c.riscv_zicntr(CONFIG), -- implement base counters?
     CPU_EXTENSION_RISCV_Zihpm    => configs_c.riscv_zihpm(CONFIG),  -- implement hardware performance monitors?
     CPU_EXTENSION_RISCV_Zifencei => true,                           -- implement instruction stream sync.?

--- a/rtl/test_setups/neorv32_test_setup_approm.vhd
+++ b/rtl/test_setups/neorv32_test_setup_approm.vhd
@@ -71,7 +71,6 @@ begin
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_C        => true,              -- implement compressed extension?
     CPU_EXTENSION_RISCV_M        => true,              -- implement mul/div extension?
-    CPU_EXTENSION_RISCV_Zicsr    => true,              -- implement CSR system?
     CPU_EXTENSION_RISCV_Zicntr   => true,              -- implement base counters?
     -- Internal Instruction memory --
     MEM_INT_IMEM_EN              => true,              -- implement processor-internal instruction memory

--- a/rtl/test_setups/neorv32_test_setup_bootloader.vhd
+++ b/rtl/test_setups/neorv32_test_setup_bootloader.vhd
@@ -74,7 +74,6 @@ begin
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_C        => true,              -- implement compressed extension?
     CPU_EXTENSION_RISCV_M        => true,              -- implement mul/div extension?
-    CPU_EXTENSION_RISCV_Zicsr    => true,              -- implement CSR system?
     CPU_EXTENSION_RISCV_Zicntr   => true,              -- implement base counters?
     -- Internal Instruction memory --
     MEM_INT_IMEM_EN              => true,              -- implement processor-internal instruction memory

--- a/rtl/test_setups/neorv32_test_setup_on_chip_debugger.vhd
+++ b/rtl/test_setups/neorv32_test_setup_on_chip_debugger.vhd
@@ -82,7 +82,6 @@ begin
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_C        => true,              -- implement compressed extension?
     CPU_EXTENSION_RISCV_M        => true,              -- implement mul/div extension?
-    CPU_EXTENSION_RISCV_Zicsr    => true,              -- implement CSR system?
     CPU_EXTENSION_RISCV_Zicntr   => true,              -- implement base counters?
     CPU_EXTENSION_RISCV_Zifencei => true,              -- implement instruction stream sync.? (required for the on-chip debugger)
     -- Internal Instruction memory --

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -228,7 +228,6 @@ begin
     CPU_EXTENSION_RISCV_M        => true,          -- implement mul/div extension?
     CPU_EXTENSION_RISCV_U        => true,          -- implement user mode extension?
     CPU_EXTENSION_RISCV_Zfinx    => true,          -- implement 32-bit floating-point extension (using INT reg!)
-    CPU_EXTENSION_RISCV_Zicsr    => true,          -- implement CSR system?
     CPU_EXTENSION_RISCV_Zicntr   => true,          -- implement base counters?
     CPU_EXTENSION_RISCV_Zicond   => true,          -- implement conditional operations extension?
     CPU_EXTENSION_RISCV_Zihpm    => true,          -- implement hardware performance monitors?

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -53,7 +53,6 @@ entity neorv32_tb_simple is
     CPU_EXTENSION_RISCV_E        : boolean := false;
     CPU_EXTENSION_RISCV_M        : boolean := true;
     CPU_EXTENSION_RISCV_U        : boolean := true;
-    CPU_EXTENSION_RISCV_Zicsr    : boolean := true;
     CPU_EXTENSION_RISCV_Zifencei : boolean := true;
     EXT_IMEM_C                   : boolean := false;   -- false: use and boot from proc-internal IMEM, true: use and boot from external (initialized) simulated IMEM (ext. mem A)
     MEM_INT_IMEM_SIZE            : natural := 16*1024  -- size in bytes of processor-internal IMEM / external mem A
@@ -180,7 +179,6 @@ begin
     CPU_EXTENSION_RISCV_M        => CPU_EXTENSION_RISCV_M, -- implement mul/div extension?
     CPU_EXTENSION_RISCV_U        => CPU_EXTENSION_RISCV_U, -- implement user mode extension?
     CPU_EXTENSION_RISCV_Zfinx    => true,          -- implement 32-bit floating-point extension (using INT reg!)
-    CPU_EXTENSION_RISCV_Zicsr    => CPU_EXTENSION_RISCV_Zicsr, -- implement CSR system?
     CPU_EXTENSION_RISCV_Zicntr   => true,          -- implement base counters?
     CPU_EXTENSION_RISCV_Zicond   => true,          -- implement conditional operations extension?
     CPU_EXTENSION_RISCV_Zihpm    => true,          -- implement hardware performance monitors?


### PR DESCRIPTION
* ⚠️ remove `CPU_EXTENSION_RISCV_Zicsr` generic; `Zicsr` ISA extension is always enabled
* optimize bus switch - less bus congestion, less wait cycles
* VHDL code cleanups