### PR TITLE
Update software framework to gcc-13.2.0

### DIFF
--- a/.github/workflows/Processor.yml
+++ b/.github/workflows/Processor.yml
@@ -57,7 +57,7 @@ jobs:
           USER_FLAGS+=-DUART0_SIM_MODE
           USER_FLAGS+=-DSUPPRESS_OPTIONAL_UART_PRINT
           USER_FLAGS+=-flto
-          MARCH=rv32imac
+          MARCH=rv32imac_zicsr_zifencei
           info
           all
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 13.10.2023 | 1.9.0.1 | update software framework to GCC-13.2.0; [#705](https://github.com/stnolting/neorv32/pull/705) |
 | 13.10.2023 | [**:rocket:1.9.0**](https://github.com/stnolting/neorv32/releases/tag/v1.9.0) | **New release** |
 | 13.10.2023 | 1.8.9.9 | minor hardware edits and optimizations; [#703](https://github.com/stnolting/neorv32/pull/703) |
 | 07.10.2023 | 1.8.9.8 | add "transfer done" flag to DMA; [#699](https://github.com/stnolting/neorv32/pull/699) |

--- a/do.py
+++ b/do.py
@@ -26,7 +26,7 @@ def task_BuildAndInstallSoftwareFrameworkTests():
             "make -C sw/bootloader clean_all info bootloader",
             # Compile and install test application, redirect UART0 TX to text.io simulation output via <UARTx_SIM_MODE> user flags
             "echo 'Compiling and installing CPU/Processor test application'",
-            "make -C sw/example/processor_check clean_all USER_FLAGS+=-DUART0_SIM_MODE USER_FLAGS+=-DUART1_SIM_MODE USER_FLAGS+=-flto EFFORT=-Os MARCH=rv32imac info all",
+            "make -C sw/example/processor_check clean_all USER_FLAGS+=-DUART0_SIM_MODE USER_FLAGS+=-DUART1_SIM_MODE USER_FLAGS+=-flto EFFORT=-Os MARCH=rv32imac_zicsr_zifencei info all",
         ],
         "doc": "Build all sw/example/*; install bootloader and processor check",
     }

--- a/docs/datasheet/software.adoc
+++ b/docs/datasheet/software.adoc
@@ -178,7 +178,7 @@ Make sure to add the bin folder of RISC-V GCC to your PATH variable.
  USER_FLAGS   - Custom toolchain flags [append only], default ""
  USER_LIBS    - Custom libraries [append only], default ""
  EFFORT       - Optimization level, default "-Os"
- MARCH        - Machine architecture, default "rv32i_zicsr"
+ MARCH        - Machine architecture, default "rv32i_zicsr_zifencei"
  MABI         - Machine binary interface, default "ilp32"
  APP_INC      - C include folder(s) [append only], default "-I ."
  ASM_INC      - ASM include folder(s) [append only], default "-I ."
@@ -197,7 +197,7 @@ makefile (`sw/common/common.mk`):
 .Customizing Makefile Variables
 [TIP]
 The makefile configuration variables can be overridden or extended directly when invoking the makefile. For
-example `$ make MARCH=rv32ic_zicsr clean_all exe` overrides the default `MARCH` variable definitions.
+example `$ make MARCH=rv32ic_zicsr_zifencei clean_all exe` overrides the default `MARCH` variable definitions.
 
 .Default Makefile Configuration
 [source,makefile]
@@ -217,7 +217,7 @@ EFFORT ?= -Os
 # Compiler toolchain
 RISCV_PREFIX ?= riscv32-unknown-elf-
 # CPU architecture and ABI
-MARCH ?= rv32i_zicsr
+MARCH ?= rv32i_zicsr_zifencei
 MABI  ?= ilp32
 # User flags for additional configuration (will be added to compiler flags)
 USER_FLAGS ?=

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -59,7 +59,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090000"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090001"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 

--- a/sw/common/common.mk
+++ b/sw/common/common.mk
@@ -51,7 +51,7 @@ EFFORT ?= -Os
 RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
-MARCH ?= rv32i_zicsr
+MARCH ?= rv32i_zicsr_zifencei
 MABI  ?= ilp32
 
 # User flags for additional configuration (will be added to compiler flags)

--- a/sw/example/demo_freeRTOS/makefile
+++ b/sw/example/demo_freeRTOS/makefile
@@ -1,5 +1,5 @@
 # *****************************************************************************
-# USER CONFIGURATION
+# USER CONFIGURATION OVERRIDE
 # *****************************************************************************
 # User's application sources (*.c, *.cpp, *.s, *.S); add additional files here
 APP_SRC ?= $(wildcard ./*.c) $(wildcard ./*.s) $(wildcard ./*.cpp) $(wildcard ./*.S)
@@ -8,13 +8,6 @@ APP_SRC ?= $(wildcard ./*.c) $(wildcard ./*.s) $(wildcard ./*.cpp) $(wildcard ./
 APP_INC ?= -I .
 # User's application include folders - for assembly files only (don't forget the '-I' before each entry)
 ASM_INC ?= -I .
-
-# Optimization
-EFFORT ?= -Os
-
-# CPU architecture and ABI
-MARCH ?= rv32i
-MABI  ?= ilp32
 
 # User flags for additional configuration (will be added to compiler flags)
 USER_FLAGS ?=

--- a/sw/example/demo_freeRTOS_xirq/makefile
+++ b/sw/example/demo_freeRTOS_xirq/makefile
@@ -1,5 +1,5 @@
 # *****************************************************************************
-# USER CONFIGURATION
+# USER CONFIGURATION OVERRIDE
 # *****************************************************************************
 # User's application sources (*.c, *.cpp, *.s, *.S); add additional files here
 APP_SRC ?= $(wildcard ./*.c) $(wildcard ./*.s) $(wildcard ./*.cpp) $(wildcard ./*.S)
@@ -8,13 +8,6 @@ APP_SRC ?= $(wildcard ./*.c) $(wildcard ./*.s) $(wildcard ./*.cpp) $(wildcard ./
 APP_INC ?= -I .
 # User's application include folders - for assembly files only (don't forget the '-I' before each entry)
 ASM_INC ?= -I .
-
-# Optimization
-EFFORT ?= -Os
-
-# CPU architecture and ABI
-MARCH ?= rv32i
-MABI  ?= ilp32
 
 # User flags for additional configuration (will be added to compiler flags)
 USER_FLAGS ?=

--- a/sw/example/processor_check/run_check.sh
+++ b/sw/example/processor_check/run_check.sh
@@ -3,4 +3,4 @@
 set -e
 
 echo "Starting processor check simulation..."
-make USER_FLAGS+="-DUART0_SIM_MODE -DUART1_SIM_MODE -g -flto" EFFORT=-Os MARCH=rv32imac clean_all all sim
+make USER_FLAGS+="-DUART0_SIM_MODE -DUART1_SIM_MODE -g -flto" EFFORT=-Os MARCH=rv32imac_zicsr_zifencei clean_all all sim

--- a/sw/ocd-firmware/makefile
+++ b/sw/ocd-firmware/makefile
@@ -55,7 +55,7 @@ EFFORT ?= -Os
 RISCV_PREFIX ?= riscv32-unknown-elf-
 
 # CPU architecture and ABI
-MARCH = rv32i
+MARCH = rv32i_zicsr_zifencei
 MABI  = ilp32
 
 # User flags for additional configuration (will be added to compiler flags)


### PR DESCRIPTION
* `march` now requires `_zicsr` when using CSR access instructions (`Zicsr` ISA extension)
* `march` now requires `_zifencei` when using the instruction fence instruction (`Zifencei` ISA extension)