### PR TITLE
[DMA] add automatic trigger option

### DIFF
--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -60,7 +60,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080501"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080502"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 
@@ -2021,6 +2021,7 @@ package neorv32_package is
       bus_rsp_o : out bus_rsp_t;  -- bus response
       dma_req_o : out bus_req_t;  -- DMA request
       dma_rsp_i : in  bus_rsp_t;  -- DMA response
+      firq_i    : in  std_ulogic_vector(15 downto 0); -- CPU FIRQ channels
       irq_o     : out std_ulogic  -- transfer done interrupt
     );
   end component;

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -647,6 +647,7 @@ begin
       bus_rsp_o => rsp_bus(DEV_DMA),
       dma_req_o => dma_req,
       dma_rsp_i => dma_rsp,
+      firq_i    => fast_irq,
       irq_o     => dma_irq
     );
 

--- a/sw/lib/include/neorv32_dma.h
+++ b/sw/lib/include/neorv32_dma.h
@@ -52,11 +52,24 @@ typedef volatile struct __attribute__((packed,aligned(4))) {
   uint32_t CTRL;     /**< offset  0: control and status register (#NEORV32_DMA_CTRL_enum) */
   uint32_t SRC_BASE; /**< offset  4: source base address register */
   uint32_t DST_BASE; /**< offset  8: destination base address register */
-  uint32_t TTYPE;    /**< offset 12: transfer type configuration register (#NEORV32_DMA_TTYPE_enum) */
+  uint32_t TTYPE;    /**< offset 12: transfer type configuration register & manual trigger (#NEORV32_DMA_TTYPE_enum) */
 } neorv32_dma_t;
 
 /** DMA module hardware access (#neorv32_dma_t) */
 #define NEORV32_DMA ((neorv32_dma_t*) (NEORV32_DMA_BASE))
+
+/** DMA control and status register bits */
+enum NEORV32_DMA_QSEL_enum {
+  DMA_CTRL_EN            =  0, /**< DMA control register(0) (r/w): DMA enable */
+  DMA_CTRL_AUTO          =  1, /**< DMA control register(1) (r/w): Automatic trigger mode enable */
+
+  DMA_CTRL_ERROR_RD      =  8, /**< DMA control register(8)  (r/-): Error during read access; SRC_BASE shows the faulting address */
+  DMA_CTRL_ERROR_WR      =  9, /**< DMA control register(9)  (r/-): Error during write access; DST_BASE shows the faulting address */
+  DMA_CTRL_BUSY          = 10, /**< DMA control register(10) (r/-): DMA busy / transfer in progress */
+
+  DMA_CTRL_FIRQ_MASK_LSB = 16, /**< DMA control register(16) (r/w): FIRQ trigger mask LSB */
+  DMA_CTRL_FIRQ_MASK_MSB = 31  /**< DMA control register(31) (r/w): FIRQ trigger mask MSB */
+};
 
 /** DMA transfer type bits */
 enum NEORV32_DMA_TTYPE_enum {
@@ -68,14 +81,6 @@ enum NEORV32_DMA_TTYPE_enum {
   DMA_TTYPE_SRC_INC  = 29, /**< DMA transfer type register(29) (r/w): SRC constant (0) or incrementing (1) address */
   DMA_TTYPE_DST_INC  = 30, /**< DMA transfer type register(30) (r/w): SRC constant (0) or incrementing (1) address */
   DMA_TTYPE_ENDIAN   = 31  /**< DMA transfer type register(31) (r/w): Convert Endianness when set */
-};
-
-/** DMA control and status register bits */
-enum NEORV32_DMA_QSEL_enum {
-  DMA_CTRL_EN       =  0, /**< DMA control register(0) (r/w): DMA enable */
-  DMA_CTRL_ERROR_RD = 29, /**< DMA control register(29) (r/-): Error during read access; SRC_BASE shows the faulting address */
-  DMA_CTRL_ERROR_WR = 30, /**< DMA control register(30) (r/-): Error during write access; DST_BASE shows the faulting address */
-  DMA_CTRL_BUSY     = 31  /**< DMA control register(31) (r/-): DMA busy / transfer in progress */
 };
 /**@}*/
 
@@ -103,10 +108,10 @@ enum NEORV32_DMA_QSEL_enum {
  * DMA status
  **************************************************************************/
 enum NEORV32_DMA_STATUS_enum {
-  DMA_STATUS_IDLE   =  0, /**< (0) DMA idle */
-  DMA_STATUS_BUSY   =  1, /**< (1) DMA busy */
-  DMA_STATUS_ERR_RD = -1, /**< (-1) read access error during last transfer */
-  DMA_STATUS_ERR_WR = -2  /**< (-2) write access error during last transfer */
+  DMA_STATUS_ERR_WR = -2, /**< write access error during last transfer (-2) */
+  DMA_STATUS_ERR_RD = -1, /**< read access error during last transfer (-1) */
+  DMA_STATUS_IDLE   =  0, /**< DMA idle (0) */
+  DMA_STATUS_BUSY   =  1  /**< DMA busy (1) */
 };
 
 
@@ -118,6 +123,7 @@ int  neorv32_dma_available(void);
 void neorv32_dma_enable(void);
 void neorv32_dma_disable(void);
 void neorv32_dma_transfer(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config);
+void neorv32_dma_transfer_auto(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config, uint32_t firq_mask);
 int  neorv32_dma_status(void);
 /**@}*/
 

--- a/sw/lib/source/neorv32_dma.c
+++ b/sw/lib/source/neorv32_dma.c
@@ -79,18 +79,42 @@ void neorv32_dma_disable(void) {
 
 
 /**********************************************************************//**
- * Trigger DMA transfer.
+ * Trigger manual DMA transfer.
  *
  * @param[in] base_src Source base address (has to be aligned to source data type!).
  * @param[in] base_dst Destination base address (has to be aligned to destination data type!).
- * @param[in] num Number of elements to transfer.
- * @param[in] config Transfer type configuration.
+ * @param[in] num Number of elements to transfer (24-bit).
+ * @param[in] config Transfer type configuration/commands.
  **************************************************************************/
 void neorv32_dma_transfer(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config) {
 
+  NEORV32_DMA->CTRL &= ~((uint32_t)(1 << DMA_CTRL_AUTO)); // manual transfer trigger
   NEORV32_DMA->SRC_BASE = base_src;
   NEORV32_DMA->DST_BASE = base_dst;
   NEORV32_DMA->TTYPE    = (num & 0x00ffffffUL) | (config & 0xff000000UL); // trigger transfer
+}
+
+
+/**********************************************************************//**
+ * Configure automatic DMA transfer (triggered by CPU FIRQ).
+ *
+ * @param[in] base_src Source base address (has to be aligned to source data type!).
+ * @param[in] base_dst Destination base address (has to be aligned to destination data type!).
+ * @param[in] num Number of elements to transfer (24-bit).
+ * @param[in] config Transfer type configuration/commands.
+ * @param[in] firq_mask  FIRQ trigger mask (#NEORV32_CSR_MIP_enum).
+ **************************************************************************/
+void neorv32_dma_transfer_auto(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config, uint32_t firq_mask) {
+
+  uint32_t tmp = NEORV32_DMA->CTRL;
+  tmp |= (uint32_t)(1 << DMA_CTRL_AUTO); // automatic transfer trigger
+  tmp &= 0x0000ffffUL; // clear current FIRQ mask
+  tmp |= firq_mask & 0xffff0000UL; // set new FIRQ mask
+  NEORV32_DMA->CTRL = tmp;
+
+  NEORV32_DMA->SRC_BASE = base_src;
+  NEORV32_DMA->DST_BASE = base_dst;
+  NEORV32_DMA->TTYPE    = (num & 0x00ffffffUL) | (config & 0xff000000UL);
 }
 
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -239,22 +239,32 @@
               <description>DMA enable flag</description>
             </field>
             <field>
+              <name>DMA_CTRL_ATUO</name>
+              <bitRange>[1:1]</bitRange>
+              <description>Enable automatic mode (FIRQ-triggered)</description>
+            </field>
+            <field>
               <name>DMA_CTRL_ERROR_RD</name>
-              <bitRange>[29:29]</bitRange>
+              <bitRange>[8:8]</bitRange>
               <access>read-only</access>
               <description>Error during last read access</description>
             </field>
             <field>
               <name>DMA_CTRL_ERROR_WR</name>
-              <bitRange>[30:30]</bitRange>
+              <bitRange>[9:9]</bitRange>
               <access>read-only</access>
               <description>Error during last write access</description>
             </field>
             <field>
               <name>DMA_CTRL_BUSY</name>
-              <bitRange>[31:31]</bitRange>
+              <bitRange>[10:10]</bitRange>
               <access>read-only</access>
               <description>DMA transfer in progress</description>
+            </field>
+            <field>
+              <name>DMA_CTRL_FIRQ_MASK</name>
+              <bitRange>[31:16]</bitRange>
+              <description>FIRQ trigger mask</description>
             </field>
           </fields>
         </register>


### PR DESCRIPTION
This PR adds an _automatic transfer trigger_ to the processor's DMA controller.

Instead of starting a transfer by writing to a specific DMA register, the DMA can be configured to start a previously programmed transfer when a specific processor-internal module issues an interrupt request.

### Exemplary Use Case

The TRNG (true-random number generator) is configured with a FIFO depth of 64 entries using the according generic. The application code configures the TRNG interrupt to fire if the FIFO is completely full - indicating that 64 bytes of entropy have been sampled.

A DMA transfer is programmed to read bytes (constant address) from TRNG (= the entropy data) and to store it to a 64-bytes array in memory (incrementing address). The automatic trigger mode is used to start the transfer when the TRNG sends the "FIFO full" interrupt.

Enabling just the DMA interrupt in the CPU's `mie` CSR will trigger an interrupt when the DMA transfer is complete (but not when the TRNG issues its FIFO full interrupt).