### PR TITLE
update XIRQ controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ mimpid = 0x01040312 => Version 01.04.03.12 => v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 05.04.2023 | 1.8.3.3 | update **external interrupt controller (XIRQ)**; [#570](https://github.com/stnolting/neorv32/pull/570) |
 | 05.04.2023 | 1.8.3.2 | `time` CSR struggles (again) and logic optimization; [#569](https://github.com/stnolting/neorv32/pull/569) |
 | 01.04.2023 | 1.8.3.1 | :sparkles: add full `NA4` and `NAPOT` support to the (now) RISC-V-compatible **physical memory protection (PMP)**; [#566](https://github.com/stnolting/neorv32/pull/566) |
 | 31.03.2023 | [**:rocket:1.8.3**](https://github.com/stnolting/neorv32/releases/tag/v1.8.3) | **New release** |

--- a/docs/datasheet/soc_xirq.adoc
+++ b/docs/datasheet/soc_xirq.adoc
@@ -25,39 +25,43 @@ _single_ CPU fast interrupt request.
 
 **Theory of Operation**
 
-The XIRQ provides up to 32 interrupt channels (configured via the `XIRQ_NUM_CH` generic). Each bit in the `xirq_i`
+The XIRQ provides up to 32 external interrupt channels configured via the `XIRQ_NUM_CH` generic. Each bit in the `xirq_i`
 input signal vector represents one interrupt channel. If less than 32 channels are configured, only the LSB-aligned channels
-are used while the remaining bits are left unconnected.
+are used while the remaining ones are left unconnected internally. The actual interrupt trigger type is configured before
+synthesis using the `XIRQ_TRIGGER_TYPE` and `XIRQ_TRIGGER_POLARITY` generics (see table below).
 
-The actual interrupt trigger (low-level, high-level, rising-edge, falling-edge) can be configured independently for each channel
-using the `XIRQ_TRIGGER_TYPE` and `XIRQ_TRIGGER_POLARITY` generics. `XIRQ_TRIGGER_TYPE` is used to define the general trigger type.
-This can be either _level-triggered_ (`0`) or _edge-triggered_ (`1`). `XIRQ_TRIGGER_POLARITY` is used to configure the polarity of
-the selected trigger: a `0` defines low-level or falling-edge and a `1` defines high-level or rising-edge trigger polarity.
+.XIRQ Trigger Configuration
+[cols="^2,^2,<3"]
+[options="header",grid="all"]
+|=======================
+| `XIRQ_TRIGGER_TYPE(i)` | `XIRQ_TRIGGER_POLARITY(i)` | Resulting Trigger of `xirq_i(i)`
+| `0`                    | `0`                        | low-level
+| `0`                    | `1`                        | high-level
+| `1`                    | `0`                        | falling-edge
+| `1`                    | `1`                        | rising-edge
+|=======================
 
-Each channel can be independently enabled or disabled via the `IER` register. If the configured trigger (see below) of an
-enabled channel fires, the request is stored into an internal buffer. This buffer is available via the interrupt pending register `IPR`.
-A `1` in this register indicates that the corresponding interrupt channel has fired but has not yet been serviced (so it is pending).
-An interrupt channel can become pending if the according `IER` bit is set. Pending IRQs can be cleared by writing `0` to the according `IPR`
-bit. As soon as there is a least one pending interrupt in the buffer, an interrupt request is send to the CPU.
+The interrupt controller features three interface registers: external interrupt channel enable (`EIE`), external interrupt
+channel pending (`EIP`) and external interrupt source (`ESC`). From a functional point of view, the functionality of these
+registers follow the one of the RISC-V <<_mie>>, <<_mip>> and <<_macuse>> CSRs.
 
-[NOTE]
-A disabled interrupt channel can still be pending if it has been triggered before clearing the according `IER` bit.
+If the configured trigger of an interrupt channel fires (e.g. a rising edge) the according interrupt channel becomes _pending_,
+which is indicated by the according channel bit being set in the `EIP` register. This pending interrupt can be cleared at any time
+by writing zero to the according `EIP` bit.
 
-The CPU can determine active external interrupt request either by checking the bits in the `IPR` register, which show all
-pending interrupt channels, or by reading the interrupt source register `SCR`.
-This register provides a 5-bit wide ID (0..31) that shows the interrupt request with _highest priority_.
-Interrupt channel `xirq_i(0)` has highest priority and `xirq_i(XIRQ_NUM_CH-1)` has lowest priority.
-This priority assignment is fixed and cannot be altered by software.
-The CPU can use the ID from `SCR` to service IRQ according to their priority. To acknowledge the according
-interrupt the CPU can write `1 << SCR` to `IPR`.
+A pending interrupt can only trigger a CPU interrupt if the according is enabled via the `EIE` register. Once triggered, disabled
+channels that were triggered remain pending until explicitly cleared. The channels are prioritized in a static order, i.e. channel 0
+(`xirq_i(0)`) has the highest priority and channel 31 (`xirq_i(31)`) has the lowest priority. If any pending interrupt channel is
+actually enabled, an interrupt request is sent to the CPU.
 
-In order to clear a pending FIRQ interrupt from the external interrupt controller again, the according <<_mip>> CSR bit has
-to be cleared. Additionally, the XIRQ interrupt has to be acknowledged by writing _any_
-value to the interrupt source register `SRC`.
+The CPU can determine the most prioritized external interrupt request either by checking the bits in the `IPR` register or by reading
+the interrupt source register `ESC`. This register provides a 5-bit wide ID (0..31) identifying the currently firing external interrupt.
+Writing _any_ value to this register will acknowledge the _current_ XIRQ interrupt (so the XIRQ controller can issue a new CPU interrupt).
 
-[NOTE]
-An interrupt handler should clear the interrupt pending bit that caused the interrupt first before
-acknowledging the interrupt by writing the `SCR` register.
+In order to acknowledge an XIRQ interrupt, the interrupt handler has to...
+* clear the pending CPU FIRQ by clearing the according <<_mip>> CSR bit
+* clear the pending XIRQ channel by clearing the according `EIP` bit
+* writing _any_ value to `ESC` to acknowledge the XIRQ interrupt
 
 
 **Register Map**
@@ -66,9 +70,9 @@ acknowledging the interrupt by writing the `SCR` register.
 [cols="^4,<2,^2,^2,<14"]
 [options="header",grid="all"]
 |=======================
-| Address | Name [C] | Bit(s) | R/W | Function
-| `0xffffff80` | `IER` | `31:0` | r/w | Interrupt enable register (one bit per channel, LSB-aligned)
-| `0xffffff84` | `IPR` | `31:0` | r/w | Interrupt pending register (one bit per channel, LSB-aligned); writing 0 to a bit clears according pending interrupt
-| `0xffffff88` | `SCR` |  `4:0` | r/w | Channel id (0..31) of firing IRQ (prioritized!); writing _any_ value will acknowledge the current interrupt
+| Address | Name [C] | Bit(s) | R/W | Description
+| `0xffffff80` | `EIE` | `31:0` | r/w | External interrupt enable register (one bit per channel, LSB-aligned)
+| `0xffffff84` | `EIP` | `31:0` | r/w | External interrupt pending register (one bit per channel, LSB-aligned); writing 0 to a bit clears the according pending interrupt
+| `0xffffff88` | `ESC` |  `4:0` | r/w | Interrupt source ID (0..31) of firing IRQ (prioritized!); writing _any_ value will acknowledge the current XIRQ interrupt
 | `0xffffff8c` | -     | `31:0` | r/- | _reserved_, read as zero
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -63,7 +63,7 @@ package neorv32_package is
 
   -- Architecture Constants (do not modify!) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080302"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080303"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
 
   -- Check if we're inside the Matrix -------------------------------------------------------

--- a/sw/example/demo_xirq/main.c
+++ b/sw/example/demo_xirq/main.c
@@ -50,11 +50,38 @@
 #define BAUD_RATE 19200
 /**@}*/
 
-// prototypes
-void xirq_handler_ch0(void);
-void xirq_handler_ch1(void);
-void xirq_handler_ch2(void);
-void xirq_handler_ch3(void);
+
+/**********************************************************************//**
+ * XIRQ handler channel 0.
+ * @warning This function has to be of type "void xyz(void)" and must not use any interrupt attributes!
+ **************************************************************************/
+void xirq_handler_ch0(void) {
+  neorv32_uart0_printf("XIRQ interrupt from channel %i\n", 0);
+}
+
+/**********************************************************************//**
+ * XIRQ handler channel 1.
+ * @warning This function has to be of type "void xyz(void)" and must not use any interrupt attributes!
+ **************************************************************************/
+void xirq_handler_ch1(void) {
+  neorv32_uart0_printf("XIRQ interrupt from channel %i\n", 1);
+}
+
+/**********************************************************************//**
+ * XIRQ handler channel 2.
+ * @warning This function has to be of type "void xyz(void)" and must not use any interrupt attributes!
+ **************************************************************************/
+void xirq_handler_ch2(void) {
+  neorv32_uart0_printf("XIRQ interrupt from channel %i\n", 2);
+}
+
+/**********************************************************************//**
+ * XIRQ handler channel 3.
+ * @warning This function has to be of type "void xyz(void)" and must not use any interrupt attributes!
+ **************************************************************************/
+void xirq_handler_ch3(void) {
+  neorv32_uart0_printf("XIRQ interrupt from channel %i\n", 3);
+}
 
 
 /**********************************************************************//**
@@ -67,7 +94,7 @@ void xirq_handler_ch3(void);
 int main() {
 
   // initialize the neorv32 runtime environment
-  // this will take care of handling all CPU traps (interrupts and exceptions)
+  // this will take care of handling all CPU traps
   neorv32_rte_setup();
 
   // setup UART at default baud rate, no interrupts
@@ -81,7 +108,7 @@ int main() {
 
 
   // intro
-  neorv32_uart0_printf("External interrupt controller (XIRQ) demo program\n\n");
+  neorv32_uart0_printf("<< External Interrupts Controller (XIRQ) Demo Program >>\n\n");
 
   int err_cnt = 0;
 
@@ -124,26 +151,29 @@ int main() {
   // so we can trigger the IRQs from software; if you have connected the XIRQs to buttons you
   // can remove the code below (note the trigger configuration using the XIRQ generics!)
   {
+    neorv32_uart0_printf("Triggering XIRQs...\n");
     // trigger XIRQs 3:0 at once
     // assumes xirq_i(31:0) <= gpio.output(31:0)
 
     // due to the prioritization this will execute
-    // -> xirq_handler_ch0
-    // -> xirq_handler_ch1
-    // -> xirq_handler_ch2
-    // -> xirq_handler_ch3
+    // 1. xirq_handler_ch0
+    // 2. xirq_handler_ch1
+    // 3. xirq_handler_ch2
+    // 4. xirq_handler_ch3
     neorv32_gpio_port_set(0xF); // set output pins 3:0 -> trigger XIRQ 3:0
     neorv32_gpio_port_set(0x0);
   }
 
-
-  // --- wait for interrupts ---
   // All incoming XIRQ interrupt requests are "prioritized" in this example. The XIRQ FIRQ handler
   // reads the ID of the interrupt with the highest priority from the XIRQ controller ("source" register) and calls the according
   // handler function (installed via neorv32_xirq_install();).
   // Non-prioritized handling of interrupts (or custom prioritization) can be implemented by manually reading the
-  // XIRQ controller's "pending" register. Then it is up to the software to define which pending IRQ should be served first.
-  while(1);
+  // XIRQ controller's "pending" register. Then it is up to the software to define which pending IRQ should be serviced first.
+
+  asm volatile ("nop");
+  asm volatile ("nop");
+  asm volatile ("nop");
+  asm volatile ("nop");
 
 
   // just as an example: to disable certain XIRQ interrupt channels, we can
@@ -161,50 +191,11 @@ int main() {
   neorv32_xirq_channel_disable(0); // disable channel 0
 
   // globally enable/disable XIRQ CPU interrupt
-  // this will not affect the XIR configuration / pending interrupts
+  // this will not affect the XIRQ configuration / pending interrupts
   neorv32_xirq_global_enable();
   neorv32_xirq_global_disable();
 
+  neorv32_uart0_printf("Program completed.\n");
+
   return 0;
-}
-
-
-/**********************************************************************//**
- * XIRQ handler channel 0.
- *
- * @warning This function has to be of type "void xyz(void)" and must not use any interrupt attributes!
- **************************************************************************/
-void xirq_handler_ch0(void) {
-
-  neorv32_uart0_printf("XIRQ interrupt from channel %i\n", 0);
-}
-
-/**********************************************************************//**
- * XIRQ handler channel 1.
- *
- * @warning This function has to be of type "void xyz(void)" and must not use any interrupt attributes!
- **************************************************************************/
-void xirq_handler_ch1(void) {
-
-  neorv32_uart0_printf("XIRQ interrupt from channel %i\n", 1);
-}
-
-/**********************************************************************//**
- * XIRQ handler channel 2.
- *
- * @warning This function has to be of type "void xyz(void)" and must not use any interrupt attributes!
- **************************************************************************/
-void xirq_handler_ch2(void) {
-
-  neorv32_uart0_printf("XIRQ interrupt from channel %i\n", 2);
-}
-
-/**********************************************************************//**
- * XIRQ handler channel 3.
- *
- * @warning This function has to be of type "void xyz(void)" and must not use any interrupt attributes!
- **************************************************************************/
-void xirq_handler_ch3(void) {
-
-  neorv32_uart0_printf("XIRQ interrupt from channel %i\n", 3);
 }

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1326,8 +1326,6 @@ int main() {
       test_fail();
     }
 
-    NEORV32_XIRQ->IER = 0;
-    NEORV32_XIRQ->IPR = -1;
   }
   else {
     PRINT_STANDARD("[skipped, n.a.]\n");

--- a/sw/lib/include/neorv32_xirq.h
+++ b/sw/lib/include/neorv32_xirq.h
@@ -47,9 +47,9 @@
 /**@{*/
 /** XIRQ module prototype */
 typedef volatile struct __attribute__((packed,aligned(4))) {
-  uint32_t       IER;      /**< offset 0:  IRQ input enable register */
-  uint32_t       IPR;      /**< offset 4:  pending IRQ register /ack/clear */
-  uint32_t       SCR;      /**< offset 8:  interrupt source register */
+  uint32_t       EIE;      /**< offset 0:  external interrupt enable register */
+  uint32_t       EIP;      /**< offset 4:  external interrupt pending register */
+  uint32_t       ESC;      /**< offset 8:  external interrupt source register */
   const uint32_t reserved; /**< offset 12: reserved */
 } neorv32_xirq_t;
 
@@ -67,11 +67,11 @@ int  neorv32_xirq_setup(void);
 void neorv32_xirq_global_enable(void);
 void neorv32_xirq_global_disable(void);
 int  neorv32_xirq_get_num(void);
-void neorv32_xirq_clear_pending(uint8_t ch);
-void neorv32_xirq_channel_enable(uint8_t ch);
-void neorv32_xirq_channel_disable(uint8_t ch);
-int  neorv32_xirq_install(uint8_t ch, void (*handler)(void));
-int  neorv32_xirq_uninstall(uint8_t ch);
+void neorv32_xirq_clear_pending(int channel);
+void neorv32_xirq_channel_enable(int channel);
+void neorv32_xirq_channel_disable(int channel);
+int  neorv32_xirq_install(int channel, void (*handler)(void));
+int  neorv32_xirq_uninstall(int channel);
 /**@}*/
 
 


### PR DESCRIPTION
* rename XIRW registers (-> `EIE`, `EIP`, `ESC`)
* use same behavior as `mie`, `mip` and `mcause` CSRs
* interrupt can become/remain pending even if the according channel is not enabled but will only trigger a CPU interrupt when actually enabled
* fixing some documentation flaws