### PR TITLE
implement vectored `mtvec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 23.09.2023 | 1.8.9.4 | :sparkles: added vectored trap handling mode of `mtvec` for reduced latency from IRQ to ISR; [#691](https://github.com/stnolting/neorv32/pull/691)
 | 22.09.2023 | 1.8.9.3 | :lock: **watchdog**: add reset password and optional "strict" mode for increased safety; [#692](https://github.com/stnolting/neorv32/pull/692) |
 | 15.09.2023 | 1.8.9.2 | :warning: rework CFU CSRs; minor rtl edits; [#690](https://github.com/stnolting/neorv32/pull/690) |
 | 11.09.2023 | 1.8.9.1 | minor rtl edits and updates; [#684](https://github.com/stnolting/neorv32/pull/684) |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -279,8 +279,7 @@ Machine-mode software can discover available `Z*` _sub-extensions_ (like `Zicsr`
 | Address     | `0x305`
 | Reset value | `0x00000000`
 | ISA         | `Zicsr`
-| Description | The `mtvec` CSR contain the address of the primary trap handler, which gets executed whenever an
-interrupt is triggered or an exception is raised.
+| Description | The `mtvec` CSR holds the trap vector configuration.
 |=======================
 
 .`mtvec` CSR bits
@@ -288,10 +287,13 @@ interrupt is triggered or an exception is raised.
 [options="header",grid="rows"]
 |=======================
 | Bit  | R/W | Function
-| 1:0  | r/- | **MODE**: always zero (= DIRECT mode); BASE defines entry for _all_ traps
-| 31:2 | r/w | **BASE**: 4-byte aligned base address of trap base handler
+| 1:0  | r/w | **MODE**: mode configuration, `00` = DIRECT, `01` = VECTORED. (Others will fall back to DIRECT mode.)
+| 31:2 | r/w | **BASE**: in DIRECT mode = 4-byte aligned base address of trap base handler, _all_ traps set `pc` = `BASE`; in VECTORED mode = 128-byte aligned base address of trap vector table, interrupts cause a jump to `pc` = `BASE` + 4 * `mcause` and exceptions to `pc` = `BASE`.
 |=======================
 
+.Interrupt Latency
+[TIP]
+The vectored `mtvec` mode is useful for reducing the time between interrupt request (IRQ) and servicing it (ISR). As software does not need to determine the interrupt cause the reduction in latency can be 5 to 10 times and as low as _26_ cycles.
 
 {empty} +
 [discrete]

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -59,7 +59,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080903"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080904"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -183,7 +183,7 @@ begin
     if ci_mode then
       -- No need to send the full expectation in one big chunk
       check_uart(net, uart1_rx_handle, nul & nul);
-      check_uart(net, uart1_rx_handle, "0/55" & cr & lf);
+      check_uart(net, uart1_rx_handle, "0/56" & cr & lf);
     end if;
 
     -- Wait until all expected data has been received


### PR DESCRIPTION
Well hello there!

I stumbled upon this:

> An implementation may have different alignment constraints for different modes. In particular, MODE=Vectored may have stricter alignment constraints than MODE=Direct.
> [...]
> Allowing coarser alignments in Vectored mode enables vectoring to be implemented without a hardware adder circuit.

Which I found very interesting and thought we could implement that! It could shorten the latency from IRQ to calling the right ISR as no intermediate generic handler is required. A simple `jal zero, <function>` as mtvec jump table could directly jump to the handler.

Example jump table:
```assembly
.balign 128 // 128 byte alignment i.e. lowest 7 bits all zero
mtvec_jump_table:
  jal zero, trap_handler          //  0 - exception (all)
  nop                             //  1 - n/a
  nop                             //  2 - n/a
  jal zero, msi_handler           //  3 - machine software interrupt
  nop                             //  4 - n/a
  nop                             //  5 - n/a
  nop                             //  6 - n/a
  jal zero, mti_handler           //  7 - machine timer interrupt
  nop                             //  8 - n/a
  nop                             //  9 - n/a
  nop                             // 10 - n/a
  jal zero, mei_handler           // 11 - machine external interrupt
  nop                             // 12 - n/a
  nop                             // 13 - n/a
  nop                             // 14 - n/a
  nop                             // 15 - n/a
  jal zero, firq0_handler         // 16 - fast interrupt  0
  jal zero, firq1_handler         // 17 - fast interrupt  1
  [...]
```

This can then be installed with:
```c
neorv32_cpu_csr_write(CSR_MTVEC, mtvec_jump_table | 0x1);
```

SiFive actually implemented this in [_plain_ C](http://five-embeddev.com/baremetal/vectored_interrupts/) using some nice GCC compiler tricks.

As the direct mode is still available, no immediate change to the current sw framework is required. But those that wish to utilize the lower latency may enable vectored `mtvec` mode.

I'm not sure about the implications about area and speed. Quartus showed non-deterministic values for LUT usage and adding the vectored mode actually decreased LUT usage (with pr: 1474; without pr: 1494).

WIP to get your feedback if this is generally wished for or not. If ok then I can come up with a test to see how much reduction in  latency there actually is and also add some documentation.

Cheers,
Nik