### PR TITLE
[CFU] add support for CFU-internal CSRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 02.09.2023 | 1.8.8.8 | :sparkles: add option to implement **up to 2^32 CFU-internal user-defined CSRs** (via indirect CSR access); [#681](https://github.com/stnolting/neorv32/pull/681) |
 | 02.09.2023 | 1.8.8.7 | :lock: (re-)add **execution monitor**: raise an exception if a multi-cycle ALU operation does not complete within a bound amount of time; [#680](https://github.com/stnolting/neorv32/pull/680) |
 | 01.09.2023 | 1.8.8.6 | minor rtl edits and cleanups; [#679](https://github.com/stnolting/neorv32/pull/679) |
 | 30.08.2023 | 1.8.8.5 | remove "branch prediction" logic - core is smaller and _even faster_ without it; [#678](https://github.com/stnolting/neorv32/pull/678) |

--- a/docs/datasheet/cpu_cfu.adoc
+++ b/docs/datasheet/cpu_cfu.adoc
@@ -228,13 +228,19 @@ interfacing the custom user logic to the CPU pipeline.
 [TIP]
 The default CFU hardware module already implement some exemplary instructions that are used for illustration
 by the CFU example program. See the CFU's VHDL source file (`rtl/core/neorv32_cpu_cp_cfu.vhd`), which
-is highly commented to explain the available signals and the handshake with the CPU pipeline.
+is highly commented to explain the available signals, implementation options and the handshake with the CPU pipeline.
 
 .CFU Hardware Resource Requirements
-[WARNING]
+[NOTE]
 Enabling the CFU and actually implementing R4-type and/or R5-type instructions (or more precisely, using
 the according operands for the CFU hardware) will add one or two, respectively, additional read ports to
 the core's register file significantly increasing resource requirements.
+
+.CFU Access
+[NOTE]
+The CFU is accessible from all privilege modes (including CFU-internal registers accessed via the indirects CSR
+access mechanism). It is the task of the CFU designers to add according access-constraining logic if certain CFU
+states shall not be exposed to all privilege levels (i.e. exncryption keys).
 
 .CFU Execution Time
 [NOTE]

--- a/docs/datasheet/cpu_cfu.adoc
+++ b/docs/datasheet/cpu_cfu.adoc
@@ -32,14 +32,14 @@ Non-Standard Encoding Space"). The NEORV32 CFU uses the `custom` opcodes to iden
 by the CFU and to differentiate between the different instruction formats. The according binary encoding of these
 opcodes is shown below:
 
-* `custom-0`: `0001011` RISC-V standard, used for CFU R3-type instructions
-* `custom-1`: `0101011` RISC-V standard, used for CFU R4-type instructions
-* `custom-2`: `1011011` NEORV32-specific, used for CFU R5-type instruction A
-* `custom-3`: `1111011` NEORV32-specific, used for CFU R5-type instruction B
+* `custom-0`: `0001011` RISC-V standard, used for <<_cfu_r3_type_instructions>>
+* `custom-1`: `0101011` RISC-V standard, used for <<_cfu_r4_type_instructions>>
+* `custom-2`: `1011011` NEORV32-specific, used for <<_cfu_r5_type_instructions>> type A
+* `custom-3`: `1111011` NEORV32-specific, used for <<_cfu_r5_type_instructions>> type B
 
 
 :sectnums:
-==== CFU R3-Type Instructions
+===== CFU R3-Type Instructions
 
 The R3-type CFU instructions operate on two source registers `rs1` and `rs2` and return the processing result to
 the destination register `rd`. The actual operation can be defined by using the `funct7` and `funct3` bit fields.
@@ -69,7 +69,7 @@ R3-type instructions can be implemented (7-bit + 3-bit = 10 bit -> 1024 differen
 
 
 :sectnums:
-==== CFU R4-Type Instructions
+===== CFU R4-Type Instructions
 
 The R4-type CFU instructions operate on three source registers `rs1`, `rs2` and `rs2` and return the processing
 result to the destination register `rd`. The actual operation can be defined by using the `funct3` bit field.
@@ -105,7 +105,7 @@ instructions can be implemented (3-bit -> 8 different values).
 
 
 :sectnums:
-==== CFU R5-Type Instructions
+===== CFU R5-Type Instructions
 
 The R5-type CFU instructions operate on four source registers `rs1`, `rs2`, `rs3` and `r4` and return the
 processing result to the destination register `rd`. As all bits of the instruction word are used to encode the
@@ -128,11 +128,6 @@ image::cfu_r5type_instruction_b.png[align=center]
 * `rd`: address of destination register (for the 32-bit processing result)
 * `opcode`: `1011011` (RISC-V "custom-2" opcode) and/or `1111011` (RISC-V "custom-3" opcode)
 
-.RS4 bit field
-[NOTE]
-The `rs4` bit-field is split into two instruction word fields `rs4.hi` and `rs4.lo`. This allows a simple
-decoding logic as the location of the remaining register fields is identical to other R-type instructions.
-
 .RISC-V compatibility
 [IMPORTANT]
 The RISC-V ISA specifications does not specify a R5-type instruction format. Hence, this instruction
@@ -153,6 +148,11 @@ The custom instructions provided by the CFU can be used in plain C code by using
 behave like "normal" C functions but under the hood they are a set of macros that hide the complexity of inline assembly.
 Using intrinsics removes the need to modify the compiler, built-in libraries or the assembler when using custom
 instructions. Each intrinsic will be compiled into a single 32-bit instruction word providing maximum code efficiency.
+
+.CFU Example Program
+[TIP]
+There is an example program for the CFU, which shows how to use the _default_ CFU hardware module.
+This example program is located in `sw/example/demo_cfu`.
 
 The NEORV32 software framework provides four pre-defined prototypes for custom instructions, which are defined in
 `sw/lib/include/neorv32_cpu_cfu.h`:
@@ -178,7 +178,7 @@ if not needed. Each intrinsic function requires several arguments depending on t
 
 The `funct3` and `funct7` bit-fields are used to pass 3-bit or 7-bit literals to the CFU. The `rs1`, `rs2`, `rs3`
 and `r4` arguments pass the actual data to the CFU. These register arguments can be populated with variables or
-literals. The following example shows how to pass arguments when executing all exemplary CFU instruction types:
+literals. The following example shows how to pass arguments:
 
 .CFU instruction usage example
 [source,c]
@@ -190,10 +190,27 @@ uint32_t foo = neorv32_cfu_r4_instr(0b011, tmp, res, (uint32_t)some_array[i]);
 uint32_t bar = neorv32_cfu_r5_instr_a(tmp, res, foo, tmp);
 ----
 
-.CFU Example Program
-[TIP]
-There is an example program for the CFU, which shows how to use the _default_ CFU hardware module.
-This example program is located in `sw/example/demo_cfu`.
+
+:sectnums:
+==== CFU-Internal Control and Status Registers (CFU-CSRs)
+
+The user-designed CFU can implement up to 2^32 CFU-internal status and control registers (CFU-CSRs) that can
+be used to provide further operands, to configure execution properties or to check processing status. For example,
+the CFU-internal CSRs could be used to program a 256-bit key that is processed by an encryption/decryption accelerator
+implemented via the CFU's custom instructions.
+
+These CFU-internal registers are accessed via an _indirect access_ mechanism.
+From the CPU side, access is controlled via just two user-mode CSRs: <<_cfusel>> and <<_cfureg>>. `cfusel` is used
+to configure the actual access address while `cfureg` is used for the actual data exchange. Hence, CFU-CSR accesses
+require two consecutive CSR instructions (making them non-atomic). The NEORV32 software framework abstracts this
+indirect interface by providing two functions that can be used to access the CFU-internal CSRs:
+
+.Indirect CFU-internal CSR access functions (prototypes)
+[source,c]
+----
+void     neorv32_cpu_cfu_write_csr(uint32_t sel, uint32_t wdata); // write to CFU-CSR
+uint32_t neorv32_cpu_cfu_read_csr(uint32_t sel); // read from CFU-CSR
+----
 
 
 :sectnums:
@@ -218,3 +235,15 @@ is highly commented to explain the available signals and the handshake with the 
 Enabling the CFU and actually implementing R4-type and/or R5-type instructions (or more precisely, using
 the according operands for the CFU hardware) will add one or two, respectively, additional read ports to
 the core's register file significantly increasing resource requirements.
+
+.CFU Execution Time
+[NOTE]
+The CFU has to complete computation within a **bound time window**. Otherwise, the CFU operation is terminated
+by the hardware and an illegal instruction exception is raised. See section <<_cpu_arithmetic_logic_unit>>
+for more information.
+
+.CFU Exception
+[NOTE]
+The CFU can intentionally raise an illegal instruction exception by not asserting the `done` at all causing an
+execution timeout. For example this can be used to signal invalid configurations/operations to the runtime
+environment. See the CFU's VHDL file for more information.

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -55,6 +55,9 @@ bits can actually be modified.
 | 0x7b0 | <<_dcsr>>      | - | DRW | Debug control and status register
 | 0x7b1 | <<_dpc>>       | - | DRW | Debug program counter
 | 0x7b2 | <<_dscratch0>> | - | DRW | Debug scratch register 0
+5+^| **<<_custom_functions_unit_cfu_csrs>>**
+| 0x800 | <<_cfusel>> | `CSR_CFUCSEL` | URW | CFU indirect register select
+| 0x801 | <<_cfureg>> | `CSR_CFUCREG` | URW | CFU indirect register alias
 5+^| **<<_machine_counter_and_timer_csrs>>**
 | 0xb00 | <<_mcycleh, `mcycle`>>      | `CSR_MCYCLE`    | MRW | Machine cycle counter low word
 | 0xb02 | <<_minstreth, `minstret`>>  | `CSR_MINSTRET`  | MRW | Machine instruction-retired counter low word
@@ -536,6 +539,46 @@ The `pmpaddr*` CSRs are used to configure the region's address boundaries.
 After writing a `pmpaddr` CSR the hardware requires up to 32 clock cycles to compute the according
 address masks. Make sure to wait for this time before completing the PMP region configuration
 (only relevant for `NA4` and `NAPOT` modes).
+
+
+<<<
+// ####################################################################################################################
+:sectnums:
+==== Custom Functions Unit (CFU) CSRs
+
+The <<_custom_functions_unit_cfu>> allows to implement up to 2^32 CFU-internal CSRs that are accessed by the CPU
+via an _indirect_ CSR interface consisting of a select CSR (`cfusel`) and a data alias (`cfureg`) CSR. See the
+CFU chapter section <<_custom_control_and_status_registers_csrs>> for more information.
+
+[discrete]
+===== **`cfusel`**
+
+[cols="<1,<8"]
+[frame="topbot",grid="none"]
+|=======================
+| Name        | CFU indirect register select
+| Address     | `0x800`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr` & `Zxcfu`
+| Description | This CSR is used to specify the address of the CFU-internal CSR that is accessed via the
+`cfureg` alias register.
+|=======================
+
+
+{empty} +
+[discrete]
+===== **`cfureg`**
+
+[cols="<1,<8"]
+[frame="topbot",grid="none"]
+|=======================
+| Name        | CFU indirect register alias
+| Address     | `0x801`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr` & `Zxcfu`
+| Description | This CSR provides indirect data access to the CFU-internal CSR that is selected via the
+`cfusel` CSR.
+|=======================
 
 
 <<<

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -548,7 +548,7 @@ address masks. Make sure to wait for this time before completing the PMP region 
 
 The <<_custom_functions_unit_cfu>> allows to implement up to 2^32 CFU-internal CSRs that are accessed by the CPU
 via an _indirect_ CSR interface consisting of a select CSR (`cfusel`) and a data alias (`cfureg`) CSR. See the
-CFU chapter section <<_custom_control_and_status_registers_csrs>> for more information.
+CFU chapter section <<_cfu_internal_control_and_status_registers_cfu_csrs>> for more information.
 
 [discrete]
 ===== **`cfusel`**

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1157,6 +1157,10 @@ begin
   begin
     case csr.addr is
 
+      -- user-defined U-mode CFU CSRs --
+      when csr_cfusel_c | csr_cfureg_c =>
+        csr_reg_valid <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zxcfu); -- available if CFU implemented
+
       -- floating-point CSRs --
       when csr_fflags_c | csr_frm_c | csr_fcsr_c =>
         csr_reg_valid <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zfinx); -- available if FPU implemented

--- a/rtl/core/neorv32_cpu_cp_cfu.vhd
+++ b/rtl/core/neorv32_cpu_cp_cfu.vhd
@@ -3,8 +3,7 @@
 -- # ********************************************************************************************* #
 -- # For user-defined custom RISC-V instructions (R3-type, R4-type and R5-type formats).           #
 -- # See the CPU's documentation for more information.                                             #
--- #                                                                                               #
--- # NOTE: Take a look at the "software-counterpart" of this CFU example in 'sw/example/demo_cfu'. #
+-- # Also take a look at the "software-counterpart" of this CFU example in 'sw/example/demo_cfu'.  #
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
@@ -47,33 +46,42 @@ use neorv32.neorv32_package.all;
 entity neorv32_cpu_cp_cfu is
   port (
     -- global control --
-    clk_i   : in  std_ulogic; -- global clock, rising edge
-    rstn_i  : in  std_ulogic; -- global reset, low-active, async
-    ctrl_i  : in  ctrl_bus_t; -- main control bus
-    start_i : in  std_ulogic; -- trigger operation
+    clk_i       : in  std_ulogic; -- global clock, rising edge
+    rstn_i      : in  std_ulogic; -- global reset, low-active, async
+    ctrl_i      : in  ctrl_bus_t; -- main control bus
+    start_i     : in  std_ulogic; -- trigger operation
+    -- CSR interface --
+    csr_we_i    : in  std_ulogic; -- global write enable
+    csr_addr_i  : in  std_ulogic_vector(11 downto 0); -- address
+    csr_wdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- write data
+    csr_rdata_o : out std_ulogic_vector(XLEN-1 downto 0); -- read data
     -- data input --
-    rs1_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
-    rs2_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
-    rs3_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 3
-    rs4_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 4
+    rs1_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+    rs2_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
+    rs3_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 3
+    rs4_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 4
     -- result and status --
-    res_o   : out std_ulogic_vector(XLEN-1 downto 0); -- operation result
-    valid_o : out std_ulogic -- data output valid
+    res_o       : out std_ulogic_vector(XLEN-1 downto 0); -- operation result
+    valid_o     : out std_ulogic -- data output valid
   );
 end neorv32_cpu_cp_cfu;
 
 architecture neorv32_cpu_cp_cfu_rtl of neorv32_cpu_cp_cfu is
 
+  -- User Configuration --------------------------------------
+  -- ------------------------------------------------------------
+  constant csr_enable_c : boolean := true; -- set 'true' to enable CFU-internal CSRs
+  constant csr_awidth_c : natural := 8; -- CFU-internal CSR access address width
+
   -- CFU Control - do not modify! ----------------------------
   -- ------------------------------------------------------------
-
   type control_t is record
     busy   : std_ulogic; -- CFU is busy
     done   : std_ulogic; -- set to '1' when processing is done
-    result : std_ulogic_vector(XLEN-1 downto 0); -- user's processing result (for write-back to register file)
+    result : std_ulogic_vector(XLEN-1 downto 0); -- CFU processing result (for write-back to register file)
     rtype  : std_ulogic_vector(1 downto 0); -- instruction type, see constants below
-    funct3 : std_ulogic_vector(2 downto 0); -- "funct3" bit-field from custom instruction
-    funct7 : std_ulogic_vector(6 downto 0); -- "funct7" bit-field from custom instruction
+    funct3 : std_ulogic_vector(2 downto 0); -- "funct3" bit-field from custom instruction word
+    funct7 : std_ulogic_vector(6 downto 0); -- "funct7" bit-field from custom instruction word
   end record;
   signal control : control_t;
 
@@ -83,9 +91,17 @@ architecture neorv32_cpu_cp_cfu_rtl of neorv32_cpu_cp_cfu is
   constant r5typeA_c : std_ulogic_vector(1 downto 0) := "10"; -- R5-type instruction A (custom-2 opcode)
   constant r5typeB_c : std_ulogic_vector(1 downto 0) := "11"; -- R5-type instruction B (custom-3 opcode)
 
-  -- User Logic ----------------------------------------------
-  -- ------------------------------------------------------------
+  -- control and status register interface --
+  type csr_t is record
+    we    : std_ulogic;
+    addr  : std_ulogic_vector(csr_awidth_c-1 downto 0);
+    wdata : std_ulogic_vector(XLEN-1 downto 0);
+    rdata : std_ulogic_vector(XLEN-1 downto 0);
+  end record;
+  signal csr : csr_t;
 
+  -- User-Defined Logic --------------------------------------
+  -- ------------------------------------------------------------
   -- multiply-add unit (r4-type instruction example) --
   type madd_t is record
     sreg : std_ulogic_vector(2 downto 0); -- 3 cycles latency = 3 bits in arbitration shift register
@@ -99,45 +115,13 @@ architecture neorv32_cpu_cp_cfu_rtl of neorv32_cpu_cp_cfu is
   end record;
   signal madd : madd_t;
 
+  -- custom control and status registers (CSRs) --
+  signal cfu_csr_0, cfu_csr_1 : std_ulogic_vector(XLEN-1 downto 0);
+
 begin
 
 -- ****************************************************************************************************************************
--- This controller is required to handle the CPU/pipeline interface. Do not modify!
--- ****************************************************************************************************************************
-
-  -- CFU Controller -------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  cfu_control: process(rstn_i, clk_i)
-  begin
-    if (rstn_i = '0') then
-      res_o        <= (others => '0');
-      control.busy <= '0';
-    elsif rising_edge(clk_i) then
-      res_o <= (others => '0'); -- default; all CPU co-processor outputs are logically OR-ed
-      if (control.busy = '0') then -- idle
-        if (start_i = '1') then
-          control.busy <= '1';
-        end if;
-      else -- busy
-        if (control.done = '1') or (ctrl_i.cpu_trap = '1') then -- processing done? abort if trap (exception)
-          res_o        <= control.result; -- output result for just one cycle, CFU output has to be all-zero otherwise
-          control.busy <= '0';
-        end if;
-      end if;
-    end if;
-  end process cfu_control;
-
-  -- CPU feedback --
-  valid_o <= control.busy and control.done; -- set one cycle before result data
-
-  -- pack user-defined instruction type/function bits --
-  control.rtype  <= ctrl_i.ir_opcode(6 downto 5);
-  control.funct3 <= ctrl_i.ir_funct3;
-  control.funct7 <= ctrl_i.ir_funct12(11 downto 5);
-
-
--- ****************************************************************************************************************************
--- CFU Hardware Documentation and Implementation Notes
+-- CFU Hardware Documentation
 -- ****************************************************************************************************************************
 
   -- ----------------------------------------------------------------------------------------
@@ -156,7 +140,6 @@ begin
   -- Two individual RISC-V R5-Type Instructions (NEORV32-specific):
   -- This format consists of four source registers ('rs1', 'rs2', 'rs3', 'rs4') and a destination register ('rd'). There are
   -- no immediate fields.
-
 
   -- ----------------------------------------------------------------------------------------
   -- Input Operands
@@ -190,20 +173,16 @@ begin
   --
   -- [NOTE] The R4-type instructions and R5-type instruction provide additional source register. When used, this will increase
   --        the hardware requirements of the register file.
-  --
-  -- [NOTE] The CFU cannot cause any kind of exception at all (yet; this feature is planned for the future).
-
 
   -- ----------------------------------------------------------------------------------------
   -- Result Output
   -- ----------------------------------------------------------------------------------------
-  -- > control.result (output, 32-bit): processing result ("data")
+  -- > control.result (output, 32-bit): processing result
   --
   -- When the CFU has completed computations, the data send via the <control.result> signal will be written to the CPU's register
   -- file. The destination register is addressed by the <rd> bit-field in the instruction word. The CFU result output is registered
   -- in the CFU controller (see above) - so do not worry too much about increasing the CPU's critical path with your custom
   -- logic.
-
 
   -- ----------------------------------------------------------------------------------------
   -- Processing Control
@@ -218,25 +197,66 @@ begin
   -- as all internal computations have completed, the <control.done> signal has to be set to indicate completion. This will
   -- complete CFU instruction operation and will also write the processing result <control.result> back to the CPU register file.
   --
-  -- [NOTE] If the <control.done> signal is not set within a bound time window (default = 128 cycles) the CFU operation is
+  -- [NOTE] If the <control.done> signal is not set within a bound time window (default = 512 cycles) the CFU operation is
   --        automatically terminated by the hardware and an illegal instruction exception is raised. This feature can also be
-  --        be used to implement custom CFU exceptions.
-
+  --        be used to implement custom CFU exceptions (for example to indicate invalid CFU operations).
 
   -- ----------------------------------------------------------------------------------------
-  -- Final Notes
+  -- CFU-Internal Control and Status Registers (CFU-CSRs)
   -- ----------------------------------------------------------------------------------------
-  -- The <control> record provides something like a "keeper" that ensures correct functionality and that also provides a
-  -- simple-to-use interface hardware designers can start with. However, the control instance adds one additional cycle of
-  -- latency. Advanced users can remove this default control instance to obtain maximum throughput.
+  -- > csr.we    (input,   1-bit): set to indicate a valid CFU CSR write access
+  -- > csr.addr  (input,   8-bit): CSR address, size defined via <csr_awidth_c> constant, valid when <csr.we> is set
+  -- > csr.wdata (input,  32-bit): CSR write data, valid when <csr.we> is set
+  -- > csr.rdata (output, 32-bit): CSR read data
+  --
+  -- The CFU can utilize up to 2^32 internal CSRs. These registers can be used to pass further operands, to check the unit's
+  -- status or to configure operation modes. For instance, a 256-bit wide key could be passed to an encryption system
+  -- implemented within the CFU. These CFU-CSRs are accessed via an _indirect access mechanism_ from the CPU. Therefore,
+  -- the CPU provides two dedicated CSRs: one for the CFU-CSR selection and one for the actual data exchange. Hence, always
+  -- two CPU CSR operations are required to alter one CFU-CSR.
+  --
+  -- If the CFU does not require any internal CSRs then this mechanism should be disabled by setting <csr_enable_c> to false.
+  -- The effective address range (i.e. the maximum number of internal CSRs) can be constrained using the <csr_awidth_c> constant.
 
 
 -- ****************************************************************************************************************************
 -- Actual CFU User Logic Example - replace this with your custom logic
 -- ****************************************************************************************************************************
 
-  -- Iterative Multiply-Add Unit - Iteration Control ----------------------------------------
+  -- CFU-Internal Control and Status Registers (CFU-CSRs) -----------------------------------
   -- -------------------------------------------------------------------------------------------
+  -- synchronous write access --
+  csr_write_access: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      cfu_csr_0 <= (others => '0');
+      cfu_csr_1 <= (others => '0');
+    elsif rising_edge(clk_i) then
+      if (csr.we = '1') and (csr.addr(1 downto 0) = "00") then
+        cfu_csr_0 <= csr.wdata;
+      end if;
+      if (csr.we = '1') and (csr.addr(1 downto 0) = "01") then
+        cfu_csr_1 <= csr.wdata;
+      end if;
+    end if;
+  end process csr_write_access;
+
+  -- asynchronous read access --
+  csr_read_access: process(csr.addr, cfu_csr_0, cfu_csr_1)
+  begin
+    case csr.addr(1 downto 0) is
+      when "00"   => csr.rdata <= cfu_csr_0;       -- CSR0: simple read/write register
+      when "01"   => csr.rdata <= cfu_csr_1;       -- CSR1: simple read/write register
+      when "10"   => csr.rdata <= x"1234abcd";     -- CSR2: hardwired/read-only register
+      when "11"   => csr.rdata <= (others => '0'); -- CSR3: not implemented
+      when others => csr.rdata <= (others => '0');
+    end case;
+  end process csr_read_access;
+
+
+  -- Iterative Multiply-Add Unit ------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  -- iteration control --
   madd_control: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
@@ -256,12 +276,10 @@ begin
     end if;
   end process madd_control;
 
-  -- processing has reached last stage (=done) when sreg's MSB is set --
+  -- processing has reached last stage (= done) when sreg's MSB is set --
   madd.done <= madd.sreg(madd.sreg'left);
 
-
-  -- Iterative Multiply-Add Unit - Arithmetic Core ------------------------------------------
-  -- -------------------------------------------------------------------------------------------
+  -- arithmetic core --
   madd_core: process(clk_i)
   begin
     if rising_edge(clk_i) then
@@ -283,12 +301,10 @@ begin
   begin
     case control.rtype is
 
-      -- --------------------------------------------------------
       when r3type_c => -- R3-type instructions
-      -- --------------------------------------------------------
-
+      -- ----------------------------------------------------------------------
         -- This is a simple ALU that implements four pure-combinatorial instructions.
-        -- The actual function is selected by the "funct3" bit-field of the custom instruction.
+        -- The actual function is selected by the "funct3" bit-field.
         case control.funct3 is
           when "000" => -- funct3 = "000": bit-reversal of rs1
             control.result <= bit_rev_f(rs1_i);
@@ -301,10 +317,8 @@ begin
             control.done   <= '0'; -- this will cause an illegal instruction exception after timeout
         end case;
 
-      -- --------------------------------------------------------
       when r4type_c => -- R4-type instructions
-      -- --------------------------------------------------------
-
+      -- ----------------------------------------------------------------------
         -- This is an iterative multiply-and-add unit that requires several cycles for processing.
         -- The actual function is selected by the lowest bit of the "funct3" bit-field.
         case control.funct3 is
@@ -319,33 +333,109 @@ begin
             control.done   <= '0'; -- this will cause an illegal instruction exception after timeout
         end case;
 
-      -- --------------------------------------------------------
       when r5typeA_c => -- R5-type instruction A
-      -- --------------------------------------------------------
-
+      -- ----------------------------------------------------------------------
         -- No function/immediate bit-fields are available for this instruction type.
         -- Hence, there is just one operation that can be implemented.
         control.result <= rs1_i and rs2_i and rs3_i and rs4_i; -- AND-all
         control.done   <= '1'; -- pure-combinatorial, so we are done "immediately"
 
-      -- --------------------------------------------------------
       when r5typeB_c => -- R5-type instruction B
-      -- --------------------------------------------------------
-
+      -- ----------------------------------------------------------------------
         -- No function/immediate bit-fields are available for this instruction type.
         -- Hence, there is just one operation that can be implemented.
         control.result <= rs1_i xor rs2_i xor rs3_i xor rs4_i; -- XOR-all
         control.done   <= '1'; -- set high to prevent permanent CPU stall
 
-      -- --------------------------------------------------------
       when others => -- undefined
-      -- --------------------------------------------------------
-
+      -- ----------------------------------------------------------------------
         control.result <= (others => '0');
         control.done   <= '0';
 
     end case;
   end process out_select;
+
+
+-- ****************************************************************************************************************************
+-- This controller / proxy-logic is required to handle the CFU <-> CPU interface. Do not modify!
+-- ****************************************************************************************************************************
+
+  -- CFU Controller -------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  -- The <control> record acts as proxy logic that ensures correct communication with the
+  -- CPU pipeline. However, this control instance adds one additional cycle of latency.
+  -- Advanced users can remove this default control instance to obtain maximum throughput.
+  cfu_control: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      res_o        <= (others => '0');
+      control.busy <= '0';
+    elsif rising_edge(clk_i) then
+      res_o <= (others => '0'); -- default; all CPU co-processor outputs are logically OR-ed
+      if (control.busy = '0') then -- idle
+        if (start_i = '1') then -- trigger new CFU operation
+          control.busy <= '1';
+        end if;
+      elsif (control.done = '1') or (ctrl_i.cpu_trap = '1') then -- operation done? abort if trap (exception)
+        res_o        <= control.result; -- output result for just one cycle, CFU output has to be all-zero otherwise
+        control.busy <= '0';
+      end if;
+    end if;
+  end process cfu_control;
+
+  -- CPU feedback --
+  valid_o <= control.busy and control.done; -- set one cycle before result data
+
+  -- pack user-defined instruction type/function bits --
+  control.rtype  <= ctrl_i.ir_opcode(6 downto 5);
+  control.funct3 <= ctrl_i.ir_funct3;
+  control.funct7 <= ctrl_i.ir_funct12(11 downto 5);
+
+
+  -- CSR Controller -------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  -- The CFU provides an **indirect** CSR access mechanism that allows to implement up to
+  -- 2^32 custom CFU-internal CSRs (using a 'select' CSR to hold the actual indirect
+  -- address and a `reg` CSR that serves as access alias).
+  cfu_csrs_enable:
+  if (csr_enable_c = true) generate
+    csr_control: process(rstn_i, clk_i)
+    begin
+      if (rstn_i = '0') then
+        csr.we      <= '0';
+        csr.addr    <= (others => '0');
+        csr.wdata   <= (others => '0');
+        csr_rdata_o <= (others => '0');
+      elsif rising_edge(clk_i) then
+        csr.we      <= '0'; -- default
+        csr_rdata_o <= (others => '0'); -- default
+        if (csr_addr_i(11 downto 1) = csr_cfusel_c(11 downto 1)) then -- access to CFU CSRs
+          -- write access --
+          if (csr_we_i = '1') and (csr_addr_i(0) = '0') then -- select register
+            csr.addr <= csr_wdata_i(csr_awidth_c-1 downto 0);
+          end if;
+          if (csr_we_i = '1') and (csr_addr_i(0) = '1') then -- data register
+            csr.we    <= '1';
+            csr.wdata <= csr_wdata_i;
+          end if;
+          -- read access --
+          if (csr_addr_i(0) = '0') then -- select register
+            csr_rdata_o(csr_awidth_c-1 downto 0) <= csr.addr;
+          else -- data register
+            csr_rdata_o <= csr.rdata;
+          end if;
+        end if;
+      end if;
+    end process csr_control;
+  end generate;
+
+  cfu_csrs_disabled:
+  if (csr_enable_c = false) generate
+    csr.we      <= '0';
+    csr.addr    <= (others => '0');
+    csr.wdata   <= (others => '0');
+    csr_rdata_o <= (others => '0');
+  end generate;
 
 
 end neorv32_cpu_cp_cfu_rtl;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -59,7 +59,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080807"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080808"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 
@@ -426,6 +426,9 @@ package neorv32_package is
   constant csr_dcsr_c           : std_ulogic_vector(11 downto 0) := x"7b0";
   constant csr_dpc_c            : std_ulogic_vector(11 downto 0) := x"7b1";
   constant csr_dscratch0_c      : std_ulogic_vector(11 downto 0) := x"7b2";
+  -- NEORV32-specific (user-mode) registers --
+  constant csr_cfusel_c         : std_ulogic_vector(11 downto 0) := x"800";
+  constant csr_cfureg_c         : std_ulogic_vector(11 downto 0) := x"801";
   -- machine counters/timers --
   constant csr_mcycle_c         : std_ulogic_vector(11 downto 0) := x"b00";
 --constant csr_mtime_c          : std_ulogic_vector(11 downto 0) := x"b01";

--- a/sw/lib/include/neorv32_cpu_cfu.h
+++ b/sw/lib/include/neorv32_cpu_cfu.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -42,7 +42,9 @@
 #define neorv32_cpu_cfu_h
 
 // prototypes
-int neorv32_cpu_cfu_available(void);
+int      neorv32_cpu_cfu_available(void);
+void     neorv32_cpu_cfu_write_csr(uint32_t sel, uint32_t wdata);
+uint32_t neorv32_cpu_cfu_read_csr(uint32_t sel);
 
 
 /**********************************************************************//**

--- a/sw/lib/include/neorv32_cpu_csr.h
+++ b/sw/lib/include/neorv32_cpu_csr.h
@@ -127,6 +127,10 @@ enum NEORV32_CSR_enum {
   CSR_DPC            = 0x7b1, /**< 0x7b1 - dpc:       Debug program counter */
   CSR_DSCRATCH0      = 0x7b2, /**< 0x7b2 - dscratch0: Debug scratch register */
 
+  /* custom functions unit (CFU) registers */
+  CSR_CFUSEL         = 0x800, /**< 0x800 - cfusel: CFU indirect register select */
+  CSR_CFUREG         = 0x801, /**< 0x801 - cfureg: CFU indirect register alias */
+
   /* machine counters and timers */
   CSR_MCYCLE         = 0xb00, /**< 0xb00 - mcycle:        Machine cycle counter low word */
   CSR_MINSTRET       = 0xb02, /**< 0xb02 - minstret:      Machine instructions-retired counter low word */

--- a/sw/lib/source/neorv32_cpu_cfu.c
+++ b/sw/lib/source/neorv32_cpu_cfu.c
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2022, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -56,4 +56,30 @@ int neorv32_cpu_cfu_available(void) {
   else {
     return 0;
   }
+}
+
+
+/**********************************************************************//**
+ * Indirect write to user-defined CFU-internal CSR.
+ *
+ * @param[in] sel User-defined CFU-internal CSR select.
+ * @param[in] wdata Write data.
+ **************************************************************************/
+void neorv32_cpu_cfu_write_csr(uint32_t sel, uint32_t wdata) {
+
+  neorv32_cpu_csr_write(CSR_CFUSEL, sel); // set address
+  neorv32_cpu_csr_write(CSR_CFUREG, wdata); // write data
+}
+
+
+/**********************************************************************//**
+ * Indirect read from user-defined CFU-internal CSR.
+ *
+ * @param[in] sel User-defined CFU-internal CSR select.
+ * @return Read data.
+ *************************************************************************/
+uint32_t neorv32_cpu_cfu_read_csr(uint32_t sel) {
+
+  neorv32_cpu_csr_write(CSR_CFUSEL, sel); // set address
+  return neorv32_cpu_csr_read(CSR_CFUREG); // read data
 }

--- a/sw/openocd/openocd_neorv32.cfg
+++ b/sw/openocd/openocd_neorv32.cfg
@@ -33,11 +33,13 @@ target create $_TARGETNAME.0 riscv -chain-position $_TARGETNAME
 riscv set_mem_access progbuf
 
 # expose NEORV32-specific CSRs
+riscv expose_csrs 2048=cfusel
+riscv expose_csrs 2049=cfureg
 riscv expose_csrs 4032=mxisa
 
 # enable access error reports
 gdb_report_data_abort enable
-gdb_report_register_access_error enable
+#gdb_report_register_access_error enable
 
 # ----------------------------------------------
 # Start session


### PR DESCRIPTION
This PR allows to implement up to 2^32 CFU-internal ([Custom Functions Subsystem](https://stnolting.github.io/neorv32/#_custom_functions_unit_cfu) for user-defined RISC-V instructions) control and status registers (CSR) for additional operand propagation, configuration and status checking (i.e. passing a 256-bit key to an encryption module implemented within the CFU).

The CFU-CSR access mechanism uses an _indirect_ approach via just two CPU-CSRs:
* `cfusel` (address `0x800`) - CFU-internal CSR select ("CFU-CSR address")
* `cfureg` (address `0x801`) - CFU-internal CSR alias register ("CFU-CSR read/write data")

This concept is similar to the RISC-V [indirect-csr-access](https://github.com/riscv/riscv-indirect-csr-access) proposal.