### PR TITLE
[cpu] remove branch prediction logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 30.08.2023 | 1.8.8.5 | remove "branch prediction" logic - core is smaller and _even faster_ without it; [#678](https://github.com/stnolting/neorv32/pull/678) |
 | 25.08.2023 | 1.8.8.4 | add new generic to downgrade on-chip debugger's debug module back to spec. version 0.13 (`DM_LEGACY_MODE` generic); [#677](https://github.com/stnolting/neorv32/pull/677) |
 | 23.08.2023 | 1.8.8.3 | :test_tube: add experimental `Smcntrpmf` ISA extension (counter privilege mode filtering; spec. is frozen but not yet ratified); remove unused `menvcfg` CSRs; [#676](https://github.com/stnolting/neorv32/pull/676) |
 | 19.08.2023 | 1.8.8.2 | :warning: constrain `mtval` CSR; add support for `mtinst` CSR (trap instruction); [#674](https://github.com/stnolting/neorv32/pull/674) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -153,11 +153,6 @@ can operate in parallel to increase performance. However, all potential side eff
 instruction fetch are already handled by the CPU front-end ensuring a defined execution stage while preventing security
 side attacks.
 
-.Branch Prediction
-[NOTE]
-The front-end implements a very simple branch prediction that **stops** fetching further instruction while
-a branch/jump/call operation is in progress.
-
 
 **Back-End**
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080804"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080805"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 


### PR DESCRIPTION
This PR removes the CPU front end 's "branch prediction" logic that was used to halt instruction fetch while a branch/jump instruction is in progress until the destination address is available (resulting in less bus traffic / congestion).

However, benchmarks show that this prediction actually lowers performance:

Exemplary CoreMark run **with** branch prediction:
```
NEORV32: Hardware Performance Monitors (low words only)
 > Active clock cycles:          2199671829
 > Retired instructions:         596184106
 > Retired compr. instructions:  349937868
 > Instr.-fetch wait cycles:     34008506
 > Instr.-issue wait cycles:     286243045
 > Multi-cycle ALU wait cycles:  99331050
 > Load operations:              108277848
 > Store operations:             28390960
 > Load/store wait cycles:       5984501
 > Unconditional jumps:          16292334
 > Conditional branches (all):   115064467
 > Conditional branches (taken): 58094389
 > Entered traps:                0
 > Illegal operations:           0
```

Exemplary CoreMark run **without** branch prediction:
```
NEORV32: Hardware Performance Monitors (low words only)
 > Active clock cycles:          2188425528 (faster!)
 > Retired instructions:         596184106
 > Retired compr. instructions:  349937868
 > Instr.-fetch wait cycles:     0
 > Instr.-issue wait cycles:     263816491
 > Multi-cycle ALU wait cycles:  99331050
 > Load operations:              108277848
 > Store operations:             28390960
 > Load/store wait cycles:       17164754
 > Unconditional jumps:          16292334
 > Conditional branches (all):   115064467
 > Conditional branches (taken): 58094389
 > Entered traps:                0
 > Illegal operations:           0
```

Adding caches results in the same speed up factor when the prediction logic is removed. Additionally, removing the prediction logic reduces core size and relaxes the critical path (= the branch taken / not taken logic).