### PR TITLE
[dma] add "transfer done" flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 07.10.2023 | 1.8.9.8 | add "transfer done" flag to DMA; [#699](https://github.com/stnolting/neorv32/pull/699) |
 | 04.10.2023 | 1.8.9.7 | :warning: rework internal bus protocol; [#697](https://github.com/stnolting/neorv32/pull/697) |
 | 29.09.2023 | 1.8.9.6 | optimize PMP logic (reducing area requirements); [#695](https://github.com/stnolting/neorv32/pull/695) |
 | 29.09.2023 | 1.8.9.5 | minor CPU optimizations and code clean-ups; [#694](https://github.com/stnolting/neorv32/pull/694) |

--- a/docs/datasheet/soc_dma.adoc
+++ b/docs/datasheet/soc_dma.adoc
@@ -54,6 +54,10 @@ Software can read the `SRC_BASE` or `DST_BASE` register to retrieve the address 
 Alternatively, software can read back the `NUM` bits of the control register to determine the index of the element
 that caused the error. The error bits are automatically cleared when starting a new transfer.
 
+When the `DMA_CTRL_DONE` flag is set the DMA has actually executed a transfer. However, the `DMA_CTRL_ERROR_*` flags
+should also be checked to verify that the executed transfer completed without errors. The `DMA_CTRL_DONE` flag is
+automatically cleared when writing the `CTRL` register.
+
 [WARNING]
 Transactions performed by the DMA use _machine mode_ permissions (having full access rights) and will
 also **bypass** any physical memory protection rules (<<_pmp_isa_extension>>).
@@ -122,13 +126,14 @@ explicitly cleared again by writing zero to the according <<_mip>> CSR bit.
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.8+<| `0xffffed00` .8+<| `CTRL` <|`0`     `DMA_CTRL_EN`                                     ^| r/w <| DMA module enable
+.9+<| `0xffffed00` .9+<| `CTRL` <|`0`     `DMA_CTRL_EN`                                     ^| r/w <| DMA module enable
                                 <|`1`     `DMA_CTRL_AUTO`                                   ^| r/w <| Enable automatic mode (FIRQ-triggered)
                                 <|`7:2`   _reserved_                                        ^| r/- <| reserved, read as zero
                                 <|`8`     `DMA_CTRL_ERROR_RD`                               ^| r/- <| Error during read access, clears when starting a new transfer
                                 <|`9`     `DMA_CTRL_ERROR_WR`                               ^| r/- <| Error during write access, clears when starting a new transfer
                                 <|`10`    `DMA_CTRL_BUSY`                                   ^| r/- <| DMA transfer in progress
-                                <|`15:11` _reserved_                                        ^| r/- <| reserved, read as zero
+                                <|`11`    `DMA_CTRL_DONE`                                   ^| r/c <| Set if a transfer was executed; auto-clears on write-access
+                                <|`15:12` _reserved_                                        ^| r/- <| reserved, read as zero
                                 <|`31:16` `DMA_CTRL_FIRQ_MASK_MSB : DMA_CTRL_FIRQ_MASK_LSB` ^| r/w <| FIRQ trigger mask (same bits as in <<_mip>>)
 | `0xffffed04` | `SRC_BASE` |`31:0` | r/w | Source base address (shows the last-accessed source address when read)
 | `0xffffed08` | `DST_BASE` |`31:0` | r/w | Destination base address (shows the last-accessed destination address when read)

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -59,7 +59,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080907"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01080908"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 

--- a/sw/example/demo_dma/main.c
+++ b/sw/example/demo_dma/main.c
@@ -202,8 +202,7 @@ int main() {
   neorv32_cpu_sleep();
 
   // check if transfer was successful
-  rc = neorv32_dma_status();
-  if ((rc == DMA_STATUS_ERR_RD) || (rc == DMA_STATUS_ERR_WR)) {
+  if (neorv32_dma_status() != DMA_STATUS_IDLE) {
     neorv32_uart0_printf("Transfer failed!\n");
   }
 
@@ -242,9 +241,9 @@ int main() {
     // sleep until interrupt (from DMA)
     neorv32_cpu_sleep();
 
-    // check DMA status
-    rc = neorv32_dma_status();
-    if ((rc == DMA_STATUS_ERR_RD) || (rc == DMA_STATUS_ERR_WR)) {
+    // transfer successful (and actually executed)?
+    if ((neorv32_dma_done() == 0) || // check if the DMA has actually completed a transfer
+        (neorv32_dma_status() != DMA_STATUS_IDLE)) { // DMA is in idle mode without errors
       neorv32_uart0_printf("Transfer failed!\n");
     }
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1489,6 +1489,7 @@ int main() {
 
     if ((neorv32_cpu_csr_read(CSR_MCAUSE) == DMA_TRAP_CODE) && // correct interrupt source
         (neorv32_crc_get() == 0x31DC476E) && // correct CRC sum
+        (neorv32_dma_done() != 0) && // DMA has actually attempted a transfer
         (neorv32_dma_status() == DMA_STATUS_IDLE)) { // DMA back in idle mode without errors
       test_ok();
     }

--- a/sw/lib/include/neorv32_dma.h
+++ b/sw/lib/include/neorv32_dma.h
@@ -59,13 +59,14 @@ typedef volatile struct __attribute__((packed,aligned(4))) {
 #define NEORV32_DMA ((neorv32_dma_t*) (NEORV32_DMA_BASE))
 
 /** DMA control and status register bits */
-enum NEORV32_DMA_QSEL_enum {
+enum NEORV32_DMA_CTRL_enum {
   DMA_CTRL_EN            =  0, /**< DMA control register(0) (r/w): DMA enable */
   DMA_CTRL_AUTO          =  1, /**< DMA control register(1) (r/w): Automatic trigger mode enable */
 
   DMA_CTRL_ERROR_RD      =  8, /**< DMA control register(8)  (r/-): Error during read access; SRC_BASE shows the faulting address */
   DMA_CTRL_ERROR_WR      =  9, /**< DMA control register(9)  (r/-): Error during write access; DST_BASE shows the faulting address */
   DMA_CTRL_BUSY          = 10, /**< DMA control register(10) (r/-): DMA busy / transfer in progress */
+  DMA_CTRL_DONE          = 11, /**< DMA control register(11) (r/c): A transfer was executed when set */
 
   DMA_CTRL_FIRQ_MASK_LSB = 16, /**< DMA control register(16) (r/w): FIRQ trigger mask LSB */
   DMA_CTRL_FIRQ_MASK_MSB = 31  /**< DMA control register(31) (r/w): FIRQ trigger mask MSB */
@@ -125,6 +126,7 @@ void neorv32_dma_disable(void);
 void neorv32_dma_transfer(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config);
 void neorv32_dma_transfer_auto(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config, uint32_t firq_mask);
 int  neorv32_dma_status(void);
+int  neorv32_dma_done(void);
 /**@}*/
 
 

--- a/sw/lib/source/neorv32_dma.c
+++ b/sw/lib/source/neorv32_dma.c
@@ -140,3 +140,21 @@ int neorv32_dma_status(void) {
     return DMA_STATUS_IDLE; // idle
   }
 }
+
+
+/**********************************************************************//**
+ * Check if a transfer has actually been executed.
+ *
+ * @return 0 if no transfer was executed, 1 if a transfer has actually been executed.
+ * Use neorv32_dma_status(void) to check if there was an error during that transfer.
+ **************************************************************************/
+int neorv32_dma_done(void) {
+
+  if (NEORV32_DMA->CTRL & (1 << DMA_CTRL_DONE)) {
+    return 1; // there was a transfer
+  }
+  else {
+    return 0; // no transfer executed
+  }
+
+}

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -390,6 +390,11 @@
               <description>DMA transfer in progress</description>
             </field>
             <field>
+              <name>DMA_CTRL_DONE</name>
+              <bitRange>[11:11]</bitRange>
+              <description>DMA transfer done; auto-clears on write access</description>
+            </field>
+            <field>
               <name>DMA_CTRL_FIRQ_MASK</name>
               <bitRange>[31:16]</bitRange>
               <description>FIRQ trigger mask</description>


### PR DESCRIPTION
Add a new flag to the DMA's control register to indicate that a configured transfer has actually been executed.

:warning: The done flag does not indicate that the transfer was successful. Check the control register's error flags to check if the transfer caused any errors.

✔️ Feature suggested by @DS-567 in https://github.com/stnolting/neorv32/discussions/689.