### PR TITLE
⚠️ Major code edits / cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 04.08.2023 | 1.8.7.5 | :warning: major code edits/cleanups and file renaming; #664 |
 | 29.07.2023 | 1.8.7.4 | RTL cleanup and optimizations (less synthesis warnings, less resource requirements); [#660](https://github.com/stnolting/neorv32/pull/660) |
 | 28.07.2023 | 1.8.7.3 | :warning: reworked **SYSINFO** module; clean-up address space layout; clean-up assertion notes; [#659](https://github.com/stnolting/neorv32/pull/659) |
 | 27.07.2023 | 1.8.7.2 | :bug: make sure that IMEM/DMEM size is always a power of two; [#658](https://github.com/stnolting/neorv32/pull/658) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -112,10 +112,6 @@ The co-processors are implemented as iterative units that require several cycles
 the co-processors are used to implement all further processing-based ISA extensions (e.g. <<_m_isa_extension>> and
 <<_b_isa_extension>>).
 
-Once triggered, the selected co-processor is required to complete processing within a bound time window. Otherwise the co-processor
-operation is terminated by the hardware and an illegal instruction exception is raised. The time window is 2^T^ clock cycles
-wide; _T_ is defined by the `cp_timeout_c` VHDL package constant (default = 7 -> 128 cycles).
-
 
 :sectnums:
 ==== CPU Bus Unit

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -676,7 +676,7 @@ will raise an illegal instruction exception if <<_mstatus>>`.TW` is set.
 
 ==== `Zihpm` ISA Extension
 
-In additions to the base counters the NEORV32 CPU provides up to 29 hardware performance monitors (HPM 3..31),
+In additions to the base counters the NEORV32 CPU provides up to 13 hardware performance monitors (HPM 3..15),
 which can be used to benchmark applications. Each HPM consists of an N-bit wide counter (split in a high-word 32-bit
 CSR and a low-word 32-bit CSR), where N is defined via the top's
 `HPM_CNT_WIDTH` generic and a corresponding event configuration CSR. The event configuration

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -5,7 +5,7 @@
 The following table shows a summary of all available NEORV32 CSRs. The address field defines the CSR address for
 the CSR access instructions. The "Name [ASM]" column provides the CSR name aliases that can be used in (inline) assembly.
 The "Name [C]" column lists the name aliases that are defined by the NEORV32 core library. These can be used in plain C code.
-The "ACC" column shows the minimal required privilege level required for accessing the according CSR (`M` = machine-mode,
+The "ACC" column shows the minimal required privilege mode required for accessing the according CSR (`M` = machine-mode,
 `U` = user-mode, `D` = debug-mode) and the read/write capabilities (`RW` = read-write, `RO` = read-only)
 
 .Unused, Reserved and Excluded CSRs
@@ -32,8 +32,8 @@ Any illegal read access to a CSR will return zero in the operation's destination
 | 0x002   | <<_frm>>                            | `CSR_FRM`            | URW | Floating-point dynamic rounding mode
 | 0x003   | <<_fcsr>>                           | `CSR_FCSR`           | URW | Floating-point control and status (`frm` + `fflags`)
 5+^| **<<_machine_configuration_csrs>>**
-| 0x30A   | <<_menvcfg>>                        | `CSR_MENVCFG`        | MRW | Machine environment configuration register - low word
-| 0x31A   | <<_menvcfgh>>                       | `CSR_MENVCFGH`       | MRW | Machine environment configuration register - low word
+| 0x30a   | <<_menvcfg>>                        | `CSR_MENVCFG`        | MRW | Machine environment configuration register - low word
+| 0x31a   | <<_menvcfgh>>                       | `CSR_MENVCFGH`       | MRW | Machine environment configuration register - low word
 5+^| **<<_machine_trap_setup_csrs>>**
 | 0x300   | <<_mstatus>>                        | `CSR_MSTATUS`        | MRW | Machine status register - low word
 | 0x301   | <<_misa>>                           | `CSR_MISA`           | MRW | Machine CPU ISA and extensions
@@ -48,46 +48,46 @@ Any illegal read access to a CSR will return zero in the operation's destination
 | 0x343   | <<_mtval>>                          | `CSR_MTVAL`          | MRW | Machine bad address or instruction
 | 0x344   | <<_mip>>                            | `CSR_MIP`            | MRW | Machine interrupt pending register
 5+^| **<<_machine_physical_memory_protection_csrs>>**
-| 0x3A0 .. 0x303 | <<_pmpcfg, `pmpcfg0`>> .. <<_pmpcfg, `pmpcfg3`>>      | `CSR_PMPCFG0` .. `CSR_PMPCFG3`    | MRW | Physical memory protection configuration registers
-| 0x3B0 .. 0x3BF | <<_pmpaddr, `pmpaddr0`>> .. <<_pmpaddr, `pmpaddr15`>> | `CSR_PMPADDR0` .. `CSR_PMPADDR15` | MRW | Physical memory protection address registers
+| 0x3a0 .. 0x303 | <<_pmpcfg, `pmpcfg0`>> .. <<_pmpcfg, `pmpcfg3`>>      | `CSR_PMPCFG0` .. `CSR_PMPCFG3`    | MRW | Physical memory protection configuration registers
+| 0x3b0 .. 0x3BF | <<_pmpaddr, `pmpaddr0`>> .. <<_pmpaddr, `pmpaddr15`>> | `CSR_PMPADDR0` .. `CSR_PMPADDR15` | MRW | Physical memory protection address registers
 5+^| **<<_trigger_module_csrs>>**
-| 0x7A0   | <<_tselect>>                        | `CSR_TSELECT`        | MRW | Trigger select register
-| 0x7A1   | <<_tdata1>>                         | `CSR_TDATA1`         | MRW | Trigger data register 1
-| 0x7A2   | <<_tdata2>>                         | `CSR_TDATA2`         | MRW | Trigger data register 2
-| 0x7A3   | <<_tdata3>>                         | `CSR_TDATA3`         | MRW | Trigger data register 3
-| 0x7A4   | <<_tinfo>>                          | `CSR_TINFO`          | MRW | Trigger information register
-| 0x7A5   | <<_tcontrol>>                       | `CSR_TCONTROL`       | MRW | Trigger control register
-| 0x7A8   | <<_mcontext>>                       | `CSR_MCONTEXT`       | MRW | Machine context register
-| 0x7AA   | <<_scontext>>                       | `CSR_SCONTEXT`       | MRW | Supervisor context register
+| 0x7a0   | <<_tselect>>                        | `CSR_TSELECT`        | MRW | Trigger select register
+| 0x7a1   | <<_tdata1>>                         | `CSR_TDATA1`         | MRW | Trigger data register 1
+| 0x7a2   | <<_tdata2>>                         | `CSR_TDATA2`         | MRW | Trigger data register 2
+| 0x7a3   | <<_tdata3>>                         | `CSR_TDATA3`         | MRW | Trigger data register 3
+| 0x7a4   | <<_tinfo>>                          | `CSR_TINFO`          | MRW | Trigger information register
+| 0x7a5   | <<_tcontrol>>                       | `CSR_TCONTROL`       | MRW | Trigger control register
+| 0x7a8   | <<_mcontext>>                       | `CSR_MCONTEXT`       | MRW | Machine context register
+| 0x7aa   | <<_scontext>>                       | `CSR_SCONTEXT`       | MRW | Supervisor context register
 5+^| **<<_cpu_debug_mode_csrs>>**
-| 0x7B0   | <<_dcsr>>                           | -                    | DRW | Debug control and status register
-| 0x7B1   | <<_dpc>>                            | -                    | DRW | Debug program counter
-| 0x7B2   | <<_dscratch0>>                      | -                    | DRW | Debug scratch register 0
+| 0x7b0   | <<_dcsr>>                           | -                    | DRW | Debug control and status register
+| 0x7b1   | <<_dpc>>                            | -                    | DRW | Debug program counter
+| 0x7b2   | <<_dscratch0>>                      | -                    | DRW | Debug scratch register 0
 5+^| **<<_machine_counter_and_timer_csrs>>**
-| 0xB00   | <<_mcycleh, `mcycle`>>              | `CSR_MCYCLE`         | MRW | Machine cycle counter low word
-| 0xB02   | <<_minstreth, `minstret`>>          | `CSR_MINSTRET`       | MRW | Machine instruction-retired counter low word
-| 0xB80   | <<_mcycleh, `mcycleh`>>             | `CSR_MCYCLEH`        | MRW | Machine cycle counter high word
-| 0xB82   | <<_minstreth, `minstreth`>>         | `CSR_MINSTRETH`      | MRW | Machine instruction-retired counter high word
-| 0xC00   | <<_cycleh, `cycle`>>                | `CSR_CYCLE`          | URO | Cycle counter low word
-| 0xC02   | <<_instreth, `instret`>>            | `CSR_INSTRET`        | URO | Instruction-retired counter low word
-| 0xC80   | <<_cycleh, `cycleh`>>               | `CSR_CYCLEH`         | URO | Cycle counter high word
-| 0xC82   | <<_instreth, `instreth`>>           | `CSR_INSTRETH`       | URO | Instruction-retired counter high word
+| 0xb00   | <<_mcycleh, `mcycle`>>              | `CSR_MCYCLE`         | MRW | Machine cycle counter low word
+| 0xb02   | <<_minstreth, `minstret`>>          | `CSR_MINSTRET`       | MRW | Machine instruction-retired counter low word
+| 0xb80   | <<_mcycleh, `mcycleh`>>             | `CSR_MCYCLEH`        | MRW | Machine cycle counter high word
+| 0xb82   | <<_minstreth, `minstreth`>>         | `CSR_MINSTRETH`      | MRW | Machine instruction-retired counter high word
+| 0xc00   | <<_cycleh, `cycle`>>                | `CSR_CYCLE`          | URO | Cycle counter low word
+| 0xc02   | <<_instreth, `instret`>>            | `CSR_INSTRET`        | URO | Instruction-retired counter low word
+| 0xc80   | <<_cycleh, `cycleh`>>               | `CSR_CYCLEH`         | URO | Cycle counter high word
+| 0xc82   | <<_instreth, `instreth`>>           | `CSR_INSTRETH`       | URO | Instruction-retired counter high word
 5+^| **<<_hardware_performance_monitors_hpm_csrs>>**
-| 0x323 .. 0x33F | <<_mhpmevent, `mhpmevent3`>> .. <<_mhpmevent, `mhpmevent31`>>             | `CSR_MHPMEVENT3` .. `CSR_MHPMEVENT31`       | MRW | Machine performance-monitoring event select for counter 3..31
-| 0xB03 .. 0xB1F | <<_mhpmcounterh, `mhpmcounter3`>> .. <<_mhpmcounterh, `mhpmcounter31`>>   | `CSR_MHPMCOUNTER3` .. `CSR_MHPMCOUNTER3H`   | MRW | Machine performance-monitoring counter 3..31 low word
-| 0xB83 .. 0xB9F | <<_mhpmcounterh, `mhpmcounter3h`>> .. <<_mhpmcounterh, `mhpmcounter31h`>> | `CSR_MHPMCOUNTER3H` .. `CSR_MHPMCOUNTER31H` | MRW | Machine performance-monitoring counter 3..31 high word
-| 0xC03 .. 0xC1F | <<_hpmcounterh, `hpmcounter3`>> .. <<_hpmcounterh, `hpmcounter31`>>       | `CSR_HPMCOUNTER3`  .. `CSR_HPMCOUNTER3H`    | URO | User performance-monitoring counter 3..31 low word
-| 0xC83 .. 0xC9F | <<_hpmcounterh, `hpmcounter3h`>> .. <<_hpmcounterh, `hpmcounter31h`>>     | `CSR_HPMCOUNTER3H` .. `CSR_HPMCOUNTER31H`   | URO | User performance-monitoring counter 3..31 high word
+| 0x323 .. 0x32F | <<_mhpmevent, `mhpmevent3`>> .. <<_mhpmevent, `mhpmevent15`>>             | `CSR_MHPMEVENT3` .. `CSR_MHPMEVENT15`       | MRW | Machine performance-monitoring event select for counter 3..15
+| 0xb03 .. 0xB0F | <<_mhpmcounterh, `mhpmcounter3`>> .. <<_mhpmcounterh, `mhpmcounter15`>>   | `CSR_MHPMCOUNTER3` .. `CSR_MHPMCOUNTER15`   | MRW | Machine performance-monitoring counter 3..15 low word
+| 0xb83 .. 0xB8F | <<_mhpmcounterh, `mhpmcounter3h`>> .. <<_mhpmcounterh, `mhpmcounter15h`>> | `CSR_MHPMCOUNTER3H` .. `CSR_MHPMCOUNTER15H` | MRW | Machine performance-monitoring counter 3..15 high word
+| 0xc03 .. 0xC0F | <<_hpmcounterh, `hpmcounter3`>> .. <<_hpmcounterh, `hpmcounter15`>>       | `CSR_HPMCOUNTER3`  .. `CSR_HPMCOUNTER15H`   | URO | User performance-monitoring counter 3..15 low word
+| 0xc83 .. 0xC8F | <<_hpmcounterh, `hpmcounter3h`>> .. <<_hpmcounterh, `hpmcounter15h`>>     | `CSR_HPMCOUNTER3H` .. `CSR_HPMCOUNTER15H`   | URO | User performance-monitoring counter 3..15 high word
 5+^| **<<_machine_counter_setup_csrs>>**
 | 0x320   | <<_mcountinhibit>>                  | `CSR_MCOUNTINHIBIT`  | MRW | Machine counter-inhibit register
 5+^| **<<_machine_information_csrs>>**
-| 0xF11   | <<_mvendorid>>                      | `CSR_MVENDORID`      | MRO | Machine vendor ID
-| 0xF12   | <<_marchid>>                        | `CSR_MARCHID`        | MRO | Machine architecture ID
-| 0xF13   | <<_mimpid>>                         | `CSR_MIMPID`         | MRO | Machine implementation ID / version
-| 0xF14   | <<_mhartid>>                        | `CSR_MHARTID`        | MRO | Machine hardware thread ID
-| 0xF15   | <<_mconfigptr>>                     | `CSR_MCONFIGPTR`     | MRO | Machine configuration pointer register
+| 0xf11   | <<_mvendorid>>                      | `CSR_MVENDORID`      | MRO | Machine vendor ID
+| 0xf12   | <<_marchid>>                        | `CSR_MARCHID`        | MRO | Machine architecture ID
+| 0xf13   | <<_mimpid>>                         | `CSR_MIMPID`         | MRO | Machine implementation ID / version
+| 0xf14   | <<_mhartid>>                        | `CSR_MHARTID`        | MRO | Machine hardware thread ID
+| 0xf15   | <<_mconfigptr>>                     | `CSR_MCONFIGPTR`     | MRO | Machine configuration pointer register
 5+^| **<<_neorv32_specific_csrs>>**
-| 0xFC0   | <<_mxisa>>                          | `CSR_MXISA`          | MRO | NEORV32-specific "extended" machine CPU ISA and extensions
+| 0xfc0   | <<_mxisa>>                          | `CSR_MXISA`          | MRO | NEORV32-specific "extended" machine CPU ISA and extensions
 |=======================
 
 
@@ -230,8 +230,8 @@ Any illegal read access to a CSR will return zero in the operation's destination
 | Bit   | Name [C] | R/W | Function
 | 3     | `CSR_MSTATUS_MIE`  | r/w | **MIE**: Machine global interrupt enable flag
 | 7     | `CSR_MSTATUS_MPIE` | r/w | **MPIE**: Previous machine global interrupt enable flag state
-| 12:11 | `CSR_MSTATUS_MPP_H` : `CSR_MSTATUS_MPP_L` | r/w | **MPP**: Previous machine privilege level, 11 = machine (M) level, 00 = user (U) level
-| 17    | `CSR_MSTATUS_MPRV` | r/w | **MPRV**: Effective privilege level for load/stores in machine mode; use `MPP`'s as effective privilege level when set; hardwired to zero if user-mode not implemented
+| 12:11 | `CSR_MSTATUS_MPP_H` : `CSR_MSTATUS_MPP_L` | r/w | **MPP**: Previous machine privilege mode, 11 = machine (M) mode, 00 = user (U) mode
+| 17    | `CSR_MSTATUS_MPRV` | r/w | **MPRV**: Effective privilege mode for load/stores in machine mode; use `MPP`'s as effective privilege mode when set; hardwired to zero if user-mode not implemented
 | 21    | `CSR_MSTATUS_TW`   | r/w | **TW**: Trap on execution of `wfi` instruction in user mode when set; hardwired to zero if user-mode not implemented
 |=======================
 
@@ -343,7 +343,7 @@ interrupt is triggered or an exception is raised.
 | Address     | `0x306`
 | Reset value | `0x00000000`
 | ISA         | `Zicsr` + `U`
-| Description | The `mcounteren` CSR is used to constrain user-level access to the CPU's counter CSRs.
+| Description | The `mcounteren` CSR is used to constrain user-mode access to the CPU's counter CSRs.
 This CSR is also available if U mode is disabled, but the register is hardwired to all-zero in this case.
 |=======================
 
@@ -352,10 +352,10 @@ This CSR is also available if U mode is disabled, but the register is hardwired 
 [options="header",grid="rows"]
 |=======================
 | Bit  | R/W | Function
-| 0    | r/w | **CY**: User-level code is allowed to read <<_cycleh>> CSRs when set
+| 0    | r/w | **CY**: User-mode code is allowed to read <<_cycleh>> CSRs when set
 | 1    | r/- | **TM**: Hardwired to zero as `time[h]` CSRs are not implemented
-| 2    | r/w | **IR**: User-level code is allowed to read <<_instreth>> CSRs when set
-| 31:3 | r/w | **HPM**: user-level code is allowed to read <<_hpmcounterh>> CSRs when set
+| 2    | r/w | **IR**: User-mode code is allowed to read <<_instreth>> CSRs when set
+| 15:3 | r/w | **HPM**: user-mode code is allowed to read <<_hpmcounterh>> CSRs when set
 |=======================
 
 
@@ -477,8 +477,8 @@ maintain RISC-V compatibility.
 | Address     | `0x344`
 | Reset value | `0x00000000`
 | ISA         | `Zicsr`
-| Description | The `mip` CSR shows currently _pending_ machine-level interrupt requests. The bits for the standard RISC-V
-machine-level interrupts (`MEIP`, `MTIP`, `MSIP`) are read-only. Hence, these interrupts cannot be
+| Description | The `mip` CSR shows currently _pending_ machine-mode interrupt requests. The bits for the standard RISC-V
+machine-mode interrupts (`MEIP`, `MTIP`, `MSIP`) are read-only. Hence, these interrupts cannot be
 cleared/set using the `mip` register. These interrupts are cleared/acknowledged by mechanism that are
 specific for the interrupt-causing modules. the according interrupt-generating device.
 |=======================
@@ -587,7 +587,7 @@ if this instruction is actually going to retire or if it causes an exception.
 | Address     | `0xc00` (`cycle`), `0xc80` (`cycleh`)
 | Reset value | `0x00000000`
 | ISA         | `Zicsr` + `Zicntr`
-| Description | The `cycle[h]` CSRs are user-mode shadow copies of the according <<_mcycleh>> CSRs. The user-level
+| Description | The `cycle[h]` CSRs are user-mode shadow copies of the according <<_mcycleh>> CSRs. The user-mode
 counter are read-only. Any write access will raise an illegal instruction exception.
 |=======================
 
@@ -603,7 +603,7 @@ counter are read-only. Any write access will raise an illegal instruction except
 | Address     | `0xc02` (`instret`), `0xc82` (`instreth`)
 | Reset value | `0x00000000`
 | ISA         | `Zicsr` + `Zicntr`
-| Description | The `instret[h]` CSRs are user-mode shadow copies of the according <<_minstreth>> CSRs. The user-level
+| Description | The `instret[h]` CSRs are user-mode shadow copies of the according <<_minstreth>> CSRs. The user-mode
 counter are read-only. Any write access will raise an illegal instruction exception.
 |=======================
 
@@ -646,7 +646,7 @@ These registers are read/write only for machine-mode software
 ==== Hardware Performance Monitors (HPM) CSRs
 
 The actual number of implemented hardware performance monitors is configured via the `HPM_NUM_CNTS` top entity generic,
-Note that always all 28 HPM counter and configuration registers (`mhpmcounter*[h]` and `mhpmevent*`) are implemented, but
+Note that always all 13 HPM counter and configuration registers (`mhpmcounter*[h]` and `mhpmevent*`) are implemented, but
 only the actually configured ones are implemented as "real" physical registers - the remaining ones will be hardwired to zero.
 
 If trying to access an HPM-related CSR beyond `HPM_NUM_CNTS` **no illegal instruction exception is
@@ -663,7 +663,7 @@ If `HPM_NUM_CNTS` is less than 64, all remaining MSB-aligned bits are hardwired 
 [frame="topbot",grid="none"]
 |=======================
 | Name        | Machine hardware performance monitor event select
-| Address     | `0x232` (`mhpmevent3`) ... `0x33f` (`mhpmevent31`)
+| Address     | `0x233` (`mhpmevent3`) ... `0x32f` (`mhpmevent15`)
 | Reset value | `0x00000000`
 | ISA         | `Zicsr` + `Zihpm`
 | Description | The value in these CSRs define the architectural events that cause an increment of the according `mhpmcounter*[h]` counter(s).
@@ -704,8 +704,8 @@ cycle even if more than one trigger event is observed.
 [frame="topbot",grid="none"]
 |=======================
 | Name        | Machine hardware performance monitor
-| Address     | `0xb03` (`mhpmcounter3`) ... `0xb1f` (mhpmcounter31)
-|             | `0xb83` (`mhpmcounter3h`) ... `0xb9f` (`mhpmcounter31h`)
+| Address     | `0xb03` (`mhpmcounter3`) ... `0xb0f` (mhpmcounter15)
+|             | `0xb83` (`mhpmcounter3h`) ... `0xb8f` (`mhpmcounter15h`)
 | Reset value | `0x00000000`
 | ISA         | `Zicsr` + `Zihpm`
 | Description | If not halted via the <<_mcountinhibit>> CSR the HPM counter CSR(s) increment whenever a
@@ -722,11 +722,11 @@ and are not accessible for lower-privileged software.
 [frame="topbot",grid="none"]
 |=======================
 | Name        | User hardware performance monitor
-| Address     | `0xc03` (`hpmcounter3`) ... `0xc1f` (hpmcounter31)
-|             | `0xc83` (`hpmcounter3h`) ... `0xc9f` (`hpmcounter31h`)
+| Address     | `0xc03` (`hpmcounter3`) ... `0xc0f` (hpmcounter15)
+|             | `0xc83` (`hpmcounter3h`) ... `0xc8f` (`hpmcounter15h`)
 | Reset value | `0x00000000`
 | ISA         | `Zicsr` + `Zihpm`
-| Description | The `hpmcounter*[h]` are user-level shadow copies of the according <<_mhpmcounterh>> CSRs. The user level
+| Description | The `hpmcounter*[h]` are user-mode shadow copies of the according <<_mhpmcounterh>> CSRs. The user mode
 counter CSRs are read-only. Any write access will raise an illegal instruction exception.
 |=======================
 
@@ -758,7 +758,7 @@ counter CSRs are read-only. Any write access will raise an illegal instruction e
 | 0    | `CSR_MCOUNTINHIBIT_IR` | r/w | **IR**: Set to `1` to halt `[m]instret[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
 | 1    | -                      | r/- | **TM**: Hardwired to zero as `time[h]` CSRs are not implemented
 | 2    | `CSR_MCOUNTINHIBIT_CY` | r/w | **CY**: Set to `1` to halt `[m]cycle[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
-| 3:31 | `CSR_MCOUNTINHIBIT_HPM3` : `CSR_MCOUNTINHIBIT_HPM31` | r/w | **HPMx**: Set to `1` to halt `[m]hpmcount*[h]`; hardwired to zero if `Zihpm` ISA extension is disabled
+| 15:3 | `CSR_MCOUNTINHIBIT_HPM3` : `CSR_MCOUNTINHIBIT_HPM31` | r/w | **HPMx**: Set to `1` to halt `[m]hpmcount*[h]`; hardwired to zero if `Zihpm` ISA extension is disabled
 |=======================
 
 

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -48,8 +48,8 @@ Any illegal read access to a CSR will return zero in the operation's destination
 | 0x343   | <<_mtval>>                          | `CSR_MTVAL`          | MRW | Machine bad address or instruction
 | 0x344   | <<_mip>>                            | `CSR_MIP`            | MRW | Machine interrupt pending register
 5+^| **<<_machine_physical_memory_protection_csrs>>**
-| 0x3A0 .. 0x3AF | <<_pmpcfg, `pmpcfg0`>> .. <<_pmpcfg, `pmpcfg15`>>     | `CSR_PMPCFG0` .. `CSR_PMPCFG15`    | MRW | Physical memory protection configuration for region 0..15
-| 0x3B0 .. 0x3EF | <<_pmpaddr, `pmpaddr0`>> .. <<_pmpaddr, `pmpaddr63`>> | `CSR_PMPADDR0` .. `CSR_PMPADDR63` | MRW | Physical memory protection address register region 0..15
+| 0x3A0 .. 0x303 | <<_pmpcfg, `pmpcfg0`>> .. <<_pmpcfg, `pmpcfg3`>>      | `CSR_PMPCFG0` .. `CSR_PMPCFG3`    | MRW | Physical memory protection configuration registers
+| 0x3B0 .. 0x3BF | <<_pmpaddr, `pmpaddr0`>> .. <<_pmpaddr, `pmpaddr15`>> | `CSR_PMPADDR0` .. `CSR_PMPADDR15` | MRW | Physical memory protection address registers
 5+^| **<<_trigger_module_csrs>>**
 | 0x7A0   | <<_tselect>>                        | `CSR_TSELECT`        | MRW | Trigger select register
 | 0x7A1   | <<_tdata1>>                         | `CSR_TDATA1`         | MRW | Trigger data register 1
@@ -518,15 +518,11 @@ See section <<_pmp_isa_extension>> for more information.
 [frame="topbot",grid="none"]
 |=======================
 | Name        | PMP region configuration registers
-| Address     | `0x3a0` (`pmpcfg0`) ... `0x3af` (`pmpcfg15`)
+| Address     | `0x3a0` (`pmpcfg0`) ... `0x3a3` (`pmpcfg3`)
 | Reset value | `0x00000000`
 | ISA         | `Zicsr` + `PMP`
 | Description | Configuration of physical memory protection regions. Each region provides an individual 8-bit array in these CSRs.
 |=======================
-
-[IMPORTANT]
-Note that only PMP configuration registers `pmpcfg0` to `pmpcfg3` will be implemented if `PMP_NUM_REGIONS` is set to its
-maximum value (=16). The remaining `pmpcfg4` to `pmpcfg15` CSRs are read-only and will always read as zero.
 
 .`pmpcfg0` CSR Bits
 [cols="^1,^2,^1,<11"]
@@ -552,15 +548,11 @@ The `pmpaddr*` CSRs are used to configure the region's address boundaries.
 [frame="topbot",grid="none"]
 |=======================
 | Name        | Physical memory protection address registers
-| Address     | `0x3b0` (`pmpaddr0`) ... `0x3ef` (`pmpaddr63`)
+| Address     | `0x3b0` (`pmpaddr0`) ... `0x3bf` (`pmpaddr15`)
 | Reset value | `0x00000000`
 | ISA         | `Zicsr` + `PMP`
 | Description | Region address configuration. The two MSBs of each CSR are hardwired to zero (= bits 33:32 of the physical address).
 |=======================
-
-[IMPORTANT]
-Note that only PMP address registers `pmpaddr0` to `pmpaddr15` will be implemented if `PMP_NUM_REGIONS` is set to its
-maximum value (=16). The remaining `pmpaddr16` to `pmpaddr63` CSRs are read-only and will always read as zero.
 
 .Address Register Update Latency
 [IMPORTANT]

--- a/docs/datasheet/overview.adoc
+++ b/docs/datasheet/overview.adoc
@@ -192,7 +192,8 @@ All core VHDL files from the list below have to be assigned to a new design libr
 │   ├-neorv32_cpu_cp_shifter.vhd   - Bit-shift co-processor (base ISA)
 │   ├-neorv32_cpu_cp_muldiv.vhd    - Mul/Div co-processor (M ext.)
 │ ┌-neorv32_cpu_alu.vhd            - Arithmetic/logic unit
-│ ├-neorv32_cpu_bus.vhd            - Load/store unit + physical memory protection
+│ ├-neorv32_cpu_pmp.vhd            - Physical memory protection unit
+│ ├-neorv32_cpu_lsu.vhd            - Load/store unit
 │ │ ┌-neorv32_cpu_decompressor.vhd - Compressed instructions decoder
 │ ├-neorv32_cpu_control.vhd        - CPU control, exception system and CSRs
 │ ├-neorv32_cpu_regfile.vhd        - Data register file

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -225,7 +225,7 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `PMP_NUM_REGIONS`       | natural   | 0          | Number of implemented PMP regions (0..16).
 | `PMP_MIN_GRANULARITY`   | natural   | 4          | Minimal region granularity in bytes. Has to be a power of two, min 4.
 4+^| **Hardware Performance Monitors (<<_zihpm_isa_extension>>)**
-| `HPM_NUM_CNTS`          | natural   | 0          | Number of implemented hardware performance monitor counters (0..29).
+| `HPM_NUM_CNTS`          | natural   | 0          | Number of implemented hardware performance monitor counters (0..13).
 | `HPM_CNT_WIDTH`         | natural   | 40         | Total LSB-aligned size of each HPM counter. Min 0, max 64.
 4+^| **Atomic Memory Access Reservation Set Granularity (<<_a_isa_extension>>)**
 | `AMO_RVS_GRANULARITY`   | natural   | 4          | Size in bytes, has to be a power of 2, min 4.

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -101,6 +101,15 @@ architecture neorv32_cpu_rtl of neorv32_cpu is
   -- auto-configuration --
   constant regfile_rs3_en_c : boolean := CPU_EXTENSION_RISCV_Zxcfu or CPU_EXTENSION_RISCV_Zfinx; -- 3rd register file read port (rs3)
   constant regfile_rs4_en_c : boolean := CPU_EXTENSION_RISCV_Zxcfu; -- 4th register file read port (rs4)
+  constant pmp_enable_c     : boolean := boolean(PMP_NUM_REGIONS > 0);
+
+  -- external CSR interface --
+  signal xcsr_we        : std_ulogic;
+  signal xcsr_addr      : std_ulogic_vector(11 downto 0);
+  signal xcsr_wdata     : std_ulogic_vector(XLEN-1 downto 0);
+  signal xcsr_rdata_pmp : std_ulogic_vector(XLEN-1 downto 0);
+  signal xcsr_rdata_alu : std_ulogic_vector(XLEN-1 downto 0);
+  signal xcsr_rdata_res : std_ulogic_vector(XLEN-1 downto 0);
 
   -- local signals --
   signal ctrl        : ctrl_bus_t; -- main control bus
@@ -114,7 +123,6 @@ architecture neorv32_cpu_rtl of neorv32_cpu is
   signal alu_cmp     : std_ulogic_vector(1 downto 0); -- comparator result
   signal mem_rdata   : std_ulogic_vector(XLEN-1 downto 0); -- memory read data
   signal cp_done     : std_ulogic; -- ALU co-processor operation done
-  signal alu_exc     : std_ulogic; -- ALU exception
   signal bus_d_wait  : std_ulogic; -- wait for current data bus access
   signal csr_rdata   : std_ulogic_vector(XLEN-1 downto 0); -- csr read data
   signal mar         : std_ulogic_vector(XLEN-1 downto 0); -- memory address register
@@ -125,12 +133,9 @@ architecture neorv32_cpu_rtl of neorv32_cpu is
   signal fetch_pc    : std_ulogic_vector(XLEN-1 downto 0); -- pc for instruction fetch
   signal curr_pc     : std_ulogic_vector(XLEN-1 downto 0); -- current pc (for currently executed instruction)
   signal next_pc     : std_ulogic_vector(XLEN-1 downto 0); -- next pc (for next executed instruction)
-  signal fpu_flags   : std_ulogic_vector(4 downto 0); -- FPU exception flags
-  signal i_pmp_fault : std_ulogic; -- instruction fetch PMP fault
-
-  -- pmp interface --
-  signal pmp_addr : pmp_addr_if_t;
-  signal pmp_ctrl : pmp_ctrl_if_t;
+  signal pmp_i_fault : std_ulogic; -- PMP instruction fetch fault
+  signal pmp_r_fault : std_ulogic; -- PMP read fault
+  signal pmp_w_fault : std_ulogic; -- PMP write fault
 
 begin
 
@@ -138,7 +143,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   -- say hello --
   assert false report
-    "The NEORV32 RISC-V Processor Version 0x" & to_hstring32_f(hw_version_c) & " - github.com/stnolting/neorv32" severity note;
+    "The NEORV32 RISC-V Processor, Version 0x" & to_hstring32_f(hw_version_c) & " - github.com/stnolting/neorv32" severity note;
 
   -- CPU ISA configuration --
   assert false report
@@ -159,7 +164,7 @@ begin
     cond_sel_string_f(CPU_EXTENSION_RISCV_Zxcfu,    "_Zxcfu", "") &
     cond_sel_string_f(CPU_EXTENSION_RISCV_Sdext,    "_Sdext", "") &
     cond_sel_string_f(CPU_EXTENSION_RISCV_Sdtrig,   "_Sdtrig", "") &
-    ""
+    cond_sel_string_f(pmp_enable_c,                 "_Smpmp", "")
     severity note;
 
   -- simulation notifier --
@@ -169,14 +174,6 @@ begin
   -- CPU boot address --
   assert not (CPU_BOOT_ADDR(1 downto 0) /= "00") report
     "NEORV32 CPU CONFIG ERROR! <CPU_BOOT_ADDR> has to be 32-bit aligned." severity error;
-
-  -- PMP --
-  assert not (PMP_NUM_REGIONS > 16) report
-    "NEORV32 CPU CONFIG ERROR! Number of PMP regions <PMP_NUM_REGIONS> out of valid range (0..16)." severity error;
-  assert not ((is_power_of_two_f(PMP_MIN_GRANULARITY) = false) and (PMP_NUM_REGIONS > 0)) report
-    "NEORV32 CPU CONFIG ERROR! <PMP_MIN_GRANULARITY> has to be a power of two." severity error;
-  assert not ((PMP_MIN_GRANULARITY < 4) and (PMP_NUM_REGIONS > 0)) report
-    "NEORV32 CPU CONFIG ERROR! <PMP_MIN_GRANULARITY> has to be >= 4 bytes." severity error;
 
   -- HPM counters --
   assert not ((CPU_EXTENSION_RISCV_Zihpm = true) and (HPM_NUM_CNTS > 29)) report
@@ -223,8 +220,7 @@ begin
     FAST_MUL_EN                  => FAST_MUL_EN,                  -- use DSPs for M extension's multiplier
     FAST_SHIFT_EN                => FAST_SHIFT_EN,                -- use barrel shifter for shift operations
     -- Physical memory protection (PMP) --
-    PMP_NUM_REGIONS              => PMP_NUM_REGIONS,              -- number of regions (0..16)
-    PMP_MIN_GRANULARITY          => PMP_MIN_GRANULARITY,          -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
+    PMP_EN                       => pmp_enable_c,                 -- physical memory protection enabled
     -- Hardware Performance Monitors (HPM) --
     HPM_NUM_CNTS                 => HPM_NUM_CNTS,                 -- number of implemented HPM counters (0..29)
     HPM_CNT_WIDTH                => HPM_CNT_WIDTH                 -- total size of HPM counters
@@ -240,10 +236,9 @@ begin
     i_bus_re_o    => ibus_req_o.re,   -- read enable
     i_bus_ack_i   => ibus_rsp_i.ack,  -- bus transfer acknowledge
     i_bus_err_i   => ibus_rsp_i.err,  -- bus transfer error
-    i_pmp_fault_i => i_pmp_fault,     -- instruction fetch pmp fault
+    i_pmp_fault_i => pmp_i_fault,     -- instruction fetch pmp fault
     -- status input --
     alu_cp_done_i => cp_done,         -- ALU iterative operation done
-    alu_exc_i     => alu_exc,         -- ALU exception
     bus_d_wait_i  => bus_d_wait,      -- wait for bus
     -- data input --
     cmp_i         => alu_cmp,         -- comparator status
@@ -254,8 +249,11 @@ begin
     curr_pc_o     => curr_pc,         -- current PC (corresponding to current instruction)
     next_pc_o     => next_pc,         -- next PC (corresponding to next instruction)
     csr_rdata_o   => csr_rdata,       -- CSR read data
-    -- FPU interface --
-    fpu_flags_i   => fpu_flags,       -- exception flags
+    -- external CSR interface --
+    xcsr_we_o     => xcsr_we,         -- global write enable
+    xcsr_addr_o   => xcsr_addr,       -- address
+    xcsr_wdata_o  => xcsr_wdata,      -- write data
+    xcsr_rdata_i  => xcsr_rdata_res,  -- read data
     -- debug mode (halt) request --
     db_halt_req_i => dbi_i,
     -- interrupts (risc-v compliant) --
@@ -264,9 +262,6 @@ begin
     mti_i         => mti_i,           -- machine timer interrupt
     -- fast interrupts (custom) --
     firq_i        => firq_i,          -- fast interrupt trigger
-    -- physical memory protection --
-    pmp_addr_o    => pmp_addr,        -- addresses
-    pmp_ctrl_o    => pmp_ctrl,        -- configs
     -- bus access exceptions --
     mar_i         => mar,             -- memory address register
     ma_load_i     => ma_load,         -- misaligned load data address
@@ -275,19 +270,22 @@ begin
     be_store_i    => be_store         -- bus error on store data access
   );
 
+  -- external CSR read-back --
+  xcsr_rdata_res <= xcsr_rdata_pmp or xcsr_rdata_alu;
+
   -- CPU state --
   sleep_o <= ctrl.cpu_sleep; -- set when CPU is sleeping (after WFI)
   debug_o <= ctrl.cpu_debug; -- set when CPU is in debug mode
 
   -- instruction/data fence --
-  ifence_o <= ctrl.bus_fencei;
-  dfence_o <= ctrl.bus_fence;
+  ifence_o <= ctrl.lsu_fencei;
+  dfence_o <= ctrl.lsu_fence;
 
   -- instruction fetch interface --
   ibus_req_o.addr <= fetch_pc;
   ibus_req_o.priv <= ctrl.cpu_priv;
-  ibus_req_o.data <= (others => '0');
-  ibus_req_o.ben  <= (others => '0');
+  ibus_req_o.data <= (others => '0'); -- read-only
+  ibus_req_o.ben  <= (others => '0'); -- read-only
   ibus_req_o.we   <= '0'; -- read-only
   ibus_req_o.src  <= '1'; -- source = instruction fetch
   ibus_req_o.rvso <= '0'; -- cannot be a reservation set operation
@@ -335,45 +333,43 @@ begin
   )
   port map (
     -- global control --
-    clk_i       => clk_i,     -- global clock, rising edge
-    rstn_i      => rstn_i,    -- global reset, low-active, async
-    ctrl_i      => ctrl,      -- main control bus
+    clk_i       => clk_i,          -- global clock, rising edge
+    rstn_i      => rstn_i,         -- global reset, low-active, async
+    ctrl_i      => ctrl,           -- main control bus
+    -- CSR interface --
+    csr_we_i    => xcsr_we,        -- global write enable
+    csr_addr_i  => xcsr_addr,      -- address
+    csr_wdata_i => xcsr_wdata,     -- write data
+    csr_rdata_o => xcsr_rdata_alu, -- read data
     -- data input --
-    rs1_i       => rs1,       -- rf source 1
-    rs2_i       => rs2,       -- rf source 2
-    rs3_i       => rs3,       -- rf source 3
-    rs4_i       => rs4,       -- rf source 4
-    pc_i        => curr_pc,   -- current PC
-    imm_i       => imm,       -- immediate
+    rs1_i       => rs1,            -- rf source 1
+    rs2_i       => rs2,            -- rf source 2
+    rs3_i       => rs3,            -- rf source 3
+    rs4_i       => rs4,            -- rf source 4
+    pc_i        => curr_pc,        -- current PC
+    imm_i       => imm,            -- immediate
     -- data output --
-    cmp_o       => alu_cmp,   -- comparator status
-    res_o       => alu_res,   -- ALU result
-    add_o       => alu_add,   -- address computation result
-    fpu_flags_o => fpu_flags, -- FPU exception flags
+    cmp_o       => alu_cmp,        -- comparator status
+    res_o       => alu_res,        -- ALU result
+    add_o       => alu_add,        -- address computation result
     -- status --
-    exc_o       => alu_exc,   -- ALU exception
-    cp_done_o   => cp_done    -- iterative processing units done?
+    cp_done_o   => cp_done         -- iterative processing units done?
   );
 
 
-  -- Bus Interface (Load/Store Unit) --------------------------------------------------------
+  -- Load/Store Unit ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  neorv32_cpu_bus_inst: entity neorv32.neorv32_cpu_bus
+  neorv32_cpu_lsu_inst: entity neorv32.neorv32_cpu_lsu
   generic map (
-    AMO_LRSC_ENABLE     => CPU_EXTENSION_RISCV_A, -- enable atomic LR/SC operations
-    PMP_NUM_REGIONS     => PMP_NUM_REGIONS,       -- number of regions (0..16)
-    PMP_MIN_GRANULARITY => PMP_MIN_GRANULARITY    -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
+    AMO_LRSC_ENABLE => CPU_EXTENSION_RISCV_A -- enable atomic LR/SC operations
   )
   port map (
     -- global control --
     clk_i         => clk_i,           -- global clock, rising edge
     rstn_i        => rstn_i,          -- global reset, low-active, async
     ctrl_i        => ctrl,            -- main control bus
-    -- cpu instruction fetch interface --
-    fetch_pc_i    => fetch_pc,        -- PC for instruction fetch
-    i_pmp_fault_o => i_pmp_fault,     -- instruction fetch pmp fault
     -- cpu data access interface --
-    addr_i        => alu_add,         -- ALU.add result -> access address
+    addr_i        => alu_add,         -- access address
     wdata_i       => rs2,             -- write data
     rdata_o       => mem_rdata,       -- read data
     mar_o         => mar,             -- current memory address register
@@ -382,9 +378,8 @@ begin
     ma_store_o    => ma_store,        -- misaligned store data address
     be_load_o     => be_load,         -- bus error on load data access
     be_store_o    => be_store,        -- bus error on store data access
-    -- physical memory protection --
-    pmp_addr_i    => pmp_addr,        -- addresses
-    pmp_ctrl_i    => pmp_ctrl,        -- configurations
+    pmp_r_fault_i => pmp_r_fault,     -- PMP read fault
+    pmp_w_fault_i => pmp_w_fault,     -- PMP write fault
     -- data bus --
     d_bus_addr_o  => dbus_req_o.addr, -- bus access address
     d_bus_rdata_i => dbus_rsp_i.data, -- bus read data
@@ -396,9 +391,48 @@ begin
     d_bus_err_i   => dbus_rsp_i.err   -- bus transfer error
   );
 
-  dbus_req_o.priv <= ctrl.bus_priv;
+  -- data access interface --
+  dbus_req_o.priv <= ctrl.lsu_priv;
   dbus_req_o.src  <= '0'; -- source = data access
-  dbus_req_o.rvso <= ctrl.bus_rvso when (CPU_EXTENSION_RISCV_A = true) else '0'; -- is LR/SC reservation set operation
+  dbus_req_o.rvso <= ctrl.lsu_rvso when (CPU_EXTENSION_RISCV_A = true) else '0'; -- is LR/SC reservation set operation
+
+
+  -- Physical Memory Protection -------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  pmp_inst_true:
+  if (pmp_enable_c = true) generate
+    neorv32_cpu_pmp_inst: entity neorv32.neorv32_cpu_pmp
+    generic map (
+      NUM_REGIONS => PMP_NUM_REGIONS,    -- number of regions (0..16)
+      GRANULARITY => PMP_MIN_GRANULARITY -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
+    )
+    port map (
+      -- global control --
+      clk_i       => clk_i,          -- global clock, rising edge
+      rstn_i      => rstn_i,         -- global reset, low-active, async
+      ctrl_i      => ctrl,           -- main control bus
+      -- CSR interface --
+      csr_we_i    => xcsr_we,        -- global write enable
+      csr_addr_i  => xcsr_addr,      -- address
+      csr_wdata_i => xcsr_wdata,     -- write data
+      csr_rdata_o => xcsr_rdata_pmp, -- read data
+      -- address input --
+      addr_if_i   => fetch_pc,       -- instruction fetch address
+      addr_ls_i   => alu_add,        -- load/store address
+      -- faults --
+      fault_if_o  => pmp_i_fault,    -- instruction fetch fault
+      fault_ld_o  => pmp_r_fault,    -- data load fault
+      fault_st_o  => pmp_w_fault     -- data store fault
+    );
+  end generate;
+
+  pmp_inst_false:
+  if (pmp_enable_c = false) generate
+    xcsr_rdata_pmp <= (others => '0');
+    pmp_i_fault    <= '0';
+    pmp_r_fault    <= '0';
+    pmp_w_fault    <= '0';
+  end generate;
 
 
 end neorv32_cpu_rtl;

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -70,7 +70,7 @@ entity neorv32_cpu is
     PMP_NUM_REGIONS              : natural; -- number of regions (0..16)
     PMP_MIN_GRANULARITY          : natural; -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
     -- Hardware Performance Monitors (HPM) --
-    HPM_NUM_CNTS                 : natural; -- number of implemented HPM counters (0..29)
+    HPM_NUM_CNTS                 : natural; -- number of implemented HPM counters (0..13)
     HPM_CNT_WIDTH                : natural  -- total size of HPM counters (0..64)
   );
   port (
@@ -176,8 +176,8 @@ begin
     "NEORV32 CPU CONFIG ERROR! <CPU_BOOT_ADDR> has to be 32-bit aligned." severity error;
 
   -- HPM counters --
-  assert not ((CPU_EXTENSION_RISCV_Zihpm = true) and (HPM_NUM_CNTS > 29)) report
-    "NEORV32 CPU CONFIG ERROR! Number of HPM counters <HPM_NUM_CNTS> out of valid range (0..29)." severity error;
+  assert not ((CPU_EXTENSION_RISCV_Zihpm = true) and (HPM_NUM_CNTS > 13)) report
+    "NEORV32 CPU CONFIG ERROR! Number of HPM counters <HPM_NUM_CNTS> out of valid range (0..13)." severity error;
   assert not ((CPU_EXTENSION_RISCV_Zihpm = true) and ((HPM_CNT_WIDTH < 0) or (HPM_CNT_WIDTH > 64))) report
     "NEORV32 CPU CONFIG ERROR! HPM counter width <HPM_CNT_WIDTH> has to be 0..64 bit." severity error;
 
@@ -222,7 +222,7 @@ begin
     -- Physical memory protection (PMP) --
     PMP_EN                       => pmp_enable_c,                 -- physical memory protection enabled
     -- Hardware Performance Monitors (HPM) --
-    HPM_NUM_CNTS                 => HPM_NUM_CNTS,                 -- number of implemented HPM counters (0..29)
+    HPM_NUM_CNTS                 => HPM_NUM_CNTS,                 -- number of implemented HPM counters (0..13)
     HPM_CNT_WIDTH                => HPM_CNT_WIDTH                 -- total size of HPM counters
   )
   port map (

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -1,5 +1,5 @@
 -- #################################################################################################
--- # << NEORV32 - Arithmetical/Logical Unit >>                                                     #
+-- # << NEORV32 CPU - Arithmetic/Logic Unit >>                                                     #
 -- # ********************************************************************************************* #
 -- # Main data/address ALU and ALU co-processors (= multi-cycle function units).                   #
 -- # ********************************************************************************************* #
@@ -72,7 +72,6 @@ entity neorv32_cpu_alu is
     add_o       : out std_ulogic_vector(XLEN-1 downto 0); -- address computation result
     fpu_flags_o : out std_ulogic_vector(4 downto 0); -- FPU exception flags
     -- status --
-    exc_o       : out std_ulogic; -- ALU exception
     cp_done_o   : out std_ulogic  -- co-processor operation done?
   );
 end neorv32_cpu_alu;
@@ -91,15 +90,6 @@ architecture neorv32_cpu_cpu_rtl of neorv32_cpu_alu is
   -- intermediate results --
   signal addsub_res : std_ulogic_vector(XLEN downto 0);
   signal cp_res     : std_ulogic_vector(XLEN-1 downto 0);
-
-  -- co-processor monitor --
-  type cp_monitor_t is record
-    run : std_ulogic;
-    fin : std_ulogic;
-    exc : std_ulogic;
-    cnt : std_ulogic_vector(cp_timeout_c downto 0); -- timeout counter
-  end record;
-  signal cp_monitor : cp_monitor_t;
 
   -- co-processor interface --
   type cp_data_t  is array (0 to 5) of std_ulogic_vector(XLEN-1 downto 0);
@@ -158,41 +148,9 @@ begin
   -- ALU Co-Processors
   -- **************************************************************************************************************************
 
-  -- Co-Processor Control -------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  coprocessor_monitor: process(rstn_i, clk_i)
-  begin
-    -- make sure that no co-processor iterates forever stalling the entire CPU;
-    -- an illegal instruction exception is raised if a co-processor operation
-    -- takes longer than 2^cp_timeout_c cycles (package constant)
-    if (rstn_i = '0') then
-      cp_monitor.run <= '0';
-      cp_monitor.fin <= '0';
-      cp_monitor.exc <= '0';
-      cp_monitor.cnt <= (others => '0');
-    elsif rising_edge(clk_i) then
-      cp_monitor.exc <= cp_monitor.run and cp_monitor.cnt(cp_monitor.cnt'left) and (not cp_monitor.fin);
-      cp_monitor.fin <= or_reduce_f(cp_valid);
-      if (cp_monitor.run = '0') then -- co-processors are idle
-        cp_monitor.cnt <= (others => '0');
-        if (or_reduce_f(ctrl_i.alu_cp_trig) = '1') then -- start
-          cp_monitor.run <= '1';
-        end if;
-      else -- co-processor operation in progress
-        cp_monitor.cnt <= std_ulogic_vector(unsigned(cp_monitor.cnt) + 1);
-        if (cp_monitor.fin = '1') or (ctrl_i.cpu_trap = '1') then -- done or abort
-          cp_monitor.run <= '0';
-        end if;
-      end if;
-    end if;
-  end process coprocessor_monitor;
-
-  -- ALU processing exception --
-  exc_o <= cp_monitor.exc;
-
   -- co-processor select / start trigger --
   -- > "cp_start" is high for one cycle to trigger operation of the according co-processor
-  cp_start(5 downto 0) <= ctrl_i.alu_cp_trig;
+  cp_start <= ctrl_i.alu_cp_trig;
 
   -- (iterative) co-processor operation done? --
   -- > "cp_valid" signal has to be set (for one cycle) one cycle before CP output data (cp_result) is valid

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1867,8 +1867,8 @@ begin
 
       -- no hardware performance monitors --
       if (CPU_EXTENSION_RISCV_Zihpm = false) then
-        csr.mcounteren((hpm_num_c+2)-1 downto 3)    <= (others => '0');
-        csr.mcountinhibit((hpm_num_c+2)-1 downto 3) <= (others => '0');
+        csr.mcounteren((hpm_num_c+3)-1 downto 3)    <= (others => '0');
+        csr.mcountinhibit((hpm_num_c+3)-1 downto 3) <= (others => '0');
       end if;
 
       -- no user mode --
@@ -1951,7 +1951,7 @@ begin
           csr_rdata(0) <= csr.mcounteren(0); -- cycle[h]
           csr_rdata(2) <= csr.mcounteren(2); -- instret[h]
           if (CPU_EXTENSION_RISCV_Zihpm = true) and (hpm_num_c > 0) then
-            for i in 3 to (hpm_num_c+2)-1 loop
+            for i in 3 to (hpm_num_c+3)-1 loop
               csr_rdata(i) <= csr.mcounteren(i); -- hpmcounter*[h]
             end loop;
           end if;
@@ -1991,7 +1991,7 @@ begin
           csr_rdata(2) <= csr.mcountinhibit(2); -- [m]instret[h]
         end if;
         if (CPU_EXTENSION_RISCV_Zihpm = true) and (hpm_num_c > 0) then
-          for i in 3 to (hpm_num_c+2)-1 loop
+          for i in 3 to (hpm_num_c+3)-1 loop
             csr_rdata(i) <= csr.mcountinhibit(i); -- [m]hpmcounter*[h]
           end loop;
         end if;

--- a/rtl/core/neorv32_cpu_cp_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_cp_bitmanip.vhd
@@ -1,5 +1,5 @@
 -- #################################################################################################
--- # << NEORV32 - CPU Co-Processor: Bit-Manipulation Co-Processor Unit (RISC-V "B" Extension) >>   #
+-- # << NEORV32 CPU - Co-Processor: Bit-Manipulation Co-Processor Unit (RISC-V "B" Extension) >>   #
 -- # ********************************************************************************************* #
 -- # Supported B sub-extensions (Zb*):                                                             #
 -- # - Zba: Address-generation instructions                                                        #

--- a/rtl/core/neorv32_cpu_cp_cfu.vhd
+++ b/rtl/core/neorv32_cpu_cp_cfu.vhd
@@ -1,5 +1,5 @@
 -- #################################################################################################
--- # << NEORV32 - CPU Co-Processor: Custom (Instructions) Functions Unit >>                        #
+-- # << NEORV32 CPU - Co-Processor: Custom (Instructions) Functions Unit >>                        #
 -- # ********************************************************************************************* #
 -- # For user-defined custom RISC-V instructions (R3-type, R4-type and R5-type formats).           #
 -- # See the CPU's documentation for more information.                                             #

--- a/rtl/core/neorv32_cpu_cp_cond.vhd
+++ b/rtl/core/neorv32_cpu_cp_cond.vhd
@@ -1,5 +1,5 @@
 -- #################################################################################################
--- # << NEORV32 - CPU Co-Processor: RISC-V Conditional Operations ('Zicond') ISA Extension >>      #
+-- # << NEORV32 CPU - Co-Processor: RISC-V Conditional Operations ('Zicond') ISA Extension >>      #
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #

--- a/rtl/core/neorv32_cpu_cp_fpu.vhd
+++ b/rtl/core/neorv32_cpu_cp_fpu.vhd
@@ -1,5 +1,5 @@
 -- #################################################################################################
--- # << NEORV32 - CPU Co-Processor: Single-Prec. Floating Point Unit (RISC-V "Zfinx" Extension) >> #
+-- # << NEORV32 CPU - Co-Processor: Single-Prec. Floating Point Unit (RISC-V "Zfinx" Extension) >> #
 -- # ********************************************************************************************* #
 -- # The Zfinx floating-point extension uses the integer register file (x) for all FP operations.  #
 -- # See the official RISC-V specs (https://github.com/riscv/riscv-zfinx) for more information.    #

--- a/rtl/core/neorv32_cpu_cp_fpu.vhd
+++ b/rtl/core/neorv32_cpu_cp_fpu.vhd
@@ -58,19 +58,23 @@ use neorv32.neorv32_package.all;
 entity neorv32_cpu_cp_fpu is
   port (
     -- global control --
-    clk_i    : in  std_ulogic; -- global clock, rising edge
-    rstn_i   : in  std_ulogic; -- global reset, low-active, async
-    ctrl_i   : in  ctrl_bus_t; -- main control bus
-    start_i  : in  std_ulogic; -- trigger operation
+    clk_i       : in  std_ulogic; -- global clock, rising edge
+    rstn_i      : in  std_ulogic; -- global reset, low-active, async
+    ctrl_i      : in  ctrl_bus_t; -- main control bus
+    start_i     : in  std_ulogic; -- trigger operation
+    -- CSR interface --
+    csr_we_i    : in  std_ulogic; -- global write enable
+    csr_addr_i  : in  std_ulogic_vector(11 downto 0); -- address
+    csr_wdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- write data
+    csr_rdata_o : out std_ulogic_vector(XLEN-1 downto 0); -- read data
     -- data input --
-    cmp_i    : in  std_ulogic_vector(1 downto 0); -- comparator status
-    rs1_i    : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
-    rs2_i    : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
-    rs3_i    : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 3
+    cmp_i       : in  std_ulogic_vector(1 downto 0); -- comparator status
+    rs1_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+    rs2_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
+    rs3_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 3
     -- result and status --
-    res_o    : out std_ulogic_vector(XLEN-1 downto 0); -- operation result
-    fflags_o : out std_ulogic_vector(4 downto 0); -- exception flags
-    valid_o  : out std_ulogic -- data output valid
+    res_o       : out std_ulogic_vector(XLEN-1 downto 0); -- operation result
+    valid_o     : out std_ulogic -- data output valid
   );
 end neorv32_cpu_cp_fpu;
 
@@ -85,6 +89,11 @@ architecture neorv32_cpu_cp_fpu_rtl of neorv32_cpu_cp_fpu is
   constant op_minmax_c : std_ulogic_vector(2 downto 0) := "101";
   constant op_addsub_c : std_ulogic_vector(2 downto 0) := "110";
   constant op_mul_c    : std_ulogic_vector(2 downto 0) := "111";
+
+  -- FPU CSRs --
+  signal csr_frm    : std_ulogic_vector(2 downto 0); -- FPU rounding mode
+  signal csr_fflags : std_ulogic_vector(4 downto 0); -- FPU exception flags
+  signal fflags     : std_ulogic_vector(4 downto 0); -- exception flags
 
   -- float-to-integer unit --
   component neorv32_cpu_cp_fpu_f2i
@@ -224,9 +233,9 @@ architecture neorv32_cpu_cp_fpu_rtl of neorv32_cpu_cp_fpu is
     -- input comparison --
     exp_comp  : std_ulogic_vector(01 downto 0); -- equal & less
     small_exp : std_ulogic_vector(07 downto 0);
-    small_man : std_ulogic_vector(23 downto 0); -- mantissa + hiden one
+    small_man : std_ulogic_vector(23 downto 0); -- mantissa + hidden one
     large_exp : std_ulogic_vector(07 downto 0);
-    large_man : std_ulogic_vector(23 downto 0); -- mantissa + hiden one
+    large_man : std_ulogic_vector(23 downto 0); -- mantissa + hidden one
     -- smaller mantissa alginment --
     man_sreg  : std_ulogic_vector(23 downto 0); -- mantissa + hidden one
     man_g_ext : std_ulogic;
@@ -235,8 +244,8 @@ architecture neorv32_cpu_cp_fpu_rtl of neorv32_cpu_cp_fpu is
     exp_cnt   : std_ulogic_vector(08 downto 0);
     -- adder/subtractor stage --
     man_comp  : std_ulogic;
-    man_s     : std_ulogic_vector(26 downto 0); -- mantissa + hiden one + GRS
-    man_l     : std_ulogic_vector(26 downto 0); -- mantissa + hiden one + GRS
+    man_s     : std_ulogic_vector(26 downto 0); -- mantissa + hidden one + GRS
+    man_l     : std_ulogic_vector(26 downto 0); -- mantissa + hidden one + GRS
     add_stage : std_ulogic_vector(27 downto 0); -- adder result incl. overflow
     -- result --
     res_sign  : std_ulogic;
@@ -270,6 +279,52 @@ begin
 -- ****************************************************************************************************************************
 -- Control
 -- ****************************************************************************************************************************
+
+  -- CSR Access -----------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+
+  -- write access --
+  csr_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      csr_frm    <= (others => '0');
+      csr_fflags <= (others => '0');
+    elsif rising_edge(clk_i) then
+      if (csr_we_i = '1') then
+        if (csr_addr_i(11 downto 2) = csr_fflags_c(11 downto 2)) then
+          -- exception flags --
+          if (csr_addr_i(1 downto 0) = csr_fflags_c(1 downto 0)) then
+            csr_fflags <= csr_wdata_i(4 downto 0);
+          end if;
+          -- rounding mode --
+          if (csr_addr_i(1 downto 0) = csr_frm_c(1 downto 0)) then
+            csr_frm <= csr_wdata_i(2 downto 0);
+          end if;
+          -- control/status (frm & fflags) --
+          if (csr_addr_i(1 downto 0) = csr_fcsr_c(1 downto 0)) then
+            csr_frm    <= csr_wdata_i(7 downto 5);
+            csr_fflags <= csr_wdata_i(4 downto 0);
+          end if;
+        end if;
+      else -- auto-update
+        csr_fflags <= csr_fflags or fflags;
+      end if;
+    end if;
+  end process csr_write;
+
+
+  -- read access --
+  csr_read: process(csr_addr_i, csr_fflags, csr_frm)
+  begin
+    csr_rdata_o <= (others => '0'); -- default
+    case csr_addr_i is
+      when csr_fflags_c => csr_rdata_o(4 downto 0) <= csr_fflags; -- exception flags
+      when csr_frm_c    => csr_rdata_o(2 downto 0) <= csr_frm; -- rounding mode
+      when csr_fcsr_c   => csr_rdata_o(7 downto 0) <= csr_frm & csr_fflags; -- control/status (frm & fflags)
+      when others       => NULL;
+    end case;
+  end process csr_read;
+
 
   -- Instruction Decoding -------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -379,7 +434,7 @@ begin
           -- rounding mode --
           -- TODO / FIXME "round to nearest, ties to max magnitude" (0b100) is not supported yet
           if (ctrl_i.ir_funct3 = "111") then
-            fpu_operands.frm <= '0' & ctrl_i.alu_frm(1 downto 0);
+            fpu_operands.frm <= '0' & csr_frm(1 downto 0);
           else
             fpu_operands.frm <= '0' & ctrl_i.ir_funct3(1 downto 0);
           end if;
@@ -1114,27 +1169,27 @@ begin
       if (ctrl_engine.valid = '1') then
         case funct_ff is
           when op_class_c =>
-            res_o    <= fu_classify.result;
-            fflags_o <= fu_classify.flags;
+            res_o  <= fu_classify.result;
+            fflags <= fu_classify.flags;
           when op_comp_c =>
-            res_o    <= fu_compare.result;
-            fflags_o <= fu_compare.flags;
+            res_o  <= fu_compare.result;
+            fflags <= fu_compare.flags;
           when op_f2i_c =>
-            res_o    <= fu_conv_f2i.result;
-            fflags_o <= fu_conv_f2i.flags;
+            res_o  <= fu_conv_f2i.result;
+            fflags <= fu_conv_f2i.flags;
           when op_sgnj_c =>
-            res_o    <= fu_sign_inject.result;
-            fflags_o <= fu_sign_inject.flags;
+            res_o  <= fu_sign_inject.result;
+            fflags <= fu_sign_inject.flags;
           when op_minmax_c =>
-            res_o    <= fu_min_max.result;
-            fflags_o <= fu_min_max.flags;
+            res_o  <= fu_min_max.result;
+            fflags <= fu_min_max.flags;
           when others => -- op_mul_c, op_addsub_c, op_i2f_c, ...
-            res_o    <= normalizer.result;
-            fflags_o <= normalizer.flags_out;
+            res_o  <= normalizer.result;
+            fflags <= normalizer.flags_out;
         end case;
       else
-        res_o    <= (others => '0');
-        fflags_o <= (others => '0');
+        res_o  <= (others => '0');
+        fflags <= (others => '0');
       end if;
     end if;
   end process output_gate;

--- a/rtl/core/neorv32_cpu_cp_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_cp_muldiv.vhd
@@ -1,5 +1,5 @@
 -- #################################################################################################
--- # << NEORV32 - CPU Co-Processor: Integer Multiplier/Divider Unit (RISC-V "M" Extension) >>      #
+-- # << NEORV32 CPU - Co-Processor: Integer Multiplier/Divider Unit (RISC-V "M" Extension) >>      #
 -- # ********************************************************************************************* #
 -- # Multiplier core (signed/unsigned) uses serial add-and-shift algorithm. Multiplications can be #
 -- # mapped to DSP blocks (faster!) when FAST_MUL_EN = true. Divider core (unsigned-only; pre and  #

--- a/rtl/core/neorv32_cpu_cp_shifter.vhd
+++ b/rtl/core/neorv32_cpu_cp_shifter.vhd
@@ -1,5 +1,5 @@
 -- #################################################################################################
--- # << NEORV32 - CPU Co-Processor: Shifter (CPU Base ISA) >>                                      #
+-- # << NEORV32 CPU - Co-Processor: Shifter (CPU Base ISA) >>                                      #
 -- # ********************************************************************************************* #
 -- # FAST_SHIFT_EN = false (default) : Use bit-serial shifter architecture (small but slow)        #
 -- # FAST_SHIFT_EN = true            : Use barrel shifter architecture (large but fast)            #

--- a/rtl/core/neorv32_cpu_decompressor.vhd
+++ b/rtl/core/neorv32_cpu_decompressor.vhd
@@ -1,5 +1,5 @@
 -- #################################################################################################
--- # << NEORV32 - CPU: Compressed Instructions Decoder (RISC-V "C" Extension) >>                   #
+-- # << NEORV32 CPU - Compressed Instructions Decoder (RISC-V "C" Extension) >>                    #
 -- # ********************************************************************************************* #
 -- # Compressed instructions decoder compatible to the RISC-V C ISA extensions. Illegal compressed #
 -- # instructions are output "as-is".                                                              #
@@ -180,7 +180,7 @@ begin
             if (ci_instr16_i(12 downto 5) = "00000000") or -- canonical illegal C instruction or C.ADDI4SPN with nzuimm = 0
                (ci_instr16_i(ci_funct3_msb_c downto ci_funct3_lsb_c) = "001") or -- C.FLS / C.LQ
                (ci_instr16_i(ci_funct3_msb_c downto ci_funct3_lsb_c) = "100") or -- reserved
-               (ci_instr16_i(ci_funct3_msb_c downto ci_funct3_lsb_c) = "101") then -- C.C.FSD / C.SQ
+               (ci_instr16_i(ci_funct3_msb_c downto ci_funct3_lsb_c) = "101") then -- C.FSD / C.SQ
               illegal <= '1';
             end if;
 

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -1,0 +1,368 @@
+-- #################################################################################################
+-- # << NEORV32 CPU - Physical Memory Protection Unit >>                                           #
+-- # ********************************************************************************************* #
+-- # BSD 3-Clause License                                                                          #
+-- #                                                                                               #
+-- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+-- #                                                                                               #
+-- # Redistribution and use in source and binary forms, with or without modification, are          #
+-- # permitted provided that the following conditions are met:                                     #
+-- #                                                                                               #
+-- # 1. Redistributions of source code must retain the above copyright notice, this list of        #
+-- #    conditions and the following disclaimer.                                                   #
+-- #                                                                                               #
+-- # 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
+-- #    conditions and the following disclaimer in the documentation and/or other materials        #
+-- #    provided with the distribution.                                                            #
+-- #                                                                                               #
+-- # 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
+-- #    endorse or promote products derived from this software without specific prior written      #
+-- #    permission.                                                                                #
+-- #                                                                                               #
+-- # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
+-- # OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
+-- # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
+-- # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
+-- # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
+-- # GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
+-- # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
+-- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
+-- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
+-- # ********************************************************************************************* #
+-- # The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32       (c) Stephan Nolting #
+-- #################################################################################################
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library neorv32;
+use neorv32.neorv32_package.all;
+
+entity neorv32_cpu_pmp is
+  generic (
+    NUM_REGIONS : natural; -- number of regions (0..16)
+    GRANULARITY : natural  -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
+  );
+  port (
+    -- global control --
+    clk_i       : in  std_ulogic; -- global clock, rising edge
+    rstn_i      : in  std_ulogic; -- global reset, low-active, async
+    ctrl_i      : in  ctrl_bus_t; -- main control bus
+    -- CSR interface --
+    csr_we_i    : in  std_ulogic; -- global write enable
+    csr_addr_i  : in  std_ulogic_vector(11 downto 0); -- address
+    csr_wdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- write data
+    csr_rdata_o : out std_ulogic_vector(XLEN-1 downto 0); -- read data
+    -- address input --
+    addr_if_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- instruction fetch address
+    addr_ls_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- load/store address
+    -- faults --
+    fault_if_o  : out std_ulogic; -- instruction fetch fault
+    fault_ld_o  : out std_ulogic; -- data load fault
+    fault_st_o  : out std_ulogic  -- data store fault
+  );
+end neorv32_cpu_pmp;
+
+architecture neorv32_cpu_pmp_rtl of neorv32_cpu_pmp is
+
+  -- PMP configuration register bits --
+  constant cfg_r_c  : natural := 0; -- read permit
+  constant cfg_w_c  : natural := 1; -- write permit
+  constant cfg_x_c  : natural := 2; -- execute permit
+  constant cfg_al_c : natural := 3; -- mode bit low
+  constant cfg_ah_c : natural := 4; -- mode bit high
+  constant cfg_rl_c : natural := 5; -- reserved
+  constant cfg_rh_c : natural := 6; -- reserved
+  constant cfg_l_c  : natural := 7; -- locked entry
+
+  -- PMP modes --
+  constant mode_off_c   : std_ulogic_vector(1 downto 0) := "00"; -- null region (disabled)
+  constant mode_tor_c   : std_ulogic_vector(1 downto 0) := "01"; -- top of range
+  constant mode_na4_c   : std_ulogic_vector(1 downto 0) := "10"; -- naturally aligned four-byte region
+  constant mode_napot_c : std_ulogic_vector(1 downto 0) := "11"; -- naturally aligned power-of-two region (>= 8 bytes)
+
+  -- PMP helpers --
+  constant pmp_lsb_c  : natural := index_size_f(GRANULARITY); -- min = 2
+  constant pmp_zero_c : std_ulogic_vector(XLEN-1 downto pmp_lsb_c) := (others => '0');
+
+  -- PMP CSRs --
+  type csr_cfg_t      is array (0 to NUM_REGIONS-1) of std_ulogic_vector(7 downto 0);
+  type csr_addr_t     is array (0 to NUM_REGIONS-1) of std_ulogic_vector(XLEN-1 downto 0);
+  type csr_cfg_rd_t   is array (0 to 15) of std_ulogic_vector(7 downto 0);
+  type csr_cfg_rd32_t is array (0 to 03) of std_ulogic_vector(XLEN-1 downto 0);
+  type csr_addr_rd_t  is array (0 to 15) of std_ulogic_vector(XLEN-1 downto 0);
+  type csr_t is record
+    we_cfg  : std_ulogic_vector(03 downto 0);
+    we_addr : std_ulogic_vector(15 downto 0);
+    cfg     : csr_cfg_t;
+    addr    : csr_addr_t;
+  end record;
+  signal csr      : csr_t;
+  signal cfg_rd   : csr_cfg_rd_t;
+  signal cfg_rd32 : csr_cfg_rd32_t;
+  signal addr_rd  : csr_addr_rd_t;
+
+  -- PMP address extension to 34 bit --
+  type xaddr_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(XLEN+1 downto 0);
+  signal xaddr : xaddr_t;
+
+  -- access permission check --
+  type addr_mask_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(XLEN-1 downto pmp_lsb_c);
+  signal addr_mask_napot, addr_mask : addr_mask_t;
+  type check_t is record
+    i_cmp_mm : std_ulogic_vector(NUM_REGIONS-1 downto 0);
+    i_cmp_ge : std_ulogic_vector(NUM_REGIONS-1 downto 0);
+    i_cmp_lt : std_ulogic_vector(NUM_REGIONS-1 downto 0);
+    d_cmp_mm : std_ulogic_vector(NUM_REGIONS-1 downto 0);
+    d_cmp_ge : std_ulogic_vector(NUM_REGIONS-1 downto 0);
+    d_cmp_lt : std_ulogic_vector(NUM_REGIONS-1 downto 0);
+    i_match  : std_ulogic_vector(NUM_REGIONS-1 downto 0);
+    d_match  : std_ulogic_vector(NUM_REGIONS-1 downto 0);
+    perm_ex  : std_ulogic_vector(NUM_REGIONS-1 downto 0);
+    perm_rd  : std_ulogic_vector(NUM_REGIONS-1 downto 0);
+    perm_wr  : std_ulogic_vector(NUM_REGIONS-1 downto 0);
+    fail_ex  : std_ulogic_vector(NUM_REGIONS   downto 0);
+    fail_rd  : std_ulogic_vector(NUM_REGIONS   downto 0);
+    fail_wr  : std_ulogic_vector(NUM_REGIONS   downto 0);
+  end record;
+  signal check : check_t;
+
+begin
+
+  -- Sanity Checks --------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  assert not (NUM_REGIONS > 16) report
+    "NEORV32 CPU CONFIG ERROR! Number of PMP regions out of valid range (0..16)." severity error;
+
+  assert not (is_power_of_two_f(GRANULARITY) = false) report
+    "NEORV32 CPU CONFIG ERROR! PMP granularity has to be a power of two." severity error;
+
+  assert not (GRANULARITY < 4) report
+    "NEORV32 CPU CONFIG ERROR! PMP granularity has to be at least 4 bytes." severity error;
+
+
+  -- CSR Write Access -----------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  csr_we: process(csr_we_i, csr_addr_i) -- write enable decoder
+  begin
+    -- Configuration registers --
+    csr.we_cfg <= (others => '0');
+    if (csr_addr_i(11 downto 2) = csr_pmpcfg0_c(11 downto 2)) and (csr_we_i = '1') then
+      csr.we_cfg(to_integer(unsigned(csr_addr_i(1 downto 0)))) <= '1';
+    end if;
+    -- Address registers --
+    csr.we_addr <= (others => '0');
+    if (csr_addr_i(11 downto 4) = csr_pmpaddr0_c(11 downto 4)) and (csr_we_i = '1') then
+      csr.we_addr(to_integer(unsigned(csr_addr_i(3 downto 0)))) <= '1';
+    end if;
+  end process csr_we;
+
+
+  -- PMP CSR registers --
+  csr_reg_gen:
+  for i in 0 to NUM_REGIONS-1 generate
+    csr_reg: process(rstn_i, clk_i)
+    begin
+      if (rstn_i = '0') then
+        csr.cfg(i)  <= (others => '0');
+        csr.addr(i) <= (others => '0');
+      elsif rising_edge(clk_i) then
+
+        -- configuration --
+        if (csr.we_cfg(i/4) = '1') and (csr.cfg(i)(7) = '0') then -- unlocked write access
+          csr.cfg(i)(cfg_r_c) <= csr_wdata_i((i mod 4)*8+0); -- R (read)
+          csr.cfg(i)(cfg_w_c) <= csr_wdata_i((i mod 4)*8+1); -- W (write)
+          csr.cfg(i)(cfg_x_c) <= csr_wdata_i((i mod 4)*8+2); -- X (execute)
+          if (GRANULARITY > 4) and (csr_wdata_i((i mod 4)*8+4 downto (i mod 4)*8+3) = mode_na4_c) then
+            csr.cfg(i)(cfg_ah_c downto cfg_al_c) <= mode_off_c; -- NA4 not available, fall back to OFF
+          else
+            csr.cfg(i)(cfg_ah_c downto cfg_al_c) <= csr_wdata_i((i mod 4)*8+4 downto (i mod 4)*8+3); -- A (mode)
+          end if;
+          csr.cfg(i)(cfg_rl_c) <= '0'; -- reserved
+          csr.cfg(i)(cfg_rh_c) <= '0'; -- reserved
+          csr.cfg(i)(cfg_l_c)  <= csr_wdata_i((i mod 4)*8+7); -- L (locked)
+        end if;
+
+        -- address --
+        if (csr.we_addr(i) = '1') and (csr.cfg(i)(cfg_l_c) = '0') then -- unlocked write access
+          if (i < NUM_REGIONS-1) then
+            if (csr.cfg(i+1)(cfg_l_c) = '0') or (csr.cfg(i+1)(cfg_ah_c downto cfg_al_c) /= mode_tor_c) then -- cfg(i+1) not "LOCKED TOR"
+              csr.addr(i) <= "00" & csr_wdata_i(XLEN-3 downto 0);
+            end if;
+          else -- very last entry
+            csr.addr(i) <= "00" & csr_wdata_i(XLEN-3 downto 0);
+          end if;
+        end if;
+
+      end if;
+    end process csr_reg;
+  end generate;
+
+
+  -- CSR Read Access ------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  csr_read_access: process(csr_addr_i, cfg_rd32, addr_rd)
+  begin
+    if (csr_addr_i(11 downto 5) = csr_pmpcfg0_c(11 downto 5)) then -- PMP CSR
+      if (csr_addr_i(4) = '0') then -- PMP configuration CSR
+        csr_rdata_o <= cfg_rd32(to_integer(unsigned(csr_addr_i(1 downto 0))));
+      else -- PMP address CSR
+        csr_rdata_o <= addr_rd(to_integer(unsigned(csr_addr_i(3 downto 0))));
+      end if;
+    else
+      csr_rdata_o <= (others => '0');
+    end if;
+  end process csr_read_access;
+
+
+  -- CSR read-back --
+  csr_read_back_gen:
+  for i in 0 to NUM_REGIONS-1 generate
+    -- configuration --
+    cfg_rd(i) <= csr.cfg(i);
+    -- address --
+    address_read_back: process(csr)
+    begin
+      addr_rd(i) <= (others => '0');
+      addr_rd(i)(XLEN-1 downto pmp_lsb_c-2) <= csr.addr(i)(XLEN-1 downto pmp_lsb_c-2);
+      if (GRANULARITY = 8) then -- bit [G-1] reads as zero in TOR or OFF mode
+        if (csr.cfg(i)(cfg_ah_c) = '0') then -- TOR/OFF mode
+          addr_rd(i)(pmp_lsb_c) <= '0';
+        end if;
+      elsif (GRANULARITY > 8) then
+        addr_rd(i)(pmp_lsb_c-2 downto 0) <= (others => '1'); -- in NAPOT mode bits [G-2:0] must read as one
+        if (csr.cfg(i)(cfg_ah_c) = '0') then -- TOR/OFF mode
+          addr_rd(i)(pmp_lsb_c-1 downto 0) <= (others => '0'); -- in TOR or OFF mode bits [G-1:0] must read as zero
+        end if;
+      end if;
+    end process address_read_back;
+  end generate;
+
+  -- terminate unused CSR read-backs --
+  csr_read_back_terminate:
+  for i in NUM_REGIONS to 15 generate
+    cfg_rd(i)  <= (others => '0');
+    addr_rd(i) <= (others => '0');
+  end generate;
+
+  -- pack configuration read-back --
+  cfg_rd32(0) <= cfg_rd(03) & cfg_rd(02) & cfg_rd(01) & cfg_rd(00);
+  cfg_rd32(1) <= cfg_rd(07) & cfg_rd(06) & cfg_rd(05) & cfg_rd(04);
+  cfg_rd32(2) <= cfg_rd(11) & cfg_rd(10) & cfg_rd(09) & cfg_rd(08);
+  cfg_rd32(3) <= cfg_rd(15) & cfg_rd(14) & cfg_rd(13) & cfg_rd(12);
+
+
+  -- Access Check Logic ---------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  region_gen:
+  for r in 0 to NUM_REGIONS-1 generate
+
+    -- extend region addresses to 34-bit --
+    xaddr(r) <= csr.addr(r) & "00"; -- mask byte offset
+
+
+    -- compute address masks for NAPOT mode --
+    addr_mask_napot(r)(pmp_lsb_c) <= '0';
+    addr_mask_napot_gen:
+    for i in pmp_lsb_c+1 to XLEN-1 generate
+      addr_mask_napot(r)(i) <= addr_mask_napot(r)(i-1) or (not xaddr(r)(i-1));
+    end generate;
+    
+    -- address mask select --
+    addr_masking: process(rstn_i, clk_i)
+    begin
+      if (rstn_i = '0') then
+        addr_mask(r) <= (others => '0');
+      elsif rising_edge(clk_i) then -- register output to relax timing of the (huge!) comparator logic
+        if (csr.cfg(r)(cfg_al_c) = '1') then -- NAPOT
+          addr_mask(r) <= addr_mask_napot(r);
+        else -- NA4
+          addr_mask(r) <= (others => '1');
+        end if;
+      end if;
+    end process addr_masking;
+
+
+    -- check region address match --
+    -- NA4 and NAPOT --
+    check.i_cmp_mm(r) <= '1' when ((addr_if_i(XLEN-1 downto pmp_lsb_c) and addr_mask(r)) = (xaddr(r)(XLEN-1 downto pmp_lsb_c) and addr_mask(r))) else '0';
+    check.d_cmp_mm(r) <= '1' when ((addr_ls_i(XLEN-1 downto pmp_lsb_c) and addr_mask(r)) = (xaddr(r)(XLEN-1 downto pmp_lsb_c) and addr_mask(r))) else '0';
+    -- TOR region 0 --
+    addr_check_r0_gen:
+    if (r = 0) generate -- first entry: use ZERO as base and current entry as bound
+      check.i_cmp_ge(r) <= '1'; -- address is always greater than or equal to zero
+      check.i_cmp_lt(r) <= '0'; -- unused
+      check.d_cmp_ge(r) <= '1'; -- address is always greater than or equal to zero
+      check.d_cmp_lt(r) <= '0'; -- unused
+    end generate;
+    -- TOR region any --
+    addr_check_rx_gen:
+    if (r > 0) generate -- use previous entry as base and current entry as bound
+      check.i_cmp_ge(r) <= '1' when (unsigned(addr_if_i(XLEN-1 downto pmp_lsb_c)) >= unsigned(xaddr(r-1)(XLEN-1 downto pmp_lsb_c))) else '0';
+      check.i_cmp_lt(r) <= '1' when (unsigned(addr_if_i(XLEN-1 downto pmp_lsb_c)) <  unsigned(xaddr(r  )(XLEN-1 downto pmp_lsb_c))) else '0';
+      check.d_cmp_ge(r) <= '1' when (unsigned(addr_ls_i(XLEN-1 downto pmp_lsb_c)) >= unsigned(xaddr(r-1)(XLEN-1 downto pmp_lsb_c))) else '0';
+      check.d_cmp_lt(r) <= '1' when (unsigned(addr_ls_i(XLEN-1 downto pmp_lsb_c)) <  unsigned(xaddr(r  )(XLEN-1 downto pmp_lsb_c))) else '0';
+    end generate;
+
+
+    -- check region match according to configured mode --
+    match_check: process(csr, check)
+    begin
+      case csr.cfg(r)(cfg_ah_c downto cfg_al_c) is
+        when mode_off_c => -- entry disabled
+          check.i_match(r) <= '0';
+          check.d_match(r) <= '0';
+        when mode_tor_c => -- top of region
+          if (r = (NUM_REGIONS-1)) then -- very last entry
+            check.i_match(r) <= check.i_cmp_ge(r) and check.i_cmp_lt(r);
+            check.d_match(r) <= check.d_cmp_ge(r) and check.d_cmp_lt(r);
+          else -- this saves a LOT of comparators
+            check.i_match(r) <= check.i_cmp_ge(r) and (not check.i_cmp_ge(r+1));
+            check.d_match(r) <= check.d_cmp_ge(r) and (not check.d_cmp_ge(r+1));
+          end if;
+        when others => -- naturally-aligned region
+          check.i_match(r) <= check.i_cmp_mm(r);
+          check.d_match(r) <= check.d_cmp_mm(r);
+        end case;
+    end process match_check;
+
+
+    -- generate permission bits --
+    -- M mode: always allow if lock bit not set, otherwise check permission
+    check.perm_ex(r) <= csr.cfg(r)(cfg_x_c) or (not csr.cfg(r)(cfg_l_c)) when (ctrl_i.cpu_priv = priv_mode_m_c) else csr.cfg(r)(cfg_x_c);
+    check.perm_rd(r) <= csr.cfg(r)(cfg_r_c) or (not csr.cfg(r)(cfg_l_c)) when (ctrl_i.lsu_priv = priv_mode_m_c) else csr.cfg(r)(cfg_r_c);
+    check.perm_wr(r) <= csr.cfg(r)(cfg_w_c) or (not csr.cfg(r)(cfg_l_c)) when (ctrl_i.lsu_priv = priv_mode_m_c) else csr.cfg(r)(cfg_w_c);
+
+  end generate;
+
+
+  -- check for access fault (using static prioritization) --
+  check.fail_ex(NUM_REGIONS) <= '1' when (ctrl_i.cpu_priv /= priv_mode_m_c) else '0'; -- default: fault if not M-mode
+  check.fail_rd(NUM_REGIONS) <= '1' when (ctrl_i.lsu_priv /= priv_mode_m_c) else '0'; -- default: fault if not M-mode
+  check.fail_wr(NUM_REGIONS) <= '1' when (ctrl_i.lsu_priv /= priv_mode_m_c) else '0'; -- default: fault if not M-mode
+  -- this is a *structural* description of a prioritization logic implemented as a multiplexer chain --
+  fault_check_gen:
+  for r in NUM_REGIONS-1 downto 0 generate -- start with lowest priority
+    check.fail_ex(r) <= not check.perm_ex(r) when (check.i_match(r) = '1') else check.fail_ex(r+1);
+    check.fail_rd(r) <= not check.perm_rd(r) when (check.d_match(r) = '1') else check.fail_rd(r+1);
+    check.fail_wr(r) <= not check.perm_wr(r) when (check.d_match(r) = '1') else check.fail_wr(r+1);
+  end generate;
+
+
+  -- final PMP access fault signals (bypass PMP rules when in debug mode) --
+  fault_reg: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      fault_if_o <= '0';
+      fault_ld_o <= '0';
+      fault_st_o <= '0';
+    elsif rising_edge(clk_i) then
+      fault_if_o <= (not ctrl_i.cpu_debug) and check.fail_ex(0);
+      fault_ld_o <= (not ctrl_i.cpu_debug) and check.fail_rd(0);
+      fault_st_o <= (not ctrl_i.cpu_debug) and check.fail_wr(0);
+    end if;
+  end process fault_reg;
+
+
+end neorv32_cpu_pmp_rtl;

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -268,7 +268,7 @@ begin
     for i in pmp_lsb_c+1 to XLEN-1 generate
       addr_mask_napot(r)(i) <= addr_mask_napot(r)(i-1) or (not xaddr(r)(i-1));
     end generate;
-    
+
     -- address mask select --
     addr_masking: process(rstn_i, clk_i)
     begin

--- a/rtl/core/neorv32_cpu_regfile.vhd
+++ b/rtl/core/neorv32_cpu_regfile.vhd
@@ -1,5 +1,5 @@
 -- #################################################################################################
--- # << NEORV32 - CPU General Purpose Data Register File >>                                        #
+-- # << NEORV32 CPU - General Purpose Data Register File >>                                        #
 -- # ********************************************************************************************* #
 -- # Data register file. 32 entries (= 1024 bit) for RV32I ISA (default), 16 entries (= 512 bit)   #
 -- # for RV32E ISA (when RISC-V "E" extension is enabled).                                         #
@@ -108,7 +108,7 @@ begin
   end process wb_select;
 
 
-  -- Register File Access -------------------------------------------------------------------
+  -- Access Logic ---------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   -- access addresses --
   opa_addr <= "00000" when (ctrl_i.rf_zero_we = '1') else -- force rd = zero

--- a/rtl/core/neorv32_intercon.vhd
+++ b/rtl/core/neorv32_intercon.vhd
@@ -604,52 +604,22 @@ architecture neorv32_bus_io_switch_rtl of neorv32_bus_io_switch is
   -- list of device base addresses --
   type dev_base_list_t is array (0 to num_devs_physical_c-1) of std_ulogic_vector(31 downto 0);
   constant dev_base_list_c : dev_base_list_t := (
-    DEV_00_BASE,
-    DEV_01_BASE,
-    DEV_02_BASE,
-    DEV_03_BASE,
-    DEV_04_BASE,
-    DEV_05_BASE,
-    DEV_06_BASE,
-    DEV_07_BASE,
-    DEV_08_BASE,
-    DEV_09_BASE,
-    DEV_10_BASE,
-    DEV_11_BASE,
-    DEV_12_BASE,
-    DEV_13_BASE,
-    DEV_14_BASE,
-    DEV_15_BASE,
-    DEV_16_BASE,
-    DEV_17_BASE,
-    DEV_18_BASE,
-    DEV_19_BASE,
+    DEV_00_BASE, DEV_01_BASE, DEV_02_BASE, DEV_03_BASE,
+    DEV_04_BASE, DEV_05_BASE, DEV_06_BASE, DEV_07_BASE,
+    DEV_08_BASE, DEV_09_BASE, DEV_10_BASE, DEV_11_BASE,
+    DEV_12_BASE, DEV_13_BASE, DEV_14_BASE, DEV_15_BASE,
+    DEV_16_BASE, DEV_17_BASE, DEV_18_BASE, DEV_19_BASE,
     DEV_20_BASE
   );
 
   -- list of enabled device ports --
   type dev_en_list_t is array (0 to num_devs_physical_c-1) of boolean;
   constant dev_en_list_c : dev_en_list_t := (
-    DEV_00_EN,
-    DEV_01_EN,
-    DEV_02_EN,
-    DEV_03_EN,
-    DEV_04_EN,
-    DEV_05_EN,
-    DEV_06_EN,
-    DEV_07_EN,
-    DEV_08_EN,
-    DEV_09_EN,
-    DEV_10_EN,
-    DEV_11_EN,
-    DEV_12_EN,
-    DEV_13_EN,
-    DEV_14_EN,
-    DEV_15_EN,
-    DEV_16_EN,
-    DEV_17_EN,
-    DEV_18_EN,
-    DEV_19_EN,
+    DEV_00_EN, DEV_01_EN, DEV_02_EN, DEV_03_EN,
+    DEV_04_EN, DEV_05_EN, DEV_06_EN, DEV_07_EN,
+    DEV_08_EN, DEV_09_EN, DEV_10_EN, DEV_11_EN,
+    DEV_12_EN, DEV_13_EN, DEV_14_EN, DEV_15_EN,
+    DEV_16_EN, DEV_17_EN, DEV_18_EN, DEV_19_EN,
     DEV_20_EN
   );
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -51,15 +51,12 @@ package neorv32_package is
   -- = cycles after which an *unacknowledged* internal bus access will timeout and trigger a bus fault exception
   constant max_proc_int_response_time_c : natural := 15; -- default = 15
 
-  -- log2 of co-processor timeout cycles --
-  constant cp_timeout_c : natural := 7; -- default = 7 (= 128 cycles)
-
   -- instruction prefetch buffer depth --
   constant ipb_depth_c : natural := 2; -- hast to be a power of two, min 2, default 2
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080704"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080705"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 
@@ -395,18 +392,6 @@ package neorv32_package is
   constant csr_pmpcfg1_c        : std_ulogic_vector(11 downto 0) := x"3a1";
   constant csr_pmpcfg2_c        : std_ulogic_vector(11 downto 0) := x"3a2";
   constant csr_pmpcfg3_c        : std_ulogic_vector(11 downto 0) := x"3a3";
-  constant csr_pmpcfg4_c        : std_ulogic_vector(11 downto 0) := x"3a4";
-  constant csr_pmpcfg5_c        : std_ulogic_vector(11 downto 0) := x"3a5";
-  constant csr_pmpcfg6_c        : std_ulogic_vector(11 downto 0) := x"3a6";
-  constant csr_pmpcfg7_c        : std_ulogic_vector(11 downto 0) := x"3a7";
-  constant csr_pmpcfg8_c        : std_ulogic_vector(11 downto 0) := x"3a8";
-  constant csr_pmpcfg9_c        : std_ulogic_vector(11 downto 0) := x"3a9";
-  constant csr_pmpcfg10_c       : std_ulogic_vector(11 downto 0) := x"3aa";
-  constant csr_pmpcfg11_c       : std_ulogic_vector(11 downto 0) := x"3ab";
-  constant csr_pmpcfg12_c       : std_ulogic_vector(11 downto 0) := x"3ac";
-  constant csr_pmpcfg13_c       : std_ulogic_vector(11 downto 0) := x"3ad";
-  constant csr_pmpcfg14_c       : std_ulogic_vector(11 downto 0) := x"3ae";
-  constant csr_pmpcfg15_c       : std_ulogic_vector(11 downto 0) := x"3af";
   -- physical memory protection - address --
   constant csr_pmpaddr0_c       : std_ulogic_vector(11 downto 0) := x"3b0";
   constant csr_pmpaddr1_c       : std_ulogic_vector(11 downto 0) := x"3b1";
@@ -424,54 +409,6 @@ package neorv32_package is
   constant csr_pmpaddr13_c      : std_ulogic_vector(11 downto 0) := x"3bd";
   constant csr_pmpaddr14_c      : std_ulogic_vector(11 downto 0) := x"3be";
   constant csr_pmpaddr15_c      : std_ulogic_vector(11 downto 0) := x"3bf";
-  constant csr_pmpaddr16_c      : std_ulogic_vector(11 downto 0) := x"3c0";
-  constant csr_pmpaddr17_c      : std_ulogic_vector(11 downto 0) := x"3c1";
-  constant csr_pmpaddr18_c      : std_ulogic_vector(11 downto 0) := x"3c2";
-  constant csr_pmpaddr19_c      : std_ulogic_vector(11 downto 0) := x"3c3";
-  constant csr_pmpaddr20_c      : std_ulogic_vector(11 downto 0) := x"3c4";
-  constant csr_pmpaddr21_c      : std_ulogic_vector(11 downto 0) := x"3c5";
-  constant csr_pmpaddr22_c      : std_ulogic_vector(11 downto 0) := x"3c6";
-  constant csr_pmpaddr23_c      : std_ulogic_vector(11 downto 0) := x"3c7";
-  constant csr_pmpaddr24_c      : std_ulogic_vector(11 downto 0) := x"3c8";
-  constant csr_pmpaddr25_c      : std_ulogic_vector(11 downto 0) := x"3c9";
-  constant csr_pmpaddr26_c      : std_ulogic_vector(11 downto 0) := x"3ca";
-  constant csr_pmpaddr27_c      : std_ulogic_vector(11 downto 0) := x"3cb";
-  constant csr_pmpaddr28_c      : std_ulogic_vector(11 downto 0) := x"3cc";
-  constant csr_pmpaddr29_c      : std_ulogic_vector(11 downto 0) := x"3cd";
-  constant csr_pmpaddr30_c      : std_ulogic_vector(11 downto 0) := x"3ce";
-  constant csr_pmpaddr31_c      : std_ulogic_vector(11 downto 0) := x"3cf";
-  constant csr_pmpaddr32_c      : std_ulogic_vector(11 downto 0) := x"3d0";
-  constant csr_pmpaddr33_c      : std_ulogic_vector(11 downto 0) := x"3d1";
-  constant csr_pmpaddr34_c      : std_ulogic_vector(11 downto 0) := x"3d2";
-  constant csr_pmpaddr35_c      : std_ulogic_vector(11 downto 0) := x"3d3";
-  constant csr_pmpaddr36_c      : std_ulogic_vector(11 downto 0) := x"3d4";
-  constant csr_pmpaddr37_c      : std_ulogic_vector(11 downto 0) := x"3d5";
-  constant csr_pmpaddr38_c      : std_ulogic_vector(11 downto 0) := x"3d6";
-  constant csr_pmpaddr39_c      : std_ulogic_vector(11 downto 0) := x"3d7";
-  constant csr_pmpaddr40_c      : std_ulogic_vector(11 downto 0) := x"3d8";
-  constant csr_pmpaddr41_c      : std_ulogic_vector(11 downto 0) := x"3d9";
-  constant csr_pmpaddr42_c      : std_ulogic_vector(11 downto 0) := x"3da";
-  constant csr_pmpaddr43_c      : std_ulogic_vector(11 downto 0) := x"3db";
-  constant csr_pmpaddr44_c      : std_ulogic_vector(11 downto 0) := x"3dc";
-  constant csr_pmpaddr45_c      : std_ulogic_vector(11 downto 0) := x"3dd";
-  constant csr_pmpaddr46_c      : std_ulogic_vector(11 downto 0) := x"3de";
-  constant csr_pmpaddr47_c      : std_ulogic_vector(11 downto 0) := x"3df";
-  constant csr_pmpaddr48_c      : std_ulogic_vector(11 downto 0) := x"3e0";
-  constant csr_pmpaddr49_c      : std_ulogic_vector(11 downto 0) := x"3e1";
-  constant csr_pmpaddr50_c      : std_ulogic_vector(11 downto 0) := x"3e2";
-  constant csr_pmpaddr51_c      : std_ulogic_vector(11 downto 0) := x"3e3";
-  constant csr_pmpaddr52_c      : std_ulogic_vector(11 downto 0) := x"3e4";
-  constant csr_pmpaddr53_c      : std_ulogic_vector(11 downto 0) := x"3e5";
-  constant csr_pmpaddr54_c      : std_ulogic_vector(11 downto 0) := x"3e6";
-  constant csr_pmpaddr55_c      : std_ulogic_vector(11 downto 0) := x"3e7";
-  constant csr_pmpaddr56_c      : std_ulogic_vector(11 downto 0) := x"3e8";
-  constant csr_pmpaddr57_c      : std_ulogic_vector(11 downto 0) := x"3e9";
-  constant csr_pmpaddr58_c      : std_ulogic_vector(11 downto 0) := x"3ea";
-  constant csr_pmpaddr59_c      : std_ulogic_vector(11 downto 0) := x"3eb";
-  constant csr_pmpaddr60_c      : std_ulogic_vector(11 downto 0) := x"3ec";
-  constant csr_pmpaddr61_c      : std_ulogic_vector(11 downto 0) := x"3ed";
-  constant csr_pmpaddr62_c      : std_ulogic_vector(11 downto 0) := x"3ee";
-  constant csr_pmpaddr63_c      : std_ulogic_vector(11 downto 0) := x"3ef";
   -- trigger module registers --
   constant csr_tselect_c        : std_ulogic_vector(11 downto 0) := x"7a0";
   constant csr_tdata1_c         : std_ulogic_vector(11 downto 0) := x"7a1";
@@ -628,13 +565,6 @@ package neorv32_package is
   -- machine extended ISA extensions information --
   constant csr_mxisa_c          : std_ulogic_vector(11 downto 0) := x"fc0";
 
-  -- PMP Modes ------------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  constant pmp_mode_off_c   : std_ulogic_vector(1 downto 0) := "00"; -- null region (disabled)
-  constant pmp_mode_tor_c   : std_ulogic_vector(1 downto 0) := "01"; -- top of range
-  constant pmp_mode_na4_c   : std_ulogic_vector(1 downto 0) := "10"; -- naturally aligned four-byte region
-  constant pmp_mode_napot_c : std_ulogic_vector(1 downto 0) := "11"; -- naturally aligned power-of-two region (>= 8 bytes)
-
 -- ****************************************************************************************************************************
 -- CPU Control
 -- ****************************************************************************************************************************
@@ -657,14 +587,14 @@ package neorv32_package is
     alu_unsigned  : std_ulogic;                     -- is unsigned ALU operation
     alu_frm       : std_ulogic_vector(02 downto 0); -- FPU rounding mode
     alu_cp_trig   : std_ulogic_vector(05 downto 0); -- co-processor trigger (one-hot)
-    -- data bus interface --
-    bus_req_rd    : std_ulogic;                     -- trigger memory read request
-    bus_req_wr    : std_ulogic;                     -- trigger memory write request
-    bus_mo_we     : std_ulogic;                     -- memory address and data output register write enable
-    bus_fence     : std_ulogic;                     -- fence operation
-    bus_fencei    : std_ulogic;                     -- fence.i operation
-    bus_priv      : std_ulogic;                     -- effective privilege level for load/store
-    bus_rvso      : std_ulogic;                     -- reservation set operation (atomic LR/SC)
+    -- load/store unit --
+    lsu_req_rd    : std_ulogic;                     -- trigger memory read request
+    lsu_req_wr    : std_ulogic;                     -- trigger memory write request
+    lsu_mo_we     : std_ulogic;                     -- memory address and data output register write enable
+    lsu_fence     : std_ulogic;                     -- fence operation
+    lsu_fencei    : std_ulogic;                     -- fence.i operation
+    lsu_priv      : std_ulogic;                     -- effective privilege level for load/store
+    lsu_rvso      : std_ulogic;                     -- reservation set operation (atomic LR/SC)
     -- instruction word --
     ir_funct3     : std_ulogic_vector(02 downto 0); -- funct3 bit field
     ir_funct12    : std_ulogic_vector(11 downto 0); -- funct12 bit field
@@ -691,13 +621,13 @@ package neorv32_package is
     alu_unsigned => '0',
     alu_frm      => (others => '0'),
     alu_cp_trig  => (others => '0'),
-    bus_req_rd   => '0',
-    bus_req_wr   => '0',
-    bus_mo_we    => '0',
-    bus_fence    => '0',
-    bus_fencei   => '0',
-    bus_priv     => '0',
-    bus_rvso     => '0',
+    lsu_req_rd   => '0',
+    lsu_req_wr   => '0',
+    lsu_mo_we    => '0',
+    lsu_fence    => '0',
+    lsu_fencei   => '0',
+    lsu_priv     => '0',
+    lsu_rvso     => '0',
     ir_funct3    => (others => '0'),
     ir_funct12   => (others => '0'),
     ir_opcode    => (others => '0'),
@@ -706,11 +636,6 @@ package neorv32_package is
     cpu_trap     => '0',
     cpu_debug    => '0'
   );
-
-  -- PMP Interface --------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  type pmp_ctrl_if_t is array (0 to 15) of std_ulogic_vector(07 downto 0);
-  type pmp_addr_if_t is array (0 to 15) of std_ulogic_vector(33 downto 0);
 
   -- Comparator Bus -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -867,6 +792,7 @@ package neorv32_package is
   function or_reduce_f(input : std_ulogic_vector) return std_ulogic;
   function and_reduce_f(input : std_ulogic_vector) return std_ulogic;
   function xor_reduce_f(input : std_ulogic_vector) return std_ulogic;
+  function su_undefined_f(input : std_ulogic) return boolean;
   function to_hexchar_f(input : std_ulogic_vector(3 downto 0)) return character;
   function to_hstring32_f(input : std_ulogic_vector(31 downto 0)) return string;
   function bit_rev_f(input : std_ulogic_vector) return std_ulogic_vector;
@@ -1180,13 +1106,24 @@ package body neorv32_package is
     return tmp_v;
   end function xor_reduce_f;
 
+  -- Check if std_ulogic is not '1' or '0' --------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  function su_undefined_f(input : std_ulogic) return boolean is
+  begin
+    case input is
+      when '1' | '0' => return false;
+      when others    => return true;
+    end case;
+  end function su_undefined_f;
+
   -- Convert std_ulogic_vector to lowercase HEX char ----------------------------------------
   -- -------------------------------------------------------------------------------------------
   function to_hexchar_f(input : std_ulogic_vector(3 downto 0)) return character is
     variable hex_v : string(1 to 16);
   begin
     hex_v := "0123456789abcdef";
-    if (to_integer(unsigned(input)) > 15) then
+    if (su_undefined_f(input(3)) = true) or (su_undefined_f(input(2)) = true) or
+       (su_undefined_f(input(1)) = true) or (su_undefined_f(input(0)) = true) then
       return '?';
     else
       return hex_v(to_integer(unsigned(input)) + 1);

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -349,7 +349,6 @@ package neorv32_package is
   constant csr_menvcfg_c        : std_ulogic_vector(11 downto 0) := x"30a";
   constant csr_menvcfgh_c       : std_ulogic_vector(11 downto 0) := x"31a";
   -- machine counter setup --
-  constant csr_cnt_setup_c      : std_ulogic_vector(06 downto 0) := x"3" & "001"; -- counter setup
   constant csr_mcountinhibit_c  : std_ulogic_vector(11 downto 0) := x"320";
   constant csr_mhpmevent3_c     : std_ulogic_vector(11 downto 0) := x"323";
   constant csr_mhpmevent4_c     : std_ulogic_vector(11 downto 0) := x"324";
@@ -364,22 +363,6 @@ package neorv32_package is
   constant csr_mhpmevent13_c    : std_ulogic_vector(11 downto 0) := x"32d";
   constant csr_mhpmevent14_c    : std_ulogic_vector(11 downto 0) := x"32e";
   constant csr_mhpmevent15_c    : std_ulogic_vector(11 downto 0) := x"32f";
-  constant csr_mhpmevent16_c    : std_ulogic_vector(11 downto 0) := x"330";
-  constant csr_mhpmevent17_c    : std_ulogic_vector(11 downto 0) := x"331";
-  constant csr_mhpmevent18_c    : std_ulogic_vector(11 downto 0) := x"332";
-  constant csr_mhpmevent19_c    : std_ulogic_vector(11 downto 0) := x"333";
-  constant csr_mhpmevent20_c    : std_ulogic_vector(11 downto 0) := x"334";
-  constant csr_mhpmevent21_c    : std_ulogic_vector(11 downto 0) := x"335";
-  constant csr_mhpmevent22_c    : std_ulogic_vector(11 downto 0) := x"336";
-  constant csr_mhpmevent23_c    : std_ulogic_vector(11 downto 0) := x"337";
-  constant csr_mhpmevent24_c    : std_ulogic_vector(11 downto 0) := x"338";
-  constant csr_mhpmevent25_c    : std_ulogic_vector(11 downto 0) := x"339";
-  constant csr_mhpmevent26_c    : std_ulogic_vector(11 downto 0) := x"33a";
-  constant csr_mhpmevent27_c    : std_ulogic_vector(11 downto 0) := x"33b";
-  constant csr_mhpmevent28_c    : std_ulogic_vector(11 downto 0) := x"33c";
-  constant csr_mhpmevent29_c    : std_ulogic_vector(11 downto 0) := x"33d";
-  constant csr_mhpmevent30_c    : std_ulogic_vector(11 downto 0) := x"33e";
-  constant csr_mhpmevent31_c    : std_ulogic_vector(11 downto 0) := x"33f";
   -- machine trap handling --
   constant csr_mscratch_c       : std_ulogic_vector(11 downto 0) := x"340";
   constant csr_mepc_c           : std_ulogic_vector(11 downto 0) := x"341";
@@ -423,7 +406,7 @@ package neorv32_package is
   constant csr_dscratch0_c      : std_ulogic_vector(11 downto 0) := x"7b2";
   -- machine counters/timers --
   constant csr_mcycle_c         : std_ulogic_vector(11 downto 0) := x"b00";
-  constant csr_mtime_c          : std_ulogic_vector(11 downto 0) := x"b01"; -- dummy address
+--constant csr_mtime_c          : std_ulogic_vector(11 downto 0) := x"b01";
   constant csr_minstret_c       : std_ulogic_vector(11 downto 0) := x"b02";
   constant csr_mhpmcounter3_c   : std_ulogic_vector(11 downto 0) := x"b03";
   constant csr_mhpmcounter4_c   : std_ulogic_vector(11 downto 0) := x"b04";
@@ -438,25 +421,9 @@ package neorv32_package is
   constant csr_mhpmcounter13_c  : std_ulogic_vector(11 downto 0) := x"b0d";
   constant csr_mhpmcounter14_c  : std_ulogic_vector(11 downto 0) := x"b0e";
   constant csr_mhpmcounter15_c  : std_ulogic_vector(11 downto 0) := x"b0f";
-  constant csr_mhpmcounter16_c  : std_ulogic_vector(11 downto 0) := x"b10";
-  constant csr_mhpmcounter17_c  : std_ulogic_vector(11 downto 0) := x"b11";
-  constant csr_mhpmcounter18_c  : std_ulogic_vector(11 downto 0) := x"b12";
-  constant csr_mhpmcounter19_c  : std_ulogic_vector(11 downto 0) := x"b13";
-  constant csr_mhpmcounter20_c  : std_ulogic_vector(11 downto 0) := x"b14";
-  constant csr_mhpmcounter21_c  : std_ulogic_vector(11 downto 0) := x"b15";
-  constant csr_mhpmcounter22_c  : std_ulogic_vector(11 downto 0) := x"b16";
-  constant csr_mhpmcounter23_c  : std_ulogic_vector(11 downto 0) := x"b17";
-  constant csr_mhpmcounter24_c  : std_ulogic_vector(11 downto 0) := x"b18";
-  constant csr_mhpmcounter25_c  : std_ulogic_vector(11 downto 0) := x"b19";
-  constant csr_mhpmcounter26_c  : std_ulogic_vector(11 downto 0) := x"b1a";
-  constant csr_mhpmcounter27_c  : std_ulogic_vector(11 downto 0) := x"b1b";
-  constant csr_mhpmcounter28_c  : std_ulogic_vector(11 downto 0) := x"b1c";
-  constant csr_mhpmcounter29_c  : std_ulogic_vector(11 downto 0) := x"b1d";
-  constant csr_mhpmcounter30_c  : std_ulogic_vector(11 downto 0) := x"b1e";
-  constant csr_mhpmcounter31_c  : std_ulogic_vector(11 downto 0) := x"b1f";
   --
   constant csr_mcycleh_c        : std_ulogic_vector(11 downto 0) := x"b80";
-  constant csr_mtimeh_c         : std_ulogic_vector(11 downto 0) := x"b81"; -- dummy address
+--constant csr_mtimeh_c         : std_ulogic_vector(11 downto 0) := x"b81";
   constant csr_minstreth_c      : std_ulogic_vector(11 downto 0) := x"b82";
   constant csr_mhpmcounter3h_c  : std_ulogic_vector(11 downto 0) := x"b83";
   constant csr_mhpmcounter4h_c  : std_ulogic_vector(11 downto 0) := x"b84";
@@ -471,22 +438,6 @@ package neorv32_package is
   constant csr_mhpmcounter13h_c : std_ulogic_vector(11 downto 0) := x"b8d";
   constant csr_mhpmcounter14h_c : std_ulogic_vector(11 downto 0) := x"b8e";
   constant csr_mhpmcounter15h_c : std_ulogic_vector(11 downto 0) := x"b8f";
-  constant csr_mhpmcounter16h_c : std_ulogic_vector(11 downto 0) := x"b90";
-  constant csr_mhpmcounter17h_c : std_ulogic_vector(11 downto 0) := x"b91";
-  constant csr_mhpmcounter18h_c : std_ulogic_vector(11 downto 0) := x"b92";
-  constant csr_mhpmcounter19h_c : std_ulogic_vector(11 downto 0) := x"b93";
-  constant csr_mhpmcounter20h_c : std_ulogic_vector(11 downto 0) := x"b94";
-  constant csr_mhpmcounter21h_c : std_ulogic_vector(11 downto 0) := x"b95";
-  constant csr_mhpmcounter22h_c : std_ulogic_vector(11 downto 0) := x"b96";
-  constant csr_mhpmcounter23h_c : std_ulogic_vector(11 downto 0) := x"b97";
-  constant csr_mhpmcounter24h_c : std_ulogic_vector(11 downto 0) := x"b98";
-  constant csr_mhpmcounter25h_c : std_ulogic_vector(11 downto 0) := x"b99";
-  constant csr_mhpmcounter26h_c : std_ulogic_vector(11 downto 0) := x"b9a";
-  constant csr_mhpmcounter27h_c : std_ulogic_vector(11 downto 0) := x"b9b";
-  constant csr_mhpmcounter28h_c : std_ulogic_vector(11 downto 0) := x"b9c";
-  constant csr_mhpmcounter29h_c : std_ulogic_vector(11 downto 0) := x"b9d";
-  constant csr_mhpmcounter30h_c : std_ulogic_vector(11 downto 0) := x"b9e";
-  constant csr_mhpmcounter31h_c : std_ulogic_vector(11 downto 0) := x"b9f";
   -- <<< standard read-only CSRs >>> --
   -- user counters/timers --
   constant csr_cycle_c          : std_ulogic_vector(11 downto 0) := x"c00";
@@ -505,22 +456,6 @@ package neorv32_package is
   constant csr_hpmcounter13_c   : std_ulogic_vector(11 downto 0) := x"c0d";
   constant csr_hpmcounter14_c   : std_ulogic_vector(11 downto 0) := x"c0e";
   constant csr_hpmcounter15_c   : std_ulogic_vector(11 downto 0) := x"c0f";
-  constant csr_hpmcounter16_c   : std_ulogic_vector(11 downto 0) := x"c10";
-  constant csr_hpmcounter17_c   : std_ulogic_vector(11 downto 0) := x"c11";
-  constant csr_hpmcounter18_c   : std_ulogic_vector(11 downto 0) := x"c12";
-  constant csr_hpmcounter19_c   : std_ulogic_vector(11 downto 0) := x"c13";
-  constant csr_hpmcounter20_c   : std_ulogic_vector(11 downto 0) := x"c14";
-  constant csr_hpmcounter21_c   : std_ulogic_vector(11 downto 0) := x"c15";
-  constant csr_hpmcounter22_c   : std_ulogic_vector(11 downto 0) := x"c16";
-  constant csr_hpmcounter23_c   : std_ulogic_vector(11 downto 0) := x"c17";
-  constant csr_hpmcounter24_c   : std_ulogic_vector(11 downto 0) := x"c18";
-  constant csr_hpmcounter25_c   : std_ulogic_vector(11 downto 0) := x"c19";
-  constant csr_hpmcounter26_c   : std_ulogic_vector(11 downto 0) := x"c1a";
-  constant csr_hpmcounter27_c   : std_ulogic_vector(11 downto 0) := x"c1b";
-  constant csr_hpmcounter28_c   : std_ulogic_vector(11 downto 0) := x"c1c";
-  constant csr_hpmcounter29_c   : std_ulogic_vector(11 downto 0) := x"c1d";
-  constant csr_hpmcounter30_c   : std_ulogic_vector(11 downto 0) := x"c1e";
-  constant csr_hpmcounter31_c   : std_ulogic_vector(11 downto 0) := x"c1f";
   --
   constant csr_cycleh_c         : std_ulogic_vector(11 downto 0) := x"c80";
   constant csr_timeh_c          : std_ulogic_vector(11 downto 0) := x"c81";
@@ -538,22 +473,6 @@ package neorv32_package is
   constant csr_hpmcounter13h_c  : std_ulogic_vector(11 downto 0) := x"c8d";
   constant csr_hpmcounter14h_c  : std_ulogic_vector(11 downto 0) := x"c8e";
   constant csr_hpmcounter15h_c  : std_ulogic_vector(11 downto 0) := x"c8f";
-  constant csr_hpmcounter16h_c  : std_ulogic_vector(11 downto 0) := x"c90";
-  constant csr_hpmcounter17h_c  : std_ulogic_vector(11 downto 0) := x"c91";
-  constant csr_hpmcounter18h_c  : std_ulogic_vector(11 downto 0) := x"c92";
-  constant csr_hpmcounter19h_c  : std_ulogic_vector(11 downto 0) := x"c93";
-  constant csr_hpmcounter20h_c  : std_ulogic_vector(11 downto 0) := x"c94";
-  constant csr_hpmcounter21h_c  : std_ulogic_vector(11 downto 0) := x"c95";
-  constant csr_hpmcounter22h_c  : std_ulogic_vector(11 downto 0) := x"c96";
-  constant csr_hpmcounter23h_c  : std_ulogic_vector(11 downto 0) := x"c97";
-  constant csr_hpmcounter24h_c  : std_ulogic_vector(11 downto 0) := x"c98";
-  constant csr_hpmcounter25h_c  : std_ulogic_vector(11 downto 0) := x"c99";
-  constant csr_hpmcounter26h_c  : std_ulogic_vector(11 downto 0) := x"c9a";
-  constant csr_hpmcounter27h_c  : std_ulogic_vector(11 downto 0) := x"c9b";
-  constant csr_hpmcounter28h_c  : std_ulogic_vector(11 downto 0) := x"c9c";
-  constant csr_hpmcounter29h_c  : std_ulogic_vector(11 downto 0) := x"c9d";
-  constant csr_hpmcounter30h_c  : std_ulogic_vector(11 downto 0) := x"c9e";
-  constant csr_hpmcounter31h_c  : std_ulogic_vector(11 downto 0) := x"c9f";
   -- machine information registers --
   constant csr_mvendorid_c      : std_ulogic_vector(11 downto 0) := x"f11";
   constant csr_marchid_c        : std_ulogic_vector(11 downto 0) := x"f12";
@@ -833,7 +752,7 @@ package neorv32_package is
       PMP_NUM_REGIONS              : natural := 0;      -- number of regions (0..16)
       PMP_MIN_GRANULARITY          : natural := 4;      -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
       -- Hardware Performance Monitors (HPM) --
-      HPM_NUM_CNTS                 : natural := 0;      -- number of implemented HPM counters (0..29)
+      HPM_NUM_CNTS                 : natural := 0;      -- number of implemented HPM counters (0..13)
       HPM_CNT_WIDTH                : natural := 40;     -- total size of HPM counters (0..64)
       -- Atomic Memory Access - Reservation Set Granularity --
       AMO_RVS_GRANULARITY          : natural := 4;      -- size in bytes, has to be a power of 2, min 4

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -332,7 +332,6 @@ package neorv32_package is
 
   -- RISC-V CSR Addresses -------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant csr_zero_c           : std_ulogic_vector(11 downto 0) := x"000"; -- always returns zero, only relevant for hardware access
   -- <<< standard read/write CSRs >>> --
   -- user floating-point CSRs --
   constant csr_fflags_c         : std_ulogic_vector(11 downto 0) := x"001";
@@ -585,7 +584,6 @@ package neorv32_package is
     alu_opa_mux   : std_ulogic;                     -- operand A select (0=rs1, 1=PC)
     alu_opb_mux   : std_ulogic;                     -- operand B select (0=rs2, 1=IMM)
     alu_unsigned  : std_ulogic;                     -- is unsigned ALU operation
-    alu_frm       : std_ulogic_vector(02 downto 0); -- FPU rounding mode
     alu_cp_trig   : std_ulogic_vector(05 downto 0); -- co-processor trigger (one-hot)
     -- load/store unit --
     lsu_req_rd    : std_ulogic;                     -- trigger memory read request
@@ -619,7 +617,6 @@ package neorv32_package is
     alu_opa_mux  => '0',
     alu_opb_mux  => '0',
     alu_unsigned => '0',
-    alu_frm      => (others => '0'),
     alu_cp_trig  => (others => '0'),
     lsu_req_rd   => '0',
     lsu_req_wr   => '0',

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -79,7 +79,7 @@ entity neorv32_top is
     PMP_MIN_GRANULARITY          : natural := 4;      -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
 
     -- Hardware Performance Monitors (HPM) --
-    HPM_NUM_CNTS                 : natural := 0;      -- number of implemented HPM counters (0..29)
+    HPM_NUM_CNTS                 : natural := 0;      -- number of implemented HPM counters (0..13)
     HPM_CNT_WIDTH                : natural := 40;     -- total size of HPM counters (0..64)
 
     -- Atomic Memory Access - Reservation Set Granularity --

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -940,8 +940,8 @@ begin
     )
     port map (
       -- host port --
-      main_req_i => io_req,
-      main_rsp_o => io_rsp,
+      main_req_i   => io_req,
+      main_rsp_o   => io_rsp,
       -- device ports --
       dev_00_req_o => io_dev_req(IODEV_OCD),     dev_00_rsp_i => io_dev_rsp(IODEV_OCD),
       dev_01_req_o => io_dev_req(IODEV_SYSINFO), dev_01_rsp_i => io_dev_rsp(IODEV_SYSINFO),

--- a/sw/lib/include/neorv32_cpu_csr.h
+++ b/sw/lib/include/neorv32_cpu_csr.h
@@ -92,10 +92,10 @@ enum NEORV32_CSR_enum {
   CSR_MIP            = 0x344, /**< 0x344 - mip:      Machine interrupt pending register */
 
   /* physical memory protection */
-  CSR_PMPCFG0        = 0x3a0, /**< 0x3a0 - pmpcfg0: Physical memory protection configuration register 0 (entries 0..3) */
-  CSR_PMPCFG1        = 0x3a1, /**< 0x3a1 - pmpcfg1: Physical memory protection configuration register 1 (entries 4..7) */
-  CSR_PMPCFG2        = 0x3a2, /**< 0x3a2 - pmpcfg2: Physical memory protection configuration register 2 (entries 8..11) */
-  CSR_PMPCFG3        = 0x3a3, /**< 0x3a3 - pmpcfg3: Physical memory protection configuration register 3 (entries 12..15) */
+  CSR_PMPCFG0        = 0x3a0, /**< 0x3a0 - pmpcfg0: Physical memory protection configuration register 0 (regions 0..3) */
+  CSR_PMPCFG1        = 0x3a1, /**< 0x3a1 - pmpcfg1: Physical memory protection configuration register 1 (regions 4..7) */
+  CSR_PMPCFG2        = 0x3a2, /**< 0x3a2 - pmpcfg2: Physical memory protection configuration register 2 (regions 8..11) */
+  CSR_PMPCFG3        = 0x3a3, /**< 0x3a3 - pmpcfg3: Physical memory protection configuration register 3 (regions 12..15) */
 
   CSR_PMPADDR0       = 0x3b0, /**< 0x3b0 - pmpaddr0: Physical memory protection address register 0 */
   CSR_PMPADDR1       = 0x3b1, /**< 0x3b1 - pmpaddr1: Physical memory protection address register 1 */

--- a/sw/lib/include/neorv32_cpu_csr.h
+++ b/sw/lib/include/neorv32_cpu_csr.h
@@ -83,22 +83,6 @@ enum NEORV32_CSR_enum {
   CSR_MHPMEVENT13    = 0x32d, /**< 0x32d - mhpmevent13: Machine hardware performance monitor event selector 13 */
   CSR_MHPMEVENT14    = 0x32e, /**< 0x32e - mhpmevent14: Machine hardware performance monitor event selector 14 */
   CSR_MHPMEVENT15    = 0x32f, /**< 0x32f - mhpmevent15: Machine hardware performance monitor event selector 15 */
-  CSR_MHPMEVENT16    = 0x330, /**< 0x330 - mhpmevent16: Machine hardware performance monitor event selector 16 */
-  CSR_MHPMEVENT17    = 0x331, /**< 0x331 - mhpmevent17: Machine hardware performance monitor event selector 17 */
-  CSR_MHPMEVENT18    = 0x332, /**< 0x332 - mhpmevent18: Machine hardware performance monitor event selector 18 */
-  CSR_MHPMEVENT19    = 0x333, /**< 0x333 - mhpmevent19: Machine hardware performance monitor event selector 19 */
-  CSR_MHPMEVENT20    = 0x334, /**< 0x334 - mhpmevent20: Machine hardware performance monitor event selector 20 */
-  CSR_MHPMEVENT21    = 0x335, /**< 0x335 - mhpmevent21: Machine hardware performance monitor event selector 21 */
-  CSR_MHPMEVENT22    = 0x336, /**< 0x336 - mhpmevent22: Machine hardware performance monitor event selector 22 */
-  CSR_MHPMEVENT23    = 0x337, /**< 0x337 - mhpmevent23: Machine hardware performance monitor event selector 23 */
-  CSR_MHPMEVENT24    = 0x338, /**< 0x338 - mhpmevent24: Machine hardware performance monitor event selector 24 */
-  CSR_MHPMEVENT25    = 0x339, /**< 0x339 - mhpmevent25: Machine hardware performance monitor event selector 25 */
-  CSR_MHPMEVENT26    = 0x33a, /**< 0x33a - mhpmevent26: Machine hardware performance monitor event selector 26 */
-  CSR_MHPMEVENT27    = 0x33b, /**< 0x33b - mhpmevent27: Machine hardware performance monitor event selector 27 */
-  CSR_MHPMEVENT28    = 0x33c, /**< 0x33c - mhpmevent28: Machine hardware performance monitor event selector 28 */
-  CSR_MHPMEVENT29    = 0x33d, /**< 0x33d - mhpmevent29: Machine hardware performance monitor event selector 29 */
-  CSR_MHPMEVENT30    = 0x33e, /**< 0x33e - mhpmevent30: Machine hardware performance monitor event selector 30 */
-  CSR_MHPMEVENT31    = 0x33f, /**< 0x33f - mhpmevent31: Machine hardware performance monitor event selector 31 */
 
   /* machine trap control */
   CSR_MSCRATCH       = 0x340, /**< 0x340 - mscratch: Machine scratch register */
@@ -162,22 +146,6 @@ enum NEORV32_CSR_enum {
   CSR_MHPMCOUNTER13  = 0xb0d, /**< 0xb0d - mhpmcounter13: Machine hardware performance monitor 13 counter low word */
   CSR_MHPMCOUNTER14  = 0xb0e, /**< 0xb0e - mhpmcounter14: Machine hardware performance monitor 14 counter low word */
   CSR_MHPMCOUNTER15  = 0xb0f, /**< 0xb0f - mhpmcounter15: Machine hardware performance monitor 15 counter low word */
-  CSR_MHPMCOUNTER16  = 0xb10, /**< 0xb10 - mhpmcounter16: Machine hardware performance monitor 16 counter low word */
-  CSR_MHPMCOUNTER17  = 0xb11, /**< 0xb11 - mhpmcounter17: Machine hardware performance monitor 17 counter low word */
-  CSR_MHPMCOUNTER18  = 0xb12, /**< 0xb12 - mhpmcounter18: Machine hardware performance monitor 18 counter low word */
-  CSR_MHPMCOUNTER19  = 0xb13, /**< 0xb13 - mhpmcounter19: Machine hardware performance monitor 19 counter low word */
-  CSR_MHPMCOUNTER20  = 0xb14, /**< 0xb14 - mhpmcounter20: Machine hardware performance monitor 20 counter low word */
-  CSR_MHPMCOUNTER21  = 0xb15, /**< 0xb15 - mhpmcounter21: Machine hardware performance monitor 21 counter low word */
-  CSR_MHPMCOUNTER22  = 0xb16, /**< 0xb16 - mhpmcounter22: Machine hardware performance monitor 22 counter low word */
-  CSR_MHPMCOUNTER23  = 0xb17, /**< 0xb17 - mhpmcounter23: Machine hardware performance monitor 23 counter low word */
-  CSR_MHPMCOUNTER24  = 0xb18, /**< 0xb18 - mhpmcounter24: Machine hardware performance monitor 24 counter low word */
-  CSR_MHPMCOUNTER25  = 0xb19, /**< 0xb19 - mhpmcounter25: Machine hardware performance monitor 25 counter low word */
-  CSR_MHPMCOUNTER26  = 0xb1a, /**< 0xb1a - mhpmcounter26: Machine hardware performance monitor 26 counter low word */
-  CSR_MHPMCOUNTER27  = 0xb1b, /**< 0xb1b - mhpmcounter27: Machine hardware performance monitor 27 counter low word */
-  CSR_MHPMCOUNTER28  = 0xb1c, /**< 0xb1c - mhpmcounter28: Machine hardware performance monitor 28 counter low word */
-  CSR_MHPMCOUNTER29  = 0xb1d, /**< 0xb1d - mhpmcounter29: Machine hardware performance monitor 29 counter low word */
-  CSR_MHPMCOUNTER30  = 0xb1e, /**< 0xb1e - mhpmcounter30: Machine hardware performance monitor 30 counter low word */
-  CSR_MHPMCOUNTER31  = 0xb1f, /**< 0xb1f - mhpmcounter31: Machine hardware performance monitor 31 counter low word */
 
   CSR_MCYCLEH        = 0xb80, /**< 0xb80 - mcycleh:        Machine cycle counter high word */
   //
@@ -195,22 +163,6 @@ enum NEORV32_CSR_enum {
   CSR_MHPMCOUNTER13H = 0xb8d, /**< 0xb8d - mhpmcounter13h: Machine hardware performance monitor 13 counter high word */
   CSR_MHPMCOUNTER14H = 0xb8e, /**< 0xb8e - mhpmcounter14h: Machine hardware performance monitor 14 counter high word */
   CSR_MHPMCOUNTER15H = 0xb8f, /**< 0xb8f - mhpmcounter15h: Machine hardware performance monitor 15 counter high word */
-  CSR_MHPMCOUNTER16H = 0xb90, /**< 0xb90 - mhpmcounter16h: Machine hardware performance monitor 16 counter high word */
-  CSR_MHPMCOUNTER17H = 0xb91, /**< 0xb91 - mhpmcounter17h: Machine hardware performance monitor 17 counter high word */
-  CSR_MHPMCOUNTER18H = 0xb92, /**< 0xb92 - mhpmcounter18h: Machine hardware performance monitor 18 counter high word */
-  CSR_MHPMCOUNTER19H = 0xb93, /**< 0xb93 - mhpmcounter19h: Machine hardware performance monitor 19 counter high word */
-  CSR_MHPMCOUNTER20H = 0xb94, /**< 0xb94 - mhpmcounter20h: Machine hardware performance monitor 20 counter high word */
-  CSR_MHPMCOUNTER21H = 0xb95, /**< 0xb95 - mhpmcounter21h: Machine hardware performance monitor 21 counter high word */
-  CSR_MHPMCOUNTER22H = 0xb96, /**< 0xb96 - mhpmcounter22h: Machine hardware performance monitor 22 counter high word */
-  CSR_MHPMCOUNTER23H = 0xb97, /**< 0xb97 - mhpmcounter23h: Machine hardware performance monitor 23 counter high word */
-  CSR_MHPMCOUNTER24H = 0xb98, /**< 0xb98 - mhpmcounter24h: Machine hardware performance monitor 24 counter high word */
-  CSR_MHPMCOUNTER25H = 0xb99, /**< 0xb99 - mhpmcounter25h: Machine hardware performance monitor 25 counter high word */
-  CSR_MHPMCOUNTER26H = 0xb9a, /**< 0xb9a - mhpmcounter26h: Machine hardware performance monitor 26 counter high word */
-  CSR_MHPMCOUNTER27H = 0xb9b, /**< 0xb9b - mhpmcounter27h: Machine hardware performance monitor 27 counter high word */
-  CSR_MHPMCOUNTER28H = 0xb9c, /**< 0xb9c - mhpmcounter28h: Machine hardware performance monitor 28 counter high word */
-  CSR_MHPMCOUNTER29H = 0xb9d, /**< 0xb9d - mhpmcounter29h: Machine hardware performance monitor 29 counter high word */
-  CSR_MHPMCOUNTER30H = 0xb9e, /**< 0xb9e - mhpmcounter30h: Machine hardware performance monitor 30 counter high word */
-  CSR_MHPMCOUNTER31H = 0xb9f, /**< 0xb9f - mhpmcounter31h: Machine hardware performance monitor 31 counter high word */
 
   /* user counters and timers */
   CSR_CYCLE          = 0xc00, /**< 0xc00 - cycle:        Cycle counter low word (from MCYCLE) */
@@ -229,22 +181,6 @@ enum NEORV32_CSR_enum {
   CSR_HPMCOUNTER13   = 0xc0d, /**< 0xc0d - hpmcounter13: User hardware performance monitor 13 counter low word */
   CSR_HPMCOUNTER14   = 0xc0e, /**< 0xc0e - hpmcounter14: User hardware performance monitor 14 counter low word */
   CSR_HPMCOUNTER15   = 0xc0f, /**< 0xc0f - hpmcounter15: User hardware performance monitor 15 counter low word */
-  CSR_HPMCOUNTER16   = 0xc10, /**< 0xc10 - hpmcounter16: User hardware performance monitor 16 counter low word */
-  CSR_HPMCOUNTER17   = 0xc11, /**< 0xc11 - hpmcounter17: User hardware performance monitor 17 counter low word */
-  CSR_HPMCOUNTER18   = 0xc12, /**< 0xc12 - hpmcounter18: User hardware performance monitor 18 counter low word */
-  CSR_HPMCOUNTER19   = 0xc13, /**< 0xc13 - hpmcounter19: User hardware performance monitor 19 counter low word */
-  CSR_HPMCOUNTER20   = 0xc14, /**< 0xc14 - hpmcounter20: User hardware performance monitor 20 counter low word */
-  CSR_HPMCOUNTER21   = 0xc15, /**< 0xc15 - hpmcounter21: User hardware performance monitor 21 counter low word */
-  CSR_HPMCOUNTER22   = 0xc16, /**< 0xc16 - hpmcounter22: User hardware performance monitor 22 counter low word */
-  CSR_HPMCOUNTER23   = 0xc17, /**< 0xc17 - hpmcounter23: User hardware performance monitor 23 counter low word */
-  CSR_HPMCOUNTER24   = 0xc18, /**< 0xc18 - hpmcounter24: User hardware performance monitor 24 counter low word */
-  CSR_HPMCOUNTER25   = 0xc19, /**< 0xc19 - hpmcounter25: User hardware performance monitor 25 counter low word */
-  CSR_HPMCOUNTER26   = 0xc1a, /**< 0xc1a - hpmcounter26: User hardware performance monitor 26 counter low word */
-  CSR_HPMCOUNTER27   = 0xc1b, /**< 0xc1b - hpmcounter27: User hardware performance monitor 27 counter low word */
-  CSR_HPMCOUNTER28   = 0xc1c, /**< 0xc1c - hpmcounter28: User hardware performance monitor 28 counter low word */
-  CSR_HPMCOUNTER29   = 0xc1d, /**< 0xc1d - hpmcounter29: User hardware performance monitor 29 counter low word */
-  CSR_HPMCOUNTER30   = 0xc1e, /**< 0xc1e - hpmcounter30: User hardware performance monitor 30 counter low word */
-  CSR_HPMCOUNTER31   = 0xc1f, /**< 0xc1f - hpmcounter31: User hardware performance monitor 31 counter low word */
 
   CSR_CYCLEH         = 0xc80, /**< 0xc80 - cycleh:        Cycle counter high word (from MCYCLEH) */
   //
@@ -262,22 +198,6 @@ enum NEORV32_CSR_enum {
   CSR_HPMCOUNTER13H  = 0xc8d, /**< 0xc8d - hpmcounter13h: User hardware performance monitor 13 counter high word */
   CSR_HPMCOUNTER14H  = 0xc8e, /**< 0xc8e - hpmcounter14h: User hardware performance monitor 14 counter high word */
   CSR_HPMCOUNTER15H  = 0xc8f, /**< 0xc8f - hpmcounter15h: User hardware performance monitor 15 counter high word */
-  CSR_HPMCOUNTER16H  = 0xc90, /**< 0xc90 - hpmcounter16h: User hardware performance monitor 16 counter high word */
-  CSR_HPMCOUNTER17H  = 0xc91, /**< 0xc91 - hpmcounter17h: User hardware performance monitor 17 counter high word */
-  CSR_HPMCOUNTER18H  = 0xc92, /**< 0xc92 - hpmcounter18h: User hardware performance monitor 18 counter high word */
-  CSR_HPMCOUNTER19H  = 0xc93, /**< 0xc93 - hpmcounter19h: User hardware performance monitor 19 counter high word */
-  CSR_HPMCOUNTER20H  = 0xc94, /**< 0xc94 - hpmcounter20h: User hardware performance monitor 20 counter high word */
-  CSR_HPMCOUNTER21H  = 0xc95, /**< 0xc95 - hpmcounter21h: User hardware performance monitor 21 counter high word */
-  CSR_HPMCOUNTER22H  = 0xc96, /**< 0xc96 - hpmcounter22h: User hardware performance monitor 22 counter high word */
-  CSR_HPMCOUNTER23H  = 0xc97, /**< 0xc97 - hpmcounter23h: User hardware performance monitor 23 counter high word */
-  CSR_HPMCOUNTER24H  = 0xc98, /**< 0xc98 - hpmcounter24h: User hardware performance monitor 24 counter high word */
-  CSR_HPMCOUNTER25H  = 0xc99, /**< 0xc99 - hpmcounter25h: User hardware performance monitor 25 counter high word */
-  CSR_HPMCOUNTER26H  = 0xc9a, /**< 0xc9a - hpmcounter26h: User hardware performance monitor 26 counter high word */
-  CSR_HPMCOUNTER27H  = 0xc9b, /**< 0xc9b - hpmcounter27h: User hardware performance monitor 27 counter high word */
-  CSR_HPMCOUNTER28H  = 0xc9c, /**< 0xc9c - hpmcounter28h: User hardware performance monitor 28 counter high word */
-  CSR_HPMCOUNTER29H  = 0xc9d, /**< 0xc9d - hpmcounter29h: User hardware performance monitor 29 counter high word */
-  CSR_HPMCOUNTER30H  = 0xc9e, /**< 0xc9e - hpmcounter30h: User hardware performance monitor 30 counter high word */
-  CSR_HPMCOUNTER31H  = 0xc9f, /**< 0xc9f - hpmcounter31h: User hardware performance monitor 31 counter high word */
 
   /* machine information registers */
   CSR_MVENDORID      = 0xf11, /**< 0xf11 - mvendorid:  Vendor ID */

--- a/sw/lib/source/neorv32_cpu.c
+++ b/sw/lib/source/neorv32_cpu.c
@@ -394,12 +394,6 @@ int neorv32_cpu_pmp_configure_region(int index, uint32_t addr, uint8_t config) {
     default: break;
   }
 
-  // wait for hardware to compute address masks
-  int i;
-  for (i=0; i<16; i++) {
-    asm volatile ("nop");
-  }
-
   // set configuration
   uint32_t clr_mask = 0xff;
   uint32_t set_mask = (uint32_t)config;
@@ -422,7 +416,7 @@ int neorv32_cpu_pmp_configure_region(int index, uint32_t addr, uint8_t config) {
 /**********************************************************************//**
  * Hardware performance monitors (HPM): Get number of available HPM counters.
  *
- * @return Returns number of available HPM counters (0..29).
+ * @return Returns number of available HPM counters.
  **************************************************************************/
 uint32_t neorv32_cpu_hpm_get_num_counters(void) {
 

--- a/sw/lib/source/neorv32_cpu_amo.c
+++ b/sw/lib/source/neorv32_cpu_amo.c
@@ -261,7 +261,7 @@ uint32_t neorv32_cpu_amomaxuw(uint32_t addr, uint32_t wdata) {
  * @note This function requires the CPU A ISA extension.
  *
  * @param[in] addr 32-bit memory address, word-aligned.
- * @param[in] wdata Data word to be atomically MAX-ed with original data at address (signed 32-bit).
+ * @param[in] wdata Data word to be atomically MIN-ed with original data at address (signed 32-bit).
  * @return Pre-operation data loaded from address (signed 32-bit)
  **************************************************************************/
 int32_t neorv32_cpu_amominw(uint32_t addr, int32_t wdata) {
@@ -290,7 +290,7 @@ int32_t neorv32_cpu_amominw(uint32_t addr, int32_t wdata) {
  * @note This function requires the CPU A ISA extension.
  *
  * @param[in] addr 32-bit memory address, word-aligned.
- * @param[in] wdata Data word to be atomically MAX-ed with original data at address (unsigned 32-bit).
+ * @param[in] wdata Data word to be atomically MIN-ed with original data at address (unsigned 32-bit).
  * @return Pre-operation data loaded from address (unsigned 32-bit)
  **************************************************************************/
 uint32_t neorv32_cpu_amominuw(uint32_t addr, uint32_t wdata) {

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -426,6 +426,15 @@ void neorv32_rte_print_hw_config(void) {
     neorv32_uart0_printf("none\n");
   }
 
+  // internal DMEM
+  neorv32_uart0_printf("Internal DMEM:       ");
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_MEM_INT_DMEM)) {
+    neorv32_uart0_printf("%u bytes\n", (uint32_t)(1 << NEORV32_SYSINFO->MEM[SYSINFO_MEM_DMEM]) & 0xFFFFFFFCUL);
+  }
+  else {
+    neorv32_uart0_printf("none\n");
+  }
+
   // internal i-cache
   neorv32_uart0_printf("Internal i-cache:    ");
   if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_ICACHE)) {
@@ -449,15 +458,6 @@ void neorv32_rte_print_hw_config(void) {
     else {
       neorv32_uart0_printf("\n");
     }
-  }
-  else {
-    neorv32_uart0_printf("none\n");
-  }
-
-  // internal DMEM
-  neorv32_uart0_printf("Internal DMEM:       ");
-  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_MEM_INT_DMEM)) {
-    neorv32_uart0_printf("%u bytes\n", (uint32_t)(1 << NEORV32_SYSINFO->MEM[SYSINFO_MEM_DMEM]) & 0xFFFFFFFCUL);
   }
   else {
     neorv32_uart0_printf("none\n");

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -340,7 +340,7 @@ void neorv32_rte_print_hw_config(void) {
     }
   }
 
-  // Z* CPU extensions
+  // CPU sub-extensions
   tmp = neorv32_cpu_csr_read(CSR_MXISA);
   if (tmp & (1<<CSR_MXISA_ZICSR)) {
     neorv32_uart0_printf("Zicsr ");
@@ -371,6 +371,9 @@ void neorv32_rte_print_hw_config(void) {
   }
   if (tmp & (1<<CSR_MXISA_SDTRIG)) {
     neorv32_uart0_printf("Sdtrig ");
+  }
+  if (tmp & (1<<CSR_MXISA_PMP)) {
+    neorv32_uart0_printf("Smpmp ");
   }
 
   // CPU tuning options


### PR DESCRIPTION
* remove co-processor timeout logic from ALU (use the watchdog timer to ensure the CPU does not get stuck instead)
* rename CPU data bus unit: `neorv32_cpu_bus.vhd -> neorv32_cpu_lsu.vhd` ("load/store unit")
* move entire PMP logic (including CSRs) into a new design file `neorv32_cpu_pmp.vhd`
* move FPU CSRs from central control unit to FPU module
* constrain maximum number of HPMs to 13 (`[m]hpmcounter3[h]` to `[m]hpmcounter15[h]`)
* minor RTL edits and cleanups

ℹ️ Moving the entire PMP/FPU CSR logic into optional (`if ... generate`) design units ensures that **all** of the logic is trimmed when the according module is not enabled.