### PR TITLE
🐛 Make sure IMEM/DMEM sizes are a power of two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ Releases are linked and highlighted. The latest release is
 A list of all releases can be found [here](https://github.com/stnolting/neorv32/releases).
 
 Starting with version `1.5.7` this project uses [semantic versioning](https://semver.org).
-The _version identifier_ uses an additional **custom** element (`MAJOR.MINOR.PATCH.custom`)
-to track _individual_ changes. The identifier number is incremented with every core RTL
-modification and also by major framework modifications.
+The **version identifier** uses an additional custom element (`MAJOR.MINOR.PATCH.custom`)
+to track individual changes. The identifier is incremented by every core RTL modification
+and also by major software/project changes.
 
 The version identifier is globally defined by the `hw_version_c` constant in the main VHDL
 [package file](https://github.com/stnolting/neorv32/blob/main/rtl/core/neorv32_package.vhd).
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 27.07.2023 | 1.8.7.2 | :bug: make sure that IMEM/DMEM size is always a power of two; [#658](https://github.com/stnolting/neorv32/pull/658) |
 | 27.07.2023 | 1.8.7.1 | :warning: remove `CUSTOM_ID` generic; cleanup and re-layout `NEORV32_SYSINFO.SOC` bits; (:bug:) fix gateway's generics (`positive` -> `natural` as these generics are allowed to be zero); [#657](https://github.com/stnolting/neorv32/pull/657) |
 | 26.07.2023 | [**:rocket:1.8.7**](https://github.com/stnolting/neorv32/releases/tag/v1.8.7) | **New release** |
 | 24.07.2023 | 1.8.6.10 | :bug: fixing some LR/SC design flaws; [#654](https://github.com/stnolting/neorv32/pull/654) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -232,10 +232,10 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `AMO_RVS_GRANULARITY`   | natural   | 4          | Size in bytes, has to be a power of 2, min 4.
 4+^| **Internal <<_instruction_memory_imem>>**
 | `MEM_INT_IMEM_EN`       | boolean   | false      | Implement the processor-internal instruction memory.
-| `MEM_INT_IMEM_SIZE`     | natural   | 16*1024    | Size in bytes of the processor internal instruction memory.
+| `MEM_INT_IMEM_SIZE`     | natural   | 16*1024    | Size in bytes of the processor internal instruction memory (use a power of 2).
 4+^| **Internal <<_data_memory_dmem>>**
 | `MEM_INT_DMEM_EN`       | boolean   | false      | Implement the processor-internal data memory.
-| `MEM_INT_DMEM_SIZE`     | natural   | 8*1024     | Size in bytes of the processor-internal data memory.
+| `MEM_INT_DMEM_SIZE`     | natural   | 8*1024     | Size in bytes of the processor-internal data memory (use a power of 2).
 4+^| **<<_processor_internal_instruction_cache_icache>>**
 | `ICACHE_EN`             | boolean   | false      | Implement the instruction cache.
 | `ICACHE_NUM_BLOCKS`     | natural   | 4          | Number of blocks ("pages" or "lines") Has to be a power of two.

--- a/docs/datasheet/soc_dmem.adoc
+++ b/docs/datasheet/soc_dmem.adoc
@@ -10,7 +10,7 @@
 | Software driver file(s): | none                         | _implicitly used_
 | Top entity port:         | none                         | 
 | Configuration generics:  | `MEM_INT_DMEM_EN`            | implement processor-internal DMEM when `true`
-|                          | `MEM_INT_DMEM_SIZE`          | DMEM size in bytes
+|                          | `MEM_INT_DMEM_SIZE`          | DMEM size in bytes (use a power of 2)
 | CPU interrupts:          | none                         | 
 |=======================
 
@@ -19,6 +19,12 @@ generic. The size in bytes is defined via the `MEM_INT_DMEM_SIZE` generic. If th
 the memory is mapped into the data memory space and located right at the beginning of the data memory
 space (default `dspace_base_c` = 0x80000000), see <<_address_space>>. The DMEM is always implemented
 as true RAM.
+
+.Memory Size
+[IMPORTANT]
+If the configured memory size (via the `MEM_INT_IMEM_SIZE` generic) is **not** a power of two the actual memory
+size will be auto-adjusted to the next power of two (e.g. configuring a memory size of 60kB will result in a
+physical memory size of 64kB).
 
 .VHDL Source File
 [NOTE]

--- a/docs/datasheet/soc_imem.adoc
+++ b/docs/datasheet/soc_imem.adoc
@@ -10,7 +10,7 @@
 | Software driver file(s): | none                         | _implicitly used_
 | Top entity port:         | none                         | 
 | Configuration generics:  | `MEM_INT_IMEM_EN`            | implement processor-internal IMEM when `true`
-|                          | `MEM_INT_IMEM_SIZE`          | IMEM size in bytes
+|                          | `MEM_INT_IMEM_SIZE`          | IMEM size in bytes (use a power of 2)
 |                          | `INT_BOOTLOADER_EN`          | use internal bootloader when `true` (implements IMEM as _uninitialized_ RAM, otherwise the IMEM is implemented an _pre-intialized_ ROM)
 | CPU interrupts:          | none                         | 
 |=======================
@@ -30,6 +30,12 @@ When the IMEM is implemented as ROM, it will be initialized during synthesis wit
 image. The compiler toolchain provides an option to generate and override the default VHDL initialization file
 `rtl/core/neorv32_application_image.vhd`, which is automatically inserted into the IMEM. If the IMEM is implemented
 as RAM (default), the memory will **not be initialized at all**.
+
+.Memory Size
+[IMPORTANT]
+If the configured memory size (via the `MEM_INT_IMEM_SIZE` generic) is **not** a power of two the actual memory
+size will be auto-adjusted to the next power of two (e.g. configuring a memory size of 60kB will result in a
+physical memory size of 64kB).
 
 .VHDL Source File
 [NOTE]

--- a/rtl/core/mem/neorv32_dmem.default.vhd
+++ b/rtl/core/mem/neorv32_dmem.default.vhd
@@ -68,6 +68,9 @@ begin
   assert false report
     "NEORV32 PROCESSOR CONFIG NOTE: Using DEFAULT platform-agnostic DMEM." severity note;
 
+  assert not (is_power_of_two_f(DMEM_SIZE) = false) report
+    "NEORV32 PROCESSOR CONFIG ERROR: Internal DMEM size has to be a power of two!" severity error;
+
   assert false report
     "NEORV32 PROCESSOR CONFIG NOTE: Implementing processor-internal DMEM (RAM, " & natural'image(DMEM_SIZE) &
     " bytes)." severity note;

--- a/rtl/core/mem/neorv32_dmem.legacy.vhd
+++ b/rtl/core/mem/neorv32_dmem.legacy.vhd
@@ -69,6 +69,9 @@ begin
   assert false report
     "NEORV32 PROCESSOR CONFIG NOTE: Using legacy HDL style DMEM." severity note;
 
+  assert not (is_power_of_two_f(DMEM_SIZE) = false) report
+    "NEORV32 PROCESSOR CONFIG ERROR: Internal DMEM size has to be a power of two!" severity error;
+
   assert false report
     "NEORV32 PROCESSOR CONFIG NOTE: Implementing processor-internal DMEM (RAM, " & natural'image(DMEM_SIZE) &
     " bytes)." severity note;

--- a/rtl/core/mem/neorv32_imem.default.vhd
+++ b/rtl/core/mem/neorv32_imem.default.vhd
@@ -85,6 +85,9 @@ begin
   assert false report
     "NEORV32 PROCESSOR CONFIG NOTE: Using DEFAULT platform-agnostic IMEM." severity note;
 
+  assert not (is_power_of_two_f(IMEM_SIZE) = false) report
+    "NEORV32 PROCESSOR CONFIG ERROR: Internal IMEM size has to be a power of two!" severity error;
+
   assert not (IMEM_AS_IROM = true) report
     "NEORV32 PROCESSOR CONFIG NOTE: Implementing processor-internal IMEM as ROM (" & natural'image(IMEM_SIZE) &
     " bytes), pre-initialized with application (" & natural'image(imem_app_size_c) & " bytes)." severity note;

--- a/rtl/core/mem/neorv32_imem.legacy.vhd
+++ b/rtl/core/mem/neorv32_imem.legacy.vhd
@@ -86,6 +86,9 @@ begin
   assert false report
     "NEORV32 PROCESSOR CONFIG NOTE: Using legacy HDL style IMEM." severity note;
 
+  assert not (is_power_of_two_f(IMEM_SIZE) = false) report
+    "NEORV32 PROCESSOR CONFIG ERROR: Internal IMEM size has to be a power of two!" severity error;
+
   assert not (IMEM_AS_IROM = true) report
     "NEORV32 PROCESSOR CONFIG NOTE: Implementing processor-internal IMEM as ROM (" & natural'image(IMEM_SIZE) &
     " bytes), pre-initialized with application (" & natural'image(imem_app_size_c) & " bytes)." severity note;

--- a/rtl/core/neorv32_dmem.entity.vhd
+++ b/rtl/core/neorv32_dmem.entity.vhd
@@ -41,7 +41,7 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_dmem is
   generic (
-    DMEM_SIZE : natural -- processor-internal instruction memory size in bytes
+    DMEM_SIZE : natural -- processor-internal instruction memory size in bytes, has to be a power of 2
   );
   port (
     clk_i     : in  std_ulogic; -- global clock line

--- a/rtl/core/neorv32_imem.entity.vhd
+++ b/rtl/core/neorv32_imem.entity.vhd
@@ -41,7 +41,7 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_imem is
   generic (
-    IMEM_SIZE    : natural; -- processor-internal instruction memory size in bytes
+    IMEM_SIZE    : natural; -- processor-internal instruction memory size in bytes, has to be a power of 2
     IMEM_AS_IROM : boolean  -- implement IMEM as pre-initialized read-only memory?
   );
   port (

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080701"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080702"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 
@@ -919,10 +919,10 @@ package neorv32_package is
       AMO_RVS_GRANULARITY          : natural := 4;      -- size in bytes, has to be a power of 2, min 4
       -- Internal Instruction memory (IMEM) --
       MEM_INT_IMEM_EN              : boolean := false;  -- implement processor-internal instruction memory
-      MEM_INT_IMEM_SIZE            : natural := 16*1024; -- size of processor-internal instruction memory in bytes
+      MEM_INT_IMEM_SIZE            : natural := 16*1024; -- size of processor-internal instruction memory in bytes (use a power of 2)
       -- Internal Data memory (DMEM) --
       MEM_INT_DMEM_EN              : boolean := false;  -- implement processor-internal data memory
-      MEM_INT_DMEM_SIZE            : natural := 8*1024; -- size of processor-internal data memory in bytes
+      MEM_INT_DMEM_SIZE            : natural := 8*1024; -- size of processor-internal data memory in bytes (use a power of 2)
       -- Internal Instruction Cache (iCACHE) --
       ICACHE_EN                    : boolean := false;  -- implement instruction cache
       ICACHE_NUM_BLOCKS            : natural := 4;      -- i-cache: number of blocks (min 1), has to be a power of 2


### PR DESCRIPTION
The address logic of the internal memories as well as the central address decoding of the bus system cannot cope with address space sizes, which are not a power of two. This is especially true for the internal IMEM and DMEM memories. This PR fixes this problem by ensuring that the configured memory sizes are always a power of two:

> If the configured memory size (via the `MEM_INT_IMEM_SIZE` / `MEM_INT_DMEM_SIZE` generic) is **not** a power of two the actual memory size will be auto-adjusted to the next power of two (e.g. configuring a memory size of 60kB will result in a physical memory size of 64kB).

:+1: Identified by GitHub user @cmenendezzz in https://github.com/stnolting/neorv32/discussions/642.

:bug: This is not a real bug, but something that can cause problems.