### PR TITLE
[rtl] cleanups and optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 05.04.2023 | 1.8.3.2 | `time` CSR struggles (again) and logic optimization; [#569](https://github.com/stnolting/neorv32/pull/569) |
 | 01.04.2023 | 1.8.3.1 | :sparkles: add full `NA4` and `NAPOT` support to the (now) RISC-V-compatible **physical memory protection (PMP)**; [#566](https://github.com/stnolting/neorv32/pull/566) |
 | 31.03.2023 | [**:rocket:1.8.3**](https://github.com/stnolting/neorv32/releases/tag/v1.8.3) | **New release** |
 | 29.03.2023 | 1.8.2.9 | :warning: remove `CPU_EXTENSION_RISCV_Zicsr` generic - `Zicsr` ISA extension is always enabled; optimize bus switch; VHDL code cleanups; [#562](https://github.com/stnolting/neorv32/pull/562) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -35,6 +35,12 @@ instruction exception (-> <<_full_virtualization>>).
 
 **Incompatibility Issues and Limitations**
 
+.`time[h]` CSRs (Wall Clock Time)
+[IMPORTANT]
+The NEORV32 does not implement the user-mode `time[h]` registers. Any access to these registers will trap.
+It is recommended that the trap handler software provides a means of accessing the platform-defined <<_machine_system_timer_mtime>>.
+
+
 .No Hardware Support of Misaligned Memory Accesses
 [IMPORTANT]
 The CPU does not support resolving unaligned memory access by the hardware (this is not a
@@ -461,12 +467,12 @@ code (see `sw/example/floating_point_test`).
 
 ==== `Zicntr` ISA Extension
 
-The `Zicntr` ISA extension adds the basic <<_cycleh>>, <<_mcycleh>>, <<_timeh>> and <<_instreth>>, <<_minstreth>>
+The `Zicntr` ISA extension adds the basic <<_cycleh>>, <<_mcycleh>>, <<_instreth>> and <<_minstreth>>
 counter CSRs. Section <<_machine_counter_and_timer_csrs>> shows a list of all `Zicntr`-related CSRs.
 
 [NOTE]
-Note that the <<_timeh>> CSRs are implemented as just another user-level shadow copy of the machine-mode cycle
-counters <<_mcycleh>> (just like <<_cycleh>>).
+The user-mode `time[h]` CSRs are **not implemented**. Any access will trap allowing the trap handler to
+retrieve system time from the <<_machine_system_timer_mtime>>.
 
 [NOTE]
 This extensions is stated as _mandatory_ by the RISC-V spec. However, area-constrained setups may remove
@@ -713,20 +719,20 @@ show the values written to the according CSRs when a trap is triggered:
 [options="header",grid="rows"]
 |=======================
 | Trap ID [C] | Triggered when ...
-| _TRAP_CODE_I_MISALIGNED_ | fetching a 32-bit instruction word that is not 32-bit-aligned (see note below)
-| _TRAP_CODE_I_ACCESS_     | bus timeout or bus access error during instruction word fetch
-| _TRAP_CODE_I_ILLEGAL_    | trying to execute an invalid instruction word (malformed or not supported) or on a privilege violation
-| _TRAP_CODE_MENV_CALL_    | executing `ecall` instruction in machine-mode
-| _TRAP_CODE_UENV_CALL_    | executing `ecall` instruction in user-mode
-| _TRAP_CODE_BREAKPOINT_   | executing `ebreak` instruction or if <<_trigger_module>> fires
-| _TRAP_CODE_S_MISALIGNED_ | storing data to an address that is not naturally aligned to the data size (byte, half, word)
-| _TRAP_CODE_L_MISALIGNED_ | loading data from an address that is not naturally aligned to the data size  (byte, half, word)
-| _TRAP_CODE_S_ACCESS_     | bus timeout or bus access error during load data operation
-| _TRAP_CODE_L_ACCESS_     | bus timeout or bus access error during store data operation
-| _TRAP_CODE_FIRQ_0_ ... _TRAP_CODE_FIRQ_15_| caused by interrupt-condition of processor-internal modules, see <<_neorv32_specific_fast_interrupt_requests>>
-| _TRAP_CODE_MEI_          | machine external interrupt (via dedicated top-entity signal)
-| _TRAP_CODE_MSI_          | machine software interrupt (via dedicated top-entity signal)
-| _TRAP_CODE_MTI_          | machine timer interrupt (internal machine timer or via dedicated top-entity signal)
+| `TRAP_CODE_I_MISALIGNED` | fetching a 32-bit instruction word that is not 32-bit-aligned (see note below)
+| `TRAP_CODE_I_ACCESS`     | bus timeout or bus access error during instruction word fetch
+| `TRAP_CODE_I_ILLEGAL`    | trying to execute an invalid instruction word (malformed or not supported) or on a privilege violation
+| `TRAP_CODE_MENV_CALL`    | executing `ecall` instruction in machine-mode
+| `TRAP_CODE_UENV_CALL`    | executing `ecall` instruction in user-mode
+| `TRAP_CODE_BREAKPOINT`   | executing `ebreak` instruction or if <<_trigger_module>> fires
+| `TRAP_CODE_S_MISALIGNED` | storing data to an address that is not naturally aligned to the data size (byte, half, word)
+| `TRAP_CODE_L_MISALIGNED` | loading data from an address that is not naturally aligned to the data size  (byte, half, word)
+| `TRAP_CODE_S_ACCESS`     | bus timeout or bus access error during load data operation
+| `TRAP_CODE_L_ACCESS`     | bus timeout or bus access error during store data operation
+| `TRAP_CODE_FIRQ_0` ... `TRAP_CODE_FIRQ_15` | caused by interrupt-condition of processor-internal modules, see <<_neorv32_specific_fast_interrupt_requests>>
+| `TRAP_CODE_MEI`          | machine external interrupt (via dedicated top-entity signal)
+| `TRAP_CODE_MSI`          | machine software interrupt (via dedicated top-entity signal)
+| `TRAP_CODE_MTI`          | machine timer interrupt (internal machine timer or via dedicated top-entity signal)
 |=======================
 
 .Resumable Exceptions

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -69,10 +69,8 @@ Any illegal read access to a CSR will return zero in the operation's destination
 | 0xB80   | <<_mcycleh, `mcycleh`>>             | `CSR_MCYCLEH`        | MRW | Machine cycle counter high word
 | 0xB82   | <<_minstreth, `minstreth`>>         | `CSR_MINSTRETH`      | MRW | Machine instruction-retired counter high word
 | 0xC00   | <<_cycleh, `cycle`>>                | `CSR_CYCLE`          | URO | Cycle counter low word
-| 0xC01   | <<_timeh, `time`>>                  | `CSR_TIME`           | URO | Time counter low word
 | 0xC02   | <<_instreth, `instret`>>            | `CSR_INSTRET`        | URO | Instruction-retired counter low word
 | 0xC80   | <<_cycleh, `cycleh`>>               | `CSR_CYCLEH`         | URO | Cycle counter high word
-| 0xC81   | <<_timeh, `timeh`>>                 | `CSR_TIMEH`          | URO | Time counter high word
 | 0xC82   | <<_instreth, `instreth`>>           | `CSR_INSTRETH`       | URO | Instruction-retired counter high word
 5+^| **<<_hardware_performance_monitors_hpm_csrs>>**
 | 0x323 .. 0x33F | <<_mhpmevent, `mhpmevent3`>> .. <<_mhpmevent, `mhpmevent31`>>             | `CSR_MHPMEVENT3` .. `CSR_MHPMEVENT31`       | MRW | Machine performance-monitoring event select for counter 3..31
@@ -259,7 +257,7 @@ bit for the higher-privilege mode." - RISC-V ISA Spec.
 
 [NOTE]
 The NEORV32 `misa` CSR is read-only. Hence, active CPU extensions are entirely defined by pre-synthesis configurations
-and cannot be switch on/off during runtime. For compatibility reasons any write access to this CSR is simply ignored and
+and cannot be switched on/off during runtime. For compatibility reasons any write access to this CSR is simply ignored and
 will _not_ cause an illegal instruction exception.
 
 .`misa` CSR bits
@@ -352,10 +350,10 @@ This CSR is also available if U mode is disabled, but the register is hardwired 
 [options="header",grid="rows"]
 |=======================
 | Bit  | R/W | Function
-| 0    | r/w | **CY** User-level code is allowed to read <<_cycleh>> CSRs when set
-| 1    | r/w | **TM** User-level code is allowed to read <<_timeh>> CSRs when set
-| 2    | r/w | **IR** User-level code is allowed to read <<_instreth>> CSRs when set
-| 31:3 | r/w | **HPM** user-level code is allowed to read <<_hpmcounterh>> CSRs when set
+| 0    | r/w | **CY**: User-level code is allowed to read <<_cycleh>> CSRs when set
+| 1    | r/- | **TM**: Hardwired to zero as `time[h]` CSRs are not implemented
+| 2    | r/w | **IR**: User-level code is allowed to read <<_instreth>> CSRs when set
+| 31:3 | r/w | **HPM**: user-level code is allowed to read <<_hpmcounterh>> CSRs when set
 |=======================
 
 
@@ -561,9 +559,10 @@ address masks. Make sure to wait for this time before completing the PMP region 
 :sectnums:
 ==== (Machine) Counter and Timer CSRs
 
-.Counter Size
-[NOTE]
-When implemented (by enabling the `Zicntr` ISA extension) the standard CPU counters are always 64-bit wide (low-word + high-word).
+.`time[h]` CSRs (Wall Clock Time)
+[IMPORTANT]
+The NEORV32 does not implement the user-mode `time[h]` registers. Any access to these registers will trap.
+It is recommended that the trap handler software provides a means of accessing the platform-defined <<_machine_system_timer_mtime>>.
 
 .Instruction Retired Counter Increment
 [NOTE]
@@ -583,22 +582,6 @@ if this instruction is actually going to retire or if it causes an exception.
 | ISA         | `Zicsr` + `Zicntr`
 | Description | The `cycle[h]` CSRs are user-mode shadow copies of the according <<_mcycleh>> CSRs. The user-level
 counter are read-only. Any write access will raise an illegal instruction exception.
-|=======================
-
-
-{empty} +
-[discrete]
-===== **`time[h]`**
-
-[cols="<1,<8"]
-[frame="topbot",grid="none"]
-|=======================
-| Name        | Time counter
-| Address     | `0xc01` (`time`), `0xc81` (`timeh`)
-| Reset value | `0x00000000`
-| ISA         | `Zicsr` + `Zicntr`
-| Description | The `time[h]` CSRs are a shadow copy of the <<_cycleh>> cycle counter CSRs. These CSRs
-are read-only. Any write access will raise an illegal instruction exception.
 |=======================
 
 
@@ -766,7 +749,7 @@ counter CSRs are read-only. Any write access will raise an illegal instruction e
 |=======================
 | Bit  | Name [C] | R/W | Event
 | 0    | `CSR_MCOUNTINHIBIT_IR` | r/w | **IR**: Set to `1` to halt `[m]instret[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
-| 1    | -                      | r/- | _reserved_, read as zero
+| 1    | -                      | r/- | **TM**: Hardwired to zero as `time[h]` CSRs are not implemented
 | 2    | `CSR_MCOUNTINHIBIT_CY` | r/w | **CY**: Set to `1` to halt `[m]cycle[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
 | 3:31 | `CSR_MCOUNTINHIBIT_HPM3` : `CSR_MCOUNTINHIBIT_HPM31` | r/w | **HPMx**: Set to `1` to halt `[m]hpmcount*[h]`; hardwired to zero if `Zihpm` ISA extension is disabled
 |=======================

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -43,7 +43,6 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_alu is
   generic (
-    XLEN                       : natural; -- data path width
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_B      : boolean; -- implement bit-manipulation extension?
     CPU_EXTENSION_RISCV_M      : boolean; -- implement mul/div extension?
@@ -216,7 +215,6 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_cp_shifter_inst: neorv32_cpu_cp_shifter
   generic map (
-    XLEN          => XLEN,         -- data path width
     FAST_SHIFT_EN => FAST_SHIFT_EN -- use barrel shifter for shift operations
   )
   port map (
@@ -240,7 +238,6 @@ begin
   if (CPU_EXTENSION_RISCV_M = true) or (CPU_EXTENSION_RISCV_Zmmul = true) generate
     neorv32_cpu_cp_muldiv_inst: neorv32_cpu_cp_muldiv
     generic map (
-      XLEN        => XLEN,                 -- data path width
       FAST_MUL_EN => FAST_MUL_EN,          -- use DSPs for faster multiplication
       DIVISION_EN => CPU_EXTENSION_RISCV_M -- implement divider hardware
     )
@@ -272,7 +269,6 @@ begin
   if (CPU_EXTENSION_RISCV_B = true) generate
     neorv32_cpu_cp_bitmanip_inst: neorv32_cpu_cp_bitmanip
     generic map (
-      XLEN          => XLEN,         -- data path width
       FAST_SHIFT_EN => FAST_SHIFT_EN -- use barrel shifter for shift operations
     )
     port map (
@@ -304,9 +300,6 @@ begin
   neorv32_cpu_cp_fpu_inst_true:
   if (CPU_EXTENSION_RISCV_Zfinx = true) generate
     neorv32_cpu_cp_fpu_inst: neorv32_cpu_cp_fpu
-    generic map (
-      XLEN => XLEN -- data path width
-    )
     port map (
       -- global control --
       clk_i    => clk_i,        -- global clock, rising edge
@@ -338,9 +331,6 @@ begin
   neorv32_cpu_cp_cfu_inst_true:
   if (CPU_EXTENSION_RISCV_Zxcfu = true) generate
     neorv32_cpu_cp_cfu_inst: neorv32_cpu_cp_cfu
-    generic map (
-      XLEN => XLEN -- data path width
-    )
     port map (
       -- global control --
       clk_i   => clk_i,        -- global clock, rising edge
@@ -370,9 +360,6 @@ begin
   neorv32_cpu_cp_cond_inst_true:
   if (CPU_EXTENSION_RISCV_Zicond = true) generate
     neorv32_cpu_cp_cond_inst: neorv32_cpu_cp_cond
-    generic map (
-      XLEN => XLEN -- data path width
-    )
     port map (
       -- global control --
       clk_i   => clk_i,        -- global clock, rising edge

--- a/rtl/core/neorv32_cpu_bus.vhd
+++ b/rtl/core/neorv32_cpu_bus.vhd
@@ -123,12 +123,9 @@ architecture neorv32_cpu_bus_rtl of neorv32_cpu_bus is
     perm_ex  : std_ulogic_vector(PMP_NUM_REGIONS-1 downto 0);
     perm_rd  : std_ulogic_vector(PMP_NUM_REGIONS-1 downto 0);
     perm_wr  : std_ulogic_vector(PMP_NUM_REGIONS-1 downto 0);
-    fail_ex  : std_ulogic_vector(PMP_NUM_REGIONS downto 0);
-    fail_rd  : std_ulogic_vector(PMP_NUM_REGIONS downto 0);
-    fail_wr  : std_ulogic_vector(PMP_NUM_REGIONS downto 0);
-    if_fault : std_ulogic;
-    ld_fault : std_ulogic;
-    st_fault : std_ulogic;
+    fail_ex  : std_ulogic_vector(PMP_NUM_REGIONS   downto 0);
+    fail_rd  : std_ulogic_vector(PMP_NUM_REGIONS   downto 0);
+    fail_wr  : std_ulogic_vector(PMP_NUM_REGIONS   downto 0);
   end record;
   signal pmp_mask : pmp_mask_t;
   signal pmp      : pmp_t;
@@ -382,15 +379,12 @@ begin
     pmp.fail_rd(r) <= not pmp.perm_rd(r) when (pmp.d_match(r) = '1') else pmp.fail_rd(r+1);
     pmp.fail_wr(r) <= not pmp.perm_wr(r) when (pmp.d_match(r) = '1') else pmp.fail_wr(r+1);
   end generate;
-  pmp.if_fault <= pmp.fail_ex(0);
-  pmp.ld_fault <= pmp.fail_rd(0);
-  pmp.st_fault <= pmp.fail_wr(0);
 
 
-  -- final PMP access fault signals (ignored when in debug mode) --
-  if_pmp_fault <= '1' when (pmp.if_fault = '1') and (PMP_NUM_REGIONS > 0) and (ctrl_i.cpu_debug = '0') else '0';
-  ld_pmp_fault <= '1' when (pmp.ld_fault = '1') and (PMP_NUM_REGIONS > 0) and (ctrl_i.cpu_debug = '0') else '0';
-  st_pmp_fault <= '1' when (pmp.st_fault = '1') and (PMP_NUM_REGIONS > 0) and (ctrl_i.cpu_debug = '0') else '0';
+  -- final PMP access fault signals (ignore PMP rules when in debug mode) --
+  if_pmp_fault <= '1' when (pmp.fail_ex(0) = '1') and (PMP_NUM_REGIONS > 0) and (ctrl_i.cpu_debug = '0') else '0';
+  ld_pmp_fault <= '1' when (pmp.fail_rd(0) = '1') and (PMP_NUM_REGIONS > 0) and (ctrl_i.cpu_debug = '0') else '0';
+  st_pmp_fault <= '1' when (pmp.fail_wr(0) = '1') and (PMP_NUM_REGIONS > 0) and (ctrl_i.cpu_debug = '0') else '0';
 
   -- instruction fetch PMP fault --
   i_pmp_fault_o <= if_pmp_fault;

--- a/rtl/core/neorv32_cpu_cp_cfu.vhd
+++ b/rtl/core/neorv32_cpu_cp_cfu.vhd
@@ -45,9 +45,6 @@ library neorv32;
 use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_cp_cfu is
-  generic (
-    XLEN : natural -- data path width
-  );
   port (
     -- global control --
     clk_i   : in  std_ulogic; -- global clock, rising edge

--- a/rtl/core/neorv32_cpu_cp_cond.vhd
+++ b/rtl/core/neorv32_cpu_cp_cond.vhd
@@ -40,9 +40,6 @@ library neorv32;
 use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_cp_cond is
-  generic (
-    XLEN : natural -- data path width
-  );
   port (
     -- global control --
     clk_i   : in  std_ulogic; -- global clock, rising edge

--- a/rtl/core/neorv32_cpu_cp_fpu.vhd
+++ b/rtl/core/neorv32_cpu_cp_fpu.vhd
@@ -56,9 +56,6 @@ library neorv32;
 use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_cp_fpu is
-  generic (
-    XLEN : natural -- data path width
-  );
   port (
     -- global control --
     clk_i    : in  std_ulogic; -- global clock, rising edge

--- a/rtl/core/neorv32_cpu_cp_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_cp_muldiv.vhd
@@ -45,7 +45,6 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_cp_muldiv is
   generic (
-    XLEN        : natural; -- data path width
     FAST_MUL_EN : boolean; -- use DSPs for faster multiplication
     DIVISION_EN : boolean  -- implement divider hardware
   );

--- a/rtl/core/neorv32_cpu_cp_shifter.vhd
+++ b/rtl/core/neorv32_cpu_cp_shifter.vhd
@@ -44,7 +44,6 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_cp_shifter is
   generic (
-    XLEN          : natural; -- data path width
     FAST_SHIFT_EN : boolean  -- implement fast but large barrel shifter
   );
   port (

--- a/rtl/core/neorv32_cpu_regfile.vhd
+++ b/rtl/core/neorv32_cpu_regfile.vhd
@@ -53,10 +53,9 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_regfile is
   generic (
-    XLEN                  : natural; -- data path width
-    CPU_EXTENSION_RISCV_E : boolean; -- implement embedded RF extension?
-    RS3_EN                : boolean; -- enable 3rd read port
-    RS4_EN                : boolean  -- enable 4th read port
+    RVE    : boolean; -- implement embedded RF extension?
+    RS3_EN : boolean; -- enable 3rd read port
+    RS4_EN : boolean  -- enable 4th read port
   );
   port (
     -- global control --
@@ -126,7 +125,7 @@ begin
   -- RV32I Register File with 32 Entries ----------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   reg_file_rv32i:
-  if (CPU_EXTENSION_RISCV_E = false) generate
+  if (RVE = false) generate
     rf_access: process(clk_i)
     begin
       if rising_edge(clk_i) then -- sync read and write
@@ -157,7 +156,7 @@ begin
   -- RV32E Register File with 16 Entries ----------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   reg_file_rv32e:
-  if (CPU_EXTENSION_RISCV_E = true) generate
+  if (RVE = true) generate
     rf_access: process(clk_i)
     begin
       if rising_edge(clk_i) then -- sync read and write

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -1,5 +1,5 @@
 -- #################################################################################################
--- # << NEORV32 - Main VHDL package file >>                                                        #
+-- # << NEORV32 - Main VHDL Package File (CPU and SoC) >>                                          #
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
@@ -58,9 +58,12 @@ package neorv32_package is
   -- log2 of co-processor timeout cycles --
   constant cp_timeout_c : natural := 7; -- default = 7 (= 128 cycles)
 
+  -- native data path width --
+  constant XLEN : natural := 32; -- do not change!
+
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080301"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080302"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
 
   -- Check if we're inside the Matrix -------------------------------------------------------
@@ -895,8 +898,8 @@ package neorv32_package is
   constant exc_iaccess_c  : natural :=  0; -- instruction access fault
   constant exc_iillegal_c : natural :=  1; -- illegal instruction
   constant exc_ialign_c   : natural :=  2; -- instruction address misaligned
-  constant exc_envcall_c  : natural :=  3; -- environment call
-  constant exc_break_c    : natural :=  4; -- breakpoint
+  constant exc_ecall_c   : natural :=  3; -- environment call
+  constant exc_ebreak_c   : natural :=  4; -- breakpoint
   constant exc_salign_c   : natural :=  5; -- store address misaligned
   constant exc_lalign_c   : natural :=  6; -- load address misaligned
   constant exc_saccess_c  : natural :=  7; -- store access fault
@@ -1203,7 +1206,6 @@ package neorv32_package is
   component neorv32_cpu_control
     generic (
       -- General --
-      XLEN                         : natural; -- data path width
       HART_ID                      : std_ulogic_vector(31 downto 0); -- hardware thread ID
       VENDOR_ID                    : std_ulogic_vector(31 downto 0); -- vendor's JEDEC ID
       CPU_BOOT_ADDR                : std_ulogic_vector(31 downto 0); -- cpu boot address
@@ -1286,10 +1288,9 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_regfile
     generic (
-      XLEN                  : natural; -- data path width
-      CPU_EXTENSION_RISCV_E : boolean; -- implement embedded RF extension?
-      RS3_EN                : boolean; -- enable 3rd read port
-      RS4_EN                : boolean  -- enable 4th read port
+      RVE    : boolean; -- implement embedded RF extension?
+      RS3_EN : boolean; -- enable 3rd read port
+      RS4_EN : boolean  -- enable 4th read port
     );
     port (
       -- global control --
@@ -1312,7 +1313,6 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_alu
     generic (
-      XLEN                       : natural; -- data path width
       -- RISC-V CPU Extensions --
       CPU_EXTENSION_RISCV_B      : boolean; -- implement bit-manipulation extension?
       CPU_EXTENSION_RISCV_M      : boolean; -- implement mul/div extension?
@@ -1351,7 +1351,6 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_cp_shifter
     generic (
-      XLEN          : natural; -- data path width
       FAST_SHIFT_EN : boolean  -- use barrel shifter for shift operations
     );
     port (
@@ -1373,7 +1372,6 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_cp_muldiv
     generic (
-      XLEN        : natural; -- data path width
       FAST_MUL_EN : boolean; -- use DSPs for faster multiplication
       DIVISION_EN : boolean  -- implement divider hardware
     );
@@ -1396,7 +1394,6 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_cp_bitmanip is
     generic (
-      XLEN          : natural; -- data path width
       FAST_SHIFT_EN : boolean  -- use barrel shifter for shift operations
     );
     port (
@@ -1419,9 +1416,6 @@ package neorv32_package is
   -- Component: CPU Co-Processor 32-bit FPU ('Zfinx' extension) -----------------------------
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_cp_fpu
-    generic (
-      XLEN : natural -- data path width
-    );
     port (
       -- global control --
       clk_i    : in  std_ulogic; -- global clock, rising edge
@@ -1443,9 +1437,6 @@ package neorv32_package is
   -- Component: CPU Co-Processor for Conditional Operations ('Zicond' extension) ------------
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_cp_cond
-    generic (
-      XLEN : natural -- data path width
-    );
     port (
       -- global control --
       clk_i   : in  std_ulogic; -- global clock, rising edge
@@ -1463,9 +1454,6 @@ package neorv32_package is
   -- Component: CPU Co-Processor Custom (Instr.) Functions Unit ('Zxcfu' extension) ---------
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_cp_cfu
-    generic (
-      XLEN : natural -- data path width
-    );
     port (
       -- global control --
       clk_i   : in  std_ulogic; -- global clock, rising edge
@@ -1487,7 +1475,6 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   component neorv32_cpu_bus
     generic (
-      XLEN                : natural; -- data path width
       PMP_NUM_REGIONS     : natural; -- number of regions (0..16)
       PMP_MIN_GRANULARITY : natural  -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
     );

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -766,19 +766,19 @@ begin
     variable ack_v   : std_ulogic;
     variable err_v   : std_ulogic;
   begin
+    -- OR all response signals: only the module that has actually
+    -- been accessed is allowed to *set* its bus output signals
     rdata_v := (others => '0');
     ack_v   := '0';
     err_v   := '0';
-    -- OR all response signals: only the module that has actually
-    -- been accessed is allowed to *set* its bus output signals
     for i in resp_bus'range loop
       rdata_v := rdata_v or resp_bus(i).rdata; -- read data
       ack_v   := ack_v   or resp_bus(i).ack;   -- acknowledge
       err_v   := err_v   or resp_bus(i).err;   -- error
     end loop; -- i
-    p_bus.rdata <= rdata_v; -- processor bus: CPU transfer data input
-    p_bus.ack   <= ack_v;   -- processor bus: CPU transfer ACK input
-    p_bus.err   <= err_v;   -- processor bus: CPU transfer data bus error input
+    p_bus.rdata <= rdata_v;
+    p_bus.ack   <= ack_v;
+    p_bus.err   <= err_v;
   end process;
 
 

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -180,7 +180,7 @@ begin
     if ci_mode then
       -- No need to send the full expectation in one big chunk
       check_uart(net, uart1_rx_handle, nul & nul);
-      check_uart(net, uart1_rx_handle, "0/47" & cr & lf);
+      check_uart(net, uart1_rx_handle, "0/48" & cr & lf);
     end if;
 
     -- Wait until all expected data has been received

--- a/sw/lib/include/neorv32_cpu_csr.h
+++ b/sw/lib/include/neorv32_cpu_csr.h
@@ -147,7 +147,7 @@ enum NEORV32_CSR_enum {
 
   /* machine counters and timers */
   CSR_MCYCLE         = 0xb00, /**< 0xb00 - mcycle:        Machine cycle counter low word */
-//CSR_MTIME          = 0xb01, /**< 0xb01 - mtime:         Machine time counter low word */
+  //
   CSR_MINSTRET       = 0xb02, /**< 0xb02 - minstret:      Machine instructions-retired counter low word */
   CSR_MHPMCOUNTER3   = 0xb03, /**< 0xb03 - mhpmcounter3:  Machine hardware performance monitor 3  counter low word */
   CSR_MHPMCOUNTER4   = 0xb04, /**< 0xb04 - mhpmcounter4:  Machine hardware performance monitor 4  counter low word */
@@ -180,7 +180,7 @@ enum NEORV32_CSR_enum {
   CSR_MHPMCOUNTER31  = 0xb1f, /**< 0xb1f - mhpmcounter31: Machine hardware performance monitor 31 counter low word */
 
   CSR_MCYCLEH        = 0xb80, /**< 0xb80 - mcycleh:        Machine cycle counter high word */
-//CSR_MTIMEH         = 0xb81, /**< 0xb81 - mtimeh:         Machine time counter high word */
+  //
   CSR_MINSTRETH      = 0xb82, /**< 0xb82 - minstreth:      Machine instructions-retired counter high word */
   CSR_MHPMCOUNTER3H  = 0xb83, /**< 0xb83 - mhpmcounter3 :  Machine hardware performance monitor 3  counter high word */
   CSR_MHPMCOUNTER4H  = 0xb84, /**< 0xb84 - mhpmcounter4h:  Machine hardware performance monitor 4  counter high word */
@@ -214,7 +214,7 @@ enum NEORV32_CSR_enum {
 
   /* user counters and timers */
   CSR_CYCLE          = 0xc00, /**< 0xc00 - cycle:        Cycle counter low word (from MCYCLE) */
-  CSR_TIME           = 0xc01, /**< 0xc01 - time:         Time counter low word */
+  //
   CSR_INSTRET        = 0xc02, /**< 0xc02 - instret:      Instructions-retired counter low word (from MINSTRET) */
   CSR_HPMCOUNTER3    = 0xc03, /**< 0xc03 - hpmcounter3:  User hardware performance monitor 3  counter low word */
   CSR_HPMCOUNTER4    = 0xc04, /**< 0xc04 - hpmcounter4:  User hardware performance monitor 4  counter low word */
@@ -247,7 +247,7 @@ enum NEORV32_CSR_enum {
   CSR_HPMCOUNTER31   = 0xc1f, /**< 0xc1f - hpmcounter31: User hardware performance monitor 31 counter low word */
 
   CSR_CYCLEH         = 0xc80, /**< 0xc80 - cycleh:        Cycle counter high word (from MCYCLEH) */
-  CSR_TIMEH          = 0xc81, /**< 0xc81 - timeh:         Time counter high word */
+  //
   CSR_INSTRETH       = 0xc82, /**< 0xc82 - instreth:      Instructions-retired counter high word (from MINSTRETH) */
   CSR_HPMCOUNTER3H   = 0xc83, /**< 0xc83 - hpmcounter3h:  User hardware performance monitor 3  counter high word */
   CSR_HPMCOUNTER4H   = 0xc84, /**< 0xc84 - hpmcounter4h:  User hardware performance monitor 4  counter high word */

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -123,7 +123,7 @@ int neorv32_rte_handler_uninstall(uint8_t id) {
 /**********************************************************************//**
  * This is the [private!] core of the NEORV32 RTE.
  *
- * @warning When using the the RTE, this function is the ONLY function that uses the 'interrupt' attribute!
+ * @warning When using the RTE this function is the ONLY function that uses the 'interrupt' attribute!
  **************************************************************************/
 static void __attribute__((__interrupt__)) __attribute__((aligned(4))) __neorv32_rte_core(void) {
 
@@ -170,8 +170,8 @@ static void __attribute__((__interrupt__)) __attribute__((aligned(4))) __neorv32
   (*handler_pnt)();
 
   // compute return address
-  // WARNING: some traps might NOT be resumable! (e.g. instruction access fault)
-  if (((int32_t)rte_mcause) >= 0) { // modify pc only if not interrupt (MSB cleared)
+  if ((((int32_t)rte_mcause) >= 0) && // modify pc only if not interrupt (MSB cleared)
+     (rte_mcause != TRAP_CODE_I_ACCESS)) { // do not try to load the instruction as this is the reason we are here already
 
     uint32_t rte_mepc = neorv32_cpu_csr_read(CSR_MEPC);
 


### PR DESCRIPTION
* "The NEORV32 does not implement the user-mode `time[h]` registers. Any access to these registers will trap. It is recommended that the trap handler software provides a means of accessing the platform-defined MTIME machine timer." - same concept is used in Ibex/openTitan :wink:
* VHDL code cleanups
* minor logic optimizations
* fix minor bug in NEORV32 runtime environment: do not try to load the trap-causing instruction word when a _instruction access fault exception_ has been raised