### PR TITLE
[OCD] add option to select DM legacy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 25.08.2023 | 1.8.8.4 | add new generic to downgrade on-chip debugger's debug module back to spec. version 0.13 (`DM_LEGACY_MODE` generic); [#677](https://github.com/stnolting/neorv32/pull/677) |
 | 23.08.2023 | 1.8.8.3 | :test_tube: add experimental `Smcntrpmf` ISA extension (counter privilege mode filtering; spec. is frozen but not yet ratified); remove unused `menvcfg` CSRs; [#676](https://github.com/stnolting/neorv32/pull/676) |
 | 19.08.2023 | 1.8.8.2 | :warning: constrain `mtval` CSR; add support for `mtinst` CSR (trap instruction); [#674](https://github.com/stnolting/neorv32/pull/674) |
 | 19.08.2023 | 1.8.8.1 | :test_tube: update RTE to support easy emulation of instructions; add example program to showcase how to emulate unaligned memory accesses; [#673](https://github.com/stnolting/neorv32/pull/673) |

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -3,8 +3,17 @@
 == On-Chip Debugger (OCD)
 
 The NEORV32 Processor features an _on-chip debugger_ (OCD) implementing the **execution-based debugging** scheme,
-which is compatible to the **Minimal RISC-V Debug Specification Version 1.0**. A copy of the specification is
+which is compatible to the **Minimal RISC-V Debug Specification**. A copy of the specification is
 available in `docs/references`.
+
+**Key Features**
+
+* standard JTAG access port
+* full control of the CPU: halting, single-stepping and resuming
+* indirect access to all core registers (via program buffer)
+* indirect access to the whole processor address space (via program buffer)
+* trigger module for hardware breakpoints
+* compatible with upstream OpenOCD and GDB
 
 **Section Structure**
 
@@ -12,21 +21,6 @@ available in `docs/references`.
 * <<_debug_module_dm>>
 * <<_cpu_debug_mode>>
 * <<_trigger_module>>
-
-**Key Features**
-
-* standard JTAG access port
-* run-control of the CPU: halting, single-stepping and resuming
-* executing arbitrary programs during debugging
-* indirect access to all core registers (via program buffer)
-* indirect access to the whole processor address space (via program buffer)
-* trigger module for hardware breakpoints
-* compatible with upstream OpenOCD and GDB
-
-.OCD Security Note
-[NOTE]
-Access via the OCD is **always authenticated** (`dmstatus.authenticated = 1`). Hence, the entire system can always
-be accessed via the on-chip debugger.
 
 .GDB + SVD
 [TIP]
@@ -39,6 +33,11 @@ A simple example on how to use NEORV32 on-chip debugger in combination with Open
 section https://stnolting.github.io/neorv32/ug/#_debugging_using_the_on_chip_debugger[Debugging using the On-Chip Debugger]
 of the User Guide.
 
+.OCD Security Note
+[NOTE]
+JTAG access via the OCD is **always authenticated** (`dmstatus.authenticated = 1`). Hence, the entire system can always
+be accessed via the on-chip debugger.
+
 The NEORV32 on-chip debugger complex is based on four hardware modules:
 
 .NEORV32 on-chip debugger complex
@@ -46,15 +45,14 @@ image::neorv32_ocd_complex.png[align=center]
 
 [start=1]
 . <<_debug_transport_module_dtm>> (`rtl/core/neorv32_debug_dtm.vhd`): JTAG access tap to allow an external
-adapter to interface with the _debug module (DM)_ using the _debug module interface (dmi)_ - this interface is compatible to
-the interface description shown in Appendix 3 of the "RISC-V debug" specification.
-. <<_debug_module_dm>> (`rtl/core/neorv32_debug_tm.vhd`): Debugger control unit that is configured by the DTM via the _dmi_.
+adapter to interface with the _debug module (DM)_ using the _debug module interface (dmi)_.
+. <<_debug_module_dm>> (`rtl/core/neorv32_debug_tm.vhd`): RISC-V debug module that is configured by the DTM via the _dmi_.
 From the CPU's "point of view" this module behaves as another memory-mapped "peripheral" that can be accessed via the
 processor-internal bus. The memory-mapped registers provide an internal _data buffer_ for data transfer from/to the DM, a
 _code ROM_ containing the "park loop" code, a _program buffer_ to allow the debugger to execute small programs defined by the
 DM and a _status register_ that is used to communicate _exception, _halt_, _resume_ and _execute_ requests/acknowledges from/to the DM.
-. CPU <<_cpu_debug_mode>> extension (part of `rtl/core/neorv32_cpu_control.vhd`): This extension provides the "debug execution mode"
-which executes the "park loop" code from the DM. The mode also provides additional CSRs.
+. CPU <<_cpu_debug_mode>> extension (part of `rtl/core/neorv32_cpu_control.vhd`): This extension provides the "debug execution mode",
+which executes the park loop code from the DM. The mode also provides additional CSRs and instructions.
 . CPU <<_trigger_module>> (also part of `rtl/core/neorv32_cpu_control.vhd`): This module provides a single _hardware_ breakpoint,
 which allows to debug code executed from ROM.
 
@@ -62,15 +60,16 @@ which allows to debug code executed from ROM.
 
 When debugging the system using the OCD, the debugger issues a halt request to the CPU (via the CPU's
 `db_halt_req_i` signal) to make the CPU enter _debug mode_. In this state, the application-defined architectural
-state of the system/CPU is "frozen" so the debugger can monitor if without interfering the actual application.
-However, the OCD can also modify the entire architectural state at any time.
+state of the system/CPU is "frozen" so the debugger can monitor if without interfering with the actual application.
+However, the OCD can also modify the entire architectural state at any time. While in debug mode, the debugger has
+full control over the entire CPU and processor.
 
-While in debug mode, the CPU executes the "park loop" code from the _code ROM_ of the DM.
+While in debug mode, the CPU executes the "park loop" code from the code ROM of the DM.
 This park loop implements an endless loop, where the CPU polls the memory-mapped _status register_ that is
-controlled by the _debug module (DM)_. The flags in this register are used to communicate requests from
+controlled by the debug module (DM). The flags in this register are used to communicate requests from
 the DM and to acknowledge them by the CPU: trigger execution of the program buffer or resume the halted
 application. Furthermore, the CPU uses this register to signal that the CPU has halted after a halt request
-and to signal that an exception has fired while being in debug mode.
+and to signal that an exception has been triggered while being in debug mode.
 
 
 <<<
@@ -86,7 +85,7 @@ External JTAG access is provided by the following top-level ports.
 [options="header",grid="rows"]
 |=======================
 | Name          | Width | Direction | Description
-| `jtag_trst_i` | 1     | in        | TAP reset (low-active); this signal is optional, make sure to pull it _high_ if not used
+| `jtag_trst_i` | 1     | in        | TAP reset (low-active); this signal is optional, make sure to pull it **high** if not used
 | `jtag_tck_i`  | 1     | in        | serial clock
 | `jtag_tdi_i`  | 1     | in        | serial data input
 | `jtag_tdo_o`  | 1     | out       | serial data output
@@ -99,6 +98,7 @@ All JTAG signals are synchronized to the processor's clock domain. Hence, no add
 However, this constraints the maximal JTAG clock frequency (`jtag_tck_i`) to be less than or equal to **1/5** of the processor
 clock frequency (`clk_i`).
 
+.Maintaining JTAG Chain
 [NOTE]
 If the on-chip debugger is disabled the JTAG serial input `jtag_tdi_i` is directly
 connected to the JTAG serial output `jtag_tdo_o` to maintain the JTAG chain.
@@ -111,10 +111,10 @@ register. The following table shows the available data registers and their addre
 [cols="^2,^2,^2,<8"]
 [options="header",grid="rows"]
 |=======================
-| Address (via `IR`) | Name     | Size [bits] | Description
+| Address (via `IR`) | Name     | Size (bits) | Description
 | `00001`            | `IDCODE` | 32          | identifier, hardwired to `0x00000001`
 | `10000`            | `DTMCS`  | 32          | debug transport module control and status register
-| `10001`            | `DMI`    | 40          | debug module interface (_dmi_); 6-bit address, 32-bit read/write data, 2-bit operation (`00` = NOP; `10` = write; `01` = read)
+| `10001`            | `DMI`    | 41          | debug module interface (_dmi_); 7-bit address, 32-bit read/write data, 2-bit operation (`00` = NOP; `10` = write; `01` = read)
 | others             | `BYPASS` | 1           | default JTAG bypass register
 |=======================
 
@@ -130,12 +130,8 @@ register. The following table shows the available data registers and their addre
 | 14:12  | `idle`         | r/- | recommended idle states (= 0, no idle states required)
 | 11:10  | `dmistat`      | r/- | DMI status: `00` = no error, `01` = reserved, `10` = operation failed, `11` = failed operation during pending DMI operation
 | 9:4    | `abits`        | r/- | number of address bits in `DMI` register (= 6)
-| 3:0    | `version`      | r/- | `0001` = DTM is compatible to spec. version 0.13 & 1.0
+| 3:0    | `version`      | r/- | `0001` = DTM is compatible to spec. versions v0.13 and v1.0
 |=======================
-
-[NOTE]
-The DTM's instruction and data registers can be accessed using OpenOCD's `irscan` and `drscan` commands.
-OpenOCD also provides low-level RISC-V-specific commands for direct DMI accesses (`riscv dmi_read` & `riscv dmi_write`).
 
 
 <<<
@@ -144,25 +140,29 @@ OpenOCD also provides low-level RISC-V-specific commands for direct DMI accesses
 === Debug Module (DM)
 
 The debug module "DM" (VHDL module: `rtl/core/neorv32_debug_dm.vhd`) acts as a translation interface between abstract
-operations issued by the debugger (application) and the platform-specific debugger (circuit) implementation.
+operations issued by the debugger (application) and the platform-specific debugger (hardware) implementation.
 It supports the following features:
 
 * Gives the debugger necessary information about the implementation.
-* Allows the hart to be halted and resumed and provides status of the current state.
+* Allows the hart to be halted/resumed and provides status of the current state.
 * Provides abstract read and write access to the halted hart's GPRs.
 * Provides access to a reset signal that allows debugging from the very first instruction after reset.
-* Provides a mechanism to allow debugging the hart immediately out of reset. (_still experimental_)
 * Provides a Program Buffer to force the hart to execute arbitrary instructions.
 * Allows memory access from a hart's point of view.
 
 The NEORV32 DM follows the "Minimal RISC-V External Debug Specification" to provide full debugging capabilities while
-keeping resource/area requirements at a minimum level. It implements the **execution based debugging scheme** for a
+keeping resource/area requirements at a minimum. It implements the **execution based debugging scheme** for a
 single hart and provides the following hardware features:
 
 * program buffer with 2 entries and implicit `ebreak` instruction afterwards
 * no _direct_ bus access; indirect bus access via the CPU using the program buffer
 * abstract commands: "access register" plus auto-execution
-* no _dedicated_ halt-on-reset capabilities yet (but can be emulated)
+* no dedicated halt-on-reset capabilities yet (but can be emulated)
+
+.DM Spec. Version
+[TIP]
+By default, the OCD's debug module supports version 1.0 of the RISC-V debug spec. For backwards compatibility, the DM
+can be "downgraded" back to version 0.13 via the `DM_LEGACY_MODE` generic (see <<_processor_top_entity_generics>>).
 
 The DM provides two access "point of views": accesses from the DTM via the _debug module interface (dmi)_ and
 accesses from the CPU via the processor-internal bus. From the DTM's point of view, the DM implements a set of
@@ -174,41 +174,41 @@ debugging control and status (<<_dm_cpu_access>>).
 :sectnums:
 ==== DM Registers
 
-The DM is controlled via a set of registers that are accessed via the DTM's _dmi_. The following registers are implemented:
+The DM is controlled via a set of registers that are accessed via the DTM's _debug module interface_.
+The following registers are implemented:
 
 [NOTE]
 Write accesses to registers that are not implemented are simply ignored and read accesses will always return zero.
-Register names that are encapsulated in "( )" are not actually implemented; however, they are listed to explicitly show
-their functionality.
 
 .Available DM registers
 [cols="^2,^3,<7"]
 [options="header",grid="rows"]
 |=======================
-| Address | Name           | Description
-|  `0x04` | `data0`        | Abstract data 0, used for data transfer between debugger and processor
-|  `0x10` | `dmcontrol`    | Debug module control
-|  `0x11` | `dmstatus`     | Debug module status
-|  `0x12` | `hartinfo`     | Hart information
-|  `0x16` | `abstracts`    | Abstract control and status
-|  `0x17` | `command`      | Abstract command
-|  `0x18` | `abstractauto` | Abstract command auto-execution
-|  `0x1d` | (`nextdm`)     | Base address of _next_ DM; reads as zero to indicate there is only _one_ DM
-|  `0x20` | `progbuf0`     | Program buffer 0
-|  `0x21` | `progbuf1`     | Program buffer 1
-|  `0x38` | (`sbcs`)       | System bus access control and status; reads as zero to indicate there is **no** direct system bus access
+| Address | Name                     | Description
+| `0x04`  | <<_data0>>               | Abstract data 0, used for data transfer between debugger and processor
+| `0x10`  | <<_dmcontrol>>           | Debug module control
+| `0x11`  | <<_dmstatus>>            | Debug module status
+| `0x12`  | <<_hartinfo>>            | Hart information
+| `0x16`  | <<_abstracts>>           | Abstract control and status
+| `0x17`  | <<_command>>             | Abstract command
+| `0x18`  | <<_abstractauto>>        | Abstract command auto-execution
+| `0x1d`  | `nextdm`                 | Base address of next DM; reads as zero to indicate there is only one DM
+| `0x20`  | <<_progbuf, `progbuf0`>> | Program buffer 0
+| `0x21`  | <<_progbuf, `progbuf1`>> | Program buffer 1
+| `0x38`  | `sbcs`                   | System bus access control and status; reads as zero to indicate there is **no** direct system bus access
+| `0x40`  | <<_haltsum0>>            | Halted harts
 |=======================
 
 
 :sectnums!:
-===== **`data`**
+===== **`data0`**
 
 [cols="4,27,>7"]
 [frame="topbot",grid="none"]
 |======
 | 0x04 | **Abstract data 0** | `data0`
 3+| Reset value: `0x00000000`
-3+| Basic read/write registers to be used with abstract commands (for example to read/write data from/to CPU GPRs).
+3+| Basic read/write data exchange register to be used with abstract commands (for example to read/write data from/to CPU GPRs).
 |======
 
 
@@ -272,7 +272,7 @@ are configured as "zero" and are read-only. Writing '1' to these bits/fields wil
 |  6    | `authbusy`        | always `0`; there is no authentication
 |  5    | `hasresethaltreq` | always `0`; halt-on-reset is not supported (directly)
 |  4    | `confstrptrvalid` | always `0`; no configuration string available
-| 3:0   | `version`         | `0011` - DM is compatible to spec. version 1.0
+| 3:0   | `version`         | debug spec. version; `0011` (v1.0) or `0010` (v0.13); configured via the `DM_LEGACY_MODE` <<_processor_top_entity_generics>>
 |=======================
 
 
@@ -399,47 +399,60 @@ hart's GPRs (abstract command register index `0x1000` - `0x101f`).
 | 0x20 | **Program buffer 0** | `progbuf0`
 | 0x21 | **Program buffer 1** | `progbuf1`
 3+| Reset value: `0x00000013` ("NOP")
-3+| Program buffer (two entries) for the DM. Note that this register is read-only for the DM (allowed since spec. version 1.0)!
+3+| Program buffer (two entries) for the DM.
 |======
+
+
+:sectnums!:
+===== **`haltsum0`**
+
+[cols="4,27,>7"]
+[frame="topbot",grid="none"]
+|======
+| 0x408 | **Halted harts status** | `haltsum0`
+3+| Reset value: `0x00000000`
+3+| Hart has halted when according bit is set.
+|======
+
+.`haltsum0` Register Bits
+[cols="^1,^2,^1,<8"]
+[options="header",grid="rows"]
+|=======================
+| Bit | Name [RISC-V] | R/W | Description
+| 0   | `haltsum0[0]` | r/- | Hart is halted when set.
+|=======================
 
 
 :sectnums:
 ==== DM CPU Access
 
-From the CPU's perspective, the DM behaves as a memory-mapped peripheral that includes the following sub-modules:
+From the CPU's perspective, the DM behaves as a memory-mapped peripheral. It occupies 256 bytes of the CPU's address
+space starting at address `dm_base_c` (see table below). This address space is divided into four sections of 64 bytes
+each to provide access to the _park loop code ROM_, the _program buffer_, the _data buffer_ and the _status register_.
+The program buffer, the data buffer and the status register do not fully occupy the 64-byte-wide sections and are
+mirrored to fill the entire section.
 
-* a small ROM that contains the code for the "park loop", which is executed when the CPU is _in_ debug mode
-* a program buffer populated by the debugger host to execute small programs
-* a data buffer to transfer data between the processor and the debugger host
-* a status register to communicate debugging requests and status
-
-The DM occupies 256 bytes of the CPU's address space starting at address `dm_base_c` (see table below).
-This address space is divided into four sections of 64 bytes each to provide access to the _park loop code ROM_,
-the _program buffer_, the _data buffer_ and the _status register_. The program buffer, the data buffer and the
-status register do not fully occupy the 64-byte-wide sections and are mirrored to fill the entire section.
-
-.DM CPU access - address map (divided into four sections)
+.DM CPU Access - Address Map
 [cols="^2,^2,<5"]
 [options="header",grid="rows"]
 |=======================
 | Base address | Actual size | Description
 | `0xffffff00` |    64 bytes | ROM for the "park loop" code
-| `0xffffff40` |    16 bytes | Program buffer, provided by DM
-| `0xffffff80` |     4 bytes | Data buffer (`dm.data0`)
-| `0xffffffc0` |     4 bytes | Control and status register
+| `0xffffff40` |    16 bytes | Program buffer (<<_progbuf>>)
+| `0xffffff80` |     4 bytes | Data buffer (<<_data0>>)
+| `0xffffffc0` |     4 bytes | Control and <<_status_register>>
 |=======================
 
 .DM Register Access
 [IMPORTANT]
-All memory-mapped registers of the DM can only be accessed by the CPU if it is actually _in_ debug mode.
+All memory-mapped registers of the DM can only be accessed by the CPU if it is actually in debug mode.
 Hence, the DM registers are not "visible" for normal CPU operations.
 Any CPU access outside of debug mode will raise a bus access fault exception.
 
 .Park Loop Code Sources ("OCD Firmware")
 [NOTE]
-The assembly sources of the **park loop code** are available in `sw/ocd-firmware/park_loop.S`. Please note, that
-these sources are not intended to be changed by the user. Hence, the makefile does not provide an automatic option
-to compile and "install" the debugger ROM code into the HDL sources and require a manual copy
+The assembly sources of the **park loop code** are available in `sw/ocd-firmware/park_loop.S`. Please note that
+these sources are not intended to be changed by the user.
 
 
 :sectnums:
@@ -447,7 +460,7 @@ to compile and "install" the debugger ROM code into the HDL sources and require 
 
 The park loop code provides two entry points, where the actual code execution can start. These are used to enter
 the park loop either when an explicit request has been issued (for example a halt request) or when an exception
-has occurred _while executing_ the park loop itself.
+has occurred _while executing_ the park loop code itself.
 
 .Park Loop Entry Points
 [cols="^6,<4"]
@@ -459,10 +472,10 @@ has occurred _while executing_ the park loop itself.
 |=======================
 
 When the CPU enters or re-enters debug mode (for example via an `ebreak` in the DM's program buffer), it jumps to
-address of the _normal entry point_ for the park loop code defined by the `CPU_DEBUG_PARK_ADDR` generic
+the _normal entry point_ that is configured via the `CPU_DEBUG_PARK_ADDR` generic
 (<<_cpu_top_entity_generics>>). By default, this generic is set to `dm_park_entry_c`, which is defined in main
 package file. If an exception is encountered during debug mode, the CPU jumps to the address of the _exception
-entry point_ defined  by the `CPU_DEBUG_EXC_ADDR` generic (<<_cpu_top_entity_generics>>). By default, this generic
+entry point_ configured via the `CPU_DEBUG_EXC_ADDR` generic (<<_cpu_top_entity_generics>>). By default, this generic
 is set to `dm_exc_entry_c`, which is also defined in main package file.
 
 
@@ -470,12 +483,12 @@ is set to `dm_exc_entry_c`, which is also defined in main package file.
 ===== Status Register
 
 The status register provides a direct communication channel between the CPU's debug mode executing the park loop
-and the host-controlled debug module (DM). This register is used to communicate _requests_, which are issued by the
-DM. and the according _acknowledges_, which are generated by the CPU.
+and the debugger-controlled debug module. This register is used to communicate _requests_, which are issued by the
+DM and the according _acknowledges_, which are generated by the CPU.
 
 There are only 4 bits in this register that are used to implement the requests/acknowledges. Each bit is left-aligned
 in one sub-byte of the entire 32-bit register. Thus, the CPU can access each bit individually using _store-byte_ and
-_load-byte_ instruction. This eliminates the need to perform bit-masking in the park loop code leading to less code size
+_load-byte_ instructions. This eliminates the need to perform bit-masking in the park loop code leading to less code size
 and faster execution.
 
 .DM Status Register - CPU Access
@@ -483,14 +496,14 @@ and faster execution.
 [options="header",grid="rows"]
 |=======================
 | Bit   | Name               | CPU access <| Description
-.2+|  0 | `sreg_halt_ack`    | read       <| _this bit is write-only_
-        | -                  | write      <| Set by the CPU while it is halted (and executing the park loop)
-.2+|  8 | `sreg_resume_req`  | read       <| Set by the DM to request the CPU to resume normal operation
-        | `sreg_resume_ack`  | write      <| Set by the CPU before it starts resuming
-.2+| 16 | `sreg_execute_req` | read       <| Set by the DM to request execution of the program buffer
-        | `sreg_execute_ack` | write      <| Set by the CPU before it starts executing the program buffer
-.2+| 24 | -                  | read       <| _this bit is write-only_
-        | `sreg_execute_ack` | write      <| Set by the CPU if an exception occurs while being in debug mode
+.2+|  0 | `sreg_halt_ack`    | read       <| -
+        | -                  | write      <| Set by the CPU while it is halted (and executing the park loop).
+.2+|  8 | `sreg_resume_req`  | read       <| Set by the DM to request the CPU to resume normal operation.
+        | `sreg_resume_ack`  | write      <| Set by the CPU before it starts resuming.
+.2+| 16 | `sreg_execute_req` | read       <| Set by the DM to request execution of the program buffer.
+        | `sreg_execute_ack` | write      <| Set by the CPU before it starts executing the program buffer.
+.2+| 24 | -                  | read       <| -
+        | `sreg_execute_ack` | write      <| Set by the CPU if an exception occurs while being in debug mode.
 |=======================
 
 
@@ -499,35 +512,35 @@ and faster execution.
 :sectnums:
 === CPU Debug Mode
 
-The NEORV32 CPU Debug Mode `DB` or `DEBUG` is compatible to the **Minimal RISC-V Debug Specification 1.0**
+The NEORV32 CPU Debug Mode is compatible to the **Minimal RISC-V Debug Specification 1.0**
 `Sdext` (external debug) ISA extension. When enabled via the <<_sdext_isa_extension>> generic (CPU) and/or
 the `ON_CHIP_DEBUGGER_EN` (Processor) it adds a new CPU operation mode ("debug mode"), three additional CSRs
 (section <<_cpu_debug_mode_csrs>>) and one additional instruction (`dret`) to the core.
 
+.ISA Requirements
 [IMPORTANT]
-The CPU debug mode requires the `Zicsr` and `Zifencei` CPU extension to be implemented (top generics
-<<_zicsr_isa_extension>> and <<_zifencei_isa_extension>> = true).
+The CPU debug mode requires the `Zicsr` and `Zifencei` CPU extension to be implemented.
 
 The CPU debug-mode is entered on any of the following events:
 
 [start=1]
-. executed `ebreak` instruction (when in machine-mode and <<_dcsr>>.ebreakm is set OR when in user-mode and <<_dcsr>>.ebreaku is set)
-. debug halt request from external DM (via CPU signal `db_halt_req_i`, high-active, triggering on rising-edge)
-. finished executing of a single instruction while in single-step debugging mode (enabled via <<_dcsr>>.step)
-. hardware trigger by the <<_trigger_module>>
+. The CPU executes a `ebreak` instruction (when in machine-mode and `ebreakm` in <<_dcsr>> is set OR when in user-mode and `ebreaku` in <<_dcsr>> is set).
+. A debug halt request is issued by the DM (via CPU signal `db_halt_req_i`, high-active, triggering on rising-edge).
+. The CPU completes executing of a single instruction while being single-step debugging mode (enabled if `step` in <<_dcsr>> is set).
+. A hardware trigger from the <<_trigger_module>> fires (if `action` in <<_tdata1>> / `mcontrol` is set).
 
 [NOTE]
-From a hardware point of view, these "entry conditions" are special traps that are handled transparently by
+From a hardware point of view these entry conditions are special traps that are handled transparently by
 the control logic.
 
 **Whenever the CPU enters debug-mode it performs the following operations:**
 
 * wake-up CPU if it was send to sleep mode by the `wfi` instruction
-* move `pc` to `dpc`
-* copy the hart's current privilege level to `dcsr.prv`
-* set `dcrs.cause` according to the cause why debug mode is entered
+* move the current program counter to <<_dpc>>
+* copy the hart's current privilege level to the `prv` flags in <<_dcsr>>
+* set `cause` in <<_dcrs>> according to the cause why debug mode is entered
 * **no update** of `mtval`, `mcause`, `mtval` and `mstatus` CSRs
-* load the address configured via the CPU's `CPU_DEBUG_PARK_ADDR` (<<_cpu_top_entity_generics>>) generic to the `pc` to jump to the
+* load the address configured via the CPU's `CPU_DEBUG_PARK_ADDR` (<<_cpu_top_entity_generics>>) generic to the program counter jumping to the
 "debugger park loop" code stored in the debug module (DM)
 
 **When the CPU is in debug-mode the following things are important:**
@@ -536,14 +549,11 @@ the control logic.
 * effective CPU privilege level is `machine` mode; any active physical memory protection (PMP) configuration is bypassed
 * the `wfi` instruction acts as a `nop` (also during single-stepping)
 * if an exception occurs while being in debug mode:
-** if the exception was caused by any debug-mode entry action the CPU jumps to the _normal entry point_
-   (defined by `CPU_DEBUG_PARK_ADDR` generic of the <<_cpu_top_entity_generics>>) of the park loop again (for example when executing `ebreak` while in debug-mode)
-** for all other exception sources the CPU jumps to the _exception entry point_ (defined by `CPU_DEBUG_EXC_ADDR` generic of the <<_cpu_top_entity_generics>>)
-   to signal an exception to the DM; the CPU restarts the park loop again afterwards
+** if the exception was caused by any debug-mode entry action the CPU jumps to the normal entry point (defined by `CPU_DEBUG_PARK_ADDR` generic of the <<_cpu_top_entity_generics>>) of the park loop again (for example when executing `ebreak` while in debug-mode)
+** for all other exception sources the CPU jumps to the exception entry point (defined by `CPU_DEBUG_EXC_ADDR` generic of the <<_cpu_top_entity_generics>>) to signal an exception to the DM; the CPU restarts the park loop again afterwards
 * interrupts are disabled; however, they will remain pending and will get executed after the CPU has left debug mode
 * if the DM makes a resume request, the park loop exits and the CPU leaves debug mode (executing `dret`)
-* the standard counters <<_machine_counter_and_timer_csrs>> `[m]cycle[h]` and `[m]instret[h]` are stopped; note that the
-<<_machine_system_timer_mtime>> keep running as well as it's shadowed copies in the `[m]time[h]` CSRs
+* the standard counters <<_machine_counter_and_timer_csrs>> `[m]cycle[h]` and `[m]instret[h]` are stopped
 * all <<_hardware_performance_monitors_hpm_csrs>> are stopped
 
 Debug mode is left either by executing the `dret` instruction or by performing a hardware reset of the CPU.
@@ -551,9 +561,8 @@ Executing `dret` outside of debug mode will raise an illegal instruction excepti
 
 **Whenever the CPU leaves debug mode it performs the following operations:**
 
-* set the hart's current privilege level according to `dcsr.prv`
-* restore `pc` from `dpcs`
-* resume normal operation at `pc`
+* set the hart's current privilege level according to the `prv` flags of <<_dcsr>>
+* restore the original program counter from <<_dpcs>> resuming normal operation
 
 
 :sectnums:
@@ -571,13 +580,15 @@ an illegal instruction exception is raised.
 :sectnums!:
 ===== **`dcsr`**
 
-[cols="4,27,>7"]
+[cols="<1,<8"]
 [frame="topbot",grid="none"]
-|======
-| 0x7b0 | **Debug control and status register** | `dcsr`
-3+<| Reset value: `0x40000413`
-3+<| The `dcsr` CSR is compatible to the RISC-V debug spec. It is used to configure debug mode and provides additional status information.
-|======
+|=======================
+| Name        | Debug control and status register
+| Address     | `0x7b0`
+| Reset value | `0x40000413`
+| ISA         | `Zicsr` & `Sdext`
+| Description | This register is used to configure the debug mode environment and provides additional status information.
+|=======================
 
 .Debug control and status register `dcsr` bits
 [cols="^1,^2,^1,<8"]
@@ -612,26 +623,30 @@ Cause codes in `dcsr.cause` (highest priority first):
 :sectnums!:
 ===== **`dpc`**
 
-[cols="4,27,>7"]
+[cols="<1,<8"]
 [frame="topbot",grid="none"]
-|======
-| 0x7b1 | **Debug program counter** | `dpc`
-3+<| Reset value: `0x00000000`
-3+<| The `dcsr` CSR is compatible to the RISC-V debug spec. It is used to store the current program counter when
-debug mode is entered. The `dret` instruction will return to `dpc` by moving `dpc` to `pc`.
-|======
+|=======================
+| Name        | Debug program counter
+| Address     | `0x7b1`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr` & `Sdext`
+| Description | The register is used to store the current program counter when debug mode is entered. The `dret` instruction will
+return to `dpc` by automatically moving `dpc` to the program counter.
+|=======================
 
 
 :sectnums!:
 ===== **`dscratch0`**
 
-[cols="4,27,>7"]
+[cols="<1,<8"]
 [frame="topbot",grid="none"]
-|======
-| 0x7b2 | **Debug scratch register 0** | `dscratch0`
-3+<| Reset value: `0x00000000`
-3+<| The `dscratch0` CSR is compatible to the RISC-V debug spec. It provides a general purpose debug mode-only scratch register.
-|======
+|=======================
+| Name        | Debug scratch register 0
+| Address     | `0x7b2`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr` & `Sdext`
+| Description | The register provides a general purpose debug mode-only scratch register.
+|=======================
 
 
 <<<
@@ -639,7 +654,7 @@ debug mode is entered. The `dret` instruction will return to `dpc` by moving `dp
 :sectnums:
 === Trigger Module
 
-The RISC-V `Sdtrig` ISA extension add a programmable _trigger module_ to the processor when enabled
+The RISC-V `Sdtrig` ISA extension adds a programmable _trigger module_ to the processor when enabled
 (via the <<_sdtrig_isa_extension>>). The NEORV32 trigger module implements a subset of the features
 described in the "RISC-V Debug Specification / Trigger Module".
 
@@ -649,11 +664,10 @@ is granted by the RISC-V specs. and is sufficient to **debug code executed from 
 instruction word by an `ebreak` instruction. This is not possible when debugging code that is executed from read-only memory
 (for example when debugging programs that are executed via the <<_execute_in_place_module_xip>>).
 Therefore, the NEORV32 trigger module provides a single "instruction address match" trigger to enter debug mode when
-executing the instruction at a specific address. These "hardware-assisted breakpoints" are used by GDB's `hb`/`hbreak` command.
+executing the instruction at a programmable address. These "hardware-assisted breakpoints" are used by GDB's `hb`/`hbreak` commands.
 
-The trigger module can also be used independently of the CPU debug-mode (so independent of the on-chip debugger).
-Machine-mode software can use the trigger module to raise a Break exception when the instruction at a programmable
-address gets executed.
+The trigger module can also be used independently of the CPU debug-mode. Machine-mode software can use the trigger module
+to raise a breakpoint exception when the instruction at the programmed address gets executed.
 
 :sectnums:
 ==== Trigger Module CSRs
@@ -665,26 +679,30 @@ for implementing a "hardware breakpoint"
 :sectnums!:
 ===== **`tselect`**
 
-[cols="4,27,>7"]
+[cols="<1,<8"]
 [frame="topbot",grid="none"]
-|======
-| 0x7a0 | **Trigger select register** | `tselect`
-3+<| Reset value: `0x00000000`
-3+<| This CSR is hardwired to zero indicating there is only one trigger available. Any write access is ignored.
-|======
+|=======================
+| Name        | Trigger select register
+| Address     | `0x7a0`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr` & `Sdtrig`
+| Description | This CSR is hardwired to zero indicating there is only one trigger available. Any write access is ignored.
+|=======================
 
 
 :sectnums!:
 ===== **`tdata1`**
 
-[cols="4,27,>7"]
+[cols="<1,<8"]
 [frame="topbot",grid="none"]
-|======
-| 0x7a1 | **Trigger data register 1 / match control register** | `tdata1` / `mcontrol`
-3+<| Reset value: `0x20040040`
-3+<| This CSR is used to configure the address match trigger. Only one bit is writable, the remaining bits are hardwired (see table below).
+|=======================
+| Name        | Trigger data register 1 / match control register
+| Address     | `0x7a1`
+| Reset value | `0x20040040`
+| ISA         | `Zicsr` & `Sdtrig`
+| Description | This CSR is used to configure the address match trigger. Only one bit is writable, the remaining bits are hardwired (see table below).
 Write attempts to the hardwired bits are ignored.
-|======
+|=======================
 
 .Match Control CSR (`tdata1`) Bits
 [cols="^1,^2,^1,<8"]
@@ -714,70 +732,82 @@ Write attempts to the hardwired bits are ignored.
 :sectnums!:
 ===== **`tdata2`**
 
-[cols="4,27,>7"]
+[cols="<1,<8"]
 [frame="topbot",grid="none"]
-|======
-| 0x7a2 | **Trigger data register 2** | `tdata2`
-3+<| Reset value: `0x00000000`
-3+<| Since only the "address match trigger" type is supported, this r/w CSR is used to configure the address of the triggering instruction.
-|======
+|=======================
+| Name        | Trigger data register 2
+| Address     | `0x7a2`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr` & `Sdtrig`
+| Description | Since only the "address match trigger" type is supported, this r/w CSR is used to configure the address of the triggering instruction.
+|=======================
 
 
 :sectnums!:
 ===== **`tdata3`**
 
-[cols="4,27,>7"]
+[cols="<1,<8"]
 [frame="topbot",grid="none"]
-|======
-| 0x7a3 | **Trigger data register 3** | `tdata3`
-3+<| Reset value: `0x00000000`
-3+<| This CSR is not required for the NEORV32 trigger module. Hence, it is hardwired to zero and any write access is ignored.
-|======
+|=======================
+| Name        | Trigger data register 3
+| Address     | `0x7a3`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr` & `Sdtrig`
+| Description | This CSR is not required for the NEORV32 trigger module. Hence, it is hardwired to zero and any write access is ignored.
+|=======================
 
 
 :sectnums!:
 ===== **`tinfo`**
 
-[cols="4,27,>7"]
+[cols="<1,<8"]
 [frame="topbot",grid="none"]
-|======
-| 0x7a4 | **Trigger information register** | `tinfo`
-3+<| Reset value: `0x00000004`
-3+<| This CSR is hardwired to "4" indicating there is only an "address match trigger" available. Any write access is ignored.
-|======
+|=======================
+| Name        | Trigger information register
+| Address     | `0x7a4`
+| Reset value | `0x00000004`
+| ISA         | `Zicsr` & `Sdtrig`
+| Description | This CSR is hardwired to "4" indicating there is only an "address match trigger" available. Any write access is ignored.
+|=======================
 
 
 :sectnums!:
 ===== **`tcontrol`**
 
-[cols="4,27,>7"]
+[cols="<1,<8"]
 [frame="topbot",grid="none"]
-|======
-| 0x7a5 | **Trigger control register** | `tcontrol`
-3+<| Reset value: `0x00000000`
-3+<| This CSR is not required for the NEORV32 trigger module. Hence, it is hardwired to zero and any write access is ignored.
-|======
+|=======================
+| Name        | Trigger control register
+| Address     | `0x7a5`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr` & `Sdtrig`
+| Description | This CSR is not required for the NEORV32 trigger module. Hence, it is hardwired to zero and any write access is ignored.
+|=======================
 
 
 :sectnums!:
 ===== **`mcontext`**
 
-[cols="4,27,>7"]
+[cols="<1,<8"]
 [frame="topbot",grid="none"]
-|======
-| 0x7a8 | **Machine context register** | `mcontext`
-3+<| Reset value: `0x00000000`
-3+<| This CSR is not required for the NEORV32 trigger module. Hence, it is hardwired to zero and any write access is ignored.
-|======
+|=======================
+| Name        | Machine context register
+| Address     | `0x7a8`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr` & `Sdtrig`
+| Description | This CSR is not required for the NEORV32 trigger module. Hence, it is hardwired to zero and any write access is ignored.
+|=======================
 
 
 :sectnums!:
 ===== **`scontext`**
 
-[cols="4,27,>7"]
+[cols="<1,<8"]
 [frame="topbot",grid="none"]
-|======
-| 0x7aa | **Supervisor context register** | `scontext`
-3+<| Reset value: `0x00000000`
-3+<| This CSR is not required for the NEORV32 trigger module. Hence, it is hardwired to zero and any write access is ignored.
-|======
+|=======================
+| Name        | Supervisor context register
+| Address     | `0x7aa`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr` & `Sdtrig`
+| Description | This CSR is not required for the NEORV32 trigger module. Hence, it is hardwired to zero and any write access is ignored.
+|=======================

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -200,11 +200,13 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 |=======================
 | Name | Type | Default | Description
 4+^| **General**
-| `CLOCK_FREQUENCY`       | natural   | -          | The clock frequency of the processor's `clk_i` input port in Hertz (Hz).
-| `INT_BOOTLOADER_EN`     | boolean   | false      | Implement the processor-internal <<_bootloader_rom_bootrom>>, pre-initialized with the default <<_bootloader>> image.
-| `HART_ID`               | suv(31:0) | 0x00000000 | The hart thread ID of the CPU (passed to <<_mhartid>> CSRs).
-| `VENDOR_ID`             | suv(31:0) | 0x00000000 | JEDEC ID (passed to <<_mvendorid>> CSRs).
-| `ON_CHIP_DEBUGGER_EN`   | boolean   | false      | Implement the on-chip debugger <<_on_chip_debugger_ocd>> and the CPU debug mode.
+| `CLOCK_FREQUENCY`   | natural   | -          | The clock frequency of the processor's `clk_i` input port in Hertz (Hz).
+| `INT_BOOTLOADER_EN` | boolean   | false      | Implement the processor-internal <<_bootloader_rom_bootrom>>, pre-initialized with the default <<_bootloader>> image.
+| `HART_ID`           | suv(31:0) | 0x00000000 | The hart thread ID of the CPU (passed to <<_mhartid>> CSRs).
+| `VENDOR_ID`         | suv(31:0) | 0x00000000 | JEDEC ID (passed to <<_mvendorid>> CSRs).
+4+^| **<<_on_chip_debugger_ocd>>**
+| `ON_CHIP_DEBUGGER_EN` | boolean | false | Implement the on-chip debugger and the CPU debug mode.
+| `DM_LEGACY_MODE`      | boolean | false | Debug module spec. version: `false` = v1.0, `true` = v0.13 (legacy mode).
 4+^| **CPU <<_instruction_sets_and_extensions>>**
 | `CPU_EXTENSION_RISCV_A`        | boolean | false | Enable <<_a_isa_extension>> (atomic memory accesses).
 | `CPU_EXTENSION_RISCV_B`        | boolean | false | Enable <<_b_isa_extension>> (bit-manipulation).

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -194,7 +194,7 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
     05 => x"00041c63",
     06 => x"fc104403",
     07 => x"fe0408e3",
-    08 => x"fc8000a3",
+    08 => x"fc0000a3",
     09 => x"7b202473",
     10 => x"7b200073",
     11 => x"fc000123",
@@ -689,11 +689,11 @@ begin
         dci.data_reg <= bus_req_i.data;
       end if;
       -- control and status register CPU write access --
-      -- NOTE: we only check the individual BYTE ACCESSES - not the actual write data --
       dci.halt_ack      <= '0'; -- all writable flags auto-clear
       dci.resume_ack    <= '0';
       dci.execute_ack   <= '0';
       dci.exception_ack <= '0';
+      -- NOTE: only check the individual BYTE ACCESSES - not the actual write data --
       if (bus_req_i.addr(7 downto 6) = dm_sreg_base_c(7 downto 6)) and (wren = '1') then
         dci.halt_ack      <= bus_req_i.ben(sreg_halt_ack_c/8);
         dci.resume_ack    <= bus_req_i.ben(sreg_resume_ack_c/8);

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -1,8 +1,8 @@
 -- #################################################################################################
 -- # << NEORV32 - RISC-V-Compatible Debug Module (DM) >>                                           #
 -- # ********************************************************************************************* #
--- # Compatible to the "Minimal RISC-V External Debug Spec. Version 1.0" using "execution-based"   #
--- # debugging scheme (via the program buffer).                                                    #
+-- # Compatible to the "Minimal RISC-V External Debug Spec. Version 1.0 [Sdext]" (or v0.13) using  #
+-- # "execution-based" debugging scheme (via the program buffer). FOR A SINGLE HART ONLY!          #
 -- # ********************************************************************************************* #
 -- # Key features:                                                                                 #
 -- # * register access commands only                                                               #
@@ -10,12 +10,6 @@
 -- # * for a single hart only                                                                      #
 -- # * 2 general purpose program buffer entries                                                    #
 -- # * 1 general purpose data buffer entry                                                         #
--- #                                                                                               #
--- # CPU access:                                                                                   #
--- # * ROM for "park loop" code                                                                    #
--- # * program buffer                                                                              #
--- # * data buffer                                                                                 #
--- # * control and status register                                                                 #
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
@@ -57,36 +51,30 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_debug_dm is
   generic (
-    CPU_BASE_ADDR : std_ulogic_vector(31 downto 0)
+    CPU_BASE_ADDR : std_ulogic_vector(31 downto 0);
+    LEGACY_MODE   : boolean -- false = spec. v1.0, true = spec. v0.13
   );
   port (
     -- global control --
-    clk_i             : in  std_ulogic; -- global clock line
-    rstn_i            : in  std_ulogic; -- global reset line, low-active
-    cpu_debug_i       : in  std_ulogic; -- CPU is in debug mode
+    clk_i          : in  std_ulogic; -- global clock line
+    rstn_i         : in  std_ulogic; -- global reset line, low-active
+    cpu_debug_i    : in  std_ulogic; -- CPU is in debug mode
     -- debug module interface (DMI) --
-    dmi_req_valid_i   : in  std_ulogic;
-    dmi_req_ready_o   : out std_ulogic; -- DMI is allowed to make new requests when set
-    dmi_req_address_i : in  std_ulogic_vector(05 downto 0);
-    dmi_req_op_i      : in  std_ulogic_vector(01 downto 0);
-    dmi_req_data_i    : in  std_ulogic_vector(31 downto 0);
-    dmi_rsp_valid_o   : out std_ulogic; -- response valid when set
-    dmi_rsp_ready_i   : in  std_ulogic; -- ready to receive respond
-    dmi_rsp_data_o    : out std_ulogic_vector(31 downto 0);
-    dmi_rsp_op_o      : out std_ulogic_vector(01 downto 0);
+    dmi_req_i      : in  dmi_req_t; -- request
+    dmi_rsp_o      : out dmi_rsp_t; -- response
     -- CPU bus access --
-    bus_req_i         : in  bus_req_t;  -- bus request
-    bus_rsp_o         : out bus_rsp_t;  -- bus response
+    bus_req_i      : in  bus_req_t; -- bus request
+    bus_rsp_o      : out bus_rsp_t; -- bus response
     -- CPU control --
-    cpu_ndmrstn_o     : out std_ulogic; -- soc reset
-    cpu_halt_req_o    : out std_ulogic  -- request hart to halt (enter debug mode)
+    cpu_ndmrstn_o  : out std_ulogic; -- soc reset
+    cpu_halt_req_o : out std_ulogic  -- request hart to halt (enter debug mode)
   );
 end neorv32_debug_dm;
 
 architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
 
   -- **********************************************************
-  -- DM Layout 
+  -- DM Memory Layout
   -- **********************************************************
   constant dm_code_base_c : std_ulogic_vector(31 downto 0) := std_ulogic_vector(unsigned(CPU_BASE_ADDR) + x"00"); -- base address of code ROM (park loop)
   constant dm_pbuf_base_c : std_ulogic_vector(31 downto 0) := std_ulogic_vector(unsigned(CPU_BASE_ADDR) + x"40"); -- base address of program buffer (PBUF)
@@ -97,24 +85,19 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   -- DMI Access
   -- **********************************************************
 
-  -- DM operations --
-  constant dmi_nop_c      : std_ulogic_vector(1 downto 0) := "00"; -- no operation
-  constant dmi_read_c     : std_ulogic_vector(1 downto 0) := "01"; -- read data
-  constant dmi_write_c    : std_ulogic_vector(1 downto 0) := "10"; -- write data
-  constant dmi_reserved_c : std_ulogic_vector(1 downto 0) := "11"; -- reserved
-
   -- available DMI registers --
-  constant addr_data0_c        : std_ulogic_vector(5 downto 0) := "00" & x"4";
-  constant addr_dmcontrol_c    : std_ulogic_vector(5 downto 0) := "01" & x"0";
-  constant addr_dmstatus_c     : std_ulogic_vector(5 downto 0) := "01" & x"1";
-  constant addr_hartinfo_c     : std_ulogic_vector(5 downto 0) := "01" & x"2";
-  constant addr_abstractcs_c   : std_ulogic_vector(5 downto 0) := "01" & x"6";
-  constant addr_command_c      : std_ulogic_vector(5 downto 0) := "01" & x"7";
-  constant addr_abstractauto_c : std_ulogic_vector(5 downto 0) := "01" & x"8";
-  constant addr_nextdm_c       : std_ulogic_vector(5 downto 0) := "01" & x"d";
-  constant addr_progbuf0_c     : std_ulogic_vector(5 downto 0) := "10" & x"0";
-  constant addr_progbuf1_c     : std_ulogic_vector(5 downto 0) := "10" & x"1";
-  constant addr_sbcs_c         : std_ulogic_vector(5 downto 0) := "11" & x"8";
+  constant addr_data0_c        : std_ulogic_vector(6 downto 0) := "000" & x"4";
+  constant addr_dmcontrol_c    : std_ulogic_vector(6 downto 0) := "001" & x"0";
+  constant addr_dmstatus_c     : std_ulogic_vector(6 downto 0) := "001" & x"1";
+  constant addr_hartinfo_c     : std_ulogic_vector(6 downto 0) := "001" & x"2";
+  constant addr_abstractcs_c   : std_ulogic_vector(6 downto 0) := "001" & x"6";
+  constant addr_command_c      : std_ulogic_vector(6 downto 0) := "001" & x"7";
+  constant addr_abstractauto_c : std_ulogic_vector(6 downto 0) := "001" & x"8";
+  constant addr_nextdm_c       : std_ulogic_vector(6 downto 0) := "001" & x"d";
+  constant addr_progbuf0_c     : std_ulogic_vector(6 downto 0) := "010" & x"0";
+  constant addr_progbuf1_c     : std_ulogic_vector(6 downto 0) := "010" & x"1";
+  constant addr_sbcs_c         : std_ulogic_vector(6 downto 0) := "011" & x"8";
+  constant addr_haltsum0_c     : std_ulogic_vector(6 downto 0) := "100" & x"0";
 
   -- RISC-V 32-bit instruction prototypes --
   constant instr_nop_c    : std_ulogic_vector(31 downto 0) := x"00000013"; -- nop
@@ -156,10 +139,11 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   -- **********************************************************
 
   -- DM configuration --
-  constant nscratch_c   : std_ulogic_vector(03 downto 0) := "0001"; -- number of dscratch registers in CPU
-  constant datasize_c   : std_ulogic_vector(03 downto 0) := "0001"; -- number of data registers in memory/CSR space
+  constant nscratch_c   : std_ulogic_vector(03 downto 0) := "0001"; -- number of dscratch registers in CPU (=1)
+  constant datasize_c   : std_ulogic_vector(03 downto 0) := "0001"; -- number of data registers in memory/CSR space (=1)
   constant dataaddr_c   : std_ulogic_vector(11 downto 0) := dm_data_base_c(11 downto 0); -- signed base address of data registers in memory/CSR space
   constant dataaccess_c : std_ulogic                     := '1';    -- 1: abstract data is memory-mapped, 0: abstract data is CSR-mapped
+  constant dm_version_c : std_ulogic_vector(03 downto 0) := cond_sel_suv_f(LEGACY_MODE, "0010", "0011"); -- version: v0.13 / v1.0
 
   -- debug module controller --
   type dm_ctrl_state_t is (CMD_IDLE, CMD_EXE_CHECK, CMD_EXE_PREPARE, CMD_EXE_TRIGGER, CMD_EXE_BUSY, CMD_EXE_ERROR);
@@ -181,9 +165,12 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   end record;
   signal dm_ctrl : dm_ctrl_t;
 
+  -- program buffer access --
+  type prog_buf_t is array (0 to 3) of std_ulogic_vector(31 downto 0);
+  signal prog_buf : prog_buf_t;
 
   -- **********************************************************
-  -- CPU Bus Interface
+  -- CPU Bus and Debug Interfaces
   -- **********************************************************
 
   -- status and control register - bits --
@@ -230,24 +217,21 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
     exception_ack : std_ulogic; -- CPU has detected an exception (single-shot)
     progbuf       : std_ulogic_vector(255 downto 0); -- program buffer, 4 32-bit entries
     data_we       : std_ulogic; -- write abstract data
-    wdata         : std_ulogic_vector(31 downto 0); -- abstract write data
-    rdata         : std_ulogic_vector(31 downto 0); -- abstract read data
+    data_reg      : std_ulogic_vector(31 downto 0); -- memory-mapped data exchange register
   end record;
   signal dci : dci_t;
 
-  -- data buffer --
-  signal data_buf : std_ulogic_vector(31 downto 0);
-
-  -- program buffer access --
-  type prog_buf_t is array (0 to 3) of std_ulogic_vector(31 downto 0);
-  signal prog_buf : prog_buf_t;
-
 begin
+
+  -- Info -----------------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  assert not (LEGACY_MODE = true)  report "NEORV32 [OCD] on-chip debugger: DM compatible to debug spec. version 0.13" severity note;
+  assert not (LEGACY_MODE = false) report "NEORV32 [OCD] on-chip debugger: DM compatible to debug spec. version 1.0"  severity note;
 
   -- DMI Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  dmi_wren <= '1' when (dmi_req_valid_i = '1') and (dmi_req_op_i = dmi_write_c) else '0';
-  dmi_rden <= '1' when (dmi_req_valid_i = '1') and (dmi_req_op_i = dmi_read_c)  else '0';
+  dmi_wren <= '1' when (dmi_req_i.op = dmi_req_wr_c) else '0';
+  dmi_rden <= '1' when (dmi_req_i.op = dmi_req_rd_c) else '0';
 
 
   -- Debug Module Command Controller --------------------------------------------------------
@@ -277,7 +261,7 @@ begin
           when CMD_IDLE => -- wait for new abstract command
           -- ------------------------------------------------------------
             if (dmi_wren = '1') then -- valid DM write access
-              if (dmi_req_address_i = addr_command_c) then
+              if (dmi_req_i.addr = addr_command_c) then
                 if (dm_ctrl.cmderr = "000") then -- only execute if no error
                   dm_ctrl.state <= CMD_EXE_CHECK;
                 end if;
@@ -299,7 +283,7 @@ begin
                 dm_ctrl.illegal_state <= '1';
                 dm_ctrl.state         <= CMD_EXE_ERROR;
               end if;
-            else -- invalid command
+            else -- error! invalid command
               dm_ctrl.illegal_cmd <= '1';
               dm_ctrl.state       <= CMD_EXE_ERROR;
             end if;
@@ -458,63 +442,63 @@ begin
       if (dmi_wren = '1') then -- valid DMI write request
 
         -- debug module control --
-        if (dmi_req_address_i = addr_dmcontrol_c) then
-          dm_reg.halt_req           <= dmi_req_data_i(31); -- haltreq (-/w): write 1 to request halt; has to be cleared again by debugger
-          dm_reg.resume_req         <= dmi_req_data_i(30); -- resumereq (-/w1): write 1 to request resume; auto-clears
-          dm_reg.reset_ack          <= dmi_req_data_i(28); -- ackhavereset (-/w1): write 1 to ACK reset; auto-clears
-          dm_reg.dmcontrol_ndmreset <= dmi_req_data_i(01); -- ndmreset (r/w): soc reset
-          dm_reg.dmcontrol_dmactive <= dmi_req_data_i(00); -- dmactive (r/w): DM reset
+        if (dmi_req_i.addr = addr_dmcontrol_c) then
+          dm_reg.halt_req           <= dmi_req_i.data(31); -- haltreq (-/w): write 1 to request halt; has to be cleared again by debugger
+          dm_reg.resume_req         <= dmi_req_i.data(30); -- resumereq (-/w1): write 1 to request resume; auto-clears
+          dm_reg.reset_ack          <= dmi_req_i.data(28); -- ackhavereset (-/w1): write 1 to ACK reset; auto-clears
+          dm_reg.dmcontrol_ndmreset <= dmi_req_i.data(01); -- ndmreset (r/w): soc reset
+          dm_reg.dmcontrol_dmactive <= dmi_req_i.data(00); -- dmactive (r/w): DM reset
         end if;
 
         -- write abstract command --
-        if (dmi_req_address_i = addr_command_c) then
+        if (dmi_req_i.addr = addr_command_c) then
           if (dm_ctrl.busy = '0') and (dm_ctrl.cmderr = "000") then -- idle and no errors yet
-            dm_reg.command <= dmi_req_data_i;
+            dm_reg.command <= dmi_req_i.data;
           end if;
         end if;
 
         -- write abstract command autoexec --
-        if (dmi_req_address_i = addr_abstractauto_c) then
+        if (dmi_req_i.addr = addr_abstractauto_c) then
           if (dm_ctrl.busy = '0') then -- idle and no errors yet
-            dm_reg.abstractauto_autoexecdata       <= dmi_req_data_i(00);
-            dm_reg.abstractauto_autoexecprogbuf(0) <= dmi_req_data_i(16);
-            dm_reg.abstractauto_autoexecprogbuf(1) <= dmi_req_data_i(17);
+            dm_reg.abstractauto_autoexecdata       <= dmi_req_i.data(00);
+            dm_reg.abstractauto_autoexecprogbuf(0) <= dmi_req_i.data(16);
+            dm_reg.abstractauto_autoexecprogbuf(1) <= dmi_req_i.data(17);
           end if;
         end if;
 
         -- auto execution trigger --
-        if ((dmi_req_address_i = addr_data0_c)    and (dm_reg.abstractauto_autoexecdata = '1')) or
-           ((dmi_req_address_i = addr_progbuf0_c) and (dm_reg.abstractauto_autoexecprogbuf(0) = '1')) or
-           ((dmi_req_address_i = addr_progbuf1_c) and (dm_reg.abstractauto_autoexecprogbuf(1) = '1')) then
+        if ((dmi_req_i.addr = addr_data0_c)    and (dm_reg.abstractauto_autoexecdata = '1')) or
+           ((dmi_req_i.addr = addr_progbuf0_c) and (dm_reg.abstractauto_autoexecprogbuf(0) = '1')) or
+           ((dmi_req_i.addr = addr_progbuf1_c) and (dm_reg.abstractauto_autoexecprogbuf(1) = '1')) then
           dm_reg.autoexec_wr <= '1';
         end if;
 
         -- acknowledge command error --
-        if (dmi_req_address_i = addr_abstractcs_c) then
-          if (dmi_req_data_i(10 downto 8) = "111") then
+        if (dmi_req_i.addr = addr_abstractcs_c) then
+          if (dmi_req_i.data(10 downto 8) = "111") then
             dm_reg.clr_acc_err <= '1';
           end if;
         end if;
 
         -- write program buffer --
-        if (dmi_req_address_i(dmi_req_address_i'left downto 1) = addr_progbuf0_c(dmi_req_address_i'left downto 1)) then
+        if (dmi_req_i.addr(dmi_req_i.addr'left downto 1) = addr_progbuf0_c(dmi_req_i.addr'left downto 1)) then
           if (dm_ctrl.busy = '0') then -- idle
-            if (dmi_req_address_i(0) = addr_progbuf0_c(0)) then
-              dm_reg.progbuf(0) <= dmi_req_data_i;
+            if (dmi_req_i.addr(0) = addr_progbuf0_c(0)) then
+              dm_reg.progbuf(0) <= dmi_req_i.data;
             else
-              dm_reg.progbuf(1) <= dmi_req_data_i;
+              dm_reg.progbuf(1) <= dmi_req_i.data;
             end if;
           end if;
         end if;
 
         -- invalid access while command is executing --
         if (dm_ctrl.busy = '1') then -- busy
-          if (dmi_req_address_i = addr_abstractcs_c) or
-             (dmi_req_address_i = addr_command_c) or
-             (dmi_req_address_i = addr_abstractauto_c) or
-             (dmi_req_address_i = addr_data0_c) or
-             (dmi_req_address_i = addr_progbuf0_c) or
-             (dmi_req_address_i = addr_progbuf1_c) then
+          if (dmi_req_i.addr = addr_abstractcs_c) or
+             (dmi_req_i.addr = addr_command_c) or
+             (dmi_req_i.addr = addr_abstractauto_c) or
+             (dmi_req_i.addr = addr_data0_c) or
+             (dmi_req_i.addr = addr_progbuf0_c) or
+             (dmi_req_i.addr = addr_progbuf1_c) then
             dm_reg.wr_acc_err <= '1';
           end if;
         end if;
@@ -527,8 +511,7 @@ begin
   -- Direct Control -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   -- write to abstract data register --
-  dci.data_we <= '1' when (dmi_wren = '1') and (dmi_req_address_i = addr_data0_c) and (dm_ctrl.busy = '0') else '0';
-  dci.wdata   <= dmi_req_data_i;
+  dci.data_we <= '1' when (dmi_wren = '1') and (dmi_req_i.addr = addr_data0_c) and (dm_ctrl.busy = '0') else '0';
 
   -- CPU halt/resume request --
   cpu_halt_req_o <= dm_reg.halt_req and dm_reg.dmcontrol_dmactive; -- single-shot
@@ -543,112 +526,112 @@ begin
   cpu_progbuf(2) <= instr_nop_c when (dm_ctrl.pbuf_en = '0') else dm_reg.progbuf(1);
   cpu_progbuf(3) <= instr_ebreak_c; -- implicit ebreak instruction
 
-  -- DMI status --
-  dmi_rsp_op_o    <= "00"; -- operation success
-  dmi_req_ready_o <= '1'; -- always ready for new read/write access
-
 
   -- Debug Module Interface - Read Access ---------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   dmi_read_access: process(clk_i)
   begin
     if rising_edge(clk_i) then
-      dmi_rsp_valid_o    <= dmi_req_valid_i; -- DMI transfer ack
-      dmi_rsp_data_o     <= (others => '0'); -- default
+      dmi_rsp_o.ack      <= dmi_wren or dmi_rden; -- always ACK any request
+      dmi_rsp_o.data     <= (others => '0'); -- default
       dm_reg.rd_acc_err  <= '0';
       dm_reg.autoexec_rd <= '0';
 
-      case dmi_req_address_i is
+      case dmi_req_i.addr is
 
         -- debug module status register --
         when addr_dmstatus_c =>
-          dmi_rsp_data_o(31 downto 23) <= (others => '0');           -- reserved (r/-)
-          dmi_rsp_data_o(22)           <= '1';                       -- impebreak (r/-): there is an implicit ebreak instruction after the visible program buffer
-          dmi_rsp_data_o(21 downto 20) <= (others => '0');           -- reserved (r/-)
-          dmi_rsp_data_o(19)           <= dm_ctrl.hart_reset;        -- allhavereset (r/-): there is only one hart that can be reset
-          dmi_rsp_data_o(18)           <= dm_ctrl.hart_reset;        -- anyhavereset (r/-): there is only one hart that can be reset
-          dmi_rsp_data_o(17)           <= dm_ctrl.hart_resume_ack;   -- allresumeack (r/-): there is only one hart that can acknowledge resume request
-          dmi_rsp_data_o(16)           <= dm_ctrl.hart_resume_ack;   -- anyresumeack (r/-): there is only one hart that can acknowledge resume request
-          dmi_rsp_data_o(15)           <= '0';                       -- allnonexistent (r/-): there is only one hart that is always existent
-          dmi_rsp_data_o(14)           <= '0';                       -- anynonexistent (r/-): there is only one hart that is always existent
-          dmi_rsp_data_o(13)           <= dm_reg.dmcontrol_ndmreset; -- allunavail (r/-): there is only one hart that is unavailable during reset
-          dmi_rsp_data_o(12)           <= dm_reg.dmcontrol_ndmreset; -- anyunavail (r/-): there is only one hart that is unavailable during reset
-          dmi_rsp_data_o(11)           <= not dm_ctrl.hart_halted;   -- allrunning (r/-): there is only one hart that can be RUNNING or HALTED
-          dmi_rsp_data_o(10)           <= not dm_ctrl.hart_halted;   -- anyrunning (r/-): there is only one hart that can be RUNNING or HALTED
-          dmi_rsp_data_o(09)           <= dm_ctrl.hart_halted;       -- allhalted (r/-): there is only one hart that can be RUNNING or HALTED
-          dmi_rsp_data_o(08)           <= dm_ctrl.hart_halted;       -- anyhalted (r/-): there is only one hart that can be RUNNING or HALTED
-          dmi_rsp_data_o(07)           <= '1';                       -- authenticated (r/-): authentication passed since there is no authentication
-          dmi_rsp_data_o(06)           <= '0';                       -- authbusy (r/-): always ready since there is no authentication
-          dmi_rsp_data_o(05)           <= '0';                       -- hasresethaltreq (r/-): halt-on-reset not implemented
-          dmi_rsp_data_o(04)           <= '0';                       -- confstrptrvalid (r/-): no configuration string available
-          dmi_rsp_data_o(03 downto 00) <= "0011";                    -- version (r/-): compatible to spec. version 1.0
+          dmi_rsp_o.data(31 downto 23) <= (others => '0');           -- reserved (r/-)
+          dmi_rsp_o.data(22)           <= '1';                       -- impebreak (r/-): there is an implicit ebreak instruction after the visible program buffer
+          dmi_rsp_o.data(21 downto 20) <= (others => '0');           -- reserved (r/-)
+          dmi_rsp_o.data(19)           <= dm_ctrl.hart_reset;        -- allhavereset (r/-): there is only one hart that can be reset
+          dmi_rsp_o.data(18)           <= dm_ctrl.hart_reset;        -- anyhavereset (r/-): there is only one hart that can be reset
+          dmi_rsp_o.data(17)           <= dm_ctrl.hart_resume_ack;   -- allresumeack (r/-): there is only one hart that can acknowledge resume request
+          dmi_rsp_o.data(16)           <= dm_ctrl.hart_resume_ack;   -- anyresumeack (r/-): there is only one hart that can acknowledge resume request
+          dmi_rsp_o.data(15)           <= '0';                       -- allnonexistent (r/-): there is only one hart that is always existent
+          dmi_rsp_o.data(14)           <= '0';                       -- anynonexistent (r/-): there is only one hart that is always existent
+          dmi_rsp_o.data(13)           <= dm_reg.dmcontrol_ndmreset; -- allunavail (r/-): there is only one hart that is unavailable during reset
+          dmi_rsp_o.data(12)           <= dm_reg.dmcontrol_ndmreset; -- anyunavail (r/-): there is only one hart that is unavailable during reset
+          dmi_rsp_o.data(11)           <= not dm_ctrl.hart_halted;   -- allrunning (r/-): there is only one hart that can be RUNNING or HALTED
+          dmi_rsp_o.data(10)           <= not dm_ctrl.hart_halted;   -- anyrunning (r/-): there is only one hart that can be RUNNING or HALTED
+          dmi_rsp_o.data(09)           <= dm_ctrl.hart_halted;       -- allhalted (r/-): there is only one hart that can be RUNNING or HALTED
+          dmi_rsp_o.data(08)           <= dm_ctrl.hart_halted;       -- anyhalted (r/-): there is only one hart that can be RUNNING or HALTED
+          dmi_rsp_o.data(07)           <= '1';                       -- authenticated (r/-): authentication passed since there is no authentication
+          dmi_rsp_o.data(06)           <= '0';                       -- authbusy (r/-): always ready since there is no authentication
+          dmi_rsp_o.data(05)           <= '0';                       -- hasresethaltreq (r/-): halt-on-reset not implemented
+          dmi_rsp_o.data(04)           <= '0';                       -- confstrptrvalid (r/-): no configuration string available
+          dmi_rsp_o.data(03 downto 00) <= dm_version_c;              -- version (r/-): DM spec. version
 
         -- debug module control --
         when addr_dmcontrol_c =>
-          dmi_rsp_data_o(31)           <= '0';                       -- haltreq (-/w): write-only
-          dmi_rsp_data_o(30)           <= '0';                       -- resumereq (-/w1): write-only
-          dmi_rsp_data_o(29)           <= '0';                       -- hartreset (r/w): not supported
-          dmi_rsp_data_o(28)           <= '0';                       -- ackhavereset (-/w1): write-only
-          dmi_rsp_data_o(27)           <= '0';                       -- reserved (r/-)
-          dmi_rsp_data_o(26)           <= '0';                       -- hasel (r/-) - there is a single currently selected hart
-          dmi_rsp_data_o(25 downto 16) <= (others => '0');           -- hartsello (r/-) - there is only one hart
-          dmi_rsp_data_o(15 downto 06) <= (others => '0');           -- hartselhi (r/-) - there is only one hart
-          dmi_rsp_data_o(05 downto 04) <= (others => '0');           -- reserved (r/-)
-          dmi_rsp_data_o(03)           <= '0';                       -- setresethaltreq (-/w1): halt-on-reset request - halt-on-reset not implemented
-          dmi_rsp_data_o(02)           <= '0';                       -- clrresethaltreq (-/w1): halt-on-reset ack - halt-on-reset not implemented
-          dmi_rsp_data_o(01)           <= dm_reg.dmcontrol_ndmreset; -- ndmreset (r/w): soc reset
-          dmi_rsp_data_o(00)           <= dm_reg.dmcontrol_dmactive; -- dmactive (r/w): DM reset
+          dmi_rsp_o.data(31)           <= '0';                       -- haltreq (-/w): write-only
+          dmi_rsp_o.data(30)           <= '0';                       -- resumereq (-/w1): write-only
+          dmi_rsp_o.data(29)           <= '0';                       -- hartreset (r/w): not supported
+          dmi_rsp_o.data(28)           <= '0';                       -- ackhavereset (-/w1): write-only
+          dmi_rsp_o.data(27)           <= '0';                       -- reserved (r/-)
+          dmi_rsp_o.data(26)           <= '0';                       -- hasel (r/-) - only a single hart can be selected at once
+          dmi_rsp_o.data(25 downto 16) <= (others => '0');           -- hartsello (r/-) - there is only one hart
+          dmi_rsp_o.data(15 downto 06) <= (others => '0');           -- hartselhi (r/-) - there is only one hart
+          dmi_rsp_o.data(05 downto 04) <= (others => '0');           -- reserved (r/-)
+          dmi_rsp_o.data(03)           <= '0';                       -- setresethaltreq (-/w1): halt-on-reset request - halt-on-reset not implemented
+          dmi_rsp_o.data(02)           <= '0';                       -- clrresethaltreq (-/w1): halt-on-reset ack - halt-on-reset not implemented
+          dmi_rsp_o.data(01)           <= dm_reg.dmcontrol_ndmreset; -- ndmreset (r/w): soc reset
+          dmi_rsp_o.data(00)           <= dm_reg.dmcontrol_dmactive; -- dmactive (r/w): DM reset
 
         -- hart info --
         when addr_hartinfo_c =>
-          dmi_rsp_data_o(31 downto 24) <= (others => '0');           -- reserved (r/-)
-          dmi_rsp_data_o(23 downto 20) <= nscratch_c;                -- nscratch (r/-): number of dscratch CSRs
-          dmi_rsp_data_o(19 downto 17) <= (others => '0');           -- reserved (r/-)
-          dmi_rsp_data_o(16)           <= dataaccess_c;              -- dataaccess (r/-): 1: data registers are memory-mapped, 0: data reisters are CSR-mapped
-          dmi_rsp_data_o(15 downto 12) <= datasize_c;                -- datasize (r/-): number data registers in memory/CSR space
-          dmi_rsp_data_o(11 downto 00) <= dataaddr_c(11 downto 0);   -- dataaddr (r/-): data registers base address (memory/CSR)
+          dmi_rsp_o.data(31 downto 24) <= (others => '0');         -- reserved (r/-)
+          dmi_rsp_o.data(23 downto 20) <= nscratch_c;              -- nscratch (r/-): number of dscratch CSRs
+          dmi_rsp_o.data(19 downto 17) <= (others => '0');         -- reserved (r/-)
+          dmi_rsp_o.data(16)           <= dataaccess_c;            -- dataaccess (r/-): 1: data registers are memory-mapped, 0: data registers are CSR-mapped
+          dmi_rsp_o.data(15 downto 12) <= datasize_c;              -- datasize (r/-): number data registers in memory/CSR space
+          dmi_rsp_o.data(11 downto 00) <= dataaddr_c(11 downto 0); -- dataaddr (r/-): data registers base address (memory/CSR)
 
         -- abstract control and status --
         when addr_abstractcs_c =>
-          dmi_rsp_data_o(31 downto 24) <= (others => '0');           -- reserved (r/-)
-          dmi_rsp_data_o(28 downto 24) <= "00010";                   -- progbufsize (r/-): number of words in program buffer = 2
-          dmi_rsp_data_o(12)           <= dm_ctrl.busy;              -- busy (r/-): abstract command in progress (1) / idle (0)
-          dmi_rsp_data_o(11)           <= '1';                       -- relaxedpriv (r/-): PMP rules are ignored when in debug-mode
-          dmi_rsp_data_o(10 downto 08) <= dm_ctrl.cmderr;            -- cmderr (r/w1c): any error during execution?
-          dmi_rsp_data_o(07 downto 04) <= (others => '0');           -- reserved (r/-)
-          dmi_rsp_data_o(03 downto 00) <= "0001";                    -- datacount (r/-): number of implemented data registers = 1
+          dmi_rsp_o.data(31 downto 24) <= (others => '0'); -- reserved (r/-)
+          dmi_rsp_o.data(28 downto 24) <= "00010";         -- progbufsize (r/-): number of words in program buffer = 2
+          dmi_rsp_o.data(12)           <= dm_ctrl.busy;    -- busy (r/-): abstract command in progress (1) / idle (0)
+          dmi_rsp_o.data(11)           <= '1';             -- relaxedpriv (r/-): PMP rules are ignored when in debug-mode
+          dmi_rsp_o.data(10 downto 08) <= dm_ctrl.cmderr;  -- cmderr (r/w1c): any error during execution?
+          dmi_rsp_o.data(07 downto 04) <= (others => '0'); -- reserved (r/-)
+          dmi_rsp_o.data(03 downto 00) <= "0001";          -- datacount (r/-): number of implemented data registers = 1
 
---      -- abstract command (-/w) --
---      when addr_command_c =>
---        dmi_rsp_data_o <= (others => '0'); -- register is write-only
+        -- abstract command (-/w) --
+        when addr_command_c =>
+          dmi_rsp_o.data <= (others => '0'); -- register is write-only
 
         -- abstract command autoexec (r/w) --
         when addr_abstractauto_c =>
-          dmi_rsp_data_o(00) <= dm_reg.abstractauto_autoexecdata;       -- autoexecdata(0):    read/write access to data0 triggers execution of program buffer
-          dmi_rsp_data_o(16) <= dm_reg.abstractauto_autoexecprogbuf(0); -- autoexecprogbuf(0): read/write access to progbuf0 triggers execution of program buffer
-          dmi_rsp_data_o(17) <= dm_reg.abstractauto_autoexecprogbuf(1); -- autoexecprogbuf(1): read/write access to progbuf1 triggers execution of program buffer
+          dmi_rsp_o.data(00) <= dm_reg.abstractauto_autoexecdata;       -- autoexecdata(0):    read/write access to data0 triggers execution of program buffer
+          dmi_rsp_o.data(16) <= dm_reg.abstractauto_autoexecprogbuf(0); -- autoexecprogbuf(0): read/write access to progbuf0 triggers execution of program buffer
+          dmi_rsp_o.data(17) <= dm_reg.abstractauto_autoexecprogbuf(1); -- autoexecprogbuf(1): read/write access to progbuf1 triggers execution of program buffer
 
---      -- next debug module (r/-) --
---      when addr_nextdm_c =>
---        dmi_rsp_data_o <= (others => '0'); -- this is the only DM
+        -- next debug module (r/-) --
+        when addr_nextdm_c =>
+          dmi_rsp_o.data <= (others => '0'); -- this is the only DM
 
         -- abstract data 0 (r/w) --
         when addr_data0_c =>
-          dmi_rsp_data_o <= dci.rdata;
+          dmi_rsp_o.data <= dci.data_reg;
 
---      -- program buffer (-/w) --
---      when addr_progbuf0_c =>
---        dmi_rsp_data_o <= dm_reg.progbuf(0); -- program buffer 0, register is write-only
---      when addr_progbuf1_c =>
---        dmi_rsp_data_o <= dm_reg.progbuf(1); -- program buffer 1, register is write-only
+        -- program buffer (r/w) --
+        when addr_progbuf0_c =>
+          if (LEGACY_MODE = true) then dmi_rsp_o.data <= dm_reg.progbuf(0); else dmi_rsp_o.data <= (others => '0'); end if; -- program buffer 0
+        when addr_progbuf1_c =>
+          if (LEGACY_MODE = true) then dmi_rsp_o.data <= dm_reg.progbuf(1); else dmi_rsp_o.data <= (others => '0'); end if; -- program buffer 1
 
---      -- system bus access control and status (r/-) --
---      when addr_sbcs_c =>
---        dmi_rsp_data_o <= (others => '0'); -- bus access not implemented
+        -- system bus access control and status (r/-) --
+        when addr_sbcs_c =>
+          dmi_rsp_o.data <= (others => '0'); -- system bus access not implemented
+
+        -- halt summary 0 (r/-) --
+        when addr_haltsum0_c =>
+          dmi_rsp_o.data(0) <= dm_ctrl.hart_halted; -- hart 0 is halted
 
         -- not implemented (r/-) --
         when others =>
-          dmi_rsp_data_o <= (others => '0');
+          dmi_rsp_o.data <= (others => '0');
 
       end case;
 
@@ -656,9 +639,9 @@ begin
       -- ------------------------------------------------------------
       if (dmi_rden = '1') then -- valid DMI read request
         if (dm_ctrl.busy = '1') then -- busy
-          if (dmi_req_address_i = addr_data0_c) or
-             (dmi_req_address_i = addr_progbuf0_c) or
-             (dmi_req_address_i = addr_progbuf1_c) then
+          if (dmi_req_i.addr = addr_data0_c) or
+             (dmi_req_i.addr = addr_progbuf0_c) or
+             (dmi_req_i.addr = addr_progbuf1_c) then
             dm_reg.rd_acc_err <= '1';
           end if;
         end if;
@@ -667,9 +650,9 @@ begin
       -- auto execution trigger --
       -- ------------------------------------------------------------
       if (dmi_rden = '1') then -- valid DMI read request
-        if ((dmi_req_address_i = addr_data0_c)    and (dm_reg.abstractauto_autoexecdata = '1')) or
-           ((dmi_req_address_i = addr_progbuf0_c) and (dm_reg.abstractauto_autoexecprogbuf(0) = '1')) or
-           ((dmi_req_address_i = addr_progbuf1_c) and (dm_reg.abstractauto_autoexecprogbuf(1) = '1')) then
+        if ((dmi_req_i.addr = addr_data0_c)    and (dm_reg.abstractauto_autoexecdata = '1')) or
+           ((dmi_req_i.addr = addr_progbuf0_c) and (dm_reg.abstractauto_autoexecprogbuf(0) = '1')) or
+           ((dmi_req_i.addr = addr_progbuf1_c) and (dm_reg.abstractauto_autoexecprogbuf(1) = '1')) then
           dm_reg.autoexec_rd <= '1';
         end if;
       end if;
@@ -693,7 +676,7 @@ begin
   write_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      data_buf          <= (others => '0');
+      dci.data_reg      <= (others => '0');
       dci.halt_ack      <= '0';
       dci.resume_ack    <= '0';
       dci.execute_ack   <= '0';
@@ -701,9 +684,9 @@ begin
     elsif rising_edge(clk_i) then
       -- data buffer --
       if (dci.data_we = '1') then -- DM write access
-        data_buf <= dci.wdata;
+        dci.data_reg <= dmi_req_i.data;
       elsif (bus_req_i.addr(7 downto 6) = dm_data_base_c(7 downto 6)) and (wren = '1') then -- CPU write access
-        data_buf <= bus_req_i.data;
+        dci.data_reg <= bus_req_i.data;
       end if;
       -- control and status register CPU write access --
       -- NOTE: we only check the individual BYTE ACCESSES - not the actual write data --
@@ -712,24 +695,13 @@ begin
       dci.execute_ack   <= '0';
       dci.exception_ack <= '0';
       if (bus_req_i.addr(7 downto 6) = dm_sreg_base_c(7 downto 6)) and (wren = '1') then
-        if (bus_req_i.ben(sreg_halt_ack_c/8) = '1') then
-          dci.halt_ack <= '1';
-        end if;
-        if (bus_req_i.ben(sreg_resume_ack_c/8) = '1') then
-          dci.resume_ack <= '1';
-        end if;
-        if (bus_req_i.ben(sreg_execute_ack_c/8) = '1') then
-          dci.execute_ack <= '1';
-        end if;
-        if (bus_req_i.ben(sreg_exception_ack_c/8) = '1') then
-          dci.exception_ack <= '1';
-        end if;
+        dci.halt_ack      <= bus_req_i.ben(sreg_halt_ack_c/8);
+        dci.resume_ack    <= bus_req_i.ben(sreg_resume_ack_c/8);
+        dci.execute_ack   <= bus_req_i.ben(sreg_execute_ack_c/8);
+        dci.exception_ack <= bus_req_i.ben(sreg_exception_ack_c/8);
       end if;
     end if;
   end process write_access;
-
-  -- DM data buffer read access --
-  dci.rdata <= data_buf;
 
 
   -- Read Access ----------------------------------------------------------------------------
@@ -746,7 +718,7 @@ begin
           when "01" => -- dm_pbuf_base_c: program buffer
             bus_rsp_o.data <= cpu_progbuf(to_integer(unsigned(bus_req_i.addr(3 downto 2))));
           when "10" => -- dm_data_base_c: data buffer
-            bus_rsp_o.data <= data_buf;
+            bus_rsp_o.data <= dci.data_reg;
           when others => -- dm_sreg_base_c: control and status register
             bus_rsp_o.data(sreg_resume_req_c)  <= dci.resume_req;
             bus_rsp_o.data(sreg_execute_req_c) <= dci.execute_req;

--- a/rtl/core/neorv32_debug_dtm.vhd
+++ b/rtl/core/neorv32_debug_dtm.vhd
@@ -38,6 +38,9 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
+library neorv32;
+use neorv32.neorv32_package.all;
+
 entity neorv32_debug_dtm is
   generic (
     IDCODE_VERSION : std_ulogic_vector(03 downto 0); -- version
@@ -46,33 +49,26 @@ entity neorv32_debug_dtm is
   );
   port (
     -- global control --
-    clk_i             : in  std_ulogic; -- global clock line
-    rstn_i            : in  std_ulogic; -- global reset line, low-active
+    clk_i       : in  std_ulogic; -- global clock line
+    rstn_i      : in  std_ulogic; -- global reset line, low-active
     -- jtag connection --
-    jtag_trst_i       : in  std_ulogic;
-    jtag_tck_i        : in  std_ulogic;
-    jtag_tdi_i        : in  std_ulogic;
-    jtag_tdo_o        : out std_ulogic;
-    jtag_tms_i        : in  std_ulogic;
+    jtag_trst_i : in  std_ulogic;
+    jtag_tck_i  : in  std_ulogic;
+    jtag_tdi_i  : in  std_ulogic;
+    jtag_tdo_o  : out std_ulogic;
+    jtag_tms_i  : in  std_ulogic;
     -- debug module interface (DMI) --
-    dmi_req_valid_o   : out std_ulogic;
-    dmi_req_ready_i   : in  std_ulogic; -- DMI is allowed to make new requests when set
-    dmi_req_address_o : out std_ulogic_vector(05 downto 0);
-    dmi_req_data_o    : out std_ulogic_vector(31 downto 0);
-    dmi_req_op_o      : out std_ulogic_vector(01 downto 0);
-    dmi_rsp_valid_i   : in  std_ulogic; -- response valid when set
-    dmi_rsp_ready_o   : out std_ulogic; -- ready to receive response
-    dmi_rsp_data_i    : in  std_ulogic_vector(31 downto 0);
-    dmi_rsp_op_i      : in  std_ulogic_vector(01 downto 0)
+    dmi_req_o   : out dmi_req_t; -- request
+    dmi_rsp_i   : in  dmi_rsp_t  -- response
   );
 end neorv32_debug_dtm;
 
 architecture neorv32_debug_dtm_rtl of neorv32_debug_dtm is
 
   -- DMI Configuration (fixed!) --
-  constant dmi_idle_c    : std_ulogic_vector(02 downto 0) := "000"; -- no idle cycles required
-  constant dmi_version_c : std_ulogic_vector(03 downto 0) := "0001"; -- debug spec. version (0.13 & 1.0)
-  constant dmi_abits_c   : std_ulogic_vector(05 downto 0) := "000110"; -- number of DMI address bits (6)
+  constant dmi_idle_c    : std_ulogic_vector(02 downto 0) := "000";    -- no idle cycles required
+  constant dmi_version_c : std_ulogic_vector(03 downto 0) := "0001";   -- debug spec. version (0.13 & 1.0)
+  constant dmi_abits_c   : std_ulogic_vector(05 downto 0) := "000111"; -- number of DMI address bits (7)
 
   -- tap JTAG signal synchronizer --
   type tap_sync_t is record
@@ -90,10 +86,20 @@ architecture neorv32_debug_dtm_rtl of neorv32_debug_dtm is
   end record;
   signal tap_sync : tap_sync_t;
 
-  -- tap controller - fsm --
+  -- tap controller --
   type tap_ctrl_state_t is (LOGIC_RESET, DR_SCAN, DR_CAPTURE, DR_SHIFT, DR_EXIT1, DR_PAUSE, DR_EXIT2, DR_UPDATE,
                                RUN_IDLE, IR_SCAN, IR_CAPTURE, IR_SHIFT, IR_EXIT1, IR_PAUSE, IR_EXIT2, IR_UPDATE);
   signal tap_ctrl_state : tap_ctrl_state_t;
+
+  -- tap registers --
+  type tap_reg_t is record
+    ireg             : std_ulogic_vector(04 downto 0);
+    bypass           : std_ulogic;
+    idcode           : std_ulogic_vector(31 downto 0);
+    dtmcs, dtmcs_nxt : std_ulogic_vector(31 downto 0);
+    dmi,   dmi_nxt   : std_ulogic_vector((7+32+2)-1 downto 0); -- 7-bit address + 32-bit data + 2-bit operation
+  end record;
+  signal tap_reg : tap_reg_t;
 
   -- update trigger --
   type dr_update_trig_t is record
@@ -103,27 +109,16 @@ architecture neorv32_debug_dtm_rtl of neorv32_debug_dtm is
   end record;
   signal dr_update_trig : dr_update_trig_t;
 
-  -- tap registers --
-  type tap_reg_t is record
-    ireg             : std_ulogic_vector(04 downto 0);
-    bypass           : std_ulogic;
-    idcode           : std_ulogic_vector(31 downto 0);
-    dtmcs, dtmcs_nxt : std_ulogic_vector(31 downto 0);
-    dmi,   dmi_nxt   : std_ulogic_vector((6+32+2)-1 downto 0); -- 6-bit address + 32-bit data + 2-bit operation
-  end record;
-  signal tap_reg : tap_reg_t;
-
-  -- debug module interface --
-  type dmi_ctrl_state_t is (DMI_IDLE, DMI_READ_WAIT, DMI_READ, DMI_READ_BUSY,
-                            DMI_WRITE_WAIT, DMI_WRITE, DMI_WRITE_BUSY);
+  -- debug module interface controller --
   type dmi_ctrl_t is record
-    state        : dmi_ctrl_state_t;
+    busy         : std_ulogic;
+    op           : std_ulogic_vector(01 downto 0);
     dmihardreset : std_ulogic;
     dmireset     : std_ulogic;
-    rsp          : std_ulogic_vector(01 downto 0); -- sticky response status
+    err          : std_ulogic;
     rdata        : std_ulogic_vector(31 downto 0);
     wdata        : std_ulogic_vector(31 downto 0);
-    addr         : std_ulogic_vector(05 downto 0);
+    addr         : std_ulogic_vector(06 downto 0);
   end record;
   signal dmi_ctrl : dmi_ctrl_t;
 
@@ -253,19 +248,19 @@ begin
   end process reg_access;
 
   -- DTM Control and Status Register (dtmcs) --
-  tap_reg.dtmcs_nxt(31 downto 18) <= (others => '0'); -- unused
-  tap_reg.dtmcs_nxt(17)           <= '0'; -- dmihardreset, always reads as zero
-  tap_reg.dtmcs_nxt(16)           <= '0'; -- dmireset, always reads as zero
-  tap_reg.dtmcs_nxt(15)           <= '0'; -- unused
+  tap_reg.dtmcs_nxt(31 downto 18) <= (others => '0'); -- reserved
+  tap_reg.dtmcs_nxt(17)           <= dmi_ctrl.dmihardreset; -- dmihardreset
+  tap_reg.dtmcs_nxt(16)           <= dmi_ctrl.dmireset; -- dmireset
+  tap_reg.dtmcs_nxt(15)           <= '0'; -- reserved
   tap_reg.dtmcs_nxt(14 downto 12) <= dmi_idle_c; -- minimum number of idle cycles
   tap_reg.dtmcs_nxt(11 downto 10) <= tap_reg.dmi_nxt(1 downto 0); -- dmistat
   tap_reg.dtmcs_nxt(09 downto 04) <= dmi_abits_c; -- number of DMI address bits
   tap_reg.dtmcs_nxt(03 downto 00) <= dmi_version_c; -- version
 
   -- DMI register read access --
-  tap_reg.dmi_nxt(39 downto 34) <= dmi_ctrl.addr; -- address
+  tap_reg.dmi_nxt(40 downto 34) <= dmi_ctrl.addr; -- address
   tap_reg.dmi_nxt(33 downto 02) <= dmi_ctrl.rdata; -- read data
-  tap_reg.dmi_nxt(01 downto 00) <= "11" when (dmi_ctrl.state /= DMI_IDLE) else (dmi_ctrl.rsp); -- status
+  tap_reg.dmi_nxt(01 downto 00) <= (others => dmi_ctrl.err); -- status
 
 
   -- Debug Module Interface -----------------------------------------------------------------
@@ -273,84 +268,55 @@ begin
   dmi_controller: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      dmi_ctrl.state        <= DMI_IDLE;
+      dmi_ctrl.busy         <= '0';
+      dmi_ctrl.op           <= "00";
       dmi_ctrl.dmihardreset <= '1';
-      dmi_ctrl.dmireset     <= '1';
-      dmi_ctrl.rsp          <= "00";
+      dmi_ctrl.dmireset     <= '0';
+      dmi_ctrl.err          <= '0';
       dmi_ctrl.rdata        <= (others => '0');
       dmi_ctrl.wdata        <= (others => '0');
       dmi_ctrl.addr         <= (others => '0');
     elsif rising_edge(clk_i) then
 
-      -- DMI status and control --
-      dmi_ctrl.dmihardreset <= '0'; -- default
-      dmi_ctrl.dmireset     <= '0'; -- default
+      -- DMI reset control --
       if (dr_update_trig.valid = '1') and (tap_reg.ireg = "10000") then
         dmi_ctrl.dmireset     <= tap_reg.dtmcs(16);
         dmi_ctrl.dmihardreset <= tap_reg.dtmcs(17);
+      elsif (dmi_ctrl.busy = '0') then
+        dmi_ctrl.dmihardreset <= '0';
+        dmi_ctrl.dmireset     <= '0';
+      end if;
+
+      -- sticky error --
+      if (dmi_ctrl.dmireset = '1') or (dmi_ctrl.dmihardreset = '1') then
+        dmi_ctrl.err <= '0';
+      elsif (dmi_ctrl.busy = '1') and (dr_update_trig.valid = '1') and (tap_reg.ireg = "10001") then -- access attempt while DMI is busy
+        dmi_ctrl.err <= '1';
       end if;
 
       -- DMI interface arbiter --
-      if (dmi_ctrl.dmihardreset = '1') then -- DMI hard reset
-        dmi_ctrl.state <= DMI_IDLE;
-      else
-        case dmi_ctrl.state is
+      dmi_ctrl.op <= dmi_req_nop_c; -- default
+      if (dmi_ctrl.busy = '0') then -- idle: waiting for new request
 
-          when DMI_IDLE => -- waiting for new request
-            if (dr_update_trig.valid = '1') and (tap_reg.ireg = "10001") then
-              dmi_ctrl.addr  <= tap_reg.dmi(39 downto 34);
-              dmi_ctrl.wdata <= tap_reg.dmi(33 downto 02);
-              if (tap_reg.dmi(1 downto 0) = "01") then -- read
-                dmi_ctrl.state <= DMI_READ_WAIT;
-              elsif (tap_reg.dmi(1 downto 0) = "10") then -- write
-                dmi_ctrl.state <= DMI_WRITE_WAIT;
-              end if;
+        if (dmi_ctrl.dmihardreset = '0') then -- no DMI hard reset
+          if (dr_update_trig.valid = '1') and (tap_reg.ireg = "10001") then
+            dmi_ctrl.addr  <= tap_reg.dmi(40 downto 34);
+            dmi_ctrl.wdata <= tap_reg.dmi(33 downto 02);
+            if (tap_reg.dmi(1 downto 0) = dmi_req_rd_c) or (tap_reg.dmi(1 downto 0) = dmi_req_wr_c) then
+              dmi_ctrl.op   <= tap_reg.dmi(1 downto 0);
+              dmi_ctrl.busy <= '1';
             end if;
-
-          when DMI_READ_WAIT => -- wait for DMI to become ready
-            if (dmi_req_ready_i = '1') then
-              dmi_ctrl.state <= DMI_READ;
-            end if;
-
-          when DMI_READ => -- trigger/start read access
-            dmi_ctrl.state <= DMI_READ_BUSY;
-
-          when DMI_READ_BUSY => -- pending read access
-            if (dmi_rsp_valid_i = '1') then
-              dmi_ctrl.rdata <= dmi_rsp_data_i;
-              dmi_ctrl.state <= DMI_IDLE;
-            end if;
-
-          when DMI_WRITE_WAIT => -- wait for DMI to become ready
-            if (dmi_req_ready_i = '1') then
-              dmi_ctrl.state <= DMI_WRITE;
-            end if;
-
-          when DMI_WRITE => -- trigger/start write access
-            dmi_ctrl.state <= DMI_WRITE_BUSY;
-
-          when DMI_WRITE_BUSY => -- pending write access
-            if (dmi_rsp_valid_i = '1') then
-              dmi_ctrl.state <= DMI_IDLE;
-            end if;
-
-          when others => -- undefined
-            dmi_ctrl.state <= DMI_IDLE;
-
-        end case;
-      end if;
-
-      -- sticky response flags --
-      if (dmi_ctrl.dmireset = '1') or (dmi_ctrl.dmihardreset = '1') then
-        dmi_ctrl.rsp <= "00";
-      else
-        if (dmi_ctrl.state /= DMI_IDLE) and (dr_update_trig.valid = '1') and (tap_reg.ireg = "10001") then -- access attempt while DMI is busy
-          dmi_ctrl.rsp <= "11";
-        elsif (dmi_ctrl.state = DMI_READ_BUSY) or (dmi_ctrl.state = DMI_WRITE_BUSY) then -- accumulate DMI response
-          dmi_ctrl.rsp <= dmi_ctrl.rsp or dmi_rsp_op_i;
+          end if;
         end if;
-      end if;
 
+        else -- busy: read/write access in progress
+
+          dmi_ctrl.rdata <= dmi_rsp_i.data;
+          if (dmi_rsp_i.ack = '1') then
+            dmi_ctrl.busy <= '0';
+          end if;
+
+      end if;
     end if;
   end process dmi_controller;
 
@@ -368,11 +334,9 @@ begin
   dr_update_trig.valid     <= '1' when (dr_update_trig.is_update = '1') and (dr_update_trig.is_update_ff = '0') else '0';
 
   -- direct DMI output --
-  dmi_req_valid_o   <= '1' when (dmi_ctrl.state = DMI_READ) or (dmi_ctrl.state = DMI_WRITE) else '0';
-  dmi_req_op_o      <= tap_reg.dmi(1 downto 0);
-  dmi_rsp_ready_o   <= '1' when (dmi_ctrl.state = DMI_READ_BUSY) or (dmi_ctrl.state = DMI_WRITE_BUSY) else '0';
-  dmi_req_address_o <= dmi_ctrl.addr;
-  dmi_req_data_o    <= dmi_ctrl.wdata;
+  dmi_req_o.op   <= dmi_ctrl.op;
+  dmi_req_o.data <= dmi_ctrl.wdata;
+  dmi_req_o.addr <= dmi_ctrl.addr;
 
 
 end neorv32_debug_dtm_rtl;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080803"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080804"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 
@@ -190,6 +190,25 @@ package neorv32_package is
     err  => '0'
   );
 
+  -- Debug Module Interface -----------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  -- request --
+  type dmi_req_t is record
+    addr : std_ulogic_vector(06 downto 0);
+    op   : std_ulogic_vector(01 downto 0);
+    data : std_ulogic_vector(31 downto 0);
+  end record;
+
+  -- request operation --
+  constant dmi_req_nop_c : std_ulogic_vector(1 downto 0) := "00"; -- no operation
+  constant dmi_req_rd_c  : std_ulogic_vector(1 downto 0) := "01"; -- read access
+  constant dmi_req_wr_c  : std_ulogic_vector(1 downto 0) := "10"; -- write access
+
+  -- response --
+  type dmi_rsp_t is record
+    data : std_ulogic_vector(31 downto 0);
+    ack  : std_ulogic;
+  end record;
 
 -- ****************************************************************************************************************************
 -- RISC-V ISA Definitions

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -751,6 +751,7 @@ package neorv32_package is
       INT_BOOTLOADER_EN            : boolean := false;  -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
       -- On-Chip Debugger (OCD) --
       ON_CHIP_DEBUGGER_EN          : boolean := false;  -- implement on-chip debugger
+      DM_LEGACY_MODE               : boolean := false;  -- debug module spec version: false = v1.0, true = v0.13
       -- RISC-V CPU Extensions --
       CPU_EXTENSION_RISCV_A        : boolean := false;  -- implement atomic memory operations extension?
       CPU_EXTENSION_RISCV_B        : boolean := false;  -- implement bit-manipulation extension?

--- a/sw/ocd-firmware/park_loop.S
+++ b/sw/ocd-firmware/park_loop.S
@@ -38,7 +38,7 @@
 .equ DM_DATA_BASE, 0xffffff80 // base address of debug_module's abstract data buffer (DATA)
 .equ DM_SREG_BASE, 0xffffffC0 // base address of debug_module's status register
 
-// status register (SREG) byte(!!!) offsets
+// status register (SREG) byte(!) offsets
 .equ SREG_HLT_ACK, ( 0 / 8) // -/w: CPU has halted in debug mode and is waiting in park loop
 .equ SREG_RES_REQ, ( 8 / 8) // r/-: DM requests to resume
 .equ SREG_RES_ACK, ( 8 / 8) // -/w: CPU starts to resume
@@ -68,24 +68,24 @@ entry_normal:
 // polling loop - waiting for requests
 park_loop:
   sb      zero, (DM_SREG_BASE+SREG_HLT_ACK)(zero) // ACK that CPU is halted
-  lbu     x8, (DM_SREG_BASE+SREG_EXE_REQ)(zero)   // request to execute program buffer?
-  bnez    x8, execute
-  lbu     x8, (DM_SREG_BASE+SREG_RES_REQ)(zero)   // request to resume?
-  beqz    x8, park_loop
+  lbu     x8,   (DM_SREG_BASE+SREG_EXE_REQ)(zero) // request to execute program buffer?
+  bnez    x8,   execute
+  lbu     x8,   (DM_SREG_BASE+SREG_RES_REQ)(zero) // request to resume?
+  beqz    x8,   park_loop
 
 // resume normal operation
 resume:
-  sb      x8, (DM_SREG_BASE+SREG_RES_ACK)(zero)   // ACK that CPU is about to resume
-  csrr    x8, dscratch0                           // restore x8 from dscratch0
+  sb      zero, (DM_SREG_BASE+SREG_RES_ACK)(zero) // ACK that CPU is about to resume
+  csrr    x8,   dscratch0                         // restore x8 from dscratch0
   dret                                            // exit debug mode
 
 // execute program buffer
 execute:
   sb      zero, (DM_SREG_BASE+SREG_EXE_ACK)(zero) // ACK that execution is about to start
-  csrr    x8, dscratch0                           // restore x8 from dscratch0
-  fence.i                                         // synchronize ifetch / i-cache & prefetch with memory (PBUF)
+  csrr    x8,   dscratch0                         // restore x8 from dscratch0
+  fence.i                                         // synchronize i-cache and prefetch with memory (PBUF)
   jalr    zero, zero, %lo(DM_PBUF_BASE)           // jump to beginning of program buffer (PBUF)
 
 // fill remaining ROM space with instructions that cause a debug-mode-internal exception
 unused:
-  ecall
+  ecall                                           // should never be reached

--- a/sw/openocd/openocd_neorv32.cfg
+++ b/sw/openocd/openocd_neorv32.cfg
@@ -22,7 +22,7 @@ ftdi layout_signal nTRST -ndata 0x0010 -noe 0x0040
 # ----------------------------------------------
 # Logical interface configuration
 # ----------------------------------------------
-adapter speed 2000
+adapter speed 4000
 transport select jtag
 
 
@@ -41,13 +41,6 @@ target create $_TARGETNAME.0 riscv -chain-position $_TARGETNAME
 # Access memory only via program buffer
 # ----------------------------------------------
 riscv set_mem_access progbuf
-
-
-# ----------------------------------------------
-# Scratch pad RAM
-# ----------------------------------------------
-# work area ("scratch pad RAM"): beginning of (internal) DMEM, 256 bytes, requires(!) backup
-$_TARGETNAME.0 configure -work-area-phys 0x80000000 -work-area-size 256 -work-area-backup 1
 
 
 # ----------------------------------------------


### PR DESCRIPTION
Triggered by @stokdam in https://github.com/stnolting/neorv32/pull/463#issuecomment-1690115103

This PR adds a new generic to the processor's top entity that allows to "downgrade" the on-chip debugger's debug module (DM) back to version 0.13.

* `DM_LEGACY_MODE = false`: DM is compatible to debug spec. version 1.0
* `DM_LEGACY_MODE = true`: DM is compatible to debug spec. version 0.13 (**legacy mode**)

This PR also provides some clean-ups and optimizations for the on-chip debugger modules (DTM & DM).