### PR TITLE
[TRNG] software can now retrieve FIFO size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ mimpid = 0x01080200 => Version 01.08.02.00 => v1.8.2
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 18.05.2023 | 1.8.5.1 | software can now retrieve the configured FIFO size of the **TRNG**; [#616](https://github.com/stnolting/neorv32/pull/616) |
 | 18.05.2023 | [**:rocket:1.8.5**](https://github.com/stnolting/neorv32/releases/tag/v1.8.5) | **New release** |
 | 18.05.2023 | 1.8.4.9 | remove `is_simulation` flag from SYSINFO; add programmable interrupt to **TRNG** module; [#615](https://github.com/stnolting/neorv32/pull/615) |
 | 12.05.2023 | 1.8.4.8 | `mtval` CSR now provides the address of `ebreak` exceptions (re-added temporarily to pass RISC-V ISA tests); [#611](https://github.com/stnolting/neorv32/pull/611) |

--- a/docs/datasheet/soc_trng.adoc
+++ b/docs/datasheet/soc_trng.adoc
@@ -49,7 +49,7 @@ valid data available and the lowest 8 bit of the `CTRL` register are set to all-
 An internal entropy FIFO can be configured using the `IO_TRNG_FIFO` generic. This FIFO automatically samples
 new random data from the TRNG to provide some kind of _random data pool_ for applications, which require a large number
 of random data in a short time. The random data FIFO can be cleared at any time either by disabling the TRNG or by
-setting the `TRNG_CTRL_FIFO_CLR` flag.
+setting the `TRNG_CTRL_FIFO_CLR` flag. The FIFO depth can be retrieved by software via the `TRNG_CTRL_FIFO_*` bits.
 
 
 **TRNG Interrupt**
@@ -71,13 +71,15 @@ an active TRNG interrupt has to be explicitly cleared again by writing zero to t
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.9+<| `0xffffffb8` .9+<| `CTRL` <|`7:0`  `TRNG_CTRL_DATA_MSB : TRNG_CTRL_DATA_MSB` ^| r/- <| 8-bit random data
-                                <|`25:8` -                                         ^| r/- <| reserved, read as zero
-                                <|`26`   `TRNG_CTRL_IRQ_FIFO_NEMPTY`               ^| r/w <| IRQ if data FIFO is not empty
-                                <|`26`   `TRNG_CTRL_IRQ_FIFO_HALF`                 ^| r/w <| IRQ if data FIFO is at least half full
-                                <|`27`   `TRNG_CTRL_IRQ_FIFO_FULL`                 ^| r/w <| IRQ if data FIFO is full
-                                <|`28`   `TRNG_CTRL_FIFO_CLR`                      ^| -/w <| flush random data FIFO when set; auto-clears
-                                <|`29`   `TRNG_CTRL_SIM_MODE`                      ^| r/- <| simulation mode (PRNG!)
-                                <|`30`   `TRNG_CTRL_EN`                            ^| r/w <| TRNG enable
-                                <|`31`   `TRNG_CTRL_VALID`                         ^| r/- <| random data is valid when set
+.11+<| `0xffffffb8` .11+<| `CTRL` <|`7:0`   `TRNG_CTRL_DATA_MSB : TRNG_CTRL_DATA_MSB` ^| r/- <| 8-bit random data
+                                  <|`15:8`   -                                        ^| r/- <| reserved, read as zero
+                                  <|`19:16` `TRNG_CTRL_FIFO_MSB : TRNG_CTRL_FIFO_MSB` ^| r/- <| FIFO depth, log2(`IO_TRNG_FIFO`)
+                                  <|`25:20`  -                                        ^| r/- <| reserved, read as zero
+                                  <|`26`    `TRNG_CTRL_IRQ_FIFO_NEMPTY`               ^| r/w <| IRQ if data FIFO is not empty
+                                  <|`26`    `TRNG_CTRL_IRQ_FIFO_HALF`                 ^| r/w <| IRQ if data FIFO is at least half full
+                                  <|`27`    `TRNG_CTRL_IRQ_FIFO_FULL`                 ^| r/w <| IRQ if data FIFO is full
+                                  <|`28`    `TRNG_CTRL_FIFO_CLR`                      ^| -/w <| flush random data FIFO when set; auto-clears
+                                  <|`29`    `TRNG_CTRL_SIM_MODE`                      ^| r/- <| simulation mode (PRNG!)
+                                  <|`30`    `TRNG_CTRL_EN`                            ^| r/w <| TRNG enable
+                                  <|`31`    `TRNG_CTRL_VALID`                         ^| r/- <| random data is valid when set
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -60,7 +60,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080500"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080501"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 

--- a/rtl/core/neorv32_trng.vhd
+++ b/rtl/core/neorv32_trng.vhd
@@ -72,6 +72,11 @@ architecture neorv32_trng_rtl of neorv32_trng is
   constant ctrl_data_lsb_c      : natural :=  0; -- r/-: Random data byte LSB
   constant ctrl_data_msb_c      : natural :=  7; -- r/-: Random data byte MSB
   --
+  constant ctrl_fifo_size0_c    : natural := 16; -- r/-: log2(FIFO size) bit 0
+  constant ctrl_fifo_size1_c    : natural := 17; -- r/-: log2(FIFO size) bit 1
+  constant ctrl_fifo_size2_c    : natural := 18; -- r/-: log2(FIFO size) bit 2
+  constant ctrl_fifo_size3_c    : natural := 19; -- r/-: log2(FIFO size) bit 3
+  --
   constant ctrl_irq_fifo_nempty : natural := 25; -- r/w: IRQ if fifo is not empty
   constant ctrl_irq_fifo_half   : natural := 26; -- r/w: IRQ if fifo is at least half-full
   constant ctrl_irq_fifo_full   : natural := 27; -- r/w: IRQ if fifo is full
@@ -132,9 +137,12 @@ begin
 
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  assert not (IO_TRNG_FIFO < 1) report "NEORV32 PROCESSOR CONFIG ERROR: TRNG FIFO size <IO_TRNG_FIFO> has to be >= 1." severity error;
-  assert not (is_power_of_two_f(IO_TRNG_FIFO) = false) report "NEORV32 PROCESSOR CONFIG ERROR: TRNG FIFO size <IO_TRNG_FIFO> has to be a power of two." severity error;
-  assert not (sim_mode_c = true) report "NEORV32 PROCESSOR CONFIG WARNING: TRNG uses SIMULATION mode!" severity warning;
+  assert not (IO_TRNG_FIFO < 1) report
+    "NEORV32 PROCESSOR CONFIG ERROR: TRNG FIFO size <IO_TRNG_FIFO> has to be >= 1." severity error;
+  assert not (is_power_of_two_f(IO_TRNG_FIFO) = false) report
+    "NEORV32 PROCESSOR CONFIG ERROR: TRNG FIFO size <IO_TRNG_FIFO> has to be a power of two." severity error;
+  assert not (sim_mode_c = true) report
+    "NEORV32 PROCESSOR CONFIG WARNING: TRNG uses SIMULATION mode!" severity warning;
 
 
   -- Write Access ---------------------------------------------------------------------------
@@ -174,6 +182,8 @@ begin
       bus_rsp_o.data <= (others => '0');
       if (rden = '1') then
         bus_rsp_o.data(ctrl_data_msb_c downto ctrl_data_lsb_c) <= fifo.rdata;
+        --
+        bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(index_size_f(IO_TRNG_FIFO), 4));
         --
         bus_rsp_o.data(ctrl_irq_fifo_nempty) <= irq_fifo_nempty;
         bus_rsp_o.data(ctrl_irq_fifo_half)   <= irq_fifo_half;

--- a/sw/example/demo_trng/main.c
+++ b/sw/example/demo_trng/main.c
@@ -87,7 +87,7 @@ int main(void) {
 
   // check if TRNG unit is implemented at all
   if (neorv32_trng_available() == 0) {
-    neorv32_uart0_printf("No TRNG implemented.\n");
+    neorv32_uart0_printf("ERROR: no TRNG implemented!\n");
     return 1;
   }
 
@@ -98,6 +98,8 @@ int main(void) {
   }
 
   // enable TRNG
+  neorv32_uart0_printf("\nTRNG FIFO depth: %i\n", neorv32_trng_get_fifo_depth());
+  neorv32_uart0_printf("Starting TRNG...\n");
   neorv32_trng_enable(0); // no interrupts
   neorv32_cpu_delay_ms(100); // TRNG "warm up"
 

--- a/sw/lib/include/neorv32_trng.h
+++ b/sw/lib/include/neorv32_trng.h
@@ -60,6 +60,9 @@ enum NEORV32_TRNG_CTRL_enum {
   TRNG_CTRL_DATA_LSB        =  0, /**< TRNG data/control register(0)  (r/-): Random data byte LSB */
   TRNG_CTRL_DATA_MSB        =  7, /**< TRNG data/control register(7)  (r/-): Random data byte MSB */
 
+  TRNG_CTRL_FIFO_LSB        = 16, /**< TRNG data/control register(16) (r/-): log2(FIFO size), LSB */
+  TRNG_CTRL_FIFO_MSB        = 19, /**< TRNG data/control register(19) (r/-): log2(FIFO size), MSB */
+
   TRNG_CTRL_IRQ_FIFO_NEMPTY = 25, /**< TRNG data/control register(25) (r/w): IRQ if FIFO is not empty */
   TRNG_CTRL_IRQ_FIFO_HALF   = 26, /**< TRNG data/control register(26) (r/w): IRQ if FIFO is at least half-full */
   TRNG_CTRL_IRQ_FIFO_FULL   = 27, /**< TRNG data/control register(27) (r/w): IRQ if FIFO is full */
@@ -79,6 +82,7 @@ int  neorv32_trng_available(void);
 void neorv32_trng_enable(uint32_t irq_mask);
 void neorv32_trng_disable(void);
 void neorv32_trng_fifo_clear(void);
+int  neorv32_trng_get_fifo_depth(void);
 int  neorv32_trng_get(uint8_t *data);
 int  neorv32_trng_check_sim_mode(void);
 /**@}*/

--- a/sw/lib/source/neorv32_trng.c
+++ b/sw/lib/source/neorv32_trng.c
@@ -113,6 +113,18 @@ void neorv32_trng_fifo_clear(void) {
 
 
 /**********************************************************************//**
+ * Get TRNG FIFO depth.
+ *
+ * @return TRNG FIFO size (number of entries).
+ **************************************************************************/
+int neorv32_trng_get_fifo_depth(void) {
+
+  uint32_t tmp = (NEORV32_TRNG->CTRL >> TRNG_CTRL_FIFO_LSB) & 0x0f;
+  return (int)(1 << tmp);
+}
+
+
+/**********************************************************************//**
  * Get random data byte from TRNG.
  *
  * @param[in,out] data uint8_t pointer for storing random data byte. Will be set to zero if no valid data available.

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -1082,6 +1082,12 @@
               <description>Random data</description>
             </field>
             <field>
+              <name>TRNG_CTRL_FIFO</name>
+              <bitRange>[19:16]</bitRange>
+              <access>read-only</access>
+              <description>Log2(FIFO size)</description>
+            </field>
+            <field>
               <name>TRNG_CTRL_IRQ_FIFO_NEMPTY</name>
               <bitRange>[25:25]</bitRange>
               <description>IRQ if FIFO is not empty</description>


### PR DESCRIPTION
Add four new (read-only) bits to the TRNG control register so software can check the configured FIFO size.