### PR TITLE
rework watchdog timer and reset system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 21.09.2023 | 1.8.9.3 | :lock: add reset password to **watchdog**; [#692](https://github.com/stnolting/neorv32/pull/692) |
 | 15.09.2023 | 1.8.9.2 | :warning: rework CFU CSRs; minor rtl edits; [#690](https://github.com/stnolting/neorv32/pull/690) |
 | 11.09.2023 | 1.8.9.1 | minor rtl edits and updates; [#684](https://github.com/stnolting/neorv32/pull/684) |
 | 09.09.2023 | [**:rocket:1.8.9**](https://github.com/stnolting/neorv32/releases/tag/v1.8.9) | **New release** |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
-| 21.09.2023 | 1.8.9.3 | :lock: add reset password to **watchdog**; [#692](https://github.com/stnolting/neorv32/pull/692) |
+| 22.09.2023 | 1.8.9.3 | :lock: **watchdog**: add reset password and optional "strict" mode for increased safety; [#692](https://github.com/stnolting/neorv32/pull/692) |
 | 15.09.2023 | 1.8.9.2 | :warning: rework CFU CSRs; minor rtl edits; [#690](https://github.com/stnolting/neorv32/pull/690) |
 | 11.09.2023 | 1.8.9.1 | minor rtl edits and updates; [#684](https://github.com/stnolting/neorv32/pull/684) |
 | 09.09.2023 | [**:rocket:1.8.9**](https://github.com/stnolting/neorv32/releases/tag/v1.8.9) | **New release** |

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -232,7 +232,7 @@ are configured as "zero" and are read-only. Writing '1' to these bits/fields wil
 | 31  | `haltreq`      | -/w | set/clear hart halt request
 | 30  | `resumereq`    | -/w | request hart to resume
 | 28  | `ackhavereset` | -/w | write `1` to clear `*havereset` flags
-|  1  | `ndmreset`     | r/w | put whole processor into reset sate when `1`
+|  1  | `ndmreset`     | r/w | put whole system (except OCD) into reset state when `1`
 |  0  | `dmactive`     | r/w | DM enable; writing `0`-`1` will reset the DM
 |=======================
 

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -362,6 +362,10 @@ The processor-wide reset can be triggered by any of the following sources:
 * the <<_on_chip_debugger_ocd>>
 * the <<_watchdog_timer_wdt>>
 
+.Reset Cause
+[TIP]
+The actual reset cause can be determined via the <<_watchdog_timer_wdt>>.
+
 If any of these sources trigger a reset, the internal reset will be triggered for at least 4 clock cycles ensuring
 a valid reset of the entire processor. The internal global reset is asserted _aysynchronoulsy_ if triggered by the external
 `rstn_i` signal. For internal reset sources, the global reset is asserted _synchronously_. If the reset cause gets inactive

--- a/docs/datasheet/soc_wdt.adoc
+++ b/docs/datasheet/soc_wdt.adoc
@@ -33,8 +33,8 @@ Whenever this counter reaches the programmed timeout value (`WDT_CTRL_TIMEOUT` b
 hardware reset is triggered. In order to inform the application of an imminent timeout, an optional CPU interrupt is
 triggered when the timeout counter reaches _half_ of the programmed timeout value.
 
-The watchdog is "fed" by writing `1` to the `WDT_CTRL_RESET` control register bit, which
-will reset the internal timeout counter back to zero.
+The watchdog's timeout counter is reset ("feeding the watchdog") by writing the reset **PASSWORD** to the `RESET` register.
+The password is hardwired to hexadecimal `0x709D1AB3`.
 
 .Forced Reset
 [NOTE]
@@ -63,8 +63,8 @@ to keep operating even when the CPU is in sleep mode by setting the control regi
 
 The watchdog control register can be _locked_ to protect the current configuration from being modified. The lock is
 activated by setting the `WDT_CTRL_LOCK` bit. In the locked state any write access to the control register is entirely
-ignored (see table below, "writable if locked"). Read accesses to the control register as well as watchdog resets
-(by setting the `WDT_CTRL_RESET` flag) are not affected.
+ignored (see table below, "writable if locked"). However, read accesses to the control register as well as watchdog resets
+are further possible.
 
 The lock bit can only be set if the WDT is already enabled (`WDT_CTRL_EN` is set). Furthermore, the lock bit can
 only be cleared again by a system-wide hardware reset.
@@ -84,12 +84,12 @@ the last system reset was caused by the watchdog itself.
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Reset value | Writable if locked | Function
-.8+<| `0xfffffb00` .8+<| `CTRL` <|`0` `WDT_CTRL_EN`     ^| r/w ^| `0` ^| no  <| watchdog enable
+.7+<| `0xfffffb00` .7+<| `CTRL` <|`0` `WDT_CTRL_EN`     ^| r/w ^| `0` ^| no  <| watchdog enable
                                 <|`1` `WDT_CTRL_LOCK`   ^| r/w ^| `0` ^| no  <| lock configuration when set, clears only on system reset, can only be set if enable bit is set already
                                 <|`2` `WDT_CTRL_DBEN`   ^| r/w ^| `0` ^| no  <| set to allow WDT to continue operation even when CPU is in debug mode
                                 <|`3` `WDT_CTRL_SEN`    ^| r/w ^| `0` ^| no  <| set to allow WDT to continue operation even when CPU is in sleep mode
-                                <|`4` `WDT_CTRL_RESET`  ^| -/w ^| -   ^| yes <| reset watchdog when set, auto-clears
-                                <|`5` `WDT_CTRL_RCAUSE` ^| r/- ^| `0` ^| -   <| cause of last system reset: `0`=caused by external reset signal, `1`=caused by watchdog
-                                <|`7:6` -               ^| r/- ^| -   ^| -   <| _reserved_, reads as zero
+                                <|`4` `WDT_CTRL_RCAUSE` ^| r/- ^| `0` ^| -   <| cause of last system reset: `0`=caused by external reset signal, `1`=caused by watchdog
+                                <|`7:5` -               ^| r/- ^| -   ^| -   <| _reserved_, reads as zero
                                 <|`31:8` `WDT_CTRL_TIMEOUT_MSB : WDT_CTRL_TIMEOUT_LSB` ^| r/w ^| 0 ^| no <| 24-bit watchdog timeout value
+| `0xfffffb04` | `RESET`         |                       | -/w  | -    | yes  | Write PASSWORD to reset WDT timeout counter ("feed the watchdog")
 |=======================

--- a/docs/datasheet/soc_wdt.adoc
+++ b/docs/datasheet/soc_wdt.adoc
@@ -36,10 +36,6 @@ triggered when the timeout counter reaches _half_ of the programmed timeout valu
 The watchdog's timeout counter is reset ("feeding the watchdog") by writing the reset **PASSWORD** to the `RESET` register.
 The password is hardwired to hexadecimal `0x709D1AB3`.
 
-.Forced Reset
-[NOTE]
-Writing all-zero to the `WDT_CTRL_TIMEOUT` bits will immediately trigger a system-wide reset.
-
 .Watchdog Interrupt
 [NOTE]
 A watchdog interrupt occurs when the watchdog is enabled and the internal counter reaches _exactly_ half of the programmed
@@ -70,11 +66,22 @@ The lock bit can only be set if the WDT is already enabled (`WDT_CTRL_EN` is set
 only be cleared again by a system-wide hardware reset.
 
 
+**Strict Mode**
+
+The _strict operation mode_ provides additional safety functions. If the strict mode is enabled by the `WDT_CTRL_STRICT`
+control register bit an **immediate hardware** reset if enforced if
+
+* the `RESET` register is written with an incorrect password or
+* the `CTRL` register is written and the `WDT_CTRL_LOCK` bit is set.
+
+
 **Cause of last Hardware Reset**
 
-The cause of the last system hardware reset can be determined via the `WDT_CTRL_RCAUSE` flag. If this flag is
-cleared, the processor has been reset via the external reset signal (or the on-chip debugger). If this flag is set,
-the last system reset was caused by the watchdog itself.
+The cause of the last system hardware reset can be determined via the `WDT_CTRL_RCAUSE_*` bits:
+
+* `0b00`: Reset caused by external reset signal/pin
+* `0b01`: Reset caused by on-chip debugger
+* `0b10`: Reset caused by watchdog
 
 
 **Register Map**
@@ -84,12 +91,13 @@ the last system reset was caused by the watchdog itself.
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Reset value | Writable if locked | Function
-.7+<| `0xfffffb00` .7+<| `CTRL` <|`0` `WDT_CTRL_EN`     ^| r/w ^| `0` ^| no  <| watchdog enable
+.8+<| `0xfffffb00` .8+<| `CTRL` <|`0` `WDT_CTRL_EN`     ^| r/w ^| `0` ^| no  <| watchdog enable
                                 <|`1` `WDT_CTRL_LOCK`   ^| r/w ^| `0` ^| no  <| lock configuration when set, clears only on system reset, can only be set if enable bit is set already
                                 <|`2` `WDT_CTRL_DBEN`   ^| r/w ^| `0` ^| no  <| set to allow WDT to continue operation even when CPU is in debug mode
                                 <|`3` `WDT_CTRL_SEN`    ^| r/w ^| `0` ^| no  <| set to allow WDT to continue operation even when CPU is in sleep mode
-                                <|`4` `WDT_CTRL_RCAUSE` ^| r/- ^| `0` ^| -   <| cause of last system reset: `0`=caused by external reset signal, `1`=caused by watchdog
-                                <|`7:5` -               ^| r/- ^| -   ^| -   <| _reserved_, reads as zero
+                                <|`4` `WDT_CTRL_STRICT` ^| r/w ^| `0` ^| no  <| set to enable strict mode (force hardware reset if reset password is incorrect or if write access to locked CTRL register)
+                                <|`6:5` `WDT_CTRL_RCAUSE_HI : WDT_CTRL_RCAUSE_LO` ^| r/- ^| `0` ^| -   <| cause of last system reset; 0=external reset, 1=ocd-reset, 2=watchdog reset
+                                <|`7` -                 ^| r/- ^| -   ^| -   <| _reserved_, reads as zero
                                 <|`31:8` `WDT_CTRL_TIMEOUT_MSB : WDT_CTRL_TIMEOUT_LSB` ^| r/w ^| 0 ^| no <| 24-bit watchdog timeout value
 | `0xfffffb04` | `RESET`         |                       | -/w  | -    | yes  | Write PASSWORD to reset WDT timeout counter ("feed the watchdog")
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -59,7 +59,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080902"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080903"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 

--- a/sw/example/demo_wdt/main.c
+++ b/sw/example/demo_wdt/main.c
@@ -48,7 +48,7 @@
 /** UART BAUD rate */
 #define BAUD_RATE 19200
 /** WDT timeout (until system reset) in seconds */
-#define WDT_TIMEOUT_S 4
+#define WDT_TIMEOUT_S 8
 /**@}*/
 
 
@@ -58,7 +58,7 @@
  **************************************************************************/
 void wdt_firq_handler(void) {
 
-  neorv32_cpu_csr_write(CSR_MIP, ~(1<<WDT_FIRQ_PENDING)); // clear/ack pending FIRQ
+  neorv32_cpu_csr_clr(CSR_MIP, 1<<WDT_FIRQ_PENDING); // clear/ack pending FIRQ
   neorv32_uart0_puts("WDT IRQ! Timeout imminent!\n");
 }
 
@@ -125,8 +125,13 @@ int main() {
 
 
   // feed the watchdog
-  neorv32_uart0_puts("Resetting WDT...\n");
-  neorv32_wdt_feed(); // reset internal counter to zero
+  neorv32_uart0_puts("Resetting WDT 5 times...\n");
+  int i;
+  for (i=0; i<5; i++) {
+    neorv32_cpu_delay_ms(750);
+    neorv32_wdt_feed(); // reset internal counter to zero
+    neorv32_uart0_puts("WDT reset.\n");
+  }
 
 
   // go to sleep mode and wait for watchdog to kick in

--- a/sw/example/demo_wdt/main.c
+++ b/sw/example/demo_wdt/main.c
@@ -95,11 +95,17 @@ int main() {
 
   // show the cause of the last processor reset
   neorv32_uart0_puts("Cause of last processor reset: ");
-  if (neorv32_wdt_get_cause() == 0) {
+  if (neorv32_wdt_get_cause() == WDT_RCAUSE_EXT) {
     neorv32_uart0_puts("External reset\n\n");
   }
+  else if (neorv32_wdt_get_cause() == WDT_RCAUSE_OCD) {
+    neorv32_uart0_puts("On-chip debugger reset\n\n");
+  }
+  else if (neorv32_wdt_get_cause() == WDT_RCAUSE_WDT) {
+    neorv32_uart0_puts("Watchdog reset\n\n");
+  }
   else {
-    neorv32_uart0_puts("Watchdog timeout\n\n");
+    neorv32_uart0_puts("Unknown\n\n");
   }
 
 
@@ -119,9 +125,9 @@ int main() {
     return -1;
   }
 
-  // setup watchdog: no lock, disable in debug mode, enable in sleep mode
+  // setup watchdog: no lock, disable in debug mode, enable in sleep mode, enable strict password check
   neorv32_uart0_puts("Starting WDT...\n");
-  neorv32_wdt_setup(timeout, 0, 0, 1);
+  neorv32_wdt_setup(timeout, 0, 0, 1, 1);
 
 
   // feed the watchdog

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1050,8 +1050,8 @@ int main() {
     neorv32_cpu_irq_enable(WDT_FIRQ_ENABLE);
 
     // configure WDT:
-    // timeout = 1*4096 cycles, no lock, disable in debug mode, enable in sleep mode
-    neorv32_wdt_setup(1, 0, 0, 1);
+    // timeout = 1*4096 cycles, no lock, disable in debug mode, enable in sleep mode, enable strict reset mode
+    neorv32_wdt_setup(1, 0, 0, 1, 1);
 
     // sleep until interrupt
     asm volatile ("wfi");

--- a/sw/lib/include/neorv32_wdt.h
+++ b/sw/lib/include/neorv32_wdt.h
@@ -62,11 +62,18 @@ enum NEORV32_WDT_CTRL_enum {
   WDT_CTRL_LOCK        =  1, /**< WDT control register(1) (r/w): Lock write access to control register, clears on reset only */
   WDT_CTRL_DBEN        =  2, /**< WDT control register(2) (r/w): Allow WDT to continue operation even when CPU is in debug mode */
   WDT_CTRL_SEN         =  3, /**< WDT control register(3) (r/w): Allow WDT to continue operation even when CPU is in sleep mode */
-  WDT_CTRL_RCAUSE      =  4, /**< WDT control register(4) (r/-): Cause of last system reset: 0=external reset, 1=watchdog */
+  WDT_CTRL_STRICT      =  4, /**< WDT control register(4) (r/w): Force hardware reset if reset password is incorrect or if write attempt to locked CTRL register */
+  WDT_CTRL_RCAUSE_LO   =  5, /**< WDT control register(5) (r/-): Cause of last system reset - low */
+  WDT_CTRL_RCAUSE_HI   =  6, /**< WDT control register(5) (r/-): Cause of last system reset - high */
 
   WDT_CTRL_TIMEOUT_LSB =  8, /**< WDT control register(8)  (r/w): Timeout value, LSB */
   WDT_CTRL_TIMEOUT_MSB = 31  /**< WDT control register(31) (r/w): Timeout value, MSB */
 };
+
+/** Reset causes */
+#define WDT_RCAUSE_EXT (0b00) /**< Reset caused by external pin */
+#define WDT_RCAUSE_OCD (0b01) /**< Reset caused by on-chip debugger */
+#define WDT_RCAUSE_WDT (0b10) /**< Reset caused by watchdog timer */
 
 /** WDT control register bits */
 #define WDT_PASSWORD (0X709D1AB3)
@@ -78,7 +85,7 @@ enum NEORV32_WDT_CTRL_enum {
  **************************************************************************/
 /**@{*/
 int  neorv32_wdt_available(void);
-void neorv32_wdt_setup(uint32_t timeout, int lock, int debug_en, int sleep_en);
+void neorv32_wdt_setup(uint32_t timeout, int lock, int debug_en, int sleep_en, int strict);
 int  neorv32_wdt_disable(void);
 void neorv32_wdt_feed(void);
 int  neorv32_wdt_get_cause(void);

--- a/sw/lib/include/neorv32_wdt.h
+++ b/sw/lib/include/neorv32_wdt.h
@@ -49,7 +49,8 @@
 /**@{*/
 /** WDT module prototype */
 typedef volatile struct __attribute__((packed,aligned(4))) {
-  uint32_t CTRL; /**< offset 0: control register (#NEORV32_WDT_CTRL_enum) */
+  uint32_t CTRL;  /**< offset 0: control register (#NEORV32_WDT_CTRL_enum) */
+  uint32_t RESET; /**< offset 4: WDT reset trigger (write password to "feed" watchdog) */
 } neorv32_wdt_t;
 
 /** WDT module hardware access (#neorv32_wdt_t) */
@@ -61,12 +62,14 @@ enum NEORV32_WDT_CTRL_enum {
   WDT_CTRL_LOCK        =  1, /**< WDT control register(1) (r/w): Lock write access to control register, clears on reset only */
   WDT_CTRL_DBEN        =  2, /**< WDT control register(2) (r/w): Allow WDT to continue operation even when CPU is in debug mode */
   WDT_CTRL_SEN         =  3, /**< WDT control register(3) (r/w): Allow WDT to continue operation even when CPU is in sleep mode */
-  WDT_CTRL_RESET       =  4, /**< WDT control register(4) (-/w): Reset WDT counter when set, auto-clears */
-  WDT_CTRL_RCAUSE      =  5, /**< WDT control register(5) (r/-): Cause of last system reset: 0=external reset, 1=watchdog */
+  WDT_CTRL_RCAUSE      =  4, /**< WDT control register(4) (r/-): Cause of last system reset: 0=external reset, 1=watchdog */
 
   WDT_CTRL_TIMEOUT_LSB =  8, /**< WDT control register(8)  (r/w): Timeout value, LSB */
   WDT_CTRL_TIMEOUT_MSB = 31  /**< WDT control register(31) (r/w): Timeout value, MSB */
 };
+
+/** WDT control register bits */
+#define WDT_PASSWORD (0X709D1AB3)
 /**@}*/
 
 

--- a/sw/lib/source/neorv32_wdt.c
+++ b/sw/lib/source/neorv32_wdt.c
@@ -70,18 +70,20 @@ int neorv32_wdt_available(void) {
  * @param[in] lock Control register will be locked when 1 (until next reset).
  * @param[in] debug_en Allow watchdog to continue operation even when CPU is in debug mode.
  * @param[in] sleep_en Allow watchdog to continue operation even when CPU is in sleep mode.
+ * @param[in] strict Force hardware reset if reset password is incorrect.
  **************************************************************************/
-void neorv32_wdt_setup(uint32_t timeout, int lock, int debug_en, int sleep_en) {
+void neorv32_wdt_setup(uint32_t timeout, int lock, int debug_en, int sleep_en, int strict) {
 
   NEORV32_WDT->CTRL = 0; // reset and disable
 
-  uint32_t enable_int   = ((uint32_t)(1))                    << WDT_CTRL_EN;
-  uint32_t timeout_int  = ((uint32_t)(timeout  & 0xffffffU)) << WDT_CTRL_TIMEOUT_LSB;
-  uint32_t debug_en_int = ((uint32_t)(debug_en & 0x1U))      << WDT_CTRL_DBEN;
-  uint32_t sleep_en_int = ((uint32_t)(sleep_en & 0x1U))      << WDT_CTRL_SEN;
-
-  // update WDT control register
-  NEORV32_WDT->CTRL = enable_int | timeout_int | debug_en_int | sleep_en_int;
+  // update configuration
+  uint32_t ctrl = 0;
+  ctrl |= ((uint32_t)(1))                    << WDT_CTRL_EN;
+  ctrl |= ((uint32_t)(timeout  & 0xffffffU)) << WDT_CTRL_TIMEOUT_LSB;
+  ctrl |= ((uint32_t)(debug_en & 0x1U))      << WDT_CTRL_DBEN;
+  ctrl |= ((uint32_t)(sleep_en & 0x1U))      << WDT_CTRL_SEN;
+  ctrl |= ((uint32_t)(strict & 0x1U))        << WDT_CTRL_STRICT;
+  NEORV32_WDT->CTRL = ctrl;
 
   // lock configuration?
   if (lock) {
@@ -123,14 +125,13 @@ void neorv32_wdt_feed(void) {
 /**********************************************************************//**
  * Get cause of last system reset.
  *
- * @return Cause of last reset (0: system reset - OCD or external, 1: watchdog timeout).
+ * @return Cause of last reset (0: external reset, 1: OCD reset, 2: WDT reset).
  **************************************************************************/
 int neorv32_wdt_get_cause(void) {
 
-  if (NEORV32_WDT->CTRL & (1 << WDT_CTRL_RCAUSE)) { // reset caused by watchdog
-    return 1;
-  }
-  else { // reset caused by system (external or OCD)
-    return 0;
-  }
+  uint32_t tmp = NEORV32_WDT->CTRL;
+  tmp = tmp >> WDT_CTRL_RCAUSE_LO;
+  tmp = tmp & 3;
+
+  return tmp;
 }

--- a/sw/lib/source/neorv32_wdt.c
+++ b/sw/lib/source/neorv32_wdt.c
@@ -116,7 +116,7 @@ int neorv32_wdt_disable(void) {
  **************************************************************************/
 void neorv32_wdt_feed(void) {
 
-  NEORV32_WDT->CTRL |= (uint32_t)(1 << WDT_CTRL_RESET);
+  NEORV32_WDT->RESET = (uint32_t)WDT_PASSWORD;
 }
 
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -1306,10 +1306,15 @@
               <description>Allow WDT to continue operation even when in sleep mode</description>
             </field>
             <field>
-              <name>WDT_CTRL_RCAUSE</name>
+              <name>WDT_CTRL_STRICT</name>
               <bitRange>[4:4]</bitRange>
+              <description>Force hardware reset if reset password is incorrect or if write attempt to locked CTRL register</description>
+            </field>
+            <field>
+              <name>WDT_CTRL_RCAUSE</name>
+              <bitRange>[6:5]</bitRange>
               <access>read-only</access>
-              <description>Cause of last system reset: 0=external reset, 1=watchdog</description>
+              <description>Cause of last system reset: 0=external reset, 1=OCD reset, 2=WDT reset</description>
             </field>
             <field>
               <name>WDT_CTRL_TIMEOUT</name>

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -1275,7 +1275,7 @@
 
       <addressBlock>
         <offset>0</offset>
-        <size>0x04</size>
+        <size>0x08</size>
         <usage>registers</usage>
       </addressBlock>
 
@@ -1306,13 +1306,8 @@
               <description>Allow WDT to continue operation even when in sleep mode</description>
             </field>
             <field>
-              <name>WDT_CTRL_RESET</name>
-              <bitRange>[4:4]</bitRange>
-              <description>Reset WDT counter when set, auto-clears</description>
-            </field>
-            <field>
               <name>WDT_CTRL_RCAUSE</name>
-              <bitRange>[5:5]</bitRange>
+              <bitRange>[4:4]</bitRange>
               <access>read-only</access>
               <description>Cause of last system reset: 0=external reset, 1=watchdog</description>
             </field>
@@ -1320,6 +1315,19 @@
               <name>WDT_CTRL_TIMEOUT</name>
               <bitRange>[31:8]</bitRange>
               <description>Timeout value</description>
+            </field>
+          </fields>
+        </register>
+
+        <register>
+          <name>RESET</name>
+          <description>Watchdog reset register</description>
+          <addressOffset>0x04</addressOffset>
+          <fields>
+            <field>
+              <name>WDT_RESET</name>
+              <bitRange>[31:0]</bitRange>
+              <description>Write password to reset/feed the watchdog (0x709D1AB3)</description>
             </field>
           </fields>
         </register>


### PR DESCRIPTION
This PR adds a new register to the watchdog module (WDT) that is used to reset the internal timeout counter. A specific 32-bit word (a.k.a. "the password") has to be written to this register to actually reset the timer (making it less likely for a _rogue_ CPU to reset the WDT).

Additionally, the WDT now provides a "strict" bit in its control register. When enabled a hardware reset will be enforced if
* a wrong password is written to `RESET` or
* a write access is attempted to the control register while the LOCK bit is set

Furthermore, the processor's reset system is slightly reworked.