### PR TITLE
Bootloader Config Parameter to Enable UART0 HW Handshaking.

### DIFF
--- a/docs/datasheet/soc_dcache.adoc
+++ b/docs/datasheet/soc_dcache.adoc
@@ -23,10 +23,10 @@ The cache is implemented if the `DCACHE_EN` generic is `true`. The size of the c
 equal to 4 bytes) and `DCACHE_NUM_BLOCKS` (the total amount of cache blocks; has to be a power of two and greater than or
 equal to 1) generics. The data cache provides only a single set, hence it is direct-mapped.
 
-The data cache provides direct accesses (= uncached) to memory in order to access memory-mapped IO (likt the
+The data cache provides direct accesses (= uncached) to memory in order to access memory-mapped IO (like the
 processor-internal IO/peripheral modules). All accesses that target the address range from `0xF0000000` to `0xFFFFFFFF`
 will not be cached at all. This also allows to attach custom IO modules via the processor's external memory interface
-when they are mapped to upper-most 257 MB address page (see section <<_address_space>>).
+when they are mapped to upper-most 256 MB address page (see section <<_address_space>>).
 
 .Caching Internal Memories
 [NOTE]

--- a/docs/userguide/customizing_the_bootloader.adoc
+++ b/docs/userguide/customizing_the_bootloader.adoc
@@ -22,6 +22,7 @@ minimal base + privileged ISA `rv32i_zicsr` only to ensure it can work independe
 4+^| Serial console interface
 | `UART_EN`   | `1` | `0`, `1` | Set to `0` to disable UART0 (no serial console at all)
 | `UART_BAUD` | `19200` | _any_ | Baud rate of UART0
+| `UART_HW_HANDSHAKE_EN`   | `0` | `0`, `1` | Set to `1` to enable UART0 hardware flow control
 4+^| Status LED
 | `STATUS_LED_EN`  | `1` | `0`, `1`     | Enable bootloader status led ("heart beat") at `GPIO` output port pin #`STATUS_LED_PIN` when `1`
 | `STATUS_LED_PIN` | `0` | `0` ... `31` | `GPIO` output pin used for the high-active status LED

--- a/sw/bootloader/bootloader.c
+++ b/sw/bootloader/bootloader.c
@@ -61,6 +61,11 @@
   #define UART_BAUD 19200
 #endif
 
+/** Set to 1 to enable UART HW handshaking */
+#ifndef UART_HW_HANDSHAKE_EN
+  #define UART_HW_HANDSHAKE_EN 0
+#endif
+
 /* -------- Status LED -------- */
 
 /** Set to 0 to disable bootloader status LED (heart beat) at GPIO.gpio_o(STATUS_LED_PIN) */
@@ -303,6 +308,9 @@ int main(void) {
 #if (UART_EN != 0)
   // setup UART0
   neorv32_uart0_setup(UART_BAUD, 0);
+#if (UART_HW_HANDSHAKE_EN != 0)
+  neorv32_uart0_rtscts_enable();
+#endif
 #endif
 
   // Configure machine system timer interrupt


### PR DESCRIPTION
Added a new bootloader config parameter (`UART_HW_HANDSHAKE_EN`) to `bootloader.c`. And, updated the docs to describe `UART_HW_HANDSHAKE_EN`.  (`UART_HW_HANDSHAKE_EN` defaults to disabled.)

Also, fix two typos in the d-cache docs.
