### PR TITLE
⚠️ Remove UART sim-mode's 32-bit dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ mimpid = 0x01080200 => Version 01.08.02.00 => v1.8.2
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 18.07.2023 | 1.8.6.6 | :warning: remove 32-bit data dump mode from UART0/1 sim-mode; [#650](https://github.com/stnolting/neorv32/pull/650) |
 | 16.07.2023 | 1.8.6.5 | :warning: **rework SoC bus system & memory map - part 3**: re-enforce PMAs (physical memory attributes); [#648](https://github.com/stnolting/neorv32/pull/648) |
 | 15.07.2023 | 1.8.6.4 | :warning: **rework SoC bus system & memory map - part 2**: move IO address decoding to central IO switch; add i-cache uncached accesses; [#648](https://github.com/stnolting/neorv32/pull/648) |
 | 14.07.2023 | 1.8.6.3 | :warning: **rework SoC bus system & memory map - part 1**: add central bus gateway to control core accesses to the main address regions; [#648](https://github.com/stnolting/neorv32/pull/648) |

--- a/docs/datasheet/soc_uart.adoc
+++ b/docs/datasheet/soc_uart.adoc
@@ -53,7 +53,7 @@ _**Baud rate**_ = (_f~main~[Hz]_ / `clock_prescaler`) / (`baud_div` + 1)
 The control register's `UART_CTRL_RX_*` and `UART_CTRL_TX_*` flags provide information about the RX and TX FIFO fill level.
 Disabling the module via the `UART_CTRL_EN` bit will also clear these FIFOs.
 
-A new TX transmission is started by writing data to the lowest byte of the `DATA` register. The
+A new TX transmission is started by writing to the `DATA` register. The
 transfer is completed when the `UART_CTRL_TX_BUSY` control register flag returns to zero. RX data is available when
 the `UART_CTRL_RX_NEMPTY` flag becomes set. The `UART_CTRL_RX_OVER` will be set if the RX FIFO overflows. This flag
 is cleared by reading the `DATA` register or by disabling the module.
@@ -106,11 +106,8 @@ unconnected. If the CTS handshake is not required it has to be tied to zero.
 
 The UART provides a _simulation-only_ mode to dump console data as well as raw data directly to a file. When the simulation
 mode is enabled (by setting the `UART_CTRL_SIM_MODE` bit) there will be **no** physical transaction on the `uart0_txd_o` signal.
-Instead, all data written to the `DATA` register is immediately dumped to a file.
-
-. Data written to `DATA[7:0]` will be dumped as ASCII chars to a file named `neorv32.uart0.sim_mode.text.out`. Additionally,
-the ASCII data is printed to the simulator console.
-. Data written to `DATA[31:0]` will be dumped as 8-chars ASCII hexadecimal value to a file named `neorv32.uart0.sim_mode.data.out`.
+Instead, all data written to the `DATA` register is immediately dumped to a file. Data written to `DATA[7:0]` will be dumped as
+ASCII chars to a file named `neorv32.uart0.sim_mode.text.out`. Additionally, the ASCII data is printed to the simulator console.
 
 Both file are created in the simulation's home folder.
 
@@ -141,11 +138,10 @@ Both file are created in the simulation's home folder.
                                   <|`29:27` -                                   ^| r/- <| _reserved_ read as zero
                                   <|`30`    `UART_CTRL_RX_OVER`                 ^| r/- <| RX FIFO overflow
                                   <|`31`    `UART_CTRL_TX_BUSY`                 ^| r/- <| TX busy or TX FIFO not empty
-.5+<| `0xfffff504` .3+<| `DATA` <|`7:0`   `UART_DATA_RTX_MSB : UART_DATA_RTX_LSB`                   ^| r/w <| receive/transmit data
+.4+<| `0xfffff504` .4+<| `DATA` <|`7:0`   `UART_DATA_RTX_MSB : UART_DATA_RTX_LSB`                   ^| r/w <| receive/transmit data
                                 <|`11:8`  `UART_DATA_RX_FIFO_SIZE_MSB : UART_DATA_RX_FIFO_SIZE_LSB` ^| r/- <| log2(RX FIFO size)
                                 <|`15:12` `UART_DATA_TX_FIFO_SIZE_MSB : UART_DATA_TX_FIFO_SIZE_LSB` ^| r/- <| log2(RX FIFO size)
                                 <|`31:16` ^| r/- <| _reserved_, read as zero
-                                <|`31:0`  ^| -/w <| **simulation data output**
 |=======================
 
 
@@ -184,9 +180,7 @@ as for the primary UART. The RX and TX interrupts of UART1 are mapped to differe
 **Simulation Mode**
 
 The secondary UART (UART1) provides the same simulation options as the primary UART (UART0). However, output data is
-written to UART1-specific files: `neorv32.uart1.sim_mode.text.out` is used to dump plain ASCII text. This data is also
-printed to the simulator console. `neorv32.uart1.sim_mode.data.out` is used to dump full 32-bit hexadecimal ASCII-chars
-data words.
+written to UART1-specific file `neorv32.uart1.sim_mode.text.out`. This data is also printed to the simulator console.
 
 
 **Register Map**

--- a/docs/userguide/simulating_the_processor.adoc
+++ b/docs/userguide/simulating_the_processor.adoc
@@ -88,7 +88,7 @@ see section <<_faster_simulation_console_output>>.
 :sectnums:
 === Faster Simulation Console Output
 
-When printing data via the UART the communication speed will always be based on the configured BAUD
+When printing data via the physical UART the communication speed will always be based on the configured BAUD
 rate. For a simulation this might take some time. To have faster output you can enable the **simulation mode**
 for UART0/UART1 (see section https://stnolting.github.io/neorv32/#_primary_universal_asynchronous_receiver_and_transmitter_uart0[Documentation: Primary Universal Asynchronous Receiver and Transmitter (UART0)]).
 
@@ -96,7 +96,6 @@ ASCII data sent to UART0|UART1 will be immediately printed to the simulator cons
 execution directory:
 
 * `neorv32.uart?.sim_mode.text.out`: ASCII data.
-* `neorv32.uart?.sim_mode.data.out`: all written 32-bit dumped as 8-char hexadecimal values.
 
 You can "automatically" enable the simulation mode of UART0/UART1 when compiling an application.
 In this case, the "real" UART0/UART1 transmitter unit is permanently disabled.

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080605"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080606"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -1100,7 +1100,7 @@ begin
     if (IO_UART0_EN = true) generate
       neorv32_uart0_inst: entity neorv32.neorv32_uart
       generic map (
-        UART_PRIMARY => true,
+        SIM_LOG_FILE => "neorv32.uart0.sim_mode.text.out",
         UART_RX_FIFO => IO_UART0_RX_FIFO,
         UART_TX_FIFO => IO_UART0_TX_FIFO
       )
@@ -1137,7 +1137,7 @@ begin
     if (IO_UART1_EN = true) generate
       neorv32_uart1_inst: entity neorv32.neorv32_uart
       generic map (
-        UART_PRIMARY => false,
+        SIM_LOG_FILE => "neorv32.uart1.sim_mode.text.out",
         UART_RX_FIFO => IO_UART1_RX_FIFO,
         UART_TX_FIFO => IO_UART1_TX_FIFO
       )

--- a/sim/simple/ghdl.run.sh
+++ b/sim/simple/ghdl.run.sh
@@ -8,12 +8,11 @@ echo "Tip: Compile application with USER_FLAGS+=-DUART[0/1]_SIM_MODE to auto-ena
 
 # Prepare simulation output files for UART0 and UART 1
 # - Testbench receiver log file (neorv32.testbench_uart?.out)
-# - Direct simulation output (neorv32.uart?.sim_mode.[text|data].out)
+# - Direct simulation output (neorv32.uart?.sim_mode.text.out)
 for uart in 0 1; do
   for item in \
     testbench_uart"$uart" \
-    uart"$uart".sim_mode.text \
-    uart"$uart".sim_mode.data; do
+    uart"$uart".sim_mode.text; do
     touch neorv32."$item".out
     chmod 777 neorv32."$item".out
   done


### PR DESCRIPTION
This PR removes the 32-bit data dump mode from the UART's sim mode. The UART is a **byte**-based IO device and should not be used to dump 32-bit data.

A simple way to dump 32-bit data to a file can be found in the neorv32-riscof repository:
https://github.com/stnolting/neorv32-riscof/blob/de8b6d145cbcb1f938418d9983a0cf2a2b3064ad/sim/neorv32_riscof_tb.vhd#L272-L286