### PR TITLE
[PMP] add support for NA4 and NAPOT modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 01.04.2023 | 1.8.3.1 | :sparkles: add full `NA4` and `NAPOT` support to the (now) RISC-V-compatible **physical memory protection (PMP)**; [#566](https://github.com/stnolting/neorv32/pull/566) |
 | 31.03.2023 | [**:rocket:1.8.3**](https://github.com/stnolting/neorv32/releases/tag/v1.8.3) | **New release** |
 | 29.03.2023 | 1.8.2.9 | :warning: remove `CPU_EXTENSION_RISCV_Zicsr` generic - `Zicsr` ISA extension is always enabled; optimize bus switch; VHDL code cleanups; [#562](https://github.com/stnolting/neorv32/pull/562) |
 | 25.03.2023 | 1.8.2.8 | :test_tube: add configurable data cache (**dCACHE**); [#560](https://github.com/stnolting/neorv32/pull/560) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -35,11 +35,6 @@ instruction exception (-> <<_full_virtualization>>).
 
 **Incompatibility Issues and Limitations**
 
-.Physical Memory Protection (PMP)
-[WARNING]
-The RISC-V-compatible NEORV32 <<_machine_physical_memory_protection_csrs>> only implements the **TOR**
-(top of region) mode and only up to 16 PMP regions.
-
 .No Hardware Support of Misaligned Memory Accesses
 [IMPORTANT]
 The CPU does not support resolving unaligned memory access by the hardware (this is not a
@@ -561,13 +556,13 @@ to the RISC-V Privileged Architecture Specifications. In general, the PMP can **
 which by default has none, and can **revoke permissions from M-mode**, which by default has full permissions.
 The PMP is configured via the <<_machine_physical_memory_protection_csrs>>.
 
-[IMPORTANT]
-The NEORV32 PMP only supports **TOR** (top of region) mode, which basically is a "base-and-bound" concept, and only
-up to 16 PMP regions.
-
 .PMP Rules when in Debug Mode
 [NOTE]
 When in debug-mode all PMP rules are ignored making the debugger have maximum access rights.
+
+[IMPORTANT]
+Instruction fetches are also triggered when denied by a certain PMP rule. However, the fetched instruction(s)
+will not be executed and will not change CPU core state to preserve memory access protection. 
 
 
 ==== `Sdext` ISA Extension

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -116,12 +116,12 @@ Any illegal read access to a CSR will return zero in the operation's destination
 [options="header",grid="rows"]
 |=======================
 | Bit  | R/W | Function
-| 31:5 | r/- | _reserved_, writes are ignored; reads always return 0
-| 4    | r/w | **NV**: invalid operation
-| 3    | r/w | **DZ**: division by zero
-| 2    | r/w | **OF**: overflow
-| 1    | r/w | **UF**: underflow
 | 0    | r/w | **NX**: inexact
+| 1    | r/w | **UF**: underflow
+| 2    | r/w | **OF**: overflow
+| 3    | r/w | **DZ**: division by zero
+| 4    | r/w | **NV**: invalid operation
+| 31:5 | r/- | _reserved_, writes are ignored; reads always return 0
 |=======================
 
 {empty} +
@@ -143,8 +143,8 @@ Any illegal read access to a CSR will return zero in the operation's destination
 [options="header",grid="rows"]
 |=======================
 | Bit  | R/W | Function
-| 31:3 | r/- | _reserved_, writes are ignored; reads always return 0
 | 2:0  | r/w | Rounding mode
+| 31:3 | r/- | _reserved_, writes are ignored; reads always return 0
 |=======================
 
 
@@ -167,9 +167,9 @@ Any illegal read access to a CSR will return zero in the operation's destination
 [options="header",grid="rows"]
 |=======================
 | Bit  | R/W | Function
-| 31:6 | r/- | _reserved_, writes are ignored; reads always return 0
-| 7:5  | r/w | Rounding mode (<<_frm>>)
 | 4:0  | r/w | Accrued exception flags (<<_fflags>>)
+| 7:5  | r/w | Rounding mode (<<_frm>>)
+| 31:6 | r/- | _reserved_, writes are ignored; reads always return 0
 |=======================
 
 
@@ -230,11 +230,11 @@ Any illegal read access to a CSR will return zero in the operation's destination
 [options="header",grid="rows"]
 |=======================
 | Bit   | Name [C] | R/W | Function
-| 21    | _CSR_MSTATUS_TW_   | r/w | **TW**: Trap on execution of `wfi` instruction in user mode when set; hardwired to zero if user-mode not implemented
-| 17    | _CSR_MSTATUS_MPRV_ | r/w | **MPRV**: Effective privilege level for load/stores in machine mode; use `MPP`'s as effective privilege level when set; hardwired to zero if user-mode not implemented
-| 12:11 | _CSR_MSTATUS_MPP_H_ : _CSR_MSTATUS_MPP_L_ | r/w | **MPP**: Previous machine privilege level, 11 = machine (M) level, 00 = user (U) level
-| 7     | _CSR_MSTATUS_MPIE_ | r/w | **MPIE**: Previous machine global interrupt enable flag state
-| 3     | _CSR_MSTATUS_MIE_  | r/w | **MIE**: Machine global interrupt enable flag
+| 3     | `CSR_MSTATUS_MIE`  | r/w | **MIE**: Machine global interrupt enable flag
+| 7     | `CSR_MSTATUS_MPIE` | r/w | **MPIE**: Previous machine global interrupt enable flag state
+| 12:11 | `CSR_MSTATUS_MPP_H` : `CSR_MSTATUS_MPP_L` | r/w | **MPP**: Previous machine privilege level, 11 = machine (M) level, 00 = user (U) level
+| 17    | `CSR_MSTATUS_MPRV` | r/w | **MPRV**: Effective privilege level for load/stores in machine mode; use `MPP`'s as effective privilege level when set; hardwired to zero if user-mode not implemented
+| 21    | `CSR_MSTATUS_TW`   | r/w | **TW**: Trap on execution of `wfi` instruction in user mode when set; hardwired to zero if user-mode not implemented
 |=======================
 
 [NOTE]
@@ -267,13 +267,13 @@ will _not_ cause an illegal instruction exception.
 [options="header",grid="rows"]
 |=======================
 | Bit   | Name [C] | R/W | Function
-| 31:30 | _CSR_MISA_MXL_HI_EXT_ : _CSR_MISA_MXL_LO_EXT_ | r/- | **MXL**: 32-bit architecture indicator (always _01_)
-| 23    | _CSR_MISA_X_EXT_ | r/- | **X**: extension bit is always set to indicate custom non-standard extensions
-| 20    | _CSR_MISA_U_EXT_ | r/- | **U**: CPU extension (user mode) available, set when <<_u_isa_extension>> enabled
-| 12    | _CSR_MISA_M_EXT_ | r/- | **M**: CPU extension (mul/div) available, set when <<_m_isa_extension>> enabled
-| 8     | _CSR_MISA_I_EXT_ | r/- | **I**: CPU base ISA, cleared when <<_e_isa_extension>> enabled
-| 4     | _CSR_MISA_E_EXT_ | r/- | **E**: CPU extension (embedded) available, set when <<_e_isa_extension>> enabled
-| 2     | _CSR_MISA_C_EXT_ | r/- | **C**: CPU extension (compressed instruction) available, set when <<_c_isa_extension>> enabled
+| 2     | `CSR_MISA_C_EXT` | r/- | **C**: CPU extension (compressed instruction) available, set when <<_c_isa_extension>> enabled
+| 4     | `CSR_MISA_E_EXT` | r/- | **E**: CPU extension (embedded) available, set when <<_e_isa_extension>> enabled
+| 8     | `CSR_MISA_I_EXT` | r/- | **I**: CPU base ISA, cleared when <<_e_isa_extension>> enabled
+| 12    | `CSR_MISA_M_EXT` | r/- | **M**: CPU extension (mul/div) available, set when <<_m_isa_extension>> enabled
+| 20    | `CSR_MISA_U_EXT` | r/- | **U**: CPU extension (user mode) available, set when <<_u_isa_extension>> enabled
+| 23    | `CSR_MISA_X_EXT` | r/- | **X**: extension bit is always set to indicate custom non-standard extensions
+| 31:30 | `CSR_MISA_MXL_HI_EXT` : `CSR_MISA_MXL_LO_EXT` | r/- | **MXL**: 32-bit architecture indicator (always `01`)
 |=======================
 
 [TIP]
@@ -300,10 +300,10 @@ Machine-mode software can discover available `Z*` _sub-extensions_ (like `Zicsr`
 [options="header",grid="rows"]
 |=======================
 | Bit   | Name [C] | R/W | Function
-| 31:16 | _CSR_MIE_FIRQ15E_ : _CSR_MIE_FIRQ0E_ | r/w | Fast interrupt channel 15..0 enable
-| 11    | _CSR_MIE_MEIE_ | r/w | **MEIE**: Machine _external_ interrupt enable
-| 7     | _CSR_MIE_MTIE_ | r/w | **MTIE**: Machine _timer_ interrupt enable (from <<_machine_system_timer_mtime>>)
-| 3     | _CSR_MIE_MSIE_ | r/w | **MSIE**: Machine _software_ interrupt enable
+| 3     | `CSR_MIE_MSIE` | r/w | **MSIE**: Machine _software_ interrupt enable
+| 7     | `CSR_MIE_MTIE` | r/w | **MTIE**: Machine _timer_ interrupt enable (from <<_machine_system_timer_mtime>>)
+| 11    | `CSR_MIE_MEIE` | r/w | **MEIE**: Machine _external_ interrupt enable
+| 31:16 | `CSR_MIE_FIRQ15E` : `CSR_MIE_FIRQ0E` | r/w | Fast interrupt channel 15..0 enable
 |=======================
 
 
@@ -352,10 +352,10 @@ This CSR is also available if U mode is disabled, but the register is hardwired 
 [options="header",grid="rows"]
 |=======================
 | Bit  | R/W | Function
-| 31:3 | r/w | **HPM** user-level code is allowed to read <<_hpmcounterh>> CSRs when set
-| 2    | r/w | **IR** User-level code is allowed to read <<_instreth>> CSRs when set
-| 1    | r/w | **TM** User-level code is allowed to read <<_timeh>> CSRs when set
 | 0    | r/w | **CY** User-level code is allowed to read <<_cycleh>> CSRs when set
+| 1    | r/w | **TM** User-level code is allowed to read <<_timeh>> CSRs when set
+| 2    | r/w | **IR** User-level code is allowed to read <<_instreth>> CSRs when set
+| 31:3 | r/w | **HPM** user-level code is allowed to read <<_hpmcounterh>> CSRs when set
 |=======================
 
 
@@ -429,9 +429,9 @@ an instruction is triggered / an exception is raised. See section <<_traps_excep
 [options="header",grid="rows"]
 |=======================
 | Bit  | R/W | Function
-| 31   | r/w | **Interrupt**: `1` if the trap is caused by an interrupt (`0` if the trap is caused by an exception)
-| 30:5 | r/- | _Reserved_, read as zero
 | 4:0  | r/w | **Exception code**: see <<_neorv32_trap_listing>>
+| 30:5 | r/- | _Reserved_, read as zero
+| 31   | r/w | **Interrupt**: `1` if the trap is caused by an interrupt (`0` if the trap is caused by an exception)
 |=======================
 
 
@@ -482,10 +482,10 @@ specific for the interrupt-causing modules. the according interrupt-generating d
 [options="header",grid="rows"]
 |=======================
 | Bit | Name [C] | R/W | Function
-| 31:16 | _CSR_MIP_FIRQ15P_ : _CSR_MIP_FIRQ0P_ | r/c | **FIRQxP**: Fast interrupt channel 15..0 pending; has to be cleared manually by writing zero
-| 11    | _CSR_MIP_MEIP_                       | r/- | **MEIP**: Machine _external_ interrupt pending; _cleared by platform-defined mechanism_
-| 7     | _CSR_MIP_MTIP_                       | r/- | **MTIP**: Machine _timer_ interrupt pending; _cleared by platform-defined mechanism_
-| 3     | _CSR_MIP_MSIP_                       | r/- | **MSIP**: Machine _software_ interrupt pending; _cleared by platform-defined mechanism_
+| 3     | `CSR_MIP_MSIP`                       | r/- | **MSIP**: Machine _software_ interrupt pending; _cleared by platform-defined mechanism_
+| 7     | `CSR_MIP_MTIP`                       | r/- | **MTIP**: Machine _timer_ interrupt pending; _cleared by platform-defined mechanism_
+| 11    | `CSR_MIP_MEIP`                       | r/- | **MEIP**: Machine _external_ interrupt pending; _cleared by platform-defined mechanism_
+| 31:16 | `CSR_MIP_FIRQ15P` : `CSR_MIP_FIRQ0P` | r/c | **FIRQxP**: Fast interrupt channel 15..0 pending; has to be cleared manually by writing zero
 |=======================
 
 .FIRQ Channel Mapping
@@ -499,16 +499,12 @@ interrupt-triggering processor module.
 :sectnums:
 ==== Machine Physical Memory Protection CSRs
 
-The available physical memory protection logic is configured via the `PMP_NUM_REGIONS` and
-`PMP_MIN_GRANULARITY` top entity generics. `PMP_NUM_REGIONS` defines the number of implemented
-protection regions and thus, the implementation of the available _PMP entries_.
-See section <<_pmp_isa_extension>> for more information.
-
-If trying to access an PMP-related CSR beyond `PMP_NUM_REGIONS` **no illegal instruction
-exception** is triggered. The according CSRs are read-only (writes are ignored) and always return zero.
-However, any access beyond `pmpcfg3` or `pmpaddr15`, which are the last physically implemented registers if
-`PMP_NUM_REGIONS` == 16, will raise an illegal instruction exception as these CSRs are not implemented at all.
-
+The physical memory protection system is configured via the `PMP_NUM_REGIONS` and `PMP_MIN_GRANULARITY` top entity
+generics. `PMP_NUM_REGIONS` defines the total number of implemented regions. If trying to access a PMP-related CSR
+beyond `PMP_NUM_REGIONS` **no illegal instruction exception** is triggered. The according CSRs are read-only (writes
+are ignored) and always return zero. However, any access beyond `pmpcfg3` or `pmpaddr15`, which are the last physically
+implemented registers if `PMP_NUM_REGIONS` == 16, will raise an illegal instruction exception as these CSRs are not
+implemented at all. See section <<_pmp_isa_extension>> for more information.
 
 [discrete]
 ===== **`pmpcfg`**
@@ -528,19 +524,13 @@ However, any access beyond `pmpcfg3` or `pmpaddr15`, which are the last physical
 [options="header",grid="rows"]
 |=======================
 | Bit | Name [C] | R/W | Function
-| 7   | _PMPCFG_L_     | r/w | **L**: Lock bit, prevents further write accesses, also enforces access rights in machine-mode, can only be cleared by CPU reset
+| 7   | `PMPCFG_L`     | r/w | **L**: Lock bit, prevents further write accesses, also enforces access rights in machine-mode, can only be cleared by CPU reset
 | 6:5 | -              | r/- | _reserved_, read as zero
-| 4   | _PMPCFG_A_MSB_ | r/- .2+<| **A**: Mode configuration; only **OFF** (`00`) and **TOR** (`01`) modes are supported, any other value will map back to OFF/TOR
-as the MSB is hardwired to zero
-| 3   | _PMPCFG_A_LSB_ | r/w
-| 2   | _PMPCFG_X_     | r/w | **X**: Execute permission
-| 1   | _PMPCFG_W_     | r/w | **W**: Write permission
-| 0   | _PMPCFG_R_     | r/w | **R**: Read permission
+| 4:3 | `PMPCFG_A_MSB` : `PMPCFG_A_LSB` | r/w | **A**: Mode configuration (`00` = OFF, `01` = TOR, `10` = NA4, `11` = NAPOT)
+| 2   | `PMPCFG_X`     | r/w | **X**: Execute permission
+| 1   | `PMPCFG_W`     | r/w | **W**: Write permission
+| 0   | `PMPCFG_R`     | r/w | **R**: Read permission
 |=======================
-
-[WARNING]
-Setting the lock bit `L` and setting TOR mode in `pmpcfg(i)` will also lock write access to `pmpaddr(i-1)`.
-See the RISC-V specs. for more information.
 
 
 {empty} +
@@ -558,6 +548,12 @@ The `pmpaddr*` CSRs are used to configure the region's address boundaries.
 | ISA         | `Zicsr` + `PMP`
 | Description | Region address configuration. The two MSBs of each CSR are hardwired to zero (= bits 33:32 of the physical address).
 |=======================
+
+.Address Register Update Latency
+[IMPORTANT]
+After writing a `pmpaddr` CSR the hardware requires up to 32 clock cycles to compute the according
+address masks. Make sure to wait for this time before completing the PMP region configuration
+(only relevant for `NA4` and `NAPOT` modes).
 
 
 <<<
@@ -691,22 +687,22 @@ cycle even if more than one trigger event is observed.
 [options="header",grid="rows"]
 |=======================
 | Bit   | Name [C]               | R/W | Event
-| 31:15 | -                      | r/- | _reserved_, writes are ignored, read always return zero
-| 14    | _HPMCNT_EVENT_ILLEGAL_ | r/w | illegal instruction exception
-| 13    | _HPMCNT_EVENT_TRAP_    | r/w | entered trap (synchronous exception or interrupt)
-| 12    | _HPMCNT_EVENT_TBRANCH_ | r/w | _taken_ conditional branch
-| 11    | _HPMCNT_EVENT_BRANCH_  | r/w | conditional branch (_taken_ or _not taken_)
-| 10    | _HPMCNT_EVENT_JUMP_    | r/w | unconditional jump
-| 9     | _HPMCNT_EVENT_WAIT_LS_ | r/w | load/store memory wait cycle: if more than 1 cycle memory latency or high bus traffic
-| 8     | _HPMCNT_EVENT_STORE_   | r/w | memory data store operation
-| 7     | _HPMCNT_EVENT_LOAD_    | r/w | memory data load operation
-| 6     | _HPMCNT_EVENT_WAIT_MC_ | r/w | multi-cycle ALU operation wait cycle (like iterative shift operation)
-| 5     | _HPMCNT_EVENT_WAIT_II_ | r/w | instruction issue pipeline wait cycle: if more than 1 cycle latency, pipelines flush (like taken branches) / cache miss or high bus traffic
-| 4     | _HPMCNT_EVENT_WAIT_IF_ | r/w | instruction fetch memory wait cycle: if more than 1 cycle memory latency, cache miss or high bus traffic
-| 3     | _HPMCNT_EVENT_CIR_     | r/w | retired compressed instruction
-| 2     | _HPMCNT_EVENT_IR_      | r/w | retired instruction (compressed or uncompressed)
+| 0     | `HPMCNT_EVENT_CY`      | r/w | active clock cycle (CPU not in sleep mode)
 | 1     | -                      | r/- | _not implemented, always read as zero_
-| 0     | _HPMCNT_EVENT_CY_      | r/w | active clock cycle (CPU not in sleep mode)
+| 2     | `HPMCNT_EVENT_IR`      | r/w | retired instruction (compressed or uncompressed)
+| 3     | `HPMCNT_EVENT_CIR`     | r/w | retired compressed instruction
+| 4     | `HPMCNT_EVENT_WAIT_IF` | r/w | instruction fetch memory wait cycle: if more than 1 cycle memory latency, cache miss or high bus traffic
+| 5     | `HPMCNT_EVENT_WAIT_II` | r/w | instruction issue pipeline wait cycle: if more than 1 cycle latency, pipelines flush (like taken branches) / cache miss or high bus traffic
+| 6     | `HPMCNT_EVENT_WAIT_MC` | r/w | multi-cycle ALU operation wait cycle (like iterative shift operation)
+| 7     | `HPMCNT_EVENT_LOAD`    | r/w | memory data load operation
+| 8     | `HPMCNT_EVENT_STORE`   | r/w | memory data store operation
+| 9     | `HPMCNT_EVENT_WAIT_LS` | r/w | load/store memory wait cycle: if more than 1 cycle memory latency or high bus traffic
+| 10    | `HPMCNT_EVENT_JUMP`    | r/w | unconditional jump
+| 11    | `HPMCNT_EVENT_BRANCH`  | r/w | conditional branch (_taken_ or _not taken_)
+| 12    | `HPMCNT_EVENT_TBRANCH` | r/w | _taken_ conditional branch
+| 13    | `HPMCNT_EVENT_TRAP`    | r/w | entered trap (synchronous exception or interrupt)
+| 14    | `HPMCNT_EVENT_ILLEGAL` | r/w | illegal instruction exception
+| 31:15 | -                      | r/- | _reserved_, writes are ignored, read as zero
 |=======================
 
 
@@ -769,9 +765,10 @@ counter CSRs are read-only. Any write access will raise an illegal instruction e
 [options="header",grid="rows"]
 |=======================
 | Bit  | Name [C] | R/W | Event
-| 3:31 | _CSR_MCOUNTINHIBIT_HPM3_ : _CSR_MCOUNTINHIBIT_HPM31_ | r/w | **HPMx**: Set to `1` to halt `[m]hpmcount*[h]`; hardwired to zero if `Zihpm` ISA extension is disabled
-| 2    | _CSR_MCOUNTINHIBIT_CY_ | r/w | **CY**: Set to `1` to halt `[m]cycle[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
-| 0    | _CSR_MCOUNTINHIBIT_IR_ | r/w | **IR**: Set to `1` to halt `[m]instret[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
+| 0    | `CSR_MCOUNTINHIBIT_IR` | r/w | **IR**: Set to `1` to halt `[m]instret[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
+| 1    | -                      | r/- | _reserved_, read as zero
+| 2    | `CSR_MCOUNTINHIBIT_CY` | r/w | **CY**: Set to `1` to halt `[m]cycle[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
+| 3:31 | `CSR_MCOUNTINHIBIT_HPM3` : `CSR_MCOUNTINHIBIT_HPM31` | r/w | **HPMx**: Set to `1` to halt `[m]hpmcount*[h]`; hardwired to zero if `Zihpm` ISA extension is disabled
 |=======================
 
 
@@ -887,21 +884,21 @@ discover ISA sub-extensions and CPU configuration options
 [options="header",grid="rows"]
 |=======================
 | Bit   | Name [C] | R/W | Function
-|  0    | _CSR_MXISA_ZICSR_     | r/- | <<_zicsr_isa_extension>> available
-|  1    | _CSR_MXISA_ZIFENCEI_  | r/- | <<_zifencei_isa_extension>> available
-|  2    | _CSR_MXISA_ZMMUL_     | r/- | <<_zmmul_isa_extension>> available
-|  3    | _CSR_MXISA_ZXCFU_     | r/- | <<_zxcfu_isa_extension>> available
-|  4    | _CSR_MXISA_ZICOND_    | r/- | <<_zicond_isa_extension>> available
-|  5    | _CSR_MXISA_ZFINX_     | r/- | <<_zfinx_isa_extension>> available
+|  0    | `CSR_MXISA_ZICSR`     | r/- | <<_zicsr_isa_extension>> available
+|  1    | `CSR_MXISA_ZIFENCEI`  | r/- | <<_zifencei_isa_extension>> available
+|  2    | `CSR_MXISA_ZMMUL`     | r/- | <<_zmmul_isa_extension>> available
+|  3    | `CSR_MXISA_ZXCFU`     | r/- | <<_zxcfu_isa_extension>> available
+|  4    | `CSR_MXISA_ZICOND`    | r/- | <<_zicond_isa_extension>> available
+|  5    | `CSR_MXISA_ZFINX`     | r/- | <<_zfinx_isa_extension>> available
 |  6    | -                     | r/- | _reserved_, read as zero
-|  7    | _CSR_MXISA_ZICNTR_    | r/- | <<_zicntr_isa_extension>> available
-|  8    | _CSR_MXISA_PMP_       | r/- | <<_pmp_isa_extension>> available
-|  9    | _CSR_MXISA_ZIHPM_     | r/- | <<_zihpm_isa_extension>> available
-| 10    | _CSR_MXISA_SDEXT_     | r/- | <<_sdext_isa_extension>> available
-| 11    | _CSR_MXISA_SDTRIG_    | r/- | <<_sdtrig_isa_extension>> available
+|  7    | `CSR_MXISA_ZICNTR`    | r/- | <<_zicntr_isa_extension>> available
+|  8    | `CSR_MXISA_PMP`       | r/- | <<_pmp_isa_extension>> available
+|  9    | `CSR_MXISA_ZIHPM`     | r/- | <<_zihpm_isa_extension>> available
+| 10    | `CSR_MXISA_SDEXT`     | r/- | <<_sdext_isa_extension>> available
+| 11    | `CSR_MXISA_SDTRIG`    | r/- | <<_sdtrig_isa_extension>> available
 | 19:12 | -                     | r/- | _reserved_, read as zero
-| 20    | _CSR_MXISA_IS_SIM_    | r/- | set if CPU is being **simulated** (⚠️ not guaranteed)
+| 20    | `CSR_MXISA_IS_SIM`    | r/- | set if CPU is being **simulated** (⚠️ not guaranteed)
 | 31:21 | -                     | r/- | _reserved_, read as zero
-| 30    | _CSR_MXISA_FASTMUL_   | r/- | fast multiplication available when set (`FAST_MUL_EN`)
-| 31    | _CSR_MXISA_FASTSHIFT_ | r/- | fast shifts available when set (`FAST_SHIFT_EN`)
+| 30    | `CSR_MXISA_FASTMUL`   | r/- | fast multiplication available when set (`FAST_MUL_EN`)
+| 31    | `CSR_MXISA_FASTSHIFT` | r/- | fast shifts available when set (`FAST_SHIFT_EN`)
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -60,7 +60,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080300"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080301"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -2615,7 +2615,7 @@ package body neorv32_package is
   impure function mem32_init_f(init : mem32_t; depth : natural) return mem32_t is
     variable mem_v : mem32_t(0 to depth-1);
   begin
-    mem_v := (others => (others => '0')); -- make sure remaining memory entries are set to zero
+    mem_v := (others => (others => '0')); -- [IMPORTANT] make sure remaining memory entries are set to zero
     if (init'length > depth) then
       return mem_v;
     end if;

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -180,7 +180,7 @@ begin
     if ci_mode then
       -- No need to send the full expectation in one big chunk
       check_uart(net, uart1_rx_handle, nul & nul);
-      check_uart(net, uart1_rx_handle, "0/46" & cr & lf);
+      check_uart(net, uart1_rx_handle, "0/47" & cr & lf);
     end if;
 
     -- Wait until all expected data has been received

--- a/sw/lib/include/neorv32_cpu.h
+++ b/sw/lib/include/neorv32_cpu.h
@@ -56,7 +56,7 @@ void     neorv32_cpu_delay_ms(uint32_t time_ms);
 uint32_t neorv32_cpu_get_clk_from_prsc(int prsc);
 uint32_t neorv32_cpu_pmp_get_num_regions(void);
 uint32_t neorv32_cpu_pmp_get_granularity(void);
-int      neorv32_cpu_pmp_configure_region(uint32_t index, uint32_t base, uint8_t config);
+int      neorv32_cpu_pmp_configure_region(int index, uint32_t addr, uint8_t config);
 uint32_t neorv32_cpu_hpm_get_num_counters(void);
 uint32_t neorv32_cpu_hpm_get_size(void);
 void     neorv32_cpu_goto_user_mode(void);

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -393,7 +393,7 @@ void neorv32_rte_print_hw_config(void) {
   neorv32_uart0_printf("\nPhys. Mem. Prot.:  ");
   uint32_t pmp_num_regions = neorv32_cpu_pmp_get_num_regions();
   if (pmp_num_regions != 0)  {
-    neorv32_uart0_printf("%u region(s), %u bytes min. granularity", pmp_num_regions, neorv32_cpu_pmp_get_granularity());
+    neorv32_uart0_printf("%u region(s), %u bytes granularity", pmp_num_regions, neorv32_cpu_pmp_get_granularity());
   }
   else {
     neorv32_uart0_printf("none");


### PR DESCRIPTION
* :sparkles: add support for `NA4` (naturally aligned power-of-two region, 4 byte wide) and `NAPOT` (naturally aligned power-of-two region, larger than 4 bytes) to the processor's physical memory protection system - PMP is now full spec-compliant
* :warning: change behavior of `neorv32_cpu_pmp_configure_region()` function