### PR TITLE
⚠️ constrain MTVAL CSR, add MTINST CSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
-| 19.08.2023 | 1.8.8.1 | update RTE to support easy emulation of instructions; add example program to showcase how to emulate unaligned memory accesses; [#673](https://github.com/stnolting/neorv32/pull/673) |
+| 19.08.2023 | 1.8.8.2 | :warning: constrain `mtval` CSR; add support for `mtinst` CSR (trap instruction); [#674](https://github.com/stnolting/neorv32/pull/674) |
+| 19.08.2023 | 1.8.8.1 | :test_tube: update RTE to support easy emulation of instructions; add example program to showcase how to emulate unaligned memory accesses; [#673](https://github.com/stnolting/neorv32/pull/673) |
 | 18.08.2023 | [**:rocket:1.8.8**](https://github.com/stnolting/neorv32/releases/tag/v1.8.8) | **New release** |
 | 17.08.2023 | 1.8.7.9 | minor rtl edits and cleanups; [#672](https://github.com/stnolting/neorv32/pull/672) |
 | 13.08.2023 | 1.8.7.8 | :warning: constrain/optimize `mtval` and `mcounteren` CSRs; [#671](https://github.com/stnolting/neorv32/pull/671) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -647,7 +647,7 @@ However, access privileges are still enforced so these instruction variants _do_
 
 [NOTE]
 The `wfi` instruction is used to enter <<_sleep_mode>>. Executing the `wfi` instruction in user-mode
-will raise an illegal instruction exception if <<_mstatus>>`.TW` is set.
+will raise an illegal instruction exception if <<_mstatus>>.TW is set.
 
 .Instructions and Timing
 [cols="<2,<4,<3"]
@@ -745,12 +745,10 @@ available at https://github.com/riscv-non-isa/riscv-trace-spec):
 * **trap**: the transfer of control to a trap handler caused by either an _exception_ or an _interrupt_
 
 Whenever an exception or interrupt is triggered, the CPU switches to machine-mode (if not already in machine-mode)
-and transfers control to the address stored in <<_mtvec>> CSR. The cause of the the trap can be determined via the
+and continues operation at the address being stored in the <<_mtvec>> CSR. The cause of the the trap can be determined via the
 <<_mcause>> CSR. A list of all implemented `mcause` values and the according description can be found below in section
 <<_neorv32_trap_listing>>. The address that reflects the current program counter when a trap was taken is stored to
-<<_mepc>> CSR. This might be the address of the instruction that actually caused the trap or that has not been executed
-yet as it was interrupted by a trap. Additional information regarding the cause of the trap can be retrieved from the
-<<_mtval>> CSR.
+<<_mepc>> CSR. Additional information regarding the cause of the trap can be retrieved from the <<_mtval>> and <<_mtinst>> CSRs.
 
 The traps are prioritized. If several _exceptions_ occur at once only the one with highest priority is triggered
 while all remaining exceptions are ignored and discarded. If several _interrupts_ trigger at once, the one with highest priority
@@ -760,7 +758,7 @@ the second highest priority will get serviced and so on until no further interru
 .Interrupts when in User-Mode
 [IMPORTANT]
 If the core is currently operating in less privileged user-mode, interrupts are globally enabled
-even if <<_mstatus>>`.mie` is cleared.
+even if <<_mstatus>>.mie is cleared.
 
 .Interrupt Signal Requirements - Standard RISC-V Interrupts
 [IMPORTANT]
@@ -803,10 +801,10 @@ and the CSR side-effects.
 
 **Table Annotations**
 
-The "Prio." column shows the priority of each trap. The highest priority is 1. The "`mcause`" column shows the
-cause ID of the according trap that is written to <<_mcause>> CSR.  The "ID [C]" names are defined by the NEORV32
-core library (the runtime environment _RTE_) and can be used in plain C code. The <<_mepc>> and <<_mtval>> columns
-show the values written to the according CSRs when a trap is triggered:
+The "Prio." column shows the priority of each trap with the highest priority being 1. The "RTE Trap ID" aliases are
+defined by the NEORV32 core library (the runtime environment _RTE_) and can be used in plain C code when interacting
+with the pre-defined RTE function. The <<_mcause>>, <<_mepc>>, <<_mtval>> and <<_mtinst>> columns show the value being
+written to the according CSRs when a trap is triggered:
 
 * **I-PC** - address of interrupted instruction (instruction has _not_ been executed yet)
 * **PC** - address of instruction that caused the trap (instruction has been executed)
@@ -815,41 +813,41 @@ show the values written to the according CSRs when a trap is triggered:
 * **0** - zero
 
 .NEORV32 Trap Listing
-[cols="1,4,8,10,2,2"]
+[cols="1,4,8,10,2,2,2"]
 [options="header",grid="rows"]
 |=======================
-| Prio. | `mcause`     | ID [C]                   | Cause                                | `mepc`   | `mtval`
-6+^| **Exceptions** (_synchronous_ to instruction execution)
-| 1     | `0x00000000` | `TRAP_CODE_I_MISALIGNED` | instruction fetch address misaligned | **I-PC** | **0**
-| 2     | `0x00000001` | `TRAP_CODE_I_ACCESS`     | instruction fetch bus access fault   | **I-PC** | **0**
-| 3     | `0x00000002` | `TRAP_CODE_I_ILLEGAL`    | illegal instruction                  | **PC**   | **INS**
-| 4     | `0x0000000b` | `TRAP_CODE_MENV_CALL`    | environment call from M-mode         | **PC**   | **0**
-| 5     | `0x00000008` | `TRAP_CODE_UENV_CALL`    | environment call from U-mode         | **PC**   | **0**
-| 6     | `0x00000003` | `TRAP_CODE_BREAKPOINT`   | software breakpoint / trigger firing | **PC**   | **0**
-| 7     | `0x00000006` | `TRAP_CODE_S_MISALIGNED` | store address misaligned             | **PC**   | **ADR**
-| 8     | `0x00000004` | `TRAP_CODE_L_MISALIGNED` | load address misaligned              | **PC**   | **ADR**
-| 9     | `0x00000007` | `TRAP_CODE_S_ACCESS`     | store bus access fault               | **PC**   | **ADR**
-| 10    | `0x00000005` | `TRAP_CODE_L_ACCESS`     | load bus access fault                | **PC**   | **ADR**
-6+^| **Interrupts** (_asynchronous_ to instruction execution)
-| 11    | `0x80000010` | `TRAP_CODE_FIRQ_0`       | fast interrupt request channel 0     | **I-PC** | **0**
-| 12    | `0x80000011` | `TRAP_CODE_FIRQ_1`       | fast interrupt request channel 1     | **I-PC** | **0**
-| 13    | `0x80000012` | `TRAP_CODE_FIRQ_2`       | fast interrupt request channel 2     | **I-PC** | **0**
-| 14    | `0x80000013` | `TRAP_CODE_FIRQ_3`       | fast interrupt request channel 3     | **I-PC** | **0**
-| 15    | `0x80000014` | `TRAP_CODE_FIRQ_4`       | fast interrupt request channel 4     | **I-PC** | **0**
-| 16    | `0x80000015` | `TRAP_CODE_FIRQ_5`       | fast interrupt request channel 5     | **I-PC** | **0**
-| 17    | `0x80000016` | `TRAP_CODE_FIRQ_6`       | fast interrupt request channel 6     | **I-PC** | **0**
-| 18    | `0x80000017` | `TRAP_CODE_FIRQ_7`       | fast interrupt request channel 7     | **I-PC** | **0**
-| 19    | `0x80000018` | `TRAP_CODE_FIRQ_8`       | fast interrupt request channel 8     | **I-PC** | **0**
-| 20    | `0x80000019` | `TRAP_CODE_FIRQ_9`       | fast interrupt request channel 9     | **I-PC** | **0**
-| 21    | `0x8000001a` | `TRAP_CODE_FIRQ_10`      | fast interrupt request channel 10    | **I-PC** | **0**
-| 22    | `0x8000001b` | `TRAP_CODE_FIRQ_11`      | fast interrupt request channel 11    | **I-PC** | **0**
-| 23    | `0x8000001c` | `TRAP_CODE_FIRQ_12`      | fast interrupt request channel 12    | **I-PC** | **0**
-| 24    | `0x8000001d` | `TRAP_CODE_FIRQ_13`      | fast interrupt request channel 13    | **I-PC** | **0**
-| 25    | `0x8000001e` | `TRAP_CODE_FIRQ_14`      | fast interrupt request channel 14    | **I-PC** | **0**
-| 26    | `0x8000001f` | `TRAP_CODE_FIRQ_15`      | fast interrupt request channel 15    | **I-PC** | **0**
-| 27    | `0x8000000B` | `TRAP_CODE_MEI`          | machine external interrupt (MEI)     | **I-PC** | **0**
-| 28    | `0x80000003` | `TRAP_CODE_MSI`          | machine software interrupt (MSI)     | **I-PC** | **0**
-| 29    | `0x80000007` | `TRAP_CODE_MTI`          | machine timer interrupt (MTI)        | **I-PC** | **0**
+| Prio. | `mcause`     | RTE Trap ID              | Cause                                | `mepc` | `mtval` | `mtinst`
+7+^| **Exceptions** (_synchronous_ to instruction execution)                                                 
+| 1     | `0x00000000` | `TRAP_CODE_I_MISALIGNED` | instruction fetch address misaligned | I-PC   | 0       | INS
+| 2     | `0x00000001` | `TRAP_CODE_I_ACCESS`     | instruction fetch bus access fault   | I-PC   | 0       | INS
+| 3     | `0x00000002` | `TRAP_CODE_I_ILLEGAL`    | illegal instruction                  | PC     | 0       | INS
+| 4     | `0x0000000b` | `TRAP_CODE_MENV_CALL`    | environment call from M-mode         | PC     | 0       | INS
+| 5     | `0x00000008` | `TRAP_CODE_UENV_CALL`    | environment call from U-mode         | PC     | 0       | INS
+| 6     | `0x00000003` | `TRAP_CODE_BREAKPOINT`   | software breakpoint / trigger firing | PC     | 0       | INS
+| 7     | `0x00000006` | `TRAP_CODE_S_MISALIGNED` | store address misaligned             | PC     | ADR     | INS
+| 8     | `0x00000004` | `TRAP_CODE_L_MISALIGNED` | load address misaligned              | PC     | ADR     | INS
+| 9     | `0x00000007` | `TRAP_CODE_S_ACCESS`     | store bus access fault               | PC     | ADR     | INS
+| 10    | `0x00000005` | `TRAP_CODE_L_ACCESS`     | load bus access fault                | PC     | ADR     | INS
+7+^| **Interrupts** (_asynchronous_ to instruction execution)                                                
+| 11    | `0x80000010` | `TRAP_CODE_FIRQ_0`       | fast interrupt request channel 0     | I-PC   | 0       | 0
+| 12    | `0x80000011` | `TRAP_CODE_FIRQ_1`       | fast interrupt request channel 1     | I-PC   | 0       | 0
+| 13    | `0x80000012` | `TRAP_CODE_FIRQ_2`       | fast interrupt request channel 2     | I-PC   | 0       | 0
+| 14    | `0x80000013` | `TRAP_CODE_FIRQ_3`       | fast interrupt request channel 3     | I-PC   | 0       | 0
+| 15    | `0x80000014` | `TRAP_CODE_FIRQ_4`       | fast interrupt request channel 4     | I-PC   | 0       | 0
+| 16    | `0x80000015` | `TRAP_CODE_FIRQ_5`       | fast interrupt request channel 5     | I-PC   | 0       | 0
+| 17    | `0x80000016` | `TRAP_CODE_FIRQ_6`       | fast interrupt request channel 6     | I-PC   | 0       | 0
+| 18    | `0x80000017` | `TRAP_CODE_FIRQ_7`       | fast interrupt request channel 7     | I-PC   | 0       | 0
+| 19    | `0x80000018` | `TRAP_CODE_FIRQ_8`       | fast interrupt request channel 8     | I-PC   | 0       | 0
+| 20    | `0x80000019` | `TRAP_CODE_FIRQ_9`       | fast interrupt request channel 9     | I-PC   | 0       | 0
+| 21    | `0x8000001a` | `TRAP_CODE_FIRQ_10`      | fast interrupt request channel 10    | I-PC   | 0       | 0
+| 22    | `0x8000001b` | `TRAP_CODE_FIRQ_11`      | fast interrupt request channel 11    | I-PC   | 0       | 0
+| 23    | `0x8000001c` | `TRAP_CODE_FIRQ_12`      | fast interrupt request channel 12    | I-PC   | 0       | 0
+| 24    | `0x8000001d` | `TRAP_CODE_FIRQ_13`      | fast interrupt request channel 13    | I-PC   | 0       | 0
+| 25    | `0x8000001e` | `TRAP_CODE_FIRQ_14`      | fast interrupt request channel 14    | I-PC   | 0       | 0
+| 26    | `0x8000001f` | `TRAP_CODE_FIRQ_15`      | fast interrupt request channel 15    | I-PC   | 0       | 0
+| 27    | `0x8000000B` | `TRAP_CODE_MEI`          | machine external interrupt (MEI)     | I-PC   | 0       | 0
+| 28    | `0x80000003` | `TRAP_CODE_MSI`          | machine software interrupt (MSI)     | I-PC   | 0       | 0
+| 29    | `0x80000007` | `TRAP_CODE_MTI`          | machine timer interrupt (MTI)        | I-PC   | 0       | 0
 |=======================
 
 .NEORV32 Trap Description
@@ -858,15 +856,15 @@ show the values written to the according CSRs when a trap is triggered:
 |=======================
 | Trap ID [C] | Triggered when ...
 | `TRAP_CODE_I_MISALIGNED` | fetching a 32-bit instruction word that is not 32-bit-aligned (see note below)
-| `TRAP_CODE_I_ACCESS`     | bus timeout or bus access error during instruction fetch
+| `TRAP_CODE_I_ACCESS`     | bus timeout, bus access error or <<_pmp_isa_extension,PMP>> rule violation during instruction fetch
 | `TRAP_CODE_I_ILLEGAL`    | trying to execute an invalid instruction word (malformed or not supported) or on a privilege violation
 | `TRAP_CODE_MENV_CALL`    | executing `ecall` instruction in machine-mode
 | `TRAP_CODE_UENV_CALL`    | executing `ecall` instruction in user-mode
-| `TRAP_CODE_BREAKPOINT`   | executing `[c.]ebreak` instruction or if <<_trigger_module>> fires
-| `TRAP_CODE_S_MISALIGNED` | storing data to an address that is not naturally aligned to the data size (byte, half, word)
-| `TRAP_CODE_L_MISALIGNED` | loading data from an address that is not naturally aligned to the data size  (byte, half, word)
-| `TRAP_CODE_S_ACCESS`     | bus timeout or bus access error during load data operation
-| `TRAP_CODE_L_ACCESS`     | bus timeout or bus access error during store data operation
+| `TRAP_CODE_BREAKPOINT`   | executing `ebreak` instruction or if <<_trigger_module>> fires
+| `TRAP_CODE_S_MISALIGNED` | storing data to an address that is not naturally aligned to the data size (half/word)
+| `TRAP_CODE_L_MISALIGNED` | loading data from an address that is not naturally aligned to the data size  (half/word)
+| `TRAP_CODE_S_ACCESS`     | bus timeout, bus access error or <<_pmp_isa_extension,PMP>> rule violation during load data operation
+| `TRAP_CODE_L_ACCESS`     | bus timeout, bus access error or <<_pmp_isa_extension,PMP>> rule violation during store data operation
 | `TRAP_CODE_FIRQ_*`       | caused by interrupt-condition of **processor-internal modules**, see <<_neorv32_specific_fast_interrupt_requests>>
 | `TRAP_CODE_MEI`          | machine external interrupt (via dedicated <<_processor_top_entity_signals>>)
 | `TRAP_CODE_MSI`          | machine software interrupt (via dedicated <<_processor_top_entity_signals>>)
@@ -882,4 +880,4 @@ address misaligned" exception are not resumable in most cases. These exception m
 [NOTE]
 For 32-bit-only instructions (= no `C` extension) the misaligned instruction exception is raised if bit 1 of the fetch
 address is set (i.e. not on a 32-bit boundary). If the `C` extension is implemented there will never be a misaligned
-instruction exception _at all_. In both cases bit 0 of the program counter (and all related CSRs) is hardwired to zero.
+instruction exception _at all_.

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -24,7 +24,7 @@ bits can actually be modified.
 5+^| **<<_floating_point_csrs>>**
 | 0x001 | <<_fflags>> | `CSR_FFLAGS` | URW | Floating-point accrued exceptions
 | 0x002 | <<_frm>>    | `CSR_FRM`    | URW | Floating-point dynamic rounding mode
-| 0x003 | <<_fcsr>>   | `CSR_FCSR`   | URW | Floating-point control and status (`frm` + `fflags`)
+| 0x003 | <<_fcsr>>   | `CSR_FCSR`   | URW | Floating-point control and status
 5+^| **<<_machine_configuration_csrs>>**
 | 0x30a | <<_menvcfg>>  | `CSR_MENVCFG`  | MRW | Machine environment configuration register - low word
 | 0x31a | <<_menvcfgh>> | `CSR_MENVCFGH` | MRW | Machine environment configuration register - low word
@@ -39,8 +39,9 @@ bits can actually be modified.
 | 0x340 | <<_mscratch>> | `CSR_MSCRATCH` | MRW | Machine scratch register
 | 0x341 | <<_mepc>>     | `CSR_MEPC`     | MRW | Machine exception program counter
 | 0x342 | <<_mcause>>   | `CSR_MCAUSE`   | MRW | Machine trap cause
-| 0x343 | <<_mtval>>    | `CSR_MTVAL`    | MRW | Machine bad address or instruction
+| 0x343 | <<_mtval>>    | `CSR_MTVAL`    | MRW | Machine trap value
 | 0x344 | <<_mip>>      | `CSR_MIP`      | MRW | Machine interrupt pending register
+| 0x34a | <<_mtinst>>   | `CSR_MTINST`   | MRW | Machine trap instruction
 5+^| **<<_machine_physical_memory_protection_csrs>>**
 | 0x3a0 .. 0x303 | <<_pmpcfg, `pmpcfg0`>> .. <<_pmpcfg, `pmpcfg3`>>      | `CSR_PMPCFG0` .. `CSR_PMPCFG3`    | MRW | Physical memory protection configuration registers
 | 0x3b0 .. 0x3bf | <<_pmpaddr, `pmpaddr0`>> .. <<_pmpaddr, `pmpaddr15`>> | `CSR_PMPADDR0` .. `CSR_PMPADDR15` | MRW | Physical memory protection address registers
@@ -81,7 +82,7 @@ bits can actually be modified.
 | 0xf14 | <<_mhartid>>    | `CSR_MHARTID`    | MRO | Machine hardware thread ID
 | 0xf15 | <<_mconfigptr>> | `CSR_MCONFIGPTR` | MRO | Machine configuration pointer register
 5+^| **<<_neorv32_specific_csrs>>**
-| 0xfc0 | <<_mxisa>> | `CSR_MXISA` | MRO | NEORV32-specific "extended" machine CPU ISA and extensions
+| 0xfc0 | <<_mxisa>> | `CSR_MXISA` | MRO | NEORV32-specific "eXtended" machine CPU ISA and extensions
 |=======================
 
 
@@ -225,7 +226,7 @@ bits can actually be modified.
 | 3     | `CSR_MSTATUS_MIE`  | r/w | **MIE**: Machine-mode interrupt enable flag
 | 7     | `CSR_MSTATUS_MPIE` | r/w | **MPIE**: Previous machine-mode interrupt enable flag state
 | 12:11 | `CSR_MSTATUS_MPP_H` : `CSR_MSTATUS_MPP_L` | r/w | **MPP**: Previous machine privilege mode, 11 = machine (M) mode, 00 = user (U) mode
-| 17    | `CSR_MSTATUS_MPRV` | r/w | **MPRV**: Effective privilege mode for load/stores in machine mode; use `MPP`'s as effective privilege mode when set; hardwired to zero if user-mode not implemented
+| 17    | `CSR_MSTATUS_MPRV` | r/w | **MPRV**: Effective privilege mode for load/stores in machine mode; use `MPP` as effective privilege mode when set; hardwired to zero if user-mode not implemented
 | 21    | `CSR_MSTATUS_TW`   | r/w | **TW**: Trap on execution of `wfi` instruction in user mode when set; hardwired to zero if user-mode not implemented
 |=======================
 
@@ -441,28 +442,17 @@ an instruction is triggered / an exception is raised. See section <<_traps_excep
 [cols="<1,<8"]
 [frame="topbot",grid="none"]
 |=======================
-| Name        | Machine trap value register
+| Name        | Machine trap value
 | Address     | `0x343`
 | Reset value | `0x00000000`
 | ISA         | `Zicsr`
-| Description | The `mtval` CSR provides additional information why a trap was entered. See section <<_traps_exceptions_and_interrupts>> for more information
+| Description | The `mtval` CSR provides additional information why a trap was entered. See section <<_traps_exceptions_and_interrupts>> for more information.
 |=======================
 
+.Read-Only
 [IMPORTANT]
-Note that the NEORV32 `mtval` register is read only. Any write-access will be ignored and will not cause an exception to
-maintain RISC-V compatibility.
-
-.`mtval` CSR bits
-[cols="^5,^5"]
-[options="header",grid="rows"]
-|=======================
-| Trap cause | `mtval` value
-| misaligned instruction fetch address or instruction fetch access fault | address of faulting instruction fetch
-| misaligned load address, load access fault, misaligned store address or store access fault | address of faulting instruction
-| illegal instruction | instruction word that caused the exception (zero-extended if compressed instruction)
-| breakpoint exception | address of breakpoint instruction / instruction address that caused a hardware trigger
-| everything else (including all interrupts) | all-zero
-|=======================
+Note that the NEORV32 `mtval` CSR is updated by the hardware only and cannot be written from software.
+However, any write-access will be ignored and will not cause an exception to maintain RISC-V compatibility.
 
 
 {empty} +
@@ -497,6 +487,33 @@ specific for the interrupt-causing modules. the according interrupt-generating d
 [TIP]
 See section <<_neorv32_specific_fast_interrupt_requests>> for the mapping of the FIRQ channels and the according
 interrupt-triggering processor module.
+
+
+{empty} +
+[discrete]
+===== **`mtinst`**
+
+[cols="<1,<8"]
+[frame="topbot",grid="none"]
+|=======================
+| Name        | Machine trap instruction
+| Address     | `0x34a`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr`
+| Description | The `mtinst` CSR provides additional information why a trap was entered. See section <<_traps_exceptions_and_interrupts>> for more information.
+|=======================
+
+.Read-Only
+[IMPORTANT]
+Note that the NEORV32 `mtinst` CSR is updated by the hardware only and cannot be written from software.
+However, any write-access will be ignored and will not cause an exception to maintain RISC-V compatibility.
+
+.Instruction Transformation
+[IMPORTANT]
+The RISC-V priv. spec. suggests that the instruction word written to `mtinst` by the hardware should be "transformed".
+However, the NEORV32 `mtinst` CSR uses a simplified transformation scheme: if the trap-causing instruction is a
+standard 32-bit instruction, `mtinst` contains the exact instruction word that caused the trap. If the trap-causing
+instruction is a compressed instruction, `mtinst` contains the de-compressed 32-bit equivalent with bit 1 being cleared.
 
 
 <<<

--- a/docs/datasheet/software_rte.adoc
+++ b/docs/datasheet/software_rte.adoc
@@ -160,17 +160,17 @@ cannot be resolved by the default debug trap handlers and will halt the CPU (see
 .RTE Default Trap Handler Output Examples
 [source]
 ----
-<RTE> [M] Illegal instruction @ PC=0x000002d6, MTVAL=0x000000FF </RTE> <1>
-<RTE> [U] Illegal instruction @ PC=0x00000302, MTVAL=0x00000000 </RTE> <2>
-<RTE> [U] Load address misaligned @ PC=0x00000440, MTVAL=0x80000101 </RTE> <3>
-<RTE> [M] Fast IRQ 0x00000003 @ PC=0x00000820, MTVAL=0x00000000 </RTE> <4>
-<RTE> [M] Instruction access fault @ PC=0x90000000, MTVAL=0x00000000 [FATAL EXCEPTION] Halting CPU. </RTE>\n <5>
+<RTE> [M] Illegal instruction @ PC=0x000002d6, MTINST=0x000000FF, MTVAL=0x00000000 </RTE> <1>
+<RTE> [U] Illegal instruction @ PC=0x00000302, MTINST=0x00000000, MTVAL=0x00000000 </RTE> <2>
+<RTE> [U] Load address misaligned @ PC=0x00000440, MTINST=0x01052603, MTVAL=0x80000101 </RTE> <3>
+<RTE> [M] Fast IRQ 0x00000003 @ PC=0x00000820, MTINST=0x00000000, MTVAL=0x00000000 </RTE> <4>
+<RTE> [M] Instruction access fault @ PC=0x90000000, MTINST=0x42078b63, MTVAL=0x00000000 [FATAL EXCEPTION] Halting CPU. </RTE>\n <5>
 ----
-<1> Illegal 32-bit instruction `0x000000FF` at address `0x000002d6` while the CPU was in machine-mode (`[M]`).
-<2> Illegal 16-bit instruction `0x0000` (zero-extended) at address `0x00000302` while the CPU was in user-mode (`[U]`).
-<3> Misaligned load access at address `0x00000440` (trying to load a full 32-bit word from address `0x80000101`) while the CPU was in machine-mode.
-<4> Fast interrupt request from channel 3 before executing instruction at address `0x00000820` while the CPU was in machine-mode.
-<5> Instruction bus access fault at address `0x90000000` - this is fatal for the default debug trap handler while the CPU was in machine-mode.
+<1> Illegal 32-bit instruction `MTINST=0x000000FF` at address `PC=0x000002d6` while the CPU was in machine-mode (`[M]`).
+<2> Illegal 16-bit instruction `MTINST=0x00000000` at address `PC=0x00000302` while the CPU was in user-mode (`[U]`).
+<3> Misaligned load access at address `PC=0x00000440` caused by instruction `MTINST=0x01052603` (trying to load a full 32-bit word from address `MTVAL=0x80000101`) while the CPU was in machine-mode (`[U]`).
+<4> Fast interrupt request from channel 3 before executing instruction at address `PC=0x00000820` while the CPU was in machine-mode (`[M]`).
+<5> Instruction bus access fault at address `PC=0x90000000` while executing instruction `MTINST=0x42078b63` - this is fatal for the default debug trap handler while the CPU was in machine-mode (`[M]`).
 
 The specific message right at the beginning of the debug trap handler message corresponds to the trap code
 obtained from the <<_mcause>> CSR (see <<_neorv32_trap_listing>>). A full list of all messages and the according

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080801"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080802"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 
@@ -368,6 +368,7 @@ package neorv32_package is
   constant csr_mcause_c         : std_ulogic_vector(11 downto 0) := x"342";
   constant csr_mtval_c          : std_ulogic_vector(11 downto 0) := x"343";
   constant csr_mip_c            : std_ulogic_vector(11 downto 0) := x"344";
+  constant csr_mtinst_c         : std_ulogic_vector(11 downto 0) := x"34a";
   -- physical memory protection - configuration --
   constant csr_pmpcfg0_c        : std_ulogic_vector(11 downto 0) := x"3a0";
   constant csr_pmpcfg1_c        : std_ulogic_vector(11 downto 0) := x"3a1";

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -155,6 +155,9 @@ int main() {
   }
 
 
+  // clear GPIOs (they are used by the TB to trigger external events)
+  neorv32_gpio_port_set(0);
+
   // check available hardware extensions and compare with compiler flags
   neorv32_rte_check_isa(0); // silent = 0 -> show message if isa mismatch
 
@@ -847,6 +850,7 @@ int main() {
 
     // wait some time for the IRQ to arrive the CPU
     asm volatile ("nop");
+    asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
     sim_irq_trigger(0);
@@ -879,6 +883,7 @@ int main() {
     sim_irq_trigger(1 << CSR_MIE_MEIE);
 
     // wait some time for the IRQ to arrive the CPU
+    asm volatile ("nop");
     asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
@@ -937,13 +942,14 @@ int main() {
   if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_MTIME)) {
     cnt_test++;
 
-    // disable all interrupt setting
+    // disable all interrupts
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
     // fire MTIME IRQ
     neorv32_mtime_set_timecmp(0); // force interrupt
 
     // wait some time for the IRQ to arrive the CPU
+    asm volatile ("nop");
     asm volatile ("nop");
 
     uint32_t was_pending = neorv32_cpu_csr_read(CSR_MIP) & (1 << CSR_MIP_MTIP); // should be pending now
@@ -981,7 +987,7 @@ int main() {
     // timeout = 1*4096 cycles, no lock, disable in debug mode, enable in sleep mode
     neorv32_wdt_setup(1, 0, 0, 1);
 
-    // wait in sleep mode for WDT interrupt
+    // sleep until interrupt
     asm volatile ("wfi");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
@@ -1032,7 +1038,8 @@ int main() {
     while(neorv32_uart0_tx_busy());
 
     // wait for interrupt
-    asm volatile ("wfi");
+    asm volatile ("nop");
+    asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1077,7 +1084,8 @@ int main() {
     neorv32_cpu_irq_enable(UART0_TX_FIRQ_ENABLE);
 
     // wait for interrupt
-    asm volatile ("wfi");
+    asm volatile ("nop");
+    asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1119,7 +1127,8 @@ int main() {
     while(neorv32_uart1_tx_busy());
 
     // wait for interrupt
-    asm volatile ("wfi");
+    asm volatile ("nop");
+    asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1161,7 +1170,8 @@ int main() {
     neorv32_cpu_irq_enable(UART1_TX_FIRQ_ENABLE);
 
     // wait for interrupt
-    asm volatile ("wfi");
+    asm volatile ("nop");
+    asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1199,7 +1209,8 @@ int main() {
     neorv32_spi_trans(0); // blocking
 
     // wait for interrupt
-    asm volatile ("wfi");
+    asm volatile ("nop");
+    asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1234,7 +1245,8 @@ int main() {
     neorv32_twi_start_trans(0xA5);
 
     // wait for interrupt
-    asm volatile ("wfi");
+    asm volatile ("nop");
+    asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1273,7 +1285,8 @@ int main() {
     neorv32_gpio_port_set(3);
 
     // wait for interrupt
-    asm volatile ("wfi");
+    asm volatile ("nop");
+    asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1312,7 +1325,8 @@ int main() {
     neorv32_neoled_write_nonblocking(0);
 
     // sleep until interrupt
-    asm volatile("wfi");
+    asm volatile ("nop");
+    asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1351,7 +1365,7 @@ int main() {
     tmp_a = DMA_CMD_B2UW | DMA_CMD_SRC_INC | DMA_CMD_DST_CONST | DMA_CMD_ENDIAN;
     neorv32_dma_transfer((uint32_t)(&dma_src), (uint32_t)(&NEORV32_CRC->DATA), 4, tmp_a);
 
-    // wait for transfer-done interrupt
+    // sleep until interrupt
     asm volatile ("wfi");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
@@ -1402,7 +1416,8 @@ int main() {
     neorv32_spi_cs_dis();
 
     // wait for interrupt
-    asm volatile ("wfi");
+    asm volatile ("nop");
+    asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1436,7 +1451,8 @@ int main() {
     neorv32_gptmr_setup(CLK_PRSC_2, 0, 2);
 
     // wait for interrupt
-    asm volatile ("wfi");
+    asm volatile ("nop");
+    asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1472,7 +1488,8 @@ int main() {
     neorv32_onewire_read_bit_blocking();
 
     // wait for interrupt
-    asm volatile ("wfi");
+    asm volatile ("nop");
+    asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1494,7 +1511,7 @@ int main() {
   // ----------------------------------------------------------
   PRINT_STANDARD("[%i] FIRQ14 (SLINK) ", cnt_test);
 
-  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_TRNG)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_SLINK)) {
     cnt_test++;
 
     // enable SLINK FIRQ
@@ -1507,7 +1524,8 @@ int main() {
     neorv32_slink_put(0xAABBCCDD);
 
     // wait for interrupt
-    asm volatile ("wfi");
+    asm volatile ("nop");
+    asm volatile ("nop");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
@@ -1540,7 +1558,7 @@ int main() {
     NEORV32_TRNG->CTRL = (1 << TRNG_CTRL_EN) |
                          (1 << TRNG_CTRL_IRQ_FIFO_FULL); // IRQ if FIFO is full
 
-    // wait for interrupt
+    // sleep until interrupt
     asm volatile ("wfi");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
@@ -1949,35 +1967,37 @@ int main() {
   // ----------------------------------------------------------
   neorv32_cpu_csr_write(CSR_MCOUNTINHIBIT, -1); // stop all HPM counters
   if (neorv32_cpu_csr_read(CSR_MXISA) & (1 << CSR_MXISA_ZIHPM)) {
-    PRINT_STANDARD("\n\nHPMs:\n"
-                   "#00 Instr.   : %u\n"
-                   "#02 Clocks   : %u\n"
-                   "#03 C instr. : %u\n"
-                   "#04 IF wait  : %u\n"
-                   "#05 II wait  : %u\n"
-                   "#06 ALU wait : %u\n"
-                   "#07 MEM LD   : %u\n"
-                   "#08 MEM ST   : %u\n"
-                   "#09 MEM wait : %u\n"
-                   "#10 Jumps    : %u\n"
-                   "#11 Branches : %u\n"
-                   "#12 >taken   : %u\n"
-                   "#13 Traps    : %u\n"
-                   "#14 Illegals : %u\n",
-                   (uint32_t)neorv32_cpu_csr_read(CSR_INSTRET),
-                   (uint32_t)neorv32_cpu_csr_read(CSR_CYCLE),
-                   (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER3),
-                   (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER4),
-                   (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER5),
-                   (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER6),
-                   (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER7),
-                   (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER8),
-                   (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER9),
-                   (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER10),
-                   (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER11),
-                   (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER12),
-                   (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER13),
-                   (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER14));
+    PRINT_STANDARD(
+      "\n\nHPMs:\n"
+      "#00 Instr.   : %u\n"
+      "#02 Clocks   : %u\n"
+      "#03 C instr. : %u\n"
+      "#04 IF wait  : %u\n"
+      "#05 II wait  : %u\n"
+      "#06 ALU wait : %u\n"
+      "#07 MEM LD   : %u\n"
+      "#08 MEM ST   : %u\n"
+      "#09 MEM wait : %u\n"
+      "#10 Jumps    : %u\n"
+      "#11 Branches : %u\n"
+      "#12 >taken   : %u\n"
+      "#13 Traps    : %u\n"
+      "#14 Illegals : %u\n",
+      neorv32_cpu_csr_read(CSR_INSTRET),
+      neorv32_cpu_csr_read(CSR_CYCLE),
+      neorv32_cpu_csr_read(CSR_MHPMCOUNTER3),
+      neorv32_cpu_csr_read(CSR_MHPMCOUNTER4),
+      neorv32_cpu_csr_read(CSR_MHPMCOUNTER5),
+      neorv32_cpu_csr_read(CSR_MHPMCOUNTER6),
+      neorv32_cpu_csr_read(CSR_MHPMCOUNTER7),
+      neorv32_cpu_csr_read(CSR_MHPMCOUNTER8),
+      neorv32_cpu_csr_read(CSR_MHPMCOUNTER9),
+      neorv32_cpu_csr_read(CSR_MHPMCOUNTER10),
+      neorv32_cpu_csr_read(CSR_MHPMCOUNTER11),
+      neorv32_cpu_csr_read(CSR_MHPMCOUNTER12),
+      neorv32_cpu_csr_read(CSR_MHPMCOUNTER13),
+      neorv32_cpu_csr_read(CSR_MHPMCOUNTER14)
+    );
   }
 
 

--- a/sw/lib/include/neorv32_cpu_csr.h
+++ b/sw/lib/include/neorv32_cpu_csr.h
@@ -46,27 +46,20 @@
  * Available CPU Control and Status Registers (CSRs)
  **************************************************************************/
 enum NEORV32_CSR_enum {
-  /* hardware-only CSR, NEORV32-specific, not accessible by software */
-//CSR_ZERO           = 0x000, /**< 0x000 - zero: Always zero */
-
   /* floating-point unit control and status */
   CSR_FFLAGS         = 0x001, /**< 0x001 - fflags: Floating-point accrued exception flags */
   CSR_FRM            = 0x002, /**< 0x002 - frm:    Floating-point dynamic rounding mode */
   CSR_FCSR           = 0x003, /**< 0x003 - fcsr:   Floating-point control/status register (frm + fflags) */
 
   /* machine control and status */
-  CSR_MSTATUS        = 0x300, /**< 0x300 - mstatus:    Machine status register */
-  CSR_MISA           = 0x301, /**< 0x301 - misa:       CPU ISA and extensions (read-only in NEORV32) */
-  CSR_MIE            = 0x304, /**< 0x304 - mie:        Machine interrupt-enable register */
-  CSR_MTVEC          = 0x305, /**< 0x305 - mtvec:      Machine trap-handler base address (for ALL traps) */
-  CSR_MCOUNTEREN     = 0x306, /**< 0x305 - mcounteren: Machine counter enable register (controls access rights from U-mode) */
-
-  CSR_MENVCFG        = 0x30a, /**< 0x30a - menvcfg: Machine environment configuration register */
-
-  CSR_MSTATUSH       = 0x310, /**< 0x310 - mstatush: Machine status register - high word */
-
-  CSR_MENVCFGH       = 0x31a, /**< 0x31a - menvcfgh: Machine environment configuration register - high word */
-
+  CSR_MSTATUS        = 0x300, /**< 0x300 - mstatus:       Machine status register */
+  CSR_MISA           = 0x301, /**< 0x301 - misa:          Machine ISA and extensions */
+  CSR_MIE            = 0x304, /**< 0x304 - mie:           Machine interrupt-enable register */
+  CSR_MTVEC          = 0x305, /**< 0x305 - mtvec:         Machine trap-handler base address */
+  CSR_MCOUNTEREN     = 0x306, /**< 0x305 - mcounteren:    Machine counter enable register */
+  CSR_MENVCFG        = 0x30a, /**< 0x30a - menvcfg:       Machine environment configuration register */
+  CSR_MSTATUSH       = 0x310, /**< 0x310 - mstatush:      Machine status register - high word */
+  CSR_MENVCFGH       = 0x31a, /**< 0x31a - menvcfgh:      Machine environment configuration register - high word */
   CSR_MCOUNTINHIBIT  = 0x320, /**< 0x320 - mcountinhibit: Machine counter-inhibit register */
 
   /* hardware performance monitors - event configuration */
@@ -88,8 +81,9 @@ enum NEORV32_CSR_enum {
   CSR_MSCRATCH       = 0x340, /**< 0x340 - mscratch: Machine scratch register */
   CSR_MEPC           = 0x341, /**< 0x341 - mepc:     Machine exception program counter */
   CSR_MCAUSE         = 0x342, /**< 0x342 - mcause:   Machine trap cause */
-  CSR_MTVAL          = 0x343, /**< 0x343 - mtval:    Machine trap value register */
+  CSR_MTVAL          = 0x343, /**< 0x343 - mtval:    Machine trap value */
   CSR_MIP            = 0x344, /**< 0x344 - mip:      Machine interrupt pending register */
+  CSR_MTINST         = 0x34a, /**< 0x34a - mtinst:   Machine trap instruction */
 
   /* physical memory protection */
   CSR_PMPCFG0        = 0x3a0, /**< 0x3a0 - pmpcfg0: Physical memory protection configuration register 0 (regions 0..3) */
@@ -131,7 +125,6 @@ enum NEORV32_CSR_enum {
 
   /* machine counters and timers */
   CSR_MCYCLE         = 0xb00, /**< 0xb00 - mcycle:        Machine cycle counter low word */
-  //
   CSR_MINSTRET       = 0xb02, /**< 0xb02 - minstret:      Machine instructions-retired counter low word */
   CSR_MHPMCOUNTER3   = 0xb03, /**< 0xb03 - mhpmcounter3:  Machine hardware performance monitor 3  counter low word */
   CSR_MHPMCOUNTER4   = 0xb04, /**< 0xb04 - mhpmcounter4:  Machine hardware performance monitor 4  counter low word */
@@ -148,7 +141,6 @@ enum NEORV32_CSR_enum {
   CSR_MHPMCOUNTER15  = 0xb0f, /**< 0xb0f - mhpmcounter15: Machine hardware performance monitor 15 counter low word */
 
   CSR_MCYCLEH        = 0xb80, /**< 0xb80 - mcycleh:        Machine cycle counter high word */
-  //
   CSR_MINSTRETH      = 0xb82, /**< 0xb82 - minstreth:      Machine instructions-retired counter high word */
   CSR_MHPMCOUNTER3H  = 0xb83, /**< 0xb83 - mhpmcounter3 :  Machine hardware performance monitor 3  counter high word */
   CSR_MHPMCOUNTER4H  = 0xb84, /**< 0xb84 - mhpmcounter4h:  Machine hardware performance monitor 4  counter high word */
@@ -165,9 +157,8 @@ enum NEORV32_CSR_enum {
   CSR_MHPMCOUNTER15H = 0xb8f, /**< 0xb8f - mhpmcounter15h: Machine hardware performance monitor 15 counter high word */
 
   /* user counters and timers */
-  CSR_CYCLE          = 0xc00, /**< 0xc00 - cycle:        Cycle counter low word (from MCYCLE) */
-  //
-  CSR_INSTRET        = 0xc02, /**< 0xc02 - instret:      Instructions-retired counter low word (from MINSTRET) */
+  CSR_CYCLE          = 0xc00, /**< 0xc00 - cycle:        User cycle counter low word */
+  CSR_INSTRET        = 0xc02, /**< 0xc02 - instret:      User instructions-retired counter low word */
   CSR_HPMCOUNTER3    = 0xc03, /**< 0xc03 - hpmcounter3:  User hardware performance monitor 3  counter low word */
   CSR_HPMCOUNTER4    = 0xc04, /**< 0xc04 - hpmcounter4:  User hardware performance monitor 4  counter low word */
   CSR_HPMCOUNTER5    = 0xc05, /**< 0xc05 - hpmcounter5:  User hardware performance monitor 5  counter low word */
@@ -182,9 +173,8 @@ enum NEORV32_CSR_enum {
   CSR_HPMCOUNTER14   = 0xc0e, /**< 0xc0e - hpmcounter14: User hardware performance monitor 14 counter low word */
   CSR_HPMCOUNTER15   = 0xc0f, /**< 0xc0f - hpmcounter15: User hardware performance monitor 15 counter low word */
 
-  CSR_CYCLEH         = 0xc80, /**< 0xc80 - cycleh:        Cycle counter high word (from MCYCLEH) */
-  //
-  CSR_INSTRETH       = 0xc82, /**< 0xc82 - instreth:      Instructions-retired counter high word (from MINSTRETH) */
+  CSR_CYCLEH         = 0xc80, /**< 0xc80 - cycleh:        User cycle counter high word */
+  CSR_INSTRETH       = 0xc82, /**< 0xc82 - instreth:      User instructions-retired counter high word */
   CSR_HPMCOUNTER3H   = 0xc83, /**< 0xc83 - hpmcounter3h:  User hardware performance monitor 3  counter high word */
   CSR_HPMCOUNTER4H   = 0xc84, /**< 0xc84 - hpmcounter4h:  User hardware performance monitor 4  counter high word */
   CSR_HPMCOUNTER5H   = 0xc85, /**< 0xc85 - hpmcounter5h:  User hardware performance monitor 5  counter high word */
@@ -200,13 +190,12 @@ enum NEORV32_CSR_enum {
   CSR_HPMCOUNTER15H  = 0xc8f, /**< 0xc8f - hpmcounter15h: User hardware performance monitor 15 counter high word */
 
   /* machine information registers */
-  CSR_MVENDORID      = 0xf11, /**< 0xf11 - mvendorid:  Vendor ID */
-  CSR_MARCHID        = 0xf12, /**< 0xf12 - marchid:    Architecture ID */
-  CSR_MIMPID         = 0xf13, /**< 0xf13 - mimpid:     Implementation ID/version */
-  CSR_MHARTID        = 0xf14, /**< 0xf14 - mhartid:    Hardware thread ID (always 0) */
+  CSR_MVENDORID      = 0xf11, /**< 0xf11 - mvendorid:  Machine vendor ID */
+  CSR_MARCHID        = 0xf12, /**< 0xf12 - marchid:    Machine architecture ID */
+  CSR_MIMPID         = 0xf13, /**< 0xf13 - mimpid:     Machine implementation ID */
+  CSR_MHARTID        = 0xf14, /**< 0xf14 - mhartid:    Machine hardware thread ID */
   CSR_MCONFIGPTR     = 0xf15, /**< 0xf15 - mconfigptr: Machine configuration pointer register */
-
-  CSR_MXISA          = 0xfc0  /**< 0xfc0 - mxisa: NEORV32-specific machine "extended CPU ISA and extensions" */
+  CSR_MXISA          = 0xfc0  /**< 0xfc0 - mxisa:      Machine extended ISA and extensions (NEORV32-specific) */
 };
 
 


### PR DESCRIPTION
* ⚠️ constrain `mtval` CSR - does no longer provide the faulting instruction word when an illegal instruction exception has been raised (allowed by RISC-V priv. spec.; simplifies hardware)
* add new `minstret` CSR that shows the (decompressed) instruction word for **all** synchronous exceptions