### PR TITLE
[cpu] add execution monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,15 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 * :bug: bug-fix
 * :sparkles: new feature
-* :test_tube: new (experimental) feature
-* :warning: change(s) that might impact compatibility with previous versions
-* :lock: security-related
-* :rocket: release
+* :test_tube: new experimental feature
+* :warning: changes that might impact compatibility with previous versions
+* :lock: security/safety-related
+* :rocket: official release
 
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 02.09.2023 | 1.8.8.7 | :lock: (re-)add **execution monitor**: raise an exception if a multi-cycle ALU operation does not complete within a bound amount of time; [#680](https://github.com/stnolting/neorv32/pull/680) |
 | 01.09.2023 | 1.8.8.6 | minor rtl edits and cleanups; [#679](https://github.com/stnolting/neorv32/pull/679) |
 | 30.08.2023 | 1.8.8.5 | remove "branch prediction" logic - core is smaller and _even faster_ without it; [#678](https://github.com/stnolting/neorv32/pull/678) |
 | 25.08.2023 | 1.8.8.4 | add new generic to downgrade on-chip debugger's debug module back to spec. version 0.13 (`DM_LEGACY_MODE` generic); [#677](https://github.com/stnolting/neorv32/pull/677) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -114,6 +114,11 @@ The co-processors are implemented as iterative units that require several cycles
 the co-processors are used to implement all further processing-based ISA extensions (e.g. <<_m_isa_extension>> and
 <<_b_isa_extension>>).
 
+.Multi-Cycle Execution Monitor
+[NOTE]
+The CPU control system will raise an illegal instruction exception if a multi-cycle functional unit (like the <<_custom_functions_unit_cfu>>)
+does not complete processing in a bound amount of time (configured via the package's `monitor_mc_tmo_c` constant; default = 512 clock cycles).
+
 
 :sectnums:
 ==== CPU Bus Unit
@@ -680,7 +685,7 @@ integer multiplications but not hardware-based divisions, which will be computed
 
 The `Zxcfu` presents a NEORV32-specific ISA extension. It adds the <<_custom_functions_unit_cfu>> to
 the CPU core, which allows to add custom RISC-V instructions to the processor core.
-For more detailed information regarding the CFU, its hardware and the according software interface
+For detailed information regarding the CFU, its hardware and the according software interface
 see section <<_custom_functions_unit_cfu>>.
 
 Software can utilize the custom instructions by using _intrinsics_, which are basically inline assembly functions that

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -54,9 +54,12 @@ package neorv32_package is
   -- instruction prefetch buffer depth --
   constant ipb_depth_c : natural := 2; -- hast to be a power of two, min 2, default 2
 
+  -- instruction monitor: raise exception if multi-cycle operation times out --
+  constant monitor_mc_tmo_c : natural := 9; -- = log2 of max execution cycles (default = 512 cycles)
+
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080806"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080807"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 
@@ -350,7 +353,6 @@ package neorv32_package is
 
   -- RISC-V CSRs ----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  -- <<< standard read/write CSRs >>> --
   -- user floating-point CSRs --
   constant csr_fflags_c         : std_ulogic_vector(11 downto 0) := x"001";
   constant csr_frm_c            : std_ulogic_vector(11 downto 0) := x"002";
@@ -458,7 +460,6 @@ package neorv32_package is
   constant csr_mhpmcounter13h_c : std_ulogic_vector(11 downto 0) := x"b8d";
   constant csr_mhpmcounter14h_c : std_ulogic_vector(11 downto 0) := x"b8e";
   constant csr_mhpmcounter15h_c : std_ulogic_vector(11 downto 0) := x"b8f";
-  -- <<< standard read-only CSRs >>> --
   -- user counters/timers --
   constant csr_cycle_c          : std_ulogic_vector(11 downto 0) := x"c00";
   constant csr_time_c           : std_ulogic_vector(11 downto 0) := x"c01";
@@ -499,8 +500,7 @@ package neorv32_package is
   constant csr_mimpid_c         : std_ulogic_vector(11 downto 0) := x"f13";
   constant csr_mhartid_c        : std_ulogic_vector(11 downto 0) := x"f14";
   constant csr_mconfigptr_c     : std_ulogic_vector(11 downto 0) := x"f15";
-  -- <<< NEORV32-specific (custom) read-only CSRs >>> ---
-  -- machine extended ISA extensions information --
+  -- NEORV32-specific (machine-mode) registers --
   constant csr_mxisa_c          : std_ulogic_vector(11 downto 0) := x"fc0";
 
 -- ****************************************************************************************************************************


### PR DESCRIPTION
raise illegal instruction exception if a multi-cycle instruction does not complete within a bound amount of time (default = 512 cycles); used to ensure that the FPU or CFU do not stall the CPU forever just because of an implementation flaw