### PR TITLE
🧪 VHDL - use entity instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ mimpid = 0x01080200 => Version 01.08.02.00 => v1.8.2
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 24.06.2023 | 1.8.5.9 | :test_tube: VHDL code: use entity instantiation instead of component instantiation; [#637](https://github.com/stnolting/neorv32/pull/637) |
 | 24.06.2023 | 1.8.5.8 | optimize CPU control logic; closed further invalid instruction word detection holes; [#636](https://github.com/stnolting/neorv32/pull/636) |
 | 23.06.2023 | 1.8.5.7 | :warning: remove **buskeeper's status register**; [#635](https://github.com/stnolting/neorv32/pull/635) |
 | 17.06.2023 | 1.8.5.6 | :sparkles: add new **Cyclic Redundancy Check module (CRC)**; [#632](https://github.com/stnolting/neorv32/pull/632) |

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -208,7 +208,7 @@ begin
 
   -- Control Unit ---------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  neorv32_cpu_control_inst: neorv32_cpu_control
+  neorv32_cpu_control_inst: entity neorv32.neorv32_cpu_control
   generic map (
     -- General --
     HART_ID                      => HART_ID,                      -- hardware thread ID
@@ -307,7 +307,7 @@ begin
 
   -- Register File --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  neorv32_cpu_regfile_inst: neorv32_cpu_regfile
+  neorv32_cpu_regfile_inst: entity neorv32.neorv32_cpu_regfile
   generic map (
     RVE    => CPU_EXTENSION_RISCV_E, -- implement embedded RF extension?
     RS3_EN => regfile_rs3_en_c,      -- enable 3rd read port
@@ -332,7 +332,7 @@ begin
 
   -- ALU ------------------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  neorv32_cpu_alu_inst: neorv32_cpu_alu
+  neorv32_cpu_alu_inst: entity neorv32.neorv32_cpu_alu
   generic map (
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_B      => CPU_EXTENSION_RISCV_B,      -- implement bit-manipulation extension?
@@ -370,7 +370,7 @@ begin
 
   -- Bus Interface (Load/Store Unit) --------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  neorv32_cpu_bus_inst: neorv32_cpu_bus
+  neorv32_cpu_bus_inst: entity neorv32.neorv32_cpu_bus
   generic map (
     PMP_NUM_REGIONS     => PMP_NUM_REGIONS,    -- number of regions (0..16)
     PMP_MIN_GRANULARITY => PMP_MIN_GRANULARITY -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -205,7 +205,7 @@ begin
 
   -- Co-Processor 0: Shifter Unit (Base ISA) ------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  neorv32_cpu_cp_shifter_inst: neorv32_cpu_cp_shifter
+  neorv32_cpu_cp_shifter_inst: entity neorv32.neorv32_cpu_cp_shifter
   generic map (
     FAST_SHIFT_EN => FAST_SHIFT_EN -- use barrel shifter for shift operations
   )
@@ -228,7 +228,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_cp_muldiv_inst_true:
   if (CPU_EXTENSION_RISCV_M = true) or (CPU_EXTENSION_RISCV_Zmmul = true) generate
-    neorv32_cpu_cp_muldiv_inst: neorv32_cpu_cp_muldiv
+    neorv32_cpu_cp_muldiv_inst: entity neorv32.neorv32_cpu_cp_muldiv
     generic map (
       FAST_MUL_EN => FAST_MUL_EN,          -- use DSPs for faster multiplication
       DIVISION_EN => CPU_EXTENSION_RISCV_M -- implement divider hardware
@@ -259,7 +259,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_cp_bitmanip_inst_true:
   if (CPU_EXTENSION_RISCV_B = true) generate
-    neorv32_cpu_cp_bitmanip_inst: neorv32_cpu_cp_bitmanip
+    neorv32_cpu_cp_bitmanip_inst: entity neorv32.neorv32_cpu_cp_bitmanip
     generic map (
       FAST_SHIFT_EN => FAST_SHIFT_EN -- use barrel shifter for shift operations
     )
@@ -291,7 +291,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_cp_fpu_inst_true:
   if (CPU_EXTENSION_RISCV_Zfinx = true) generate
-    neorv32_cpu_cp_fpu_inst: neorv32_cpu_cp_fpu
+    neorv32_cpu_cp_fpu_inst: entity neorv32.neorv32_cpu_cp_fpu
     port map (
       -- global control --
       clk_i    => clk_i,        -- global clock, rising edge
@@ -322,7 +322,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_cp_cfu_inst_true:
   if (CPU_EXTENSION_RISCV_Zxcfu = true) generate
-    neorv32_cpu_cp_cfu_inst: neorv32_cpu_cp_cfu
+    neorv32_cpu_cp_cfu_inst: entity neorv32.neorv32_cpu_cp_cfu
     port map (
       -- global control --
       clk_i   => clk_i,        -- global clock, rising edge
@@ -351,7 +351,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_cp_cond_inst_true:
   if (CPU_EXTENSION_RISCV_Zicond = true) generate
-    neorv32_cpu_cp_cond_inst: neorv32_cpu_cp_cond
+    neorv32_cpu_cp_cond_inst: entity neorv32.neorv32_cpu_cp_cond
     port map (
       -- global control --
       clk_i   => clk_i,        -- global clock, rising edge

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -472,7 +472,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   prefetch_buffer:
   for i in 0 to 1 generate -- low half-word and high half-word (+status)
-    prefetch_buffer_inst: neorv32_fifo
+    prefetch_buffer_inst: entity neorv32.neorv32_fifo
     generic map (
       FIFO_DEPTH => CPU_IPB_ENTRIES,     -- number of fifo entries; has to be a power of two; min 1
       FIFO_WIDTH => ipb.wdata(i)'length, -- size of data elements in fifo
@@ -563,7 +563,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_decompressor_inst_true:
   if (CPU_EXTENSION_RISCV_C = true) generate
-    neorv32_cpu_decompressor_inst: neorv32_cpu_decompressor
+    neorv32_cpu_decompressor_inst: entity neorv32.neorv32_cpu_decompressor
     generic map (
       FPU_ENABLE => CPU_EXTENSION_RISCV_Zfinx -- floating-point instructions enabled
     )

--- a/rtl/core/neorv32_neoled.vhd
+++ b/rtl/core/neorv32_neoled.vhd
@@ -241,7 +241,7 @@ begin
 
   -- TX Buffer (FIFO) -----------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  data_buffer: neorv32_fifo
+  data_buffer: entity neorv32.neorv32_fifo
   generic map (
     FIFO_DEPTH => FIFO_DEPTH, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 32+2,       -- size of data elements in fifo

--- a/rtl/core/neorv32_sdi.vhd
+++ b/rtl/core/neorv32_sdi.vhd
@@ -220,7 +220,7 @@ begin
   -- -------------------------------------------------------------------------------------------
 
   -- TX --
-  tx_fifo_inst: neorv32_fifo
+  tx_fifo_inst: entity neorv32.neorv32_fifo
   generic map (
     FIFO_DEPTH => RTX_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,        -- size of data elements in fifo (32-bit only for simulation)
@@ -252,7 +252,7 @@ begin
   tx_fifo.re <= serial.start;
 
   -- RX --
-  rx_fifo_inst: neorv32_fifo
+  rx_fifo_inst: entity neorv32.neorv32_fifo
   generic map (
     FIFO_DEPTH => RTX_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,        -- size of data elements in fifo (32-bit only for simulation)

--- a/rtl/core/neorv32_slink.vhd
+++ b/rtl/core/neorv32_slink.vhd
@@ -221,7 +221,7 @@ begin
 
   -- RX Data FIFO ---------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  rx_fifo_inst: neorv32_fifo
+  rx_fifo_inst: entity neorv32.neorv32_fifo
   generic map (
     FIFO_DEPTH => SLINK_RX_FIFO,
     FIFO_WIDTH => 32,
@@ -254,7 +254,7 @@ begin
 
   -- TX Data FIFO ---------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  tx_fifo_inst: neorv32_fifo
+  tx_fifo_inst: entity neorv32.neorv32_fifo
   generic map (
     FIFO_DEPTH => SLINK_TX_FIFO,
     FIFO_WIDTH => 32,

--- a/rtl/core/neorv32_spi.vhd
+++ b/rtl/core/neorv32_spi.vhd
@@ -245,7 +245,7 @@ begin
   -- -------------------------------------------------------------------------------------------
 
   -- TX FIFO --
-  tx_fifo_inst: neorv32_fifo
+  tx_fifo_inst: entity neorv32.neorv32_fifo
   generic map (
     FIFO_DEPTH => IO_SPI_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,           -- size of data elements in fifo
@@ -275,7 +275,7 @@ begin
 
 
   -- RX FIFO --
-  rx_fifo_inst: neorv32_fifo
+  rx_fifo_inst: entity neorv32.neorv32_fifo
   generic map (
     FIFO_DEPTH => IO_SPI_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,           -- size of data elements in fifo

--- a/rtl/core/neorv32_trng.vhd
+++ b/rtl/core/neorv32_trng.vhd
@@ -221,7 +221,7 @@ begin
 
   -- Data FIFO ("Random Pool") --------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  rnd_pool_fifo_inst: neorv32_fifo
+  rnd_pool_fifo_inst: entity neorv32.neorv32_fifo
   generic map (
     FIFO_DEPTH => IO_TRNG_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,            -- size of data elements in fifo

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -310,7 +310,7 @@ begin
   -- -------------------------------------------------------------------------------------------
 
   -- TX FIFO --
-  tx_engine_fifo_inst: neorv32_fifo
+  tx_engine_fifo_inst: entity neorv32.neorv32_fifo
   generic map (
     FIFO_DEPTH => UART_TX_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,            -- size of data elements in fifo (32-bit only for simulation)
@@ -350,7 +350,7 @@ begin
 
 
   -- RX FIFO --
-  rx_engine_fifo_inst: neorv32_fifo
+  rx_engine_fifo_inst: entity neorv32.neorv32_fifo
   generic map (
     FIFO_DEPTH => UART_RX_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,            -- size of data elements in fifo


### PR DESCRIPTION
VHDL code: use **entity instantiation** instead of component instantiation as suggested by @biosbob in https://github.com/stnolting/neorv32/discussions/613 [_EXPERIMENTAL!_].

Component instantiation is further used for components that are placed in the same file.