### PR TITLE
[SW] Expand xirq interrupt function by a parameter.

### DIFF
--- a/sw/example/demo_xirq/main.c
+++ b/sw/example/demo_xirq/main.c
@@ -55,7 +55,8 @@
  * XIRQ handler channel 0.
  * @warning This function has to be of type "void xyz(void)" and must not use any interrupt attributes!
  **************************************************************************/
-void xirq_handler_ch0(void) {
+void xirq_handler_ch0(void *param) {
+  (void)param;
   neorv32_uart0_printf("XIRQ interrupt from channel %i\n", 0);
 }
 
@@ -63,7 +64,8 @@ void xirq_handler_ch0(void) {
  * XIRQ handler channel 1.
  * @warning This function has to be of type "void xyz(void)" and must not use any interrupt attributes!
  **************************************************************************/
-void xirq_handler_ch1(void) {
+void xirq_handler_ch1(void *param) {
+  (void)param;
   neorv32_uart0_printf("XIRQ interrupt from channel %i\n", 1);
 }
 
@@ -71,7 +73,8 @@ void xirq_handler_ch1(void) {
  * XIRQ handler channel 2.
  * @warning This function has to be of type "void xyz(void)" and must not use any interrupt attributes!
  **************************************************************************/
-void xirq_handler_ch2(void) {
+void xirq_handler_ch2(void *param) {
+  (void)param;
   neorv32_uart0_printf("XIRQ interrupt from channel %i\n", 2);
 }
 
@@ -79,7 +82,8 @@ void xirq_handler_ch2(void) {
  * XIRQ handler channel 3.
  * @warning This function has to be of type "void xyz(void)" and must not use any interrupt attributes!
  **************************************************************************/
-void xirq_handler_ch3(void) {
+void xirq_handler_ch3(void *param) {
+  (void)param;
   neorv32_uart0_printf("XIRQ interrupt from channel %i\n", 3);
 }
 
@@ -129,10 +133,10 @@ int main() {
   // (details: these are "third-level" interrupt handlers)
   // neorv32_xirq_install() also enables the specified XIRQ channel and clears any pending interrupts
   err_cnt = 0;
-  err_cnt += neorv32_xirq_install(0, xirq_handler_ch0); // handler function for channel 0
-  err_cnt += neorv32_xirq_install(1, xirq_handler_ch1); // handler function for channel 1
-  err_cnt += neorv32_xirq_install(2, xirq_handler_ch2); // handler function for channel 2
-  err_cnt += neorv32_xirq_install(3, xirq_handler_ch3); // handler function for channel 3
+  err_cnt += neorv32_xirq_install(0, xirq_handler_ch0, NULL); // handler function for channel 0
+  err_cnt += neorv32_xirq_install(1, xirq_handler_ch1, NULL); // handler function for channel 1
+  err_cnt += neorv32_xirq_install(2, xirq_handler_ch2, NULL); // handler function for channel 2
+  err_cnt += neorv32_xirq_install(3, xirq_handler_ch3, NULL); // handler function for channel 3
 
   // check if installation went fine
   if (err_cnt) {

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -84,8 +84,8 @@
 // Prototypes
 void sim_irq_trigger(uint32_t sel);
 void global_trap_handler(void);
-void xirq_trap_handler0(void);
-void xirq_trap_handler1(void);
+void xirq_trap_handler0(void *param);
+void xirq_trap_handler1(void *param);
 void test_ok(void);
 void test_fail(void);
 
@@ -295,7 +295,7 @@ int main() {
 
 
   // ----------------------------------------------------------
-  // Test standard RISC-V counters 
+  // Test standard RISC-V counters
   // ----------------------------------------------------------
   neorv32_cpu_csr_write(CSR_MCAUSE, mcause_never_c);
   PRINT_STANDARD("[%i] Zicntr CNTs ", cnt_test);
@@ -371,7 +371,7 @@ int main() {
 
 
   // ----------------------------------------------------------
-  // Test mcountinhibit: inhibit counter auto-inc 
+  // Test mcountinhibit: inhibit counter auto-inc
   // ----------------------------------------------------------
   neorv32_cpu_csr_write(CSR_MCAUSE, mcause_never_c);
   PRINT_STANDARD("[%i] mcountinhibit CSR ", cnt_test);
@@ -1286,8 +1286,8 @@ int main() {
     xirq_trap_handler_ack = 0;
 
     xirq_err_cnt += neorv32_xirq_setup(); // initialize XIRQ
-    xirq_err_cnt += neorv32_xirq_install(0, xirq_trap_handler0); // install XIRQ IRQ handler channel 0
-    xirq_err_cnt += neorv32_xirq_install(1, xirq_trap_handler1); // install XIRQ IRQ handler channel 1
+    xirq_err_cnt += neorv32_xirq_install(0, xirq_trap_handler0, NULL); // install XIRQ IRQ handler channel 0
+    xirq_err_cnt += neorv32_xirq_install(1, xirq_trap_handler1, NULL); // install XIRQ IRQ handler channel 1
 
     // enable XIRQ FIRQ
     neorv32_cpu_irq_enable(XIRQ_FIRQ_ENABLE);
@@ -1926,8 +1926,9 @@ void global_trap_handler(void) {
 /**********************************************************************//**
  * XIRQ handler channel 0.
  **************************************************************************/
-void xirq_trap_handler0(void) {
+void xirq_trap_handler0(void *param) {
 
+  (void)param;
   xirq_trap_handler_ack += 2;
 }
 
@@ -1935,8 +1936,9 @@ void xirq_trap_handler0(void) {
 /**********************************************************************//**
  * XIRQ handler channel 1.
  **************************************************************************/
-void xirq_trap_handler1(void) {
+void xirq_trap_handler1(void *param) {
 
+  (void)param;
   xirq_trap_handler_ack *= 2;
 }
 

--- a/sw/lib/include/neorv32_xirq.h
+++ b/sw/lib/include/neorv32_xirq.h
@@ -70,7 +70,7 @@ int  neorv32_xirq_get_num(void);
 void neorv32_xirq_clear_pending(int channel);
 void neorv32_xirq_channel_enable(int channel);
 void neorv32_xirq_channel_disable(int channel);
-int  neorv32_xirq_install(int channel, void (*handler)(void));
+int  neorv32_xirq_install(int channel, void (*handler)(void *param), void *param);
 int  neorv32_xirq_uninstall(int channel);
 /**@}*/
 


### PR DESCRIPTION
Now the interrupt function is expanded by a parameter:

```
void xirq_handler_ch0(void *param) {
  (void)param;
  neorv32_uart0_printf("XIRQ interrupt from channel %i\n", 0);
}

neorv32_xirq_install(0, xirq_handler_ch0, NULL);
```