### PR TITLE
Added a test case to show the 1.0 + -1.0 instruction time-out under f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ mimpid = 0x01080200 => Version 01.08.02.00 => v1.8.2
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 21.04.2023 | 1.8.3.9 | :bug: fix timeout bug in **FPU** normalizer; [#592](https://github.com/stnolting/neorv32/pull/592) |
 | 19.04.2023 | 1.8.3.8 | minor processor bus system optimizations and clean-ups; [#591](https://github.com/stnolting/neorv32/pull/591) |
 | 15.04.2023 | 1.8.3.7 | :bug: :warning: `wfi` and XIRQ bug fixes; massive RTL code cleanup and optimization of CPU control; [#586](https://github.com/stnolting/neorv32/pull/586) |
 | 14.04.2023 | 1.8.3.6 | [UARTs] software can now retrieve the configured RX/TX FIFO sizes from the `DATA` register; [#581](https://github.com/stnolting/neorv32/pull/581) |

--- a/rtl/core/neorv32_cpu_cp_fpu.vhd
+++ b/rtl/core/neorv32_cpu_cp_fpu.vhd
@@ -1358,6 +1358,14 @@ begin
                ctrl.flags(fp_exc_of_c) or -- overflow
                ctrl.flags(fp_exc_nv_c)) = '1') then -- invalid
             ctrl.state <= S_FINALIZE;
+          -- The normalizer only checks the class of the inputs and not the result.
+          -- Check whether adder result is 0.0 which can happen if eg. 1.0 - 1.0
+          -- Set the ctrl.cnt to 0 to force the resulting exponent to be 0
+          -- Do not change sreg.lower as that is already all 0s
+          -- Do not change sign as that should be the right sign from the add/sub
+          elsif (unsigned(mantissa_i(47 downto 0)) = 0) then 
+            ctrl.cnt <= (others => '0');
+            ctrl.state <= S_FINALIZE;
           else
             ctrl.state <= S_PREPARE_SHIFT;
           end if;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -60,7 +60,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080308"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080309"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 


### PR DESCRIPTION
A specific corner test exist in the floating point add/sub function which results in the post add/sub normalizer running for sreg.exp cycles, which for the number 1.0f is enough to trigger the time-out in the execution engine.
An example has been added to the float_corner_test that performs: 1.0f + -1.0f which results in 0.0f but also times out.
A fix has been added to the normalizer in which the S_PERPARE_NORM state has an additional check whether mantissa_i is all 0's. If so the resulting add/sub is 0.0 and we set ctrl.cnt to 0 to ensure the exp is 0 and jump straight to S_FINALIZE. Which should now correctly generate a +/- 0.0f result.