### PR TITLE
🐛 [rtl] fix bug in DMA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ mimpid = 0x01080200 => Version 01.08.02.00 => v1.8.2
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 25.04.2023 | 1.8.4.3 | :bug: fix bug in **DMA** (corrupted write-back when there are bus wait cycles - e.g. when no caches are implemented); [#601](https://github.com/stnolting/neorv32/pull/601) |
 | 24.04.2023 | 1.8.4.2 | minor rtl edits; shorten critical path of d-cache setup; [#599](https://github.com/stnolting/neorv32/pull/599) |
 | 22.04.2023 | 1.8.4.1 | :sparkles: add optional **direct memory access controller (DMA)**; [#593](https://github.com/stnolting/neorv32/pull/593) |
 | 21.04.2023 | [**:rocket:1.8.4**](https://github.com/stnolting/neorv32/releases/tag/v1.8.4) | **New release** |

--- a/rtl/core/neorv32_dma.vhd
+++ b/rtl/core/neorv32_dma.vhd
@@ -331,23 +331,25 @@ begin
     if (rstn_i = '0') then
       align_buf <= (others => '0');
     elsif rising_edge(clk_i) then
-      if (config.qsel = qsel_w2w_c) then -- word
-        align_buf <= align_end;
-      else -- byte
-        case engine.src_addr(1 downto 0) is
-          when "00" => -- byte 0
-            align_buf(07 downto 0) <= align_end(07 downto 00);
-            align_buf(31 downto 8) <= (others => (config.qsel(1) and align_end(07))); -- sign extension
-          when "01" => -- byte 1
-            align_buf(07 downto 0) <= align_end(15 downto 08);
-            align_buf(31 downto 8) <= (others => (config.qsel(1) and align_end(15))); -- sign extension
-          when "10" => -- byte 2
-            align_buf(07 downto 0) <= align_end(23 downto 16);
-            align_buf(31 downto 8) <= (others => (config.qsel(1) and align_end(23))); -- sign extension
-          when others => -- byte 3
-            align_buf(07 downto 0) <= align_end(31 downto 24);
-            align_buf(31 downto 8) <= (others => (config.qsel(1) and align_end(31))); -- sign extension
-        end case;
+      if (engine.state = S_READ) then
+        if (config.qsel = qsel_w2w_c) then -- word
+          align_buf <= align_end;
+        else -- byte
+          case engine.src_addr(1 downto 0) is
+            when "00" => -- byte 0
+              align_buf(07 downto 0) <= align_end(07 downto 00);
+              align_buf(31 downto 8) <= (others => (config.qsel(1) and align_end(07))); -- sign extension
+            when "01" => -- byte 1
+              align_buf(07 downto 0) <= align_end(15 downto 08);
+              align_buf(31 downto 8) <= (others => (config.qsel(1) and align_end(15))); -- sign extension
+            when "10" => -- byte 2
+              align_buf(07 downto 0) <= align_end(23 downto 16);
+              align_buf(31 downto 8) <= (others => (config.qsel(1) and align_end(23))); -- sign extension
+            when others => -- byte 3
+              align_buf(07 downto 0) <= align_end(31 downto 24);
+              align_buf(31 downto 8) <= (others => (config.qsel(1) and align_end(31))); -- sign extension
+          end case;
+        end if;
       end if;
     end if;
   end process src_align;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -60,7 +60,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080402"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080403"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -73,8 +73,6 @@ architecture neorv32_tb_rtl of neorv32_tb is
   constant f_clock_c               : natural := 100000000; -- main clock in Hz
   constant baud0_rate_c            : natural := 19200; -- simulation UART0 (primary UART) baud rate
   constant baud1_rate_c            : natural := 19200; -- simulation UART1 (secondary UART) baud rate
-  constant icache_en_c             : boolean := true; -- implement i-cache
-  constant icache_block_size_c     : natural := 64; -- i-cache block size in bytes
   -- simulated external Wishbone memory A (can be used as external IMEM) --
   constant ext_mem_a_base_addr_c   : std_ulogic_vector(31 downto 0) := x"00000000"; -- wishbone memory base address (external IMEM base)
   constant ext_mem_a_size_c        : natural := imem_size_c; -- wishbone memory size in bytes
@@ -251,14 +249,9 @@ begin
     MEM_INT_DMEM_EN              => int_dmem_c,    -- implement processor-internal data memory
     MEM_INT_DMEM_SIZE            => dmem_size_c,   -- size of processor-internal data memory in bytes
     -- Internal Cache memory --
-    ICACHE_EN                    => icache_en_c,   -- implement instruction cache
-    ICACHE_NUM_BLOCKS            => 8,             -- i-cache: number of blocks (min 2), has to be a power of 2
-    ICACHE_BLOCK_SIZE            => icache_block_size_c, -- i-cache: block size in bytes (min 4), has to be a power of 2
-    ICACHE_ASSOCIATIVITY         => 2,             -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
+    ICACHE_EN                    => false,         -- implement instruction cache
     -- Internal Data Cache (dCACHE) --
-    DCACHE_EN                    => true,          -- implement data cache
-    DCACHE_NUM_BLOCKS            => 8,             -- d-cache: number of blocks (min 1), has to be a power of 2
-    DCACHE_BLOCK_SIZE            => 64,            -- d-cache: block size in bytes (min 4), has to be a power of 2
+    DCACHE_EN                    => false,         -- implement data cache
     -- External memory interface --
     MEM_EXT_EN                   => true,          -- implement external memory bus interface?
     MEM_EXT_TIMEOUT              => 256,           -- cycles after a pending bus access auto-terminates (0 = disabled)

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -73,6 +73,8 @@ architecture neorv32_tb_rtl of neorv32_tb is
   constant f_clock_c               : natural := 100000000; -- main clock in Hz
   constant baud0_rate_c            : natural := 19200; -- simulation UART0 (primary UART) baud rate
   constant baud1_rate_c            : natural := 19200; -- simulation UART1 (secondary UART) baud rate
+  constant icache_en_c             : boolean := false; -- implement i-cache
+  constant icache_block_size_c     : natural := 64; -- i-cache block size in bytes
   -- simulated external Wishbone memory A (can be used as external IMEM) --
   constant ext_mem_a_base_addr_c   : std_ulogic_vector(31 downto 0) := x"00000000"; -- wishbone memory base address (external IMEM base)
   constant ext_mem_a_size_c        : natural := imem_size_c; -- wishbone memory size in bytes


### PR DESCRIPTION
Write data gets corrupted if there are DMA wait states (e.g. if no caches are implemented).
Disabled caches in VUnit testbench to have a test case for this.

(thx @biosbob for finding this bug!)