### PR TITLE
[rtl] minor rtl updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ mimpid = 0x01080200 => Version 01.08.02.00 => v1.8.2
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 02.05.2023 | 1.8.4.6 | make SDI FIFO access entirely synchronous; upgrade processor memory modules; update test setup wrappers; [#608]((https://github.com/stnolting/neorv32/pull/608) |
 | 30.04.2023 | 1.8.4.5 | rework processor-internal bus system; [#607](https://github.com/stnolting/neorv32/pull/607) |
 | 27.04.2023 | 1.8.4.4 | minor hardware edits and switching activity optimizations of CPU bus unit; [#605](https://github.com/stnolting/neorv32/pull/605) |
 | 25.04.2023 | 1.8.4.3 | :bug: fix bug in **DMA** (corrupted write-back when there are bus wait cycles - e.g. when no caches are implemented); [#601](https://github.com/stnolting/neorv32/pull/601) |

--- a/rtl/core/mem/neorv32_dmem.default.vhd
+++ b/rtl/core/mem/neorv32_dmem.default.vhd
@@ -54,6 +54,7 @@ architecture neorv32_dmem_rtl of neorv32_dmem is
   -- -------------------------------------------------------------------------------------------------------------- --
   -- The memory (RAM) is built from 4 individual byte-wide memories b0..b3, since some synthesis tools have         --
   -- problems with 32-bit memories that provide dedicated byte-enable signals AND/OR with multi-dimensional arrays. --
+  -- [NOTE] Read-during-write behavior is irrelevant as read and write access are mutually exclusive.               --
   -- -------------------------------------------------------------------------------------------------------------- --
 
   -- RAM - not initialized at all --
@@ -88,30 +89,22 @@ begin
   mem_access: process(clk_i)
   begin
     if rising_edge(clk_i) then
-      -- this RAM style should not require "no_rw_check" attributes as the read-after-write behavior
-      -- is intended to be defined implicitly via the if-WRITE-else-READ construct
-      if (acc_en = '1') then -- reduce switching activity when not accessed
-        if (bus_req_i.we = '1') and (bus_req_i.ben(0) = '1') then -- byte 0
-          mem_ram_b0(to_integer(unsigned(addr))) <= bus_req_i.data(07 downto 00);
-        else
-          mem_ram_b0_rd <= mem_ram_b0(to_integer(unsigned(addr)));
-        end if;
-        if (bus_req_i.we = '1') and (bus_req_i.ben(1) = '1') then -- byte 1
-          mem_ram_b1(to_integer(unsigned(addr))) <= bus_req_i.data(15 downto 08);
-        else
-          mem_ram_b1_rd <= mem_ram_b1(to_integer(unsigned(addr)));
-        end if;
-        if (bus_req_i.we = '1') and (bus_req_i.ben(2) = '1') then -- byte 2
-          mem_ram_b2(to_integer(unsigned(addr))) <= bus_req_i.data(23 downto 16);
-        else
-          mem_ram_b2_rd <= mem_ram_b2(to_integer(unsigned(addr)));
-        end if;
-        if (bus_req_i.we = '1') and (bus_req_i.ben(3) = '1') then -- byte 3
-          mem_ram_b3(to_integer(unsigned(addr))) <= bus_req_i.data(31 downto 24);
-        else
-          mem_ram_b3_rd <= mem_ram_b3(to_integer(unsigned(addr)));
-        end if;
+      if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(0) = '1') then -- byte 0
+        mem_ram_b0(to_integer(unsigned(addr))) <= bus_req_i.data(07 downto 00);
       end if;
+      if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(1) = '1') then -- byte 1
+        mem_ram_b1(to_integer(unsigned(addr))) <= bus_req_i.data(15 downto 08);
+      end if;
+      if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(2) = '1') then -- byte 2
+        mem_ram_b2(to_integer(unsigned(addr))) <= bus_req_i.data(23 downto 16);
+      end if;
+      if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(3) = '1') then -- byte 3
+        mem_ram_b3(to_integer(unsigned(addr))) <= bus_req_i.data(31 downto 24);
+      end if;
+      mem_ram_b0_rd <= mem_ram_b0(to_integer(unsigned(addr)));
+      mem_ram_b1_rd <= mem_ram_b1(to_integer(unsigned(addr)));
+      mem_ram_b2_rd <= mem_ram_b2(to_integer(unsigned(addr)));
+      mem_ram_b3_rd <= mem_ram_b3(to_integer(unsigned(addr)));
     end if;
   end process mem_access;
 

--- a/rtl/core/mem/neorv32_dmem.legacy.vhd
+++ b/rtl/core/mem/neorv32_dmem.legacy.vhd
@@ -55,6 +55,7 @@ architecture neorv32_dmem_rtl of neorv32_dmem is
   -- -------------------------------------------------------------------------------------------------------------- --
   -- The memory (RAM) is built from 4 individual byte-wide memories b0..b3, since some synthesis tools have         --
   -- problems with 32-bit memories that provide dedicated byte-enable signals AND/OR with multi-dimensional arrays. --
+  -- [NOTE] Read-during-write behavior is irrelevant as read and write access are mutually exclusive.               --
   -- -------------------------------------------------------------------------------------------------------------- --
 
   -- RAM - not initialized at all --
@@ -90,19 +91,17 @@ begin
   begin
     if rising_edge(clk_i) then
       addr_ff <= addr;
-      if (acc_en = '1') then -- reduce switching activity when not accessed
-        if (bus_req_i.we = '1') and (bus_req_i.ben(0) = '1') then -- byte 0
-          mem_ram_b0(to_integer(unsigned(addr))) <= bus_req_i.data(07 downto 00);
-        end if;
-        if (bus_req_i.we = '1') and (bus_req_i.ben(1) = '1') then -- byte 1
-          mem_ram_b1(to_integer(unsigned(addr))) <= bus_req_i.data(15 downto 08);
-        end if;
-        if (bus_req_i.we = '1') and (bus_req_i.ben(2) = '1') then -- byte 2
-          mem_ram_b2(to_integer(unsigned(addr))) <= bus_req_i.data(23 downto 16);
-        end if;
-        if (bus_req_i.we = '1') and (bus_req_i.ben(3) = '1') then -- byte 3
-          mem_ram_b3(to_integer(unsigned(addr))) <= bus_req_i.data(31 downto 24);
-        end if;
+      if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(0) = '1') then -- byte 0
+        mem_ram_b0(to_integer(unsigned(addr))) <= bus_req_i.data(07 downto 00);
+      end if;
+      if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(1) = '1') then -- byte 1
+        mem_ram_b1(to_integer(unsigned(addr))) <= bus_req_i.data(15 downto 08);
+      end if;
+      if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(2) = '1') then -- byte 2
+        mem_ram_b2(to_integer(unsigned(addr))) <= bus_req_i.data(23 downto 16);
+      end if;
+      if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(3) = '1') then -- byte 3
+        mem_ram_b3(to_integer(unsigned(addr))) <= bus_req_i.data(31 downto 24);
       end if;
     end if;
   end process mem_access;

--- a/rtl/core/mem/neorv32_imem.default.vhd
+++ b/rtl/core/mem/neorv32_imem.default.vhd
@@ -71,6 +71,7 @@ architecture neorv32_imem_rtl of neorv32_imem is
   -- -------------------------------------------------------------------------------------------------------------- --
   -- The memory (RAM) is built from 4 individual byte-wide memories b0..b3, since some synthesis tools have         --
   -- problems with 32-bit memories that provide dedicated byte-enable signals AND/OR with multi-dimensional arrays. --
+  -- [NOTE] Read-during-write behavior is irrelevant as read and write access are mutually exclusive.               --
   -- -------------------------------------------------------------------------------------------------------------- --
 
   -- RAM - not initialized at all --
@@ -125,37 +126,29 @@ begin
   end generate;
 
 
-  -- Implement IMEM as not-initialized RAM --------------------------------------------------
+  -- Implement IMEM as non-initialized RAM --------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   imem_ram:
   if (IMEM_AS_IROM = false) generate
     mem_access: process(clk_i)
     begin
       if rising_edge(clk_i) then
-        -- this RAM style should not require "no_rw_check" attributes as the read-after-write behavior
-        -- is intended to be defined implicitly via the if-WRITE-else-READ construct
-        if (acc_en = '1') then -- reduce switching activity when not accessed
-          if (bus_req_i.we = '1') and (bus_req_i.ben(0) = '1') then -- byte 0
-            mem_ram_b0(to_integer(unsigned(addr))) <= bus_req_i.data(07 downto 00);
-          else
-            mem_b0_rd <= mem_ram_b0(to_integer(unsigned(addr)));
-          end if;
-          if (bus_req_i.we = '1') and (bus_req_i.ben(1) = '1') then -- byte 1
-            mem_ram_b1(to_integer(unsigned(addr))) <= bus_req_i.data(15 downto 08);
-          else
-            mem_b1_rd <= mem_ram_b1(to_integer(unsigned(addr)));
-          end if;
-          if (bus_req_i.we = '1') and (bus_req_i.ben(2) = '1') then -- byte 2
-            mem_ram_b2(to_integer(unsigned(addr))) <= bus_req_i.data(23 downto 16);
-          else
-            mem_b2_rd <= mem_ram_b2(to_integer(unsigned(addr)));
-          end if;
-          if (bus_req_i.we = '1') and (bus_req_i.ben(3) = '1') then -- byte 3
-            mem_ram_b3(to_integer(unsigned(addr))) <= bus_req_i.data(31 downto 24);
-          else
-            mem_b3_rd <= mem_ram_b3(to_integer(unsigned(addr)));
-          end if;
+        if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(0) = '1') then -- byte 0
+          mem_ram_b0(to_integer(unsigned(addr))) <= bus_req_i.data(07 downto 00);
         end if;
+        if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(1) = '1') then -- byte 1
+          mem_ram_b1(to_integer(unsigned(addr))) <= bus_req_i.data(15 downto 08);
+        end if;
+        if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(2) = '1') then -- byte 2
+          mem_ram_b2(to_integer(unsigned(addr))) <= bus_req_i.data(23 downto 16);
+        end if;
+        if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(3) = '1') then -- byte 3
+          mem_ram_b3(to_integer(unsigned(addr))) <= bus_req_i.data(31 downto 24);
+        end if;
+        mem_b0_rd <= mem_ram_b0(to_integer(unsigned(addr)));
+        mem_b1_rd <= mem_ram_b1(to_integer(unsigned(addr)));
+        mem_b2_rd <= mem_ram_b2(to_integer(unsigned(addr)));
+        mem_b3_rd <= mem_ram_b3(to_integer(unsigned(addr)));
       end if;
     end process mem_access;
     -- read data --

--- a/rtl/core/mem/neorv32_imem.legacy.vhd
+++ b/rtl/core/mem/neorv32_imem.legacy.vhd
@@ -72,6 +72,7 @@ architecture neorv32_imem_rtl of neorv32_imem is
   -- -------------------------------------------------------------------------------------------------------------- --
   -- The memory (RAM) is built from 4 individual byte-wide memories b0..b3, since some synthesis tools have         --
   -- problems with 32-bit memories that provide dedicated byte-enable signals AND/OR with multi-dimensional arrays. --
+  -- [NOTE] Read-during-write behavior is irrelevant as read and write access are mutually exclusive.               --
   -- -------------------------------------------------------------------------------------------------------------- --
 
   -- RAM - not initialized at all --
@@ -126,7 +127,7 @@ begin
   end generate;
 
 
-  -- Implement IMEM as not-initialized RAM --------------------------------------------------
+  -- Implement IMEM as non-initialized RAM --------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   imem_ram:
   if (IMEM_AS_IROM = false) generate
@@ -134,19 +135,17 @@ begin
     begin
       if rising_edge(clk_i) then
         addr_ff <= addr;
-        if (acc_en = '1') then -- reduce switching activity when not accessed
-          if (bus_req_i.we = '1') and (bus_req_i.ben(0) = '1') then -- byte 0
-            mem_ram_b0(to_integer(unsigned(addr))) <= bus_req_i.data(07 downto 00);
-          end if;
-          if (bus_req_i.we = '1') and (bus_req_i.ben(1) = '1') then -- byte 1
-            mem_ram_b1(to_integer(unsigned(addr))) <= bus_req_i.data(15 downto 08);
-          end if;
-          if (bus_req_i.we = '1') and (bus_req_i.ben(2) = '1') then -- byte 2
-            mem_ram_b2(to_integer(unsigned(addr))) <= bus_req_i.data(23 downto 16);
-          end if;
-          if (bus_req_i.we = '1') and (bus_req_i.ben(3) = '1') then -- byte 3
-            mem_ram_b3(to_integer(unsigned(addr))) <= bus_req_i.data(31 downto 24);
-          end if;
+        if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(0) = '1') then -- byte 0
+          mem_ram_b0(to_integer(unsigned(addr))) <= bus_req_i.data(07 downto 00);
+        end if;
+        if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(1) = '1') then -- byte 1
+          mem_ram_b1(to_integer(unsigned(addr))) <= bus_req_i.data(15 downto 08);
+        end if;
+        if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(2) = '1') then -- byte 2
+          mem_ram_b2(to_integer(unsigned(addr))) <= bus_req_i.data(23 downto 16);
+        end if;
+        if (acc_en = '1') and (bus_req_i.we = '1') and (bus_req_i.ben(3) = '1') then -- byte 3
+          mem_ram_b3(to_integer(unsigned(addr))) <= bus_req_i.data(31 downto 24);
         end if;
       end if;
     end process mem_access;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -60,7 +60,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080405"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080406"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 

--- a/rtl/core/neorv32_sdi.vhd
+++ b/rtl/core/neorv32_sdi.vhd
@@ -224,7 +224,7 @@ begin
   generic map (
     FIFO_DEPTH => RTX_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,        -- size of data elements in fifo (32-bit only for simulation)
-    FIFO_RSYNC => false,    -- async read
+    FIFO_RSYNC => true,     -- sync read
     FIFO_SAFE  => true      -- safe access
   )
   port map (
@@ -256,7 +256,7 @@ begin
   generic map (
     FIFO_DEPTH => RTX_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,        -- size of data elements in fifo (32-bit only for simulation)
-    FIFO_RSYNC => false,    -- async read
+    FIFO_RSYNC => true,     -- sync read
     FIFO_SAFE  => true      -- safe access
   )
   port map (

--- a/rtl/test_setups/neorv32_test_setup_approm.vhd
+++ b/rtl/test_setups/neorv32_test_setup_approm.vhd
@@ -72,6 +72,8 @@ begin
     CPU_EXTENSION_RISCV_C        => true,              -- implement compressed extension?
     CPU_EXTENSION_RISCV_M        => true,              -- implement mul/div extension?
     CPU_EXTENSION_RISCV_Zicntr   => true,              -- implement base counters?
+    -- Tuning Options --
+    CPU_IPB_ENTRIES              => 2,                 -- entries in instruction prefetch buffer, has to be a power of 2, min 1
     -- Internal Instruction memory --
     MEM_INT_IMEM_EN              => true,              -- implement processor-internal instruction memory
     MEM_INT_IMEM_SIZE            => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes

--- a/rtl/test_setups/neorv32_test_setup_bootloader.vhd
+++ b/rtl/test_setups/neorv32_test_setup_bootloader.vhd
@@ -75,6 +75,8 @@ begin
     CPU_EXTENSION_RISCV_C        => true,              -- implement compressed extension?
     CPU_EXTENSION_RISCV_M        => true,              -- implement mul/div extension?
     CPU_EXTENSION_RISCV_Zicntr   => true,              -- implement base counters?
+    -- Tuning Options --
+    CPU_IPB_ENTRIES              => 2,                 -- entries in instruction prefetch buffer, has to be a power of 2, min 1
     -- Internal Instruction memory --
     MEM_INT_IMEM_EN              => true,              -- implement processor-internal instruction memory
     MEM_INT_IMEM_SIZE            => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes

--- a/rtl/test_setups/neorv32_test_setup_on_chip_debugger.vhd
+++ b/rtl/test_setups/neorv32_test_setup_on_chip_debugger.vhd
@@ -84,6 +84,8 @@ begin
     CPU_EXTENSION_RISCV_M        => true,              -- implement mul/div extension?
     CPU_EXTENSION_RISCV_Zicntr   => true,              -- implement base counters?
     CPU_EXTENSION_RISCV_Zifencei => true,              -- implement instruction stream sync.? (required for the on-chip debugger)
+    -- Tuning Options --
+    CPU_IPB_ENTRIES              => 2,                 -- entries in instruction prefetch buffer, has to be a power of 2, min 1
     -- Internal Instruction memory --
     MEM_INT_IMEM_EN              => true,              -- implement processor-internal instruction memory
     MEM_INT_IMEM_SIZE            => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes


### PR DESCRIPTION
* update test setup wrappers (add explicit instruction prefetch buffer configuration)
* optimize default IMEM and DMEM modules (synthesis tools like Quartus will no longer issue a warning about adding "bypass logic" -> less hardware requirements)
* make **SDI** FIFO access _synchronous_ to improve BRAM mapping