### PR TITLE
Minor rtl optimizations and cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 29.09.2023 | 1.8.9.5 | minor CPU optimizations and code clean-ups; [#694](https://github.com/stnolting/neorv32/pull/694) |
 | 23.09.2023 | 1.8.9.4 | :sparkles: added vectored trap handling mode of `mtvec` for reduced latency from IRQ to ISR; [#691](https://github.com/stnolting/neorv32/pull/691)
 | 22.09.2023 | 1.8.9.3 | :lock: **watchdog**: add reset password and optional "strict" mode for increased safety; [#692](https://github.com/stnolting/neorv32/pull/692) |
 | 15.09.2023 | 1.8.9.2 | :warning: rework CFU CSRs; minor rtl edits; [#690](https://github.com/stnolting/neorv32/pull/690) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -462,7 +462,7 @@ The `I` ISA extensions is the base RISC-V integer ISA that is always enabled.
 | Jump/call     | `jal[r]`                                                                  | 6
 | Load/store    | `lb` `lh` `lw` `lbu` `lhu` `sb` `sh` `sw`                                 | 5
 | System        | `ecall` `ebreak`                                                          | 3
-| Data fence    | `fence`                                                                   | 5
+| Data fence    | `fence`                                                                   | 3
 | System        | `wfi`                                                                     | 3
 | System        | `mret`                                                                    | 5
 | Illegal inst. | -                                                                         | 3

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -122,7 +122,7 @@ architecture neorv32_cpu_rtl of neorv32_cpu is
   signal alu_cmp     : std_ulogic_vector(1 downto 0); -- comparator result
   signal mem_rdata   : std_ulogic_vector(XLEN-1 downto 0); -- memory read data
   signal cp_done     : std_ulogic; -- ALU co-processor operation done
-  signal bus_d_wait  : std_ulogic; -- wait for current data bus access
+  signal lsu_wait    : std_ulogic; -- wait for current data bus access
   signal csr_rdata   : std_ulogic_vector(XLEN-1 downto 0); -- csr read data
   signal mar         : std_ulogic_vector(XLEN-1 downto 0); -- memory address register
   signal ma_load     : std_ulogic; -- misaligned load data address
@@ -230,7 +230,7 @@ begin
     i_pmp_fault_i => pmp_i_fault,     -- instruction fetch pmp fault
     -- status input --
     alu_cp_done_i => cp_done,         -- ALU iterative operation done
-    bus_d_wait_i  => bus_d_wait,      -- wait for bus
+    bus_d_wait_i  => lsu_wait,        -- wait for data bus
     -- data input --
     cmp_i         => alu_cmp,         -- comparator status
     alu_add_i     => alu_add,         -- ALU address result
@@ -363,7 +363,7 @@ begin
     wdata_i       => rs2,             -- write data
     rdata_o       => mem_rdata,       -- read data
     mar_o         => mar,             -- memory address register
-    d_wait_o      => bus_d_wait,      -- wait for access to complete
+    wait_o        => lsu_wait,        -- wait for access to complete
     ma_load_o     => ma_load,         -- misaligned load data address
     ma_store_o    => ma_store,        -- misaligned store data address
     be_load_o     => be_load,         -- bus error on load data access
@@ -371,20 +371,9 @@ begin
     pmp_r_fault_i => pmp_r_fault,     -- PMP read fault
     pmp_w_fault_i => pmp_w_fault,     -- PMP write fault
     -- data bus --
-    d_bus_addr_o  => dbus_req_o.addr, -- bus access address
-    d_bus_rdata_i => dbus_rsp_i.data, -- bus read data
-    d_bus_wdata_o => dbus_req_o.data, -- bus write data
-    d_bus_ben_o   => dbus_req_o.ben,  -- byte enable
-    d_bus_we_o    => dbus_req_o.we,   -- write enable
-    d_bus_re_o    => dbus_req_o.re,   -- read enable
-    d_bus_ack_i   => dbus_rsp_i.ack,  -- bus transfer acknowledge
-    d_bus_err_i   => dbus_rsp_i.err   -- bus transfer error
+    bus_req_o     => dbus_req_o,      -- request
+    bus_rsp_i     => dbus_rsp_i       -- response
   );
-
-  -- data access interface --
-  dbus_req_o.priv <= ctrl.lsu_priv;
-  dbus_req_o.src  <= '0'; -- source = data access
-  dbus_req_o.rvso <= ctrl.lsu_rvso when (CPU_EXTENSION_RISCV_A = true) else '0'; -- is LR/SC reservation set operation
 
 
   -- Physical Memory Protection -------------------------------------------------------------

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -140,7 +140,8 @@ begin
       when alu_op_add_c  => res_o <= addsub_res(XLEN-1 downto 0);
       when alu_op_sub_c  => res_o <= addsub_res(XLEN-1 downto 0);
       when alu_op_cp_c   => res_o <= cp_res;
-      when alu_op_slt_c  => res_o <= (others => '0'); res_o(0) <= addsub_res(addsub_res'left); -- carry/borrow
+      when alu_op_slt_c  => res_o(XLEN-1 downto 1) <= (others => '0');
+                            res_o(0) <= addsub_res(addsub_res'left); -- carry/borrow
       when alu_op_movb_c => res_o <= opb;
       when alu_op_xor_c  => res_o <= rs1_i xor opb; -- only rs1 is required for logic ops (opa would also contain pc)
       when alu_op_or_c   => res_o <= rs1_i or  opb;

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -189,7 +189,7 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
 
   -- instruction execution engine --
   -- make sure reset state is the first item in the list (discussion #415)
-  type execute_engine_state_t is (DISPATCH, TRAP_ENTER, TRAP_EXIT, TRAP_EXECUTE, SLEEP,
+  type execute_engine_state_t is (DISPATCH, TRAP_ENTER, TRAP_EXIT, TRAP_EXECUTE, FENCE, SLEEP,
                                   EXECUTE, ALU_WAIT, BRANCH, BRANCHED, SYSTEM, MEM_REQ, MEM_WAIT);
   type execute_engine_t is record
     state        : execute_engine_state_t;
@@ -329,15 +329,12 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
   signal cnt_event : std_ulogic_vector(hpmcnt_event_size_c-1 downto 0);
 
   -- debug mode controller --
-  type debug_ctrl_state_t is (DEBUG_OFFLINE, DEBUG_ONLINE, DEBUG_LEAVING);
   type debug_ctrl_t is record
-    state        : debug_ctrl_state_t;
     running      : std_ulogic; -- CPU is in debug mode
     trig_hw      : std_ulogic; -- hardware trigger
     trig_break   : std_ulogic; -- ebreak instruction trigger
     trig_halt    : std_ulogic; -- external request trigger
     trig_step    : std_ulogic; -- single-stepping mode trigger
-    dret         : std_ulogic; -- executed DRET instruction
     ext_halt_req : std_ulogic; -- external halt request buffer
   end record;
   signal debug_ctrl : debug_ctrl_t;
@@ -806,7 +803,6 @@ begin
     trap_ctrl.instr_ma          <= '0';
     trap_ctrl.env_call          <= '0';
     trap_ctrl.break_point       <= '0';
-    debug_ctrl.dret             <= '0';
     --
     csr.we_nxt                  <= '0';
     csr.re_nxt                  <= '0';
@@ -861,7 +857,7 @@ begin
         end if;
 
 
-      when TRAP_ENTER => -- Start trap environment and get trap vector
+      when TRAP_ENTER => -- Enter trap environment and get trap vector
       -- ------------------------------------------------------------
         if (trap_ctrl.env_pending = '1') then
           trap_ctrl.env_enter      <= '1';
@@ -873,7 +869,7 @@ begin
         trap_ctrl.env_exit       <= '1';
         execute_engine.state_nxt <= TRAP_EXECUTE;
 
-      when TRAP_EXECUTE => -- Process trap environment
+      when TRAP_EXECUTE => -- Process trap enter/exit (update PC)
       -- ------------------------------------------------------------
         execute_engine.pc_mux_sel <= '0'; -- next_pc
         fetch_engine.reset        <= '1';
@@ -884,8 +880,7 @@ begin
       when EXECUTE => -- Decode and execute instruction (control has to be here for exactly 1 cycle in any case!)
       -- [NOTE] register file is read in this stage; due to the sync read, data will be available in the _next_ state
       -- ------------------------------------------------------------
-        -- clear branch flipflop --
-        execute_engine.branched_nxt <= '0';
+        execute_engine.branched_nxt <= '0'; -- clear branch flipflop
 
         -- decode instruction class --
         case decode_aux.opcode is
@@ -954,25 +949,17 @@ begin
 
           when opcode_fence_c => -- fence operations
           -- ------------------------------------------------------------
-            if (execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_fencei_c) and (CPU_EXTENSION_RISCV_Zifencei = true) then
-              ctrl_nxt.lsu_fencei      <= '1'; -- fence.i
-              execute_engine.state_nxt <= TRAP_EXECUTE; -- used to flush IPB
-            else
-              if (execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_fence_c) then
-                ctrl_nxt.lsu_fence <= '1'; -- fence
-              end if;
-              execute_engine.state_nxt <= DISPATCH;
-            end if;
+            execute_engine.state_nxt <= FENCE;
 
           when opcode_fop_c => -- FPU: floating-point operations
           -- ------------------------------------------------------------
             ctrl_nxt.alu_cp_trig(cp_sel_fpu_c) <= '1'; -- trigger FPU CP
-            execute_engine.state_nxt <= ALU_WAIT; -- will be aborted via monitor exception if FPU not implemented
+            execute_engine.state_nxt           <= ALU_WAIT; -- will be aborted via monitor exception if FPU not implemented
 
           when opcode_cust0_c | opcode_cust1_c | opcode_cust2_c | opcode_cust3_c => -- CFU: custom RISC-V instructions
           -- ------------------------------------------------------------
             ctrl_nxt.alu_cp_trig(cp_sel_cfu_c) <= '1'; -- trigger CFU CP
-            execute_engine.state_nxt <= ALU_WAIT; -- will be aborted via monitor exception if CFU not implemented
+            execute_engine.state_nxt           <= ALU_WAIT; -- will be aborted via monitor exception if CFU not implemented
 
           when others => -- environment/CSR operation or ILLEGAL opcode
           -- ------------------------------------------------------------
@@ -987,6 +974,21 @@ begin
         ctrl_nxt.alu_op <= alu_op_cp_c;
         if (alu_cp_done_i = '1') or (trap_ctrl.exc_buf(exc_iillegal_c) = '1') then
           ctrl_nxt.rf_wb_en        <= '1'; -- valid RF write-back (won't happen in case of an illegal instruction)
+          execute_engine.state_nxt <= DISPATCH;
+        end if;
+
+
+      when FENCE => -- memory fence
+      -- ------------------------------------------------------------
+        if (trap_ctrl.exc_buf(exc_iillegal_c) = '1') then -- abort if illegal instruction
+          execute_engine.state_nxt <= DISPATCH;
+        elsif (execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_fencei_c) and (CPU_EXTENSION_RISCV_Zifencei = true) then
+          ctrl_nxt.lsu_fencei      <= '1'; -- instruction fence
+          execute_engine.state_nxt <= TRAP_EXECUTE; -- used to flush instruction prefetch buffer
+        elsif (execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_fence_c) then
+          ctrl_nxt.lsu_fence       <= '1'; -- fence
+          execute_engine.state_nxt <= DISPATCH;
+        else
           execute_engine.state_nxt <= DISPATCH;
         end if;
 
@@ -1025,7 +1027,6 @@ begin
           if (CPU_EXTENSION_RISCV_A = true) and (decode_aux.opcode(2) = opcode_amo_c(2)) then -- atomic operation
             ctrl_nxt.lsu_req_rd <=  not execute_engine.ir(instr_funct7_lsb_c+2); -- LR.W
             ctrl_nxt.lsu_req_wr <=      execute_engine.ir(instr_funct7_lsb_c+2); -- SC.W
-            ctrl_nxt.lsu_rvso   <= '1'; -- this is a reservation set operation
           else -- normal load/store
             ctrl_nxt.lsu_req_rd <= not execute_engine.ir(5); -- load
             ctrl_nxt.lsu_req_wr <=     execute_engine.ir(5); -- store
@@ -1036,9 +1037,6 @@ begin
       when MEM_WAIT => -- wait for bus transaction to finish
       -- ------------------------------------------------------------
         ctrl_nxt.rf_mux <= rf_mux_mem_c; -- RF input = memory read data
-        if (CPU_EXTENSION_RISCV_A = true) and (decode_aux.opcode(2) = opcode_amo_c(2)) then
-          ctrl_nxt.lsu_rvso <= '1'; -- this is a reservation set operation
-        end if;
         if (trap_ctrl.exc_buf(exc_laccess_c)  = '1') or (trap_ctrl.exc_buf(exc_saccess_c) = '1') or -- bus access error
            (trap_ctrl.exc_buf(exc_lalign_c)   = '1') or (trap_ctrl.exc_buf(exc_salign_c)  = '1') then -- alignment error
           execute_engine.state_nxt <= DISPATCH; -- abort
@@ -1065,11 +1063,10 @@ begin
         if (execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_env_c) and -- ENVIRONMENT
            (trap_ctrl.exc_buf(exc_iillegal_c) = '0') then -- and NOT already identified as illegal instruction
           case execute_engine.ir(instr_funct12_msb_c downto instr_funct12_lsb_c) is
-            when funct12_ecall_c  => trap_ctrl.env_call       <= '1'; -- ecall
-            when funct12_ebreak_c => trap_ctrl.break_point    <= '1'; -- ebreak
-            when funct12_mret_c   => execute_engine.state_nxt <= TRAP_EXIT; -- mret
-            when funct12_dret_c   => execute_engine.state_nxt <= TRAP_EXIT; debug_ctrl.dret <= '1'; -- dret
-            when others           => execute_engine.state_nxt <= SLEEP; -- "funct12_wfi_c" - wfi/sleep
+            when funct12_ecall_c                 => trap_ctrl.env_call       <= '1'; -- ecall
+            when funct12_ebreak_c                => trap_ctrl.break_point    <= '1'; -- ebreak
+            when funct12_mret_c | funct12_dret_c => execute_engine.state_nxt <= TRAP_EXIT; -- xRET
+            when others                          => execute_engine.state_nxt <= SLEEP; -- "funct12_wfi_c" - wfi/sleep
           end case;
         else -- CSR ACCESS - no CSR/GPR will be altered if illegal instruction
           if (execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_csrrw_c) or  -- CSRRW:  always write CSR
@@ -1110,7 +1107,6 @@ begin
   ctrl_o.lsu_fence    <= ctrl.lsu_fence;
   ctrl_o.lsu_fencei   <= ctrl.lsu_fencei;
   ctrl_o.lsu_priv     <= csr.mstatus_mpp when (csr.mstatus_mprv = '1') else csr.privilege_eff; -- effective privilege level for loads/stores in M-mode
-  ctrl_o.lsu_rvso     <= ctrl.lsu_rvso;
 
   -- instruction word bit fields --
   ctrl_o.ir_funct3    <= execute_engine.ir(instr_funct3_msb_c  downto instr_funct3_lsb_c);
@@ -1341,8 +1337,8 @@ begin
             case execute_engine.ir(instr_funct12_msb_c downto instr_funct12_lsb_c) is
               when funct12_ecall_c | funct12_ebreak_c => illegal_cmd <= '0'; -- ECALL, EBREAK
               when funct12_mret_c                     => illegal_cmd <= not csr.privilege; -- MRET allowed in M-mode only
-              when funct12_wfi_c                      => illegal_cmd <= (not csr.privilege) and csr.mstatus_tw; -- WFI allowed in M-mode or if TW is zero
               when funct12_dret_c                     => illegal_cmd <= not debug_ctrl.running; -- DRET allowed in debug mode only
+              when funct12_wfi_c                      => illegal_cmd <= (not csr.privilege) and csr.mstatus_tw; -- WFI allowed in M-mode or if TW is zero
               when others => illegal_cmd <= '1';
             end case;
           else
@@ -2317,48 +2313,29 @@ begin
 
   -- Debug Control --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  ocd_true:
-  if (CPU_EXTENSION_RISCV_Sdext = true) generate
-    debug_control: process(rstn_i, clk_i)
-    begin
-      if (rstn_i = '0') then
-        debug_ctrl.ext_halt_req <= '0';
-        debug_ctrl.state        <= DEBUG_OFFLINE;
-      elsif rising_edge(clk_i) then
+  debug_control: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      debug_ctrl.ext_halt_req <= '0';
+      debug_ctrl.running      <= '0';
+    elsif rising_edge(clk_i) then
+      if (CPU_EXTENSION_RISCV_Sdext = true) then
         debug_ctrl.ext_halt_req <= db_halt_req_i; -- external halt request (from Debug Module)
-        case debug_ctrl.state is -- state machine
-
-          when DEBUG_OFFLINE => -- waiting to start debug mode
-            if (trap_ctrl.env_enter = '1') and (trap_ctrl.cause(5) = '1') then -- processing trap entry into debug mode
-              debug_ctrl.state <= DEBUG_ONLINE;
-            end if;
-
-          when DEBUG_ONLINE => -- we are in debug mode
-            if (debug_ctrl.dret = '1') then -- DRET instruction
-              debug_ctrl.state <= DEBUG_LEAVING;
-            end if;
-
-          when DEBUG_LEAVING => -- leaving debug mode
-            if (execute_engine.state = TRAP_EXECUTE) then -- processing trap exit (updating PC and status registers)
-              debug_ctrl.state <= DEBUG_OFFLINE;
-            end if;
-
-          when others => -- undefined
-            debug_ctrl.state <= DEBUG_OFFLINE;
-
-        end case;
+        if (debug_ctrl.running = '0') then -- debug mode OFFLINE - waiting for entry event
+          if (trap_ctrl.env_enter = '1') and (trap_ctrl.cause(5) = '1') then
+            debug_ctrl.running <= '1';
+          end if;
+        else -- debug mode ONLINE - waiting for exit event
+          if (trap_ctrl.env_exit = '1') then
+            debug_ctrl.running <= '0';
+          end if;
+        end if;
+      else
+        debug_ctrl.ext_halt_req <= '0';
+        debug_ctrl.running      <= '0';
       end if;
-    end process debug_control;
-  end generate;
-
-  ocd_false:
-  if (CPU_EXTENSION_RISCV_Sdext = false) generate
-    debug_ctrl.ext_halt_req <= '0';
-    debug_ctrl.state        <= DEBUG_OFFLINE;
-  end generate;
-
-  -- CPU is in debug mode --
-  debug_ctrl.running <= '0' when (debug_ctrl.state = DEBUG_OFFLINE) else '1';
+    end if;
+  end process debug_control;
 
   -- debug mode entry triggers --
   debug_ctrl.trig_hw    <= hw_trigger_fire and (not debug_ctrl.running) and csr.tdata1_action and csr.tdata1_dmode; -- enter debug mode by HW trigger module request (only valid if dmode = 1)

--- a/rtl/core/neorv32_cpu_lsu.vhd
+++ b/rtl/core/neorv32_cpu_lsu.vhd
@@ -53,7 +53,7 @@ entity neorv32_cpu_lsu is
     wdata_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- write data
     rdata_o       : out std_ulogic_vector(XLEN-1 downto 0); -- read data
     mar_o         : out std_ulogic_vector(XLEN-1 downto 0); -- current memory address register
-    d_wait_o      : out std_ulogic; -- wait for access to complete
+    wait_o        : out std_ulogic; -- wait for access to complete
     ma_load_o     : out std_ulogic; -- misaligned load data address
     ma_store_o    : out std_ulogic; -- misaligned store data address
     be_load_o     : out std_ulogic; -- bus error on load data access
@@ -61,14 +61,8 @@ entity neorv32_cpu_lsu is
     pmp_r_fault_i : in  std_ulogic; -- PMP read fault
     pmp_w_fault_i : in  std_ulogic; -- PMP write fault
     -- data bus --
-    d_bus_addr_o  : out std_ulogic_vector(XLEN-1 downto 0); -- bus access address
-    d_bus_rdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- bus read data
-    d_bus_wdata_o : out std_ulogic_vector(XLEN-1 downto 0); -- bus write data
-    d_bus_ben_o   : out std_ulogic_vector((XLEN/8)-1 downto 0); -- byte enable
-    d_bus_we_o    : out std_ulogic; -- write enable
-    d_bus_re_o    : out std_ulogic; -- read enable
-    d_bus_ack_i   : in  std_ulogic; -- bus transfer acknowledge
-    d_bus_err_i   : in  std_ulogic  -- bus transfer error
+    bus_req_o     : out bus_req_t;  -- request
+    bus_rsp_i     : in  bus_rsp_t   -- response
   );
 end neorv32_cpu_lsu;
 
@@ -109,8 +103,33 @@ begin
   end process mem_adr_reg;
 
   -- address output --
-  d_bus_addr_o <= mar;
-  mar_o        <= mar; -- for MTVAL CSR
+  bus_req_o.addr <= mar;
+  mar_o          <= mar; -- for MTVAL CSR
+
+
+  -- Access Type ----------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  mem_type_reg: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      bus_req_o.priv <= '0';
+      bus_req_o.rvso <= '0';
+    elsif rising_edge(clk_i) then
+      if (ctrl_i.lsu_mo_we = '1') then
+        -- privilege level --
+        bus_req_o.priv <= ctrl_i.lsu_priv;
+        -- reservation set operation --
+        if (AMO_LRSC_ENABLE = true) and (ctrl_i.ir_opcode(2) = opcode_amo_c(2)) then
+          bus_req_o.rvso <= '1';
+        else
+          bus_req_o.rvso <= '0';
+        end if;
+      end if;
+    end if;
+  end process mem_type_reg;
+
+  -- source identifier --
+  bus_req_o.src <= '0'; -- 0 = data access
 
 
   -- Write Data: Alignment and Byte Enable --------------------------------------------------
@@ -118,29 +137,29 @@ begin
   mem_do_reg: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      d_bus_wdata_o <= (others => '0');
-      d_bus_ben_o   <= (others => '0');
+      bus_req_o.data <= (others => '0');
+      bus_req_o.ben  <= (others => '0');
     elsif rising_edge(clk_i) then
       if (ctrl_i.lsu_mo_we = '1') then
-        d_bus_ben_o <= (others => '0'); -- default
         case ctrl_i.ir_funct3(1 downto 0) is
           when "00" => -- byte
-            d_bus_wdata_o(07 downto 00) <= wdata_i(7 downto 0);
-            d_bus_wdata_o(15 downto 08) <= wdata_i(7 downto 0);
-            d_bus_wdata_o(23 downto 16) <= wdata_i(7 downto 0);
-            d_bus_wdata_o(31 downto 24) <= wdata_i(7 downto 0);
-            d_bus_ben_o(to_integer(unsigned(addr_i(1 downto 0)))) <= '1';
+            bus_req_o.data(07 downto 00) <= wdata_i(7 downto 0);
+            bus_req_o.data(15 downto 08) <= wdata_i(7 downto 0);
+            bus_req_o.data(23 downto 16) <= wdata_i(7 downto 0);
+            bus_req_o.data(31 downto 24) <= wdata_i(7 downto 0);
+            bus_req_o.ben <= (others => '0');
+            bus_req_o.ben(to_integer(unsigned(addr_i(1 downto 0)))) <= '1';
           when "01" => -- half-word
-            d_bus_wdata_o(15 downto 00) <= wdata_i(15 downto 0);
-            d_bus_wdata_o(31 downto 16) <= wdata_i(15 downto 0);
+            bus_req_o.data(15 downto 00) <= wdata_i(15 downto 0);
+            bus_req_o.data(31 downto 16) <= wdata_i(15 downto 0);
             if (addr_i(1) = '0') then
-              d_bus_ben_o <= "0011"; -- low half-word
+              bus_req_o.ben <= "0011"; -- low half-word
             else
-              d_bus_ben_o <= "1100"; -- high half-word
+              bus_req_o.ben <= "1100"; -- high half-word
             end if;
           when others => -- word
-            d_bus_wdata_o <= wdata_i;
-            d_bus_ben_o   <= "1111";
+            bus_req_o.data <= wdata_i;
+            bus_req_o.ben  <= "1111";
         end case;
       end if;
     end if;
@@ -159,28 +178,28 @@ begin
           when "00" => -- byte
             case mar(1 downto 0) is
               when "00" => -- byte 0
-                rdata_o(7 downto 0) <= d_bus_rdata_i(07 downto 00);
-                rdata_o(XLEN-1 downto 8) <= (others => ((not ctrl_i.ir_funct3(2)) and d_bus_rdata_i(07))); -- sign-ext
+                rdata_o(7 downto 0) <= bus_rsp_i.data(07 downto 00);
+                rdata_o(XLEN-1 downto 8) <= (others => ((not ctrl_i.ir_funct3(2)) and bus_rsp_i.data(07))); -- sign-ext
               when "01" => -- byte 1
-                rdata_o(7 downto 0) <= d_bus_rdata_i(15 downto 08);
-                rdata_o(XLEN-1 downto 8) <= (others => ((not ctrl_i.ir_funct3(2)) and d_bus_rdata_i(15))); -- sign-ext
+                rdata_o(7 downto 0) <= bus_rsp_i.data(15 downto 08);
+                rdata_o(XLEN-1 downto 8) <= (others => ((not ctrl_i.ir_funct3(2)) and bus_rsp_i.data(15))); -- sign-ext
               when "10" => -- byte 2
-                rdata_o(7 downto 0) <= d_bus_rdata_i(23 downto 16);
-                rdata_o(XLEN-1 downto 8) <= (others => ((not ctrl_i.ir_funct3(2)) and d_bus_rdata_i(23))); -- sign-ext
+                rdata_o(7 downto 0) <= bus_rsp_i.data(23 downto 16);
+                rdata_o(XLEN-1 downto 8) <= (others => ((not ctrl_i.ir_funct3(2)) and bus_rsp_i.data(23))); -- sign-ext
               when others => -- byte 3
-                rdata_o(7 downto 0) <= d_bus_rdata_i(31 downto 24);
-                rdata_o(XLEN-1 downto 8) <= (others => ((not ctrl_i.ir_funct3(2)) and d_bus_rdata_i(31))); -- sign-ext
+                rdata_o(7 downto 0) <= bus_rsp_i.data(31 downto 24);
+                rdata_o(XLEN-1 downto 8) <= (others => ((not ctrl_i.ir_funct3(2)) and bus_rsp_i.data(31))); -- sign-ext
             end case;
           when "01" => -- half-word
             if (mar(1) = '0') then
-              rdata_o(15 downto 0) <= d_bus_rdata_i(15 downto 00); -- low half-word
-              rdata_o(XLEN-1 downto 16) <= (others => ((not ctrl_i.ir_funct3(2)) and d_bus_rdata_i(15))); -- sign-ext
+              rdata_o(15 downto 0) <= bus_rsp_i.data(15 downto 00); -- low half-word
+              rdata_o(XLEN-1 downto 16) <= (others => ((not ctrl_i.ir_funct3(2)) and bus_rsp_i.data(15))); -- sign-ext
             else
-              rdata_o(15 downto 0) <= d_bus_rdata_i(31 downto 16); -- high half-word
-              rdata_o(XLEN-1 downto 16) <= (others => ((not ctrl_i.ir_funct3(2)) and d_bus_rdata_i(31))); -- sign-ext
+              rdata_o(15 downto 0) <= bus_rsp_i.data(31 downto 16); -- high half-word
+              rdata_o(XLEN-1 downto 16) <= (others => ((not ctrl_i.ir_funct3(2)) and bus_rsp_i.data(31))); -- sign-ext
             end if;
           when others => -- word
-            rdata_o(XLEN-1 downto 0) <= d_bus_rdata_i(XLEN-1 downto 0); -- full word
+            rdata_o(XLEN-1 downto 0) <= bus_rsp_i.data(XLEN-1 downto 0); -- full word
         end case;
       end if;
     end if;
@@ -196,11 +215,11 @@ begin
       arbiter.pend_rd <= '0';
       arbiter.pend_wr <= '0';
     elsif rising_edge(clk_i) then
-      arbiter.bus_err <= d_bus_err_i and (arbiter.pend_rd or arbiter.pend_wr); -- bus error during access
+      arbiter.bus_err <= bus_rsp_i.err and (arbiter.pend_rd or arbiter.pend_wr); -- bus error during access
       if (arbiter.pend_rd = '0') and (arbiter.pend_wr = '0') then -- idle
         arbiter.pend_rd <= ctrl_i.lsu_req_rd;
         arbiter.pend_wr <= ctrl_i.lsu_req_wr;
-      elsif (d_bus_ack_i = '1') or (ctrl_i.cpu_trap = '1') then -- normal termination or start of trap handling
+      elsif (bus_rsp_i.ack = '1') or (ctrl_i.cpu_trap = '1') then -- normal termination or start of trap handling
         arbiter.pend_rd <= '0';
         arbiter.pend_wr <= '0';
       end if;
@@ -208,7 +227,7 @@ begin
   end process access_arbiter;
 
   -- wait for bus response --
-  d_wait_o <= not d_bus_ack_i;
+  wait_o <= not bus_rsp_i.ack;
 
   -- output data access/alignment errors to control unit --
   ma_load_o  <= arbiter.pend_rd and misaligned;
@@ -217,8 +236,8 @@ begin
   be_store_o <= arbiter.pend_wr and (arbiter.bus_err or pmp_w_fault_i);
 
   -- access requests (all source signals are driven by registers!) --
-  d_bus_re_o <= ctrl_i.lsu_req_rd and (not misaligned) and (not pmp_r_fault_i);
-  d_bus_we_o <= ctrl_i.lsu_req_wr and (not misaligned) and (not pmp_w_fault_i);
+  bus_req_o.re <= ctrl_i.lsu_req_rd and (not misaligned) and (not pmp_r_fault_i);
+  bus_req_o.we <= ctrl_i.lsu_req_wr and (not misaligned) and (not pmp_w_fault_i);
 
 
 end neorv32_cpu_lsu_rtl;

--- a/rtl/core/neorv32_dma.vhd
+++ b/rtl/core/neorv32_dma.vhd
@@ -69,7 +69,7 @@ architecture neorv32_dma_rtl of neorv32_dma is
 
   -- control and status register bits --
   constant ctrl_en_c            : natural :=  0; -- r/w: DMA enable
-  constant ctrl_auto_c          : natural :=  1; -- r/w: enable FIRQ-triggered  transfer
+  constant ctrl_auto_c          : natural :=  1; -- r/w: enable FIRQ-triggered transfer
   --
   constant ctrl_error_rd_c      : natural :=  8; -- r/-: error during read transfer
   constant ctrl_error_wr_c      : natural :=  9; -- r/-: error during write transfer

--- a/rtl/core/neorv32_gpio.vhd
+++ b/rtl/core/neorv32_gpio.vhd
@@ -55,7 +55,6 @@ end neorv32_gpio;
 
 architecture neorv32_gpio_rtl of neorv32_gpio is
 
-  -- accessible regs --
   signal din, din_rd, dout, dout_rd : std_ulogic_vector(63 downto 0);
 
 begin
@@ -84,9 +83,7 @@ begin
   read_access: process(clk_i)
   begin
     if rising_edge(clk_i) then
-      -- bus handshake --
-      bus_rsp_o.ack <= bus_req_i.we or bus_req_i.re;
-      -- read data --
+      bus_rsp_o.ack  <= bus_req_i.we or bus_req_i.re;
       bus_rsp_o.data <= (others => '0');
       if (bus_req_i.re = '1') then
         case bus_req_i.addr(3 downto 2) is
@@ -116,9 +113,16 @@ begin
     end loop;
   end process pin_mapping;
 
-  -- IO --
+  -- output --
   gpio_o <= dout_rd;
-  din    <= gpio_i when rising_edge(clk_i); -- sample buffer to prevent metastability
+
+  -- synchronize input --
+  input_sync: process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      din <= gpio_i; -- to prevent metastability
+    end if;
+  end process input_sync;
 
 
 end neorv32_gpio_rtl;

--- a/rtl/core/neorv32_onewire.vhd
+++ b/rtl/core/neorv32_onewire.vhd
@@ -327,8 +327,8 @@ begin
 
         when others => -- "0--" OFFLINE: deactivated, reset externally-readable signals
         -- ------------------------------------------------------------
-          serial.sreg     <= (others => '0');
-          serial.presence <= '0';
+          serial.sreg              <= (others => '0');
+          serial.presence          <= '0';
           serial.state(1 downto 0) <= "00"; -- stay here, go to IDLE when module is enabled
 
       end case;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -59,7 +59,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080904"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080905"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 
@@ -534,7 +534,6 @@ package neorv32_package is
     lsu_fence    : std_ulogic;                     -- fence operation
     lsu_fencei   : std_ulogic;                     -- fence.i operation
     lsu_priv     : std_ulogic;                     -- effective privilege level for load/store
-    lsu_rvso     : std_ulogic;                     -- reservation set operation (atomic LR/SC)
     -- instruction word --
     ir_funct3    : std_ulogic_vector(02 downto 0); -- funct3 bit field
     ir_funct12   : std_ulogic_vector(11 downto 0); -- funct12 bit field
@@ -566,7 +565,6 @@ package neorv32_package is
     lsu_fence    => '0',
     lsu_fencei   => '0',
     lsu_priv     => '0',
-    lsu_rvso     => '0',
     ir_funct3    => (others => '0'),
     ir_funct12   => (others => '0'),
     ir_opcode    => (others => '0'),

--- a/rtl/core/neorv32_wdt.vhd
+++ b/rtl/core/neorv32_wdt.vhd
@@ -175,9 +175,13 @@ begin
 
   -- Timeout Counter ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  wdt_counter: process(clk_i)
+  wdt_counter: process(rstn_i, clk_i)
   begin
-    if rising_edge(clk_i) then
+    if (rstn_i = '0') then
+      cnt_inc_ff  <= '0';
+      cnt_started <= '0';
+      cnt         <= (others => '0');
+    elsif rising_edge(clk_i) then
       cnt_inc_ff  <= cnt_inc;
       cnt_started <= ctrl.enable and (cnt_started or prsc_tick); -- start with next clock tick
       if (ctrl.enable = '0') or (reset_wdt = '1') then -- watchdog disabled or reset with correct password


### PR DESCRIPTION
* simplify TWI transfer trigger logic
* optimize CPU control logic (less logic in EXECUTE state; simplify debug mode controller)
* clean-up load/store unit (use buy type for IO; move bus access type logic to LSU)
* use _bus types_ for CPU front-end and load/store unit bus interfaces
* minor code clean-ups