### PR TITLE
⚠️ remove Zifencei generic - Zifencei ISA extension is now always enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 18.10.2023 | 1.9.0.3 | :warning: remove top's `CPU_EXTENSION_RISCV_Zifencei` generic - `Zifencei` ISA extension is now always enabled; [#709](https://github.com/stnolting/neorv32/pull/709) |
 | 16.10.2023 | 1.9.0.2 | minor CPU control cleanups and optimizations (branch system); [#707](https://github.com/stnolting/neorv32/pull/707) |
 | 13.10.2023 | 1.9.0.1 | update software framework to GCC-13.2.0; [#705](https://github.com/stnolting/neorv32/pull/705) |
 | 13.10.2023 | [**:rocket:1.9.0**](https://github.com/stnolting/neorv32/releases/tag/v1.9.0) | **New release** |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -1,9 +1,9 @@
 :sectnums:
 == NEORV32 Central Processing Unit (CPU)
 
-The NEORV32 CPU is an area-optimized RISC-V core implementing the `rv32iZicsr` base ISA and supporting
-several additional/optional ISA extensions. The CPU's micro architecture is based on a von-Neumann machine build
-upon a mixture of multi-cycle and pipelined execution schemes.
+The NEORV32 CPU is an area-optimized RISC-V core implementing the `rv32i_zicsr_zifencei` base (privileged) ISA and
+supporting several additional/optional ISA extensions. The CPU's micro architecture is based on a von-Neumann
+machine build upon a mixture of multi-cycle and pipelined execution schemes.
 
 [NOTE]
 This chapter assumes that the reader is familiar with the official
@@ -385,7 +385,7 @@ via the according <<_processor_top_entity_generics>>. This chapter gives a brief
 | <<_m_isa_extension,`M`>> | Integer multiplication and division instructions |
 | <<_u_isa_extension,`U`>> | Less-privileged _user_ mode extension |
 | <<_x_isa_extension,`X`>> | Platform-specific / NEORV32-specific extension | **Always enabled**
-| <<_zifencei_isa_extension,`Zifencei`>> | Instruction stream synchronization instruction |
+| <<_zifencei_isa_extension,`Zifencei`>> | Instruction stream synchronization instruction | **Always enabled**
 | <<_zfinx_isa_extension,`Zfinx`>> | Floating-point instructions using integer registers | `F` alternative
 | <<_zicntr_isa_extension,`Zicntr`>> | Base counters extension |
 | <<_zicsr_isa_extension,`Zicsr`>> | Control and status register access instructions | **Always enabled**
@@ -590,7 +590,8 @@ RISC-V specs. Also, custom trap codes for <<_mcause>> are implemented.
 
 ==== `Zifencei` ISA Extension
 
-The `Zifencei` CPU extension allows manual synchronization of the instruction stream.
+The `Zifencei` CPU extension allows manual synchronization of the instruction stream. This extension is always enabled.
+
 The `fence.i` instruction resets the CPU's front-end (instruction fetch) and flushes the prefetch buffer.
 This allows a clean re-fetch of modified instructions from memory. Also, the top's `i_bus_fencei_o` signal is set
 high for one cycle to inform the memory system (like the <<_processor_internal_instruction_cache_icache>> to perform a flush/reload.

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -208,18 +208,17 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `ON_CHIP_DEBUGGER_EN` | boolean | false | Implement the on-chip debugger and the CPU debug mode.
 | `DM_LEGACY_MODE`      | boolean | false | Debug module spec. version: `false` = v1.0, `true` = v0.13 (legacy mode).
 4+^| **CPU <<_instruction_sets_and_extensions>>**
-| `CPU_EXTENSION_RISCV_A`        | boolean | false | Enable <<_a_isa_extension>> (atomic memory accesses).
-| `CPU_EXTENSION_RISCV_B`        | boolean | false | Enable <<_b_isa_extension>> (bit-manipulation).
-| `CPU_EXTENSION_RISCV_C`        | boolean | false | Enable <<_c_isa_extension>> (compressed instructions).
-| `CPU_EXTENSION_RISCV_E`        | boolean | false | Enable <<_e_isa_extension>> (reduced register file size).
-| `CPU_EXTENSION_RISCV_M`        | boolean | false | Enable <<_m_isa_extension>> (hardware-based integer multiplication and division).
-| `CPU_EXTENSION_RISCV_U`        | boolean | false | Enable <<_u_isa_extension>> (less-privileged user mode).
-| `CPU_EXTENSION_RISCV_Zfinx`    | boolean | false | Enable <<_zfinx_isa_extension>> (single-precision floating-point unit).
-| `CPU_EXTENSION_RISCV_Zicntr`   | boolean | true  | Enable <<_zicntr_isa_extension>> (CPU base counters).
-| `CPU_EXTENSION_RISCV_Zihpm`    | boolean | false | Enable <<_zihpm_isa_extension>> (hardware performance monitors).
-| `CPU_EXTENSION_RISCV_Zifencei` | boolean | false | Enable <<_zifencei_isa_extension>> (instruction stream synchronization).
-| `CPU_EXTENSION_RISCV_Zmmul`    | boolean | false | Enable <<_zmmul_isa_extension>> (hardware-based integer multiplication).
-| `CPU_EXTENSION_RISCV_Zxcfu`    | boolean | false | Enable NEORV32-specific <<_zxcfu_isa_extension>> (custom RISC-V instructions).
+| `CPU_EXTENSION_RISCV_A`      | boolean | false | Enable <<_a_isa_extension>> (atomic memory accesses).
+| `CPU_EXTENSION_RISCV_B`      | boolean | false | Enable <<_b_isa_extension>> (bit-manipulation).
+| `CPU_EXTENSION_RISCV_C`      | boolean | false | Enable <<_c_isa_extension>> (compressed instructions).
+| `CPU_EXTENSION_RISCV_E`      | boolean | false | Enable <<_e_isa_extension>> (reduced register file size).
+| `CPU_EXTENSION_RISCV_M`      | boolean | false | Enable <<_m_isa_extension>> (hardware-based integer multiplication and division).
+| `CPU_EXTENSION_RISCV_U`      | boolean | false | Enable <<_u_isa_extension>> (less-privileged user mode).
+| `CPU_EXTENSION_RISCV_Zfinx`  | boolean | false | Enable <<_zfinx_isa_extension>> (single-precision floating-point unit).
+| `CPU_EXTENSION_RISCV_Zicntr` | boolean | true  | Enable <<_zicntr_isa_extension>> (CPU base counters).
+| `CPU_EXTENSION_RISCV_Zihpm`  | boolean | false | Enable <<_zihpm_isa_extension>> (hardware performance monitors).
+| `CPU_EXTENSION_RISCV_Zmmul`  | boolean | false | Enable <<_zmmul_isa_extension>> (hardware-based integer multiplication).
+| `CPU_EXTENSION_RISCV_Zxcfu`  | boolean | false | Enable NEORV32-specific <<_zxcfu_isa_extension>> (custom RISC-V instructions).
 4+^| **CPU Tuning Options**
 | `FAST_MUL_EN`           | boolean   | false      | Implement fast (but large) full-parallel multipliers (trying to infer DSP blocks).
 | `FAST_SHIFT_EN`         | boolean   | false      | Implement fast (but large) full-parallel barrel shifters.

--- a/docs/userguide/customizing_the_bootloader.adoc
+++ b/docs/userguide/customizing_the_bootloader.adoc
@@ -12,7 +12,7 @@ bootloader ROM) and the processor has to be re-synthesized.
 
 [NOTE]
 Keep in mind that the maximum size for the bootloader is limited to 8kB and it should be compiled using the
-minimal base & privileged ISA `rv32i_zicsr` only to ensure it can work independently of the actual CPU configuration.
+minimal base & privileged ISA `rv32i_zicsr_zifencei` only to ensure it can work independently of the actual CPU configuration.
 
 .Bootloader configuration parameters
 [cols="<2,^1,^2,<6"]

--- a/docs/userguide/debugging_with_ocd.adoc
+++ b/docs/userguide/debugging_with_ocd.adoc
@@ -21,8 +21,7 @@ for more information regarding the actual hardware.
 .OCD CPU Requirements
 [NOTE]
 The on-chip debugger is only implemented if the _ON_CHIP_DEBUGGER_EN_ generic is set _true_. Furthermore, it requires
-the `Zicsr` and `Zifencei` CPU extension to be implemented (top generics _CPU_EXTENSION_RISCV_Zicsr_ = _true_
-and _CPU_EXTENSION_RISCV_Zifencei_ = _true_).
+the `Zicsr` and `Zifencei` CPU extension, which are always enabled by the CPU.
 
 
 :sectnums:

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -57,7 +57,6 @@ entity neorv32_cpu is
     CPU_EXTENSION_RISCV_Zfinx    : boolean; -- implement 32-bit floating-point extension (using INT reg!)
     CPU_EXTENSION_RISCV_Zicntr   : boolean; -- implement base counters?
     CPU_EXTENSION_RISCV_Zihpm    : boolean; -- implement hardware performance monitors?
-    CPU_EXTENSION_RISCV_Zifencei : boolean; -- implement instruction stream sync.?
     CPU_EXTENSION_RISCV_Zmmul    : boolean; -- implement multiply-only M sub-extension?
     CPU_EXTENSION_RISCV_Zxcfu    : boolean; -- implement custom (instr.) functions unit?
     CPU_EXTENSION_RISCV_Sdext    : boolean; -- implement external debug mode extension?
@@ -146,22 +145,22 @@ begin
   -- CPU ISA configuration --
   assert false report
     "NEORV32 CPU Configuration: RV32" &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_E,        "E", "I") &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_M,        "M", "") &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_A,        "A", "") &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_C,        "C", "") &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_B,        "B", "") &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_U,        "U", "") &
-    cond_sel_string_f(true,                         "_Zicsr", "") & -- always enabled
-    cond_sel_string_f(CPU_EXTENSION_RISCV_Zicntr,   "_Zicntr", "") &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_Zifencei, "_Zifencei", "") &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_Zfinx,    "_Zfinx", "") &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_Zihpm,    "_Zihpm", "") &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_Zmmul,    "_Zmmul", "") &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_Zxcfu,    "_Zxcfu", "") &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_Sdext,    "_Sdext", "") &
-    cond_sel_string_f(CPU_EXTENSION_RISCV_Sdtrig,   "_Sdtrig", "") &
-    cond_sel_string_f(pmp_enable_c,                 "_Smpmp", "")
+    cond_sel_string_f(CPU_EXTENSION_RISCV_E,      "E", "I") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_M,      "M", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_A,      "A", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_C,      "C", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_B,      "B", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_U,      "U", "") &
+    cond_sel_string_f(true,                       "_Zicsr", "") & -- always enabled
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Zicntr, "_Zicntr", "") &
+    cond_sel_string_f(true,                       "_Zifencei", "") & -- always enabled
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Zfinx,  "_Zfinx", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Zihpm,  "_Zihpm", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Zmmul,  "_Zmmul", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Zxcfu,  "_Zxcfu", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Sdext,  "_Sdext", "") &
+    cond_sel_string_f(CPU_EXTENSION_RISCV_Sdtrig, "_Sdtrig", "") &
+    cond_sel_string_f(pmp_enable_c,               "_Smpmp", "")
     severity note;
 
   -- simulation notifier --
@@ -176,44 +175,39 @@ begin
   assert not ((CPU_EXTENSION_RISCV_Zmmul = true) and (CPU_EXTENSION_RISCV_M = true)) report
     "NEORV32 CPU CONFIG ERROR! <M> and <Zmmul> extensions cannot co-exist!" severity error;
 
-  -- Debug mode --
-  assert not ((CPU_EXTENSION_RISCV_Sdext = true) and (CPU_EXTENSION_RISCV_Zifencei = false)) report
-    "NEORV32 CPU CONFIG ERROR! Debug mode requires <CPU_EXTENSION_RISCV_Zifencei> extension to be enabled." severity error;
-
 
   -- Control Unit ---------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_control_inst: entity neorv32.neorv32_cpu_control
   generic map (
     -- General --
-    HART_ID                      => HART_ID,                      -- hardware thread ID
-    VENDOR_ID                    => VENDOR_ID,                    -- vendor's JEDEC ID
-    CPU_BOOT_ADDR                => CPU_BOOT_ADDR,                -- cpu boot address
-    CPU_DEBUG_PARK_ADDR          => CPU_DEBUG_PARK_ADDR,          -- cpu debug mode parking loop entry address
-    CPU_DEBUG_EXC_ADDR           => CPU_DEBUG_EXC_ADDR,           -- cpu debug mode exception entry address
+    HART_ID                    => HART_ID,                      -- hardware thread ID
+    VENDOR_ID                  => VENDOR_ID,                    -- vendor's JEDEC ID
+    CPU_BOOT_ADDR              => CPU_BOOT_ADDR,                -- cpu boot address
+    CPU_DEBUG_PARK_ADDR        => CPU_DEBUG_PARK_ADDR,          -- cpu debug mode parking loop entry address
+    CPU_DEBUG_EXC_ADDR         => CPU_DEBUG_EXC_ADDR,           -- cpu debug mode exception entry address
     -- RISC-V CPU Extensions --
-    CPU_EXTENSION_RISCV_A        => CPU_EXTENSION_RISCV_A,        -- implement atomic memory operations extension?
-    CPU_EXTENSION_RISCV_B        => CPU_EXTENSION_RISCV_B,        -- implement bit-manipulation extension?
-    CPU_EXTENSION_RISCV_C        => CPU_EXTENSION_RISCV_C,        -- implement compressed extension?
-    CPU_EXTENSION_RISCV_E        => CPU_EXTENSION_RISCV_E,        -- implement embedded RF extension?
-    CPU_EXTENSION_RISCV_M        => CPU_EXTENSION_RISCV_M,        -- implement mul/div extension?
-    CPU_EXTENSION_RISCV_U        => CPU_EXTENSION_RISCV_U,        -- implement user mode extension?
-    CPU_EXTENSION_RISCV_Zfinx    => CPU_EXTENSION_RISCV_Zfinx,    -- implement 32-bit floating-point extension (using INT reg!)
-    CPU_EXTENSION_RISCV_Zicntr   => CPU_EXTENSION_RISCV_Zicntr,   -- implement base counters?
-    CPU_EXTENSION_RISCV_Zihpm    => CPU_EXTENSION_RISCV_Zihpm,    -- implement hardware performance monitors?
-    CPU_EXTENSION_RISCV_Zifencei => CPU_EXTENSION_RISCV_Zifencei, -- implement instruction stream sync.?
-    CPU_EXTENSION_RISCV_Zmmul    => CPU_EXTENSION_RISCV_Zmmul,    -- implement multiply-only M sub-extension?
-    CPU_EXTENSION_RISCV_Zxcfu    => CPU_EXTENSION_RISCV_Zxcfu,    -- implement custom (instr.) functions unit?
-    CPU_EXTENSION_RISCV_Sdext    => CPU_EXTENSION_RISCV_Sdext,    -- implement external debug mode extension?
-    CPU_EXTENSION_RISCV_Sdtrig   => CPU_EXTENSION_RISCV_Sdtrig,   -- implement trigger module extension?
+    CPU_EXTENSION_RISCV_A      => CPU_EXTENSION_RISCV_A,        -- implement atomic memory operations extension?
+    CPU_EXTENSION_RISCV_B      => CPU_EXTENSION_RISCV_B,        -- implement bit-manipulation extension?
+    CPU_EXTENSION_RISCV_C      => CPU_EXTENSION_RISCV_C,        -- implement compressed extension?
+    CPU_EXTENSION_RISCV_E      => CPU_EXTENSION_RISCV_E,        -- implement embedded RF extension?
+    CPU_EXTENSION_RISCV_M      => CPU_EXTENSION_RISCV_M,        -- implement mul/div extension?
+    CPU_EXTENSION_RISCV_U      => CPU_EXTENSION_RISCV_U,        -- implement user mode extension?
+    CPU_EXTENSION_RISCV_Zfinx  => CPU_EXTENSION_RISCV_Zfinx,    -- implement 32-bit floating-point extension (using INT reg!)
+    CPU_EXTENSION_RISCV_Zicntr => CPU_EXTENSION_RISCV_Zicntr,   -- implement base counters?
+    CPU_EXTENSION_RISCV_Zihpm  => CPU_EXTENSION_RISCV_Zihpm,    -- implement hardware performance monitors?
+    CPU_EXTENSION_RISCV_Zmmul  => CPU_EXTENSION_RISCV_Zmmul,    -- implement multiply-only M sub-extension?
+    CPU_EXTENSION_RISCV_Zxcfu  => CPU_EXTENSION_RISCV_Zxcfu,    -- implement custom (instr.) functions unit?
+    CPU_EXTENSION_RISCV_Sdext  => CPU_EXTENSION_RISCV_Sdext,    -- implement external debug mode extension?
+    CPU_EXTENSION_RISCV_Sdtrig => CPU_EXTENSION_RISCV_Sdtrig,   -- implement trigger module extension?
     -- Tuning Options --
-    FAST_MUL_EN                  => FAST_MUL_EN,                  -- use DSPs for M extension's multiplier
-    FAST_SHIFT_EN                => FAST_SHIFT_EN,                -- use barrel shifter for shift operations
+    FAST_MUL_EN                => FAST_MUL_EN,                  -- use DSPs for M extension's multiplier
+    FAST_SHIFT_EN              => FAST_SHIFT_EN,                -- use barrel shifter for shift operations
     -- Physical memory protection (PMP) --
-    PMP_EN                       => pmp_enable_c,                 -- physical memory protection enabled
+    PMP_EN                     => pmp_enable_c,                 -- physical memory protection enabled
     -- Hardware Performance Monitors (HPM) --
-    HPM_NUM_CNTS                 => HPM_NUM_CNTS,                 -- number of implemented HPM counters (0..13)
-    HPM_CNT_WIDTH                => HPM_CNT_WIDTH                 -- total size of HPM counters
+    HPM_NUM_CNTS               => HPM_NUM_CNTS,                 -- number of implemented HPM counters (0..13)
+    HPM_CNT_WIDTH              => HPM_CNT_WIDTH                 -- total size of HPM counters
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -59,7 +59,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090002"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090003"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 
@@ -746,95 +746,94 @@ package neorv32_package is
   component neorv32_top
     generic (
       -- General --
-      CLOCK_FREQUENCY              : natural;
-      HART_ID                      : std_ulogic_vector(31 downto 0) := x"00000000";
-      VENDOR_ID                    : std_ulogic_vector(31 downto 0) := x"00000000";
-      INT_BOOTLOADER_EN            : boolean := false;
+      CLOCK_FREQUENCY            : natural;
+      HART_ID                    : std_ulogic_vector(31 downto 0) := x"00000000";
+      VENDOR_ID                  : std_ulogic_vector(31 downto 0) := x"00000000";
+      INT_BOOTLOADER_EN          : boolean := false;
       -- On-Chip Debugger (OCD) --
-      ON_CHIP_DEBUGGER_EN          : boolean := false;
-      DM_LEGACY_MODE               : boolean := false;
+      ON_CHIP_DEBUGGER_EN        : boolean := false;
+      DM_LEGACY_MODE             : boolean := false;
       -- RISC-V CPU Extensions --
-      CPU_EXTENSION_RISCV_A        : boolean := false;
-      CPU_EXTENSION_RISCV_B        : boolean := false;
-      CPU_EXTENSION_RISCV_C        : boolean := false;
-      CPU_EXTENSION_RISCV_E        : boolean := false;
-      CPU_EXTENSION_RISCV_M        : boolean := false;
-      CPU_EXTENSION_RISCV_U        : boolean := false;
-      CPU_EXTENSION_RISCV_Zfinx    : boolean := false;
-      CPU_EXTENSION_RISCV_Zicntr   : boolean := true;
-      CPU_EXTENSION_RISCV_Zihpm    : boolean := false;
-      CPU_EXTENSION_RISCV_Zifencei : boolean := false;
-      CPU_EXTENSION_RISCV_Zmmul    : boolean := false;
-      CPU_EXTENSION_RISCV_Zxcfu    : boolean := false;
+      CPU_EXTENSION_RISCV_A      : boolean := false;
+      CPU_EXTENSION_RISCV_B      : boolean := false;
+      CPU_EXTENSION_RISCV_C      : boolean := false;
+      CPU_EXTENSION_RISCV_E      : boolean := false;
+      CPU_EXTENSION_RISCV_M      : boolean := false;
+      CPU_EXTENSION_RISCV_U      : boolean := false;
+      CPU_EXTENSION_RISCV_Zfinx  : boolean := false;
+      CPU_EXTENSION_RISCV_Zicntr : boolean := true;
+      CPU_EXTENSION_RISCV_Zihpm  : boolean := false;
+      CPU_EXTENSION_RISCV_Zmmul  : boolean := false;
+      CPU_EXTENSION_RISCV_Zxcfu  : boolean := false;
       -- Tuning Options --
-      FAST_MUL_EN                  : boolean := false;
-      FAST_SHIFT_EN                : boolean := false;
+      FAST_MUL_EN                : boolean := false;
+      FAST_SHIFT_EN              : boolean := false;
       -- Physical Memory Protection (PMP) --
-      PMP_NUM_REGIONS              : natural range 0 to 16 := 0;
-      PMP_MIN_GRANULARITY          : natural := 4;
+      PMP_NUM_REGIONS            : natural range 0 to 16 := 0;
+      PMP_MIN_GRANULARITY        : natural := 4;
       -- Hardware Performance Monitors (HPM) --
-      HPM_NUM_CNTS                 : natural range 0 to 13 := 0;
-      HPM_CNT_WIDTH                : natural range 0 to 64 := 40;
+      HPM_NUM_CNTS               : natural range 0 to 13 := 0;
+      HPM_CNT_WIDTH              : natural range 0 to 64 := 40;
       -- Atomic Memory Access - Reservation Set Granularity --
-      AMO_RVS_GRANULARITY          : natural := 4;
+      AMO_RVS_GRANULARITY        : natural := 4;
       -- Internal Instruction memory (IMEM) --
-      MEM_INT_IMEM_EN              : boolean := false;
-      MEM_INT_IMEM_SIZE            : natural := 16*1024;
+      MEM_INT_IMEM_EN            : boolean := false;
+      MEM_INT_IMEM_SIZE          : natural := 16*1024;
       -- Internal Data memory (DMEM) --
-      MEM_INT_DMEM_EN              : boolean := false;
-      MEM_INT_DMEM_SIZE            : natural := 8*1024;
+      MEM_INT_DMEM_EN            : boolean := false;
+      MEM_INT_DMEM_SIZE          : natural := 8*1024;
       -- Internal Instruction Cache (iCACHE) --
-      ICACHE_EN                    : boolean                  := false;
-      ICACHE_NUM_BLOCKS            : natural range 1 to 256   := 4;
-      ICACHE_BLOCK_SIZE            : natural range 4 to 2**16 := 64;
-      ICACHE_ASSOCIATIVITY         : natural range 1 to 2     := 1;
+      ICACHE_EN                  : boolean                  := false;
+      ICACHE_NUM_BLOCKS          : natural range 1 to 256   := 4;
+      ICACHE_BLOCK_SIZE          : natural range 4 to 2**16 := 64;
+      ICACHE_ASSOCIATIVITY       : natural range 1 to 2     := 1;
       -- Internal Data Cache (dCACHE) --
-      DCACHE_EN                    : boolean                  := false;
-      DCACHE_NUM_BLOCKS            : natural range 1 to 256   := 4;
-      DCACHE_BLOCK_SIZE            : natural range 4 to 2**16 := 64;
+      DCACHE_EN                  : boolean                  := false;
+      DCACHE_NUM_BLOCKS          : natural range 1 to 256   := 4;
+      DCACHE_BLOCK_SIZE          : natural range 4 to 2**16 := 64;
       -- External memory interface (WISHBONE) --
-      MEM_EXT_EN                   : boolean := false;
-      MEM_EXT_TIMEOUT              : natural := 255;
-      MEM_EXT_PIPE_MODE            : boolean := false;
-      MEM_EXT_BIG_ENDIAN           : boolean := false;
-      MEM_EXT_ASYNC_RX             : boolean := false;
-      MEM_EXT_ASYNC_TX             : boolean := false;
+      MEM_EXT_EN                 : boolean := false;
+      MEM_EXT_TIMEOUT            : natural := 255;
+      MEM_EXT_PIPE_MODE          : boolean := false;
+      MEM_EXT_BIG_ENDIAN         : boolean := false;
+      MEM_EXT_ASYNC_RX           : boolean := false;
+      MEM_EXT_ASYNC_TX           : boolean := false;
       -- External Interrupts Controller (XIRQ) --
-      XIRQ_NUM_CH                  : natural range 0 to 32          := 0;
-      XIRQ_TRIGGER_TYPE            : std_ulogic_vector(31 downto 0) := x"ffffffff";
-      XIRQ_TRIGGER_POLARITY        : std_ulogic_vector(31 downto 0) := x"ffffffff";
+      XIRQ_NUM_CH                : natural range 0 to 32          := 0;
+      XIRQ_TRIGGER_TYPE          : std_ulogic_vector(31 downto 0) := x"ffffffff";
+      XIRQ_TRIGGER_POLARITY      : std_ulogic_vector(31 downto 0) := x"ffffffff";
       -- Processor peripherals --
-      IO_GPIO_NUM                  : natural range 0 to 64          := 0;
-      IO_MTIME_EN                  : boolean                        := false;
-      IO_UART0_EN                  : boolean                        := false;
-      IO_UART0_RX_FIFO             : natural range 1 to 2**15       := 1;
-      IO_UART0_TX_FIFO             : natural range 1 to 2**15       := 1;
-      IO_UART1_EN                  : boolean                        := false;
-      IO_UART1_RX_FIFO             : natural range 1 to 2**15       := 1;
-      IO_UART1_TX_FIFO             : natural range 1 to 2**15       := 1;
-      IO_SPI_EN                    : boolean                        := false;
-      IO_SPI_FIFO                  : natural range 1 to 2**15       := 1;
-      IO_SDI_EN                    : boolean                        := false;
-      IO_SDI_FIFO                  : natural range 1 to 2**15       := 1;
-      IO_TWI_EN                    : boolean                        := false;
-      IO_PWM_NUM_CH                : natural range 0 to 12          := 0;
-      IO_WDT_EN                    : boolean                        := false;
-      IO_TRNG_EN                   : boolean                        := false;
-      IO_TRNG_FIFO                 : natural range 1 to 2**15       := 1;
-      IO_CFS_EN                    : boolean                        := false;
-      IO_CFS_CONFIG                : std_ulogic_vector(31 downto 0) := x"00000000";
-      IO_CFS_IN_SIZE               : natural                        := 32;
-      IO_CFS_OUT_SIZE              : natural                        := 32;
-      IO_NEOLED_EN                 : boolean                        := false;
-      IO_NEOLED_TX_FIFO            : natural range 1 to 2**15       := 1;
-      IO_GPTMR_EN                  : boolean                        := false;
-      IO_XIP_EN                    : boolean                        := false;
-      IO_ONEWIRE_EN                : boolean                        := false;
-      IO_DMA_EN                    : boolean                        := false;
-      IO_SLINK_EN                  : boolean                        := false;
-      IO_SLINK_RX_FIFO             : natural range 1 to 2**15       := 1;
-      IO_SLINK_TX_FIFO             : natural range 1 to 2**15       := 1;
-      IO_CRC_EN                    : boolean                        := false
+      IO_GPIO_NUM                : natural range 0 to 64          := 0;
+      IO_MTIME_EN                : boolean                        := false;
+      IO_UART0_EN                : boolean                        := false;
+      IO_UART0_RX_FIFO           : natural range 1 to 2**15       := 1;
+      IO_UART0_TX_FIFO           : natural range 1 to 2**15       := 1;
+      IO_UART1_EN                : boolean                        := false;
+      IO_UART1_RX_FIFO           : natural range 1 to 2**15       := 1;
+      IO_UART1_TX_FIFO           : natural range 1 to 2**15       := 1;
+      IO_SPI_EN                  : boolean                        := false;
+      IO_SPI_FIFO                : natural range 1 to 2**15       := 1;
+      IO_SDI_EN                  : boolean                        := false;
+      IO_SDI_FIFO                : natural range 1 to 2**15       := 1;
+      IO_TWI_EN                  : boolean                        := false;
+      IO_PWM_NUM_CH              : natural range 0 to 12          := 0;
+      IO_WDT_EN                  : boolean                        := false;
+      IO_TRNG_EN                 : boolean                        := false;
+      IO_TRNG_FIFO               : natural range 1 to 2**15       := 1;
+      IO_CFS_EN                  : boolean                        := false;
+      IO_CFS_CONFIG              : std_ulogic_vector(31 downto 0) := x"00000000";
+      IO_CFS_IN_SIZE             : natural                        := 32;
+      IO_CFS_OUT_SIZE            : natural                        := 32;
+      IO_NEOLED_EN               : boolean                        := false;
+      IO_NEOLED_TX_FIFO          : natural range 1 to 2**15       := 1;
+      IO_GPTMR_EN                : boolean                        := false;
+      IO_XIP_EN                  : boolean                        := false;
+      IO_ONEWIRE_EN              : boolean                        := false;
+      IO_DMA_EN                  : boolean                        := false;
+      IO_SLINK_EN                : boolean                        := false;
+      IO_SLINK_RX_FIFO           : natural range 1 to 2**15       := 1;
+      IO_SLINK_TX_FIFO           : natural range 1 to 2**15       := 1;
+      IO_CRC_EN                  : boolean                        := false
     );
     port (
       -- Global control --

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -47,108 +47,107 @@ use neorv32.neorv32_package.all;
 entity neorv32_top is
   generic (
     -- General --
-    CLOCK_FREQUENCY              : natural;                                       -- clock frequency of clk_i in Hz
-    HART_ID                      : std_ulogic_vector(31 downto 0) := x"00000000"; -- hardware thread ID
-    VENDOR_ID                    : std_ulogic_vector(31 downto 0) := x"00000000"; -- vendor's JEDEC ID
-    INT_BOOTLOADER_EN            : boolean := false;                              -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
+    CLOCK_FREQUENCY            : natural;                                       -- clock frequency of clk_i in Hz
+    HART_ID                    : std_ulogic_vector(31 downto 0) := x"00000000"; -- hardware thread ID
+    VENDOR_ID                  : std_ulogic_vector(31 downto 0) := x"00000000"; -- vendor's JEDEC ID
+    INT_BOOTLOADER_EN          : boolean := false;                              -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
 
     -- On-Chip Debugger (OCD) --
-    ON_CHIP_DEBUGGER_EN          : boolean := false;                              -- implement on-chip debugger
-    DM_LEGACY_MODE               : boolean := false;                              -- debug module spec version: false = v1.0, true = v0.13
+    ON_CHIP_DEBUGGER_EN        : boolean := false;                              -- implement on-chip debugger
+    DM_LEGACY_MODE             : boolean := false;                              -- debug module spec version: false = v1.0, true = v0.13
 
     -- RISC-V CPU Extensions --
-    CPU_EXTENSION_RISCV_A        : boolean := false;                              -- implement atomic memory operations extension?
-    CPU_EXTENSION_RISCV_B        : boolean := false;                              -- implement bit-manipulation extension?
-    CPU_EXTENSION_RISCV_C        : boolean := false;                              -- implement compressed extension?
-    CPU_EXTENSION_RISCV_E        : boolean := false;                              -- implement embedded RF extension?
-    CPU_EXTENSION_RISCV_M        : boolean := false;                              -- implement mul/div extension?
-    CPU_EXTENSION_RISCV_U        : boolean := false;                              -- implement user mode extension?
-    CPU_EXTENSION_RISCV_Zfinx    : boolean := false;                              -- implement 32-bit floating-point extension (using INT regs!)
-    CPU_EXTENSION_RISCV_Zicntr   : boolean := true;                               -- implement base counters?
-    CPU_EXTENSION_RISCV_Zihpm    : boolean := false;                              -- implement hardware performance monitors?
-    CPU_EXTENSION_RISCV_Zifencei : boolean := false;                              -- implement instruction stream sync.?
-    CPU_EXTENSION_RISCV_Zmmul    : boolean := false;                              -- implement multiply-only M sub-extension?
-    CPU_EXTENSION_RISCV_Zxcfu    : boolean := false;                              -- implement custom (instr.) functions unit?
+    CPU_EXTENSION_RISCV_A      : boolean := false;                              -- implement atomic memory operations extension?
+    CPU_EXTENSION_RISCV_B      : boolean := false;                              -- implement bit-manipulation extension?
+    CPU_EXTENSION_RISCV_C      : boolean := false;                              -- implement compressed extension?
+    CPU_EXTENSION_RISCV_E      : boolean := false;                              -- implement embedded RF extension?
+    CPU_EXTENSION_RISCV_M      : boolean := false;                              -- implement mul/div extension?
+    CPU_EXTENSION_RISCV_U      : boolean := false;                              -- implement user mode extension?
+    CPU_EXTENSION_RISCV_Zfinx  : boolean := false;                              -- implement 32-bit floating-point extension (using INT regs!)
+    CPU_EXTENSION_RISCV_Zicntr : boolean := true;                               -- implement base counters?
+    CPU_EXTENSION_RISCV_Zihpm  : boolean := false;                              -- implement hardware performance monitors?
+    CPU_EXTENSION_RISCV_Zmmul  : boolean := false;                              -- implement multiply-only M sub-extension?
+    CPU_EXTENSION_RISCV_Zxcfu  : boolean := false;                              -- implement custom (instr.) functions unit?
 
     -- Tuning Options --
-    FAST_MUL_EN                  : boolean := false;                              -- use DSPs for M extension's multiplier
-    FAST_SHIFT_EN                : boolean := false;                              -- use barrel shifter for shift operations
+    FAST_MUL_EN                : boolean := false;                              -- use DSPs for M extension's multiplier
+    FAST_SHIFT_EN              : boolean := false;                              -- use barrel shifter for shift operations
 
     -- Physical Memory Protection (PMP) --
-    PMP_NUM_REGIONS              : natural range 0 to 16 := 0;                    -- number of regions (0..16)
-    PMP_MIN_GRANULARITY          : natural := 4;                                  -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
+    PMP_NUM_REGIONS            : natural range 0 to 16 := 0;                    -- number of regions (0..16)
+    PMP_MIN_GRANULARITY        : natural := 4;                                  -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
 
     -- Hardware Performance Monitors (HPM) --
-    HPM_NUM_CNTS                 : natural range 0 to 13 := 0;                    -- number of implemented HPM counters (0..13)
-    HPM_CNT_WIDTH                : natural range 0 to 64 := 40;                   -- total size of HPM counters (0..64)
+    HPM_NUM_CNTS               : natural range 0 to 13 := 0;                    -- number of implemented HPM counters (0..13)
+    HPM_CNT_WIDTH              : natural range 0 to 64 := 40;                   -- total size of HPM counters (0..64)
 
     -- Atomic Memory Access - Reservation Set Granularity --
-    AMO_RVS_GRANULARITY          : natural := 4;                                  -- size in bytes, has to be a power of 2, min 4
+    AMO_RVS_GRANULARITY        : natural := 4;                                  -- size in bytes, has to be a power of 2, min 4
 
     -- Internal Instruction memory (IMEM) --
-    MEM_INT_IMEM_EN              : boolean := false;                              -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE            : natural := 16*1024;                            -- size of processor-internal instruction memory in bytes (use a power of 2)
+    MEM_INT_IMEM_EN            : boolean := false;                              -- implement processor-internal instruction memory
+    MEM_INT_IMEM_SIZE          : natural := 16*1024;                            -- size of processor-internal instruction memory in bytes (use a power of 2)
 
     -- Internal Data memory (DMEM) --
-    MEM_INT_DMEM_EN              : boolean := false;                              -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE            : natural := 8*1024;                             -- size of processor-internal data memory in bytes (use a power of 2)
+    MEM_INT_DMEM_EN            : boolean := false;                              -- implement processor-internal data memory
+    MEM_INT_DMEM_SIZE          : natural := 8*1024;                             -- size of processor-internal data memory in bytes (use a power of 2)
 
     -- Internal Instruction Cache (iCACHE) --
-    ICACHE_EN                    : boolean                  := false;             -- implement instruction cache
-    ICACHE_NUM_BLOCKS            : natural range 1 to 256   := 4;                 -- i-cache: number of blocks (min 1), has to be a power of 2
-    ICACHE_BLOCK_SIZE            : natural range 4 to 2**16 := 64;                -- i-cache: block size in bytes (min 4), has to be a power of 2
-    ICACHE_ASSOCIATIVITY         : natural range 1 to 2     := 1;                 -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
+    ICACHE_EN                  : boolean                  := false;             -- implement instruction cache
+    ICACHE_NUM_BLOCKS          : natural range 1 to 256   := 4;                 -- i-cache: number of blocks (min 1), has to be a power of 2
+    ICACHE_BLOCK_SIZE          : natural range 4 to 2**16 := 64;                -- i-cache: block size in bytes (min 4), has to be a power of 2
+    ICACHE_ASSOCIATIVITY       : natural range 1 to 2     := 1;                 -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
 
     -- Internal Data Cache (dCACHE) --
-    DCACHE_EN                    : boolean                  := false;             -- implement data cache
-    DCACHE_NUM_BLOCKS            : natural range 1 to 256   := 4;                 -- d-cache: number of blocks (min 1), has to be a power of 2
-    DCACHE_BLOCK_SIZE            : natural range 4 to 2**16 := 64;                -- d-cache: block size in bytes (min 4), has to be a power of 2
+    DCACHE_EN                  : boolean                  := false;             -- implement data cache
+    DCACHE_NUM_BLOCKS          : natural range 1 to 256   := 4;                 -- d-cache: number of blocks (min 1), has to be a power of 2
+    DCACHE_BLOCK_SIZE          : natural range 4 to 2**16 := 64;                -- d-cache: block size in bytes (min 4), has to be a power of 2
 
     -- External memory interface (WISHBONE) --
-    MEM_EXT_EN                   : boolean := false;                              -- implement external memory bus interface?
-    MEM_EXT_TIMEOUT              : natural := 255;                                -- cycles after a pending bus access auto-terminates (0 = disabled)
-    MEM_EXT_PIPE_MODE            : boolean := false;                              -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
-    MEM_EXT_BIG_ENDIAN           : boolean := false;                              -- byte order: true=big-endian, false=little-endian
-    MEM_EXT_ASYNC_RX             : boolean := false;                              -- use register buffer for RX data when false
-    MEM_EXT_ASYNC_TX             : boolean := false;                              -- use register buffer for TX data when false
+    MEM_EXT_EN                 : boolean := false;                              -- implement external memory bus interface?
+    MEM_EXT_TIMEOUT            : natural := 255;                                -- cycles after a pending bus access auto-terminates (0 = disabled)
+    MEM_EXT_PIPE_MODE          : boolean := false;                              -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
+    MEM_EXT_BIG_ENDIAN         : boolean := false;                              -- byte order: true=big-endian, false=little-endian
+    MEM_EXT_ASYNC_RX           : boolean := false;                              -- use register buffer for RX data when false
+    MEM_EXT_ASYNC_TX           : boolean := false;                              -- use register buffer for TX data when false
 
     -- External Interrupts Controller (XIRQ) --
-    XIRQ_NUM_CH                  : natural range 0 to 32          := 0;           -- number of external IRQ channels (0..32)
-    XIRQ_TRIGGER_TYPE            : std_ulogic_vector(31 downto 0) := x"ffffffff"; -- trigger type: 0=level, 1=edge
-    XIRQ_TRIGGER_POLARITY        : std_ulogic_vector(31 downto 0) := x"ffffffff"; -- trigger polarity: 0=low-level/falling-edge, 1=high-level/rising-edge
+    XIRQ_NUM_CH                : natural range 0 to 32          := 0;           -- number of external IRQ channels (0..32)
+    XIRQ_TRIGGER_TYPE          : std_ulogic_vector(31 downto 0) := x"ffffffff"; -- trigger type: 0=level, 1=edge
+    XIRQ_TRIGGER_POLARITY      : std_ulogic_vector(31 downto 0) := x"ffffffff"; -- trigger polarity: 0=low-level/falling-edge, 1=high-level/rising-edge
 
     -- Processor peripherals --
-    IO_GPIO_NUM                  : natural range 0 to 64          := 0;           -- number of GPIO input/output pairs (0..64)
-    IO_MTIME_EN                  : boolean                        := false;       -- implement machine system timer (MTIME)?
-    IO_UART0_EN                  : boolean                        := false;       -- implement primary universal asynchronous receiver/transmitter (UART0)?
-    IO_UART0_RX_FIFO             : natural range 1 to 2**15       := 1;           -- RX fifo depth, has to be a power of two, min 1
-    IO_UART0_TX_FIFO             : natural range 1 to 2**15       := 1;           -- TX fifo depth, has to be a power of two, min 1
-    IO_UART1_EN                  : boolean                        := false;       -- implement secondary universal asynchronous receiver/transmitter (UART1)?
-    IO_UART1_RX_FIFO             : natural range 1 to 2**15       := 1;           -- RX fifo depth, has to be a power of two, min 1
-    IO_UART1_TX_FIFO             : natural range 1 to 2**15       := 1;           -- TX fifo depth, has to be a power of two, min 1
-    IO_SPI_EN                    : boolean                        := false;       -- implement serial peripheral interface (SPI)?
-    IO_SPI_FIFO                  : natural range 1 to 2**15       := 1;           -- RTX fifo depth, has to be a power of two, min 1
-    IO_SDI_EN                    : boolean                        := false;       -- implement serial data interface (SDI)?
-    IO_SDI_FIFO                  : natural range 1 to 2**15       := 1;           -- RTX fifo depth, has to be zero or a power of two, min 1
-    IO_TWI_EN                    : boolean                        := false;       -- implement two-wire interface (TWI)?
-    IO_PWM_NUM_CH                : natural range 0 to 12          := 0;           -- number of PWM channels to implement (0..12); 0 = disabled
-    IO_WDT_EN                    : boolean                        := false;       -- implement watch dog timer (WDT)?
-    IO_TRNG_EN                   : boolean                        := false;       -- implement true random number generator (TRNG)?
-    IO_TRNG_FIFO                 : natural range 1 to 2**15       := 1;           -- data fifo depth, has to be a power of two, min 1
-    IO_CFS_EN                    : boolean                        := false;       -- implement custom functions subsystem (CFS)?
-    IO_CFS_CONFIG                : std_ulogic_vector(31 downto 0) := x"00000000"; -- custom CFS configuration generic
-    IO_CFS_IN_SIZE               : natural                        := 32;          -- size of CFS input conduit in bits
-    IO_CFS_OUT_SIZE              : natural                        := 32;          -- size of CFS output conduit in bits
-    IO_NEOLED_EN                 : boolean                        := false;       -- implement NeoPixel-compatible smart LED interface (NEOLED)?
-    IO_NEOLED_TX_FIFO            : natural range 1 to 2**15       := 1;           -- NEOLED FIFO depth, has to be a power of two, min 1
-    IO_GPTMR_EN                  : boolean                        := false;       -- implement general purpose timer (GPTMR)?
-    IO_XIP_EN                    : boolean                        := false;       -- implement execute in place module (XIP)?
-    IO_ONEWIRE_EN                : boolean                        := false;       -- implement 1-wire interface (ONEWIRE)?
-    IO_DMA_EN                    : boolean                        := false;       -- implement direct memory access controller (DMA)?
-    IO_SLINK_EN                  : boolean                        := false;       -- implement stream link interface (SLINK)?
-    IO_SLINK_RX_FIFO             : natural range 1 to 2**15       := 1;           -- RX fifo depth, has to be a power of two, min 1
-    IO_SLINK_TX_FIFO             : natural range 1 to 2**15       := 1;           -- TX fifo depth, has to be a power of two, min 1
-    IO_CRC_EN                    : boolean                        := false        -- implement cyclic redundancy check unit (CRC)?
+    IO_GPIO_NUM                : natural range 0 to 64          := 0;           -- number of GPIO input/output pairs (0..64)
+    IO_MTIME_EN                : boolean                        := false;       -- implement machine system timer (MTIME)?
+    IO_UART0_EN                : boolean                        := false;       -- implement primary universal asynchronous receiver/transmitter (UART0)?
+    IO_UART0_RX_FIFO           : natural range 1 to 2**15       := 1;           -- RX fifo depth, has to be a power of two, min 1
+    IO_UART0_TX_FIFO           : natural range 1 to 2**15       := 1;           -- TX fifo depth, has to be a power of two, min 1
+    IO_UART1_EN                : boolean                        := false;       -- implement secondary universal asynchronous receiver/transmitter (UART1)?
+    IO_UART1_RX_FIFO           : natural range 1 to 2**15       := 1;           -- RX fifo depth, has to be a power of two, min 1
+    IO_UART1_TX_FIFO           : natural range 1 to 2**15       := 1;           -- TX fifo depth, has to be a power of two, min 1
+    IO_SPI_EN                  : boolean                        := false;       -- implement serial peripheral interface (SPI)?
+    IO_SPI_FIFO                : natural range 1 to 2**15       := 1;           -- RTX fifo depth, has to be a power of two, min 1
+    IO_SDI_EN                  : boolean                        := false;       -- implement serial data interface (SDI)?
+    IO_SDI_FIFO                : natural range 1 to 2**15       := 1;           -- RTX fifo depth, has to be zero or a power of two, min 1
+    IO_TWI_EN                  : boolean                        := false;       -- implement two-wire interface (TWI)?
+    IO_PWM_NUM_CH              : natural range 0 to 12          := 0;           -- number of PWM channels to implement (0..12); 0 = disabled
+    IO_WDT_EN                  : boolean                        := false;       -- implement watch dog timer (WDT)?
+    IO_TRNG_EN                 : boolean                        := false;       -- implement true random number generator (TRNG)?
+    IO_TRNG_FIFO               : natural range 1 to 2**15       := 1;           -- data fifo depth, has to be a power of two, min 1
+    IO_CFS_EN                  : boolean                        := false;       -- implement custom functions subsystem (CFS)?
+    IO_CFS_CONFIG              : std_ulogic_vector(31 downto 0) := x"00000000"; -- custom CFS configuration generic
+    IO_CFS_IN_SIZE             : natural                        := 32;          -- size of CFS input conduit in bits
+    IO_CFS_OUT_SIZE            : natural                        := 32;          -- size of CFS output conduit in bits
+    IO_NEOLED_EN               : boolean                        := false;       -- implement NeoPixel-compatible smart LED interface (NEOLED)?
+    IO_NEOLED_TX_FIFO          : natural range 1 to 2**15       := 1;           -- NEOLED FIFO depth, has to be a power of two, min 1
+    IO_GPTMR_EN                : boolean                        := false;       -- implement general purpose timer (GPTMR)?
+    IO_XIP_EN                  : boolean                        := false;       -- implement execute in place module (XIP)?
+    IO_ONEWIRE_EN              : boolean                        := false;       -- implement 1-wire interface (ONEWIRE)?
+    IO_DMA_EN                  : boolean                        := false;       -- implement direct memory access controller (DMA)?
+    IO_SLINK_EN                : boolean                        := false;       -- implement stream link interface (SLINK)?
+    IO_SLINK_RX_FIFO           : natural range 1 to 2**15       := 1;           -- RX fifo depth, has to be a power of two, min 1
+    IO_SLINK_TX_FIFO           : natural range 1 to 2**15       := 1;           -- TX fifo depth, has to be a power of two, min 1
+    IO_CRC_EN                  : boolean                        := false        -- implement cyclic redundancy check unit (CRC)?
   );
   port (
     -- Global control --
@@ -380,10 +379,6 @@ begin
       "NEORV32 PROCESSOR CONFIG WARNING: Configured internal DMEM size (" & natural'image(MEM_INT_DMEM_SIZE) & " bytes) is not a power of two. " &
       "Auto-adjusting memory size to the next power of two (" & natural'image(dmem_size_c) & " bytes)" severity warning;
 
-    -- caches --
-    assert not ((ICACHE_EN = true) and (CPU_EXTENSION_RISCV_Zifencei = false)) report
-      "NEORV32 CPU CONFIG ERROR: <CPU_EXTENSION_RISCV_Zifencei> ISA extension is required to perform i-cache memory sync. operations." severity error;
-
   end generate; -- /sanity_checks
 
 
@@ -480,35 +475,34 @@ begin
     neorv32_cpu_inst: entity neorv32.neorv32_cpu
     generic map (
       -- General --
-      HART_ID                      => HART_ID,
-      VENDOR_ID                    => VENDOR_ID,
-      CPU_BOOT_ADDR                => cpu_boot_addr_c,
-      CPU_DEBUG_PARK_ADDR          => dm_park_entry_c,
-      CPU_DEBUG_EXC_ADDR           => dm_exc_entry_c,
+      HART_ID                    => HART_ID,
+      VENDOR_ID                  => VENDOR_ID,
+      CPU_BOOT_ADDR              => cpu_boot_addr_c,
+      CPU_DEBUG_PARK_ADDR        => dm_park_entry_c,
+      CPU_DEBUG_EXC_ADDR         => dm_exc_entry_c,
       -- RISC-V CPU Extensions --
-      CPU_EXTENSION_RISCV_A        => CPU_EXTENSION_RISCV_A,
-      CPU_EXTENSION_RISCV_B        => CPU_EXTENSION_RISCV_B,
-      CPU_EXTENSION_RISCV_C        => CPU_EXTENSION_RISCV_C,
-      CPU_EXTENSION_RISCV_E        => CPU_EXTENSION_RISCV_E,
-      CPU_EXTENSION_RISCV_M        => CPU_EXTENSION_RISCV_M,
-      CPU_EXTENSION_RISCV_U        => CPU_EXTENSION_RISCV_U,
-      CPU_EXTENSION_RISCV_Zfinx    => CPU_EXTENSION_RISCV_Zfinx,
-      CPU_EXTENSION_RISCV_Zicntr   => CPU_EXTENSION_RISCV_Zicntr,
-      CPU_EXTENSION_RISCV_Zihpm    => CPU_EXTENSION_RISCV_Zihpm,
-      CPU_EXTENSION_RISCV_Zifencei => CPU_EXTENSION_RISCV_Zifencei,
-      CPU_EXTENSION_RISCV_Zmmul    => CPU_EXTENSION_RISCV_Zmmul,
-      CPU_EXTENSION_RISCV_Zxcfu    => CPU_EXTENSION_RISCV_Zxcfu,
-      CPU_EXTENSION_RISCV_Sdext    => ON_CHIP_DEBUGGER_EN,
-      CPU_EXTENSION_RISCV_Sdtrig   => ON_CHIP_DEBUGGER_EN,
+      CPU_EXTENSION_RISCV_A      => CPU_EXTENSION_RISCV_A,
+      CPU_EXTENSION_RISCV_B      => CPU_EXTENSION_RISCV_B,
+      CPU_EXTENSION_RISCV_C      => CPU_EXTENSION_RISCV_C,
+      CPU_EXTENSION_RISCV_E      => CPU_EXTENSION_RISCV_E,
+      CPU_EXTENSION_RISCV_M      => CPU_EXTENSION_RISCV_M,
+      CPU_EXTENSION_RISCV_U      => CPU_EXTENSION_RISCV_U,
+      CPU_EXTENSION_RISCV_Zfinx  => CPU_EXTENSION_RISCV_Zfinx,
+      CPU_EXTENSION_RISCV_Zicntr => CPU_EXTENSION_RISCV_Zicntr,
+      CPU_EXTENSION_RISCV_Zihpm  => CPU_EXTENSION_RISCV_Zihpm,
+      CPU_EXTENSION_RISCV_Zmmul  => CPU_EXTENSION_RISCV_Zmmul,
+      CPU_EXTENSION_RISCV_Zxcfu  => CPU_EXTENSION_RISCV_Zxcfu,
+      CPU_EXTENSION_RISCV_Sdext  => ON_CHIP_DEBUGGER_EN,
+      CPU_EXTENSION_RISCV_Sdtrig => ON_CHIP_DEBUGGER_EN,
       -- Tuning Options --
-      FAST_MUL_EN                  => FAST_MUL_EN,
-      FAST_SHIFT_EN                => FAST_SHIFT_EN,
+      FAST_MUL_EN                => FAST_MUL_EN,
+      FAST_SHIFT_EN              => FAST_SHIFT_EN,
       -- Physical Memory Protection (PMP) --
-      PMP_NUM_REGIONS              => PMP_NUM_REGIONS,
-      PMP_MIN_GRANULARITY          => PMP_MIN_GRANULARITY,
+      PMP_NUM_REGIONS            => PMP_NUM_REGIONS,
+      PMP_MIN_GRANULARITY        => PMP_MIN_GRANULARITY,
       -- Hardware Performance Monitors (HPM) --
-      HPM_NUM_CNTS                 => HPM_NUM_CNTS,
-      HPM_CNT_WIDTH                => HPM_CNT_WIDTH
+      HPM_NUM_CNTS               => HPM_NUM_CNTS,
+      HPM_CNT_WIDTH              => HPM_CNT_WIDTH
     )
     port map (
       -- global control --

--- a/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_UP5KDemo.vhd
@@ -102,26 +102,25 @@ begin
   neorv32_inst: entity neorv32.neorv32_top
   generic map (
     -- General --
-    CLOCK_FREQUENCY              => CLOCK_FREQUENCY,   -- clock frequency of clk_i in Hz
-    INT_BOOTLOADER_EN            => true,              -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
+    CLOCK_FREQUENCY            => CLOCK_FREQUENCY,   -- clock frequency of clk_i in Hz
+    INT_BOOTLOADER_EN          => true,              -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
     -- RISC-V CPU Extensions --
-    CPU_EXTENSION_RISCV_M        => true,              -- implement mul/div extension?
-    CPU_EXTENSION_RISCV_U        => true,              -- implement user mode extension?
-    CPU_EXTENSION_RISCV_Zicntr   => true,                          -- implement base counters?
-    CPU_EXTENSION_RISCV_Zifencei => true,              -- implement instruction stream sync.?
+    CPU_EXTENSION_RISCV_M      => true,              -- implement mul/div extension?
+    CPU_EXTENSION_RISCV_U      => true,              -- implement user mode extension?
+    CPU_EXTENSION_RISCV_Zicntr => true,                          -- implement base counters?
     -- Internal Instruction memory --
-    MEM_INT_IMEM_EN              => MEM_INT_IMEM_EN,   -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE            => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes
+    MEM_INT_IMEM_EN            => MEM_INT_IMEM_EN,   -- implement processor-internal instruction memory
+    MEM_INT_IMEM_SIZE          => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes
     -- Internal Data memory --
-    MEM_INT_DMEM_EN              => MEM_INT_DMEM_EN,   -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE            => MEM_INT_DMEM_SIZE, -- size of processor-internal data memory in bytes
+    MEM_INT_DMEM_EN            => MEM_INT_DMEM_EN,   -- implement processor-internal data memory
+    MEM_INT_DMEM_SIZE          => MEM_INT_DMEM_SIZE, -- size of processor-internal data memory in bytes
     -- Processor peripherals --
-    IO_GPIO_NUM                  => IO_GPIO_NUM,       -- number of GPIO input/output pairs (0..64)
-    IO_MTIME_EN                  => true,              -- implement machine system timer (MTIME)?
-    IO_UART0_EN                  => true,              -- implement primary universal asynchronous receiver/transmitter (UART0)?
-    IO_SPI_EN                    => true,              -- implement serial peripheral interface (SPI)?
-    IO_TWI_EN                    => true,              -- implement two-wire interface (TWI)?
-    IO_PWM_NUM_CH                => IO_PWM_NUM_CH      -- number of PWM channels to implement (0..12); 0 = disabled
+    IO_GPIO_NUM                => IO_GPIO_NUM,       -- number of GPIO input/output pairs (0..64)
+    IO_MTIME_EN                => true,              -- implement machine system timer (MTIME)?
+    IO_UART0_EN                => true,              -- implement primary universal asynchronous receiver/transmitter (UART0)?
+    IO_SPI_EN                  => true,              -- implement serial peripheral interface (SPI)?
+    IO_TWI_EN                  => true,              -- implement two-wire interface (TWI)?
+    IO_PWM_NUM_CH              => IO_PWM_NUM_CH      -- number of PWM channels to implement (0..12); 0 = disabled
   )
   port map (
     -- Global control --

--- a/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_AvalonMM.vhd
@@ -62,7 +62,6 @@ entity neorv32_top_avalonmm is
     CPU_EXTENSION_RISCV_Zfinx    : boolean := false;  -- implement 32-bit floating-point extension (using INT regs!)
     CPU_EXTENSION_RISCV_Zicntr   : boolean := true;   -- implement base counters?
     CPU_EXTENSION_RISCV_Zihpm    : boolean := false;  -- implement hardware performance monitors?
-    CPU_EXTENSION_RISCV_Zifencei : boolean := false;  -- implement instruction stream sync.?
     CPU_EXTENSION_RISCV_Zmmul    : boolean := false;  -- implement multiply-only M sub-extension?
     CPU_EXTENSION_RISCV_Zxcfu    : boolean := false;  -- implement custom (instr.) functions unit?
 
@@ -246,7 +245,6 @@ begin
     CPU_EXTENSION_RISCV_Zfinx => CPU_EXTENSION_RISCV_Zfinx,
     CPU_EXTENSION_RISCV_Zicntr => CPU_EXTENSION_RISCV_Zicntr,
     CPU_EXTENSION_RISCV_Zihpm => CPU_EXTENSION_RISCV_Zihpm,
-    CPU_EXTENSION_RISCV_Zifencei => CPU_EXTENSION_RISCV_Zifencei,
     CPU_EXTENSION_RISCV_Zmmul => CPU_EXTENSION_RISCV_Zmmul,
     CPU_EXTENSION_RISCV_Zxcfu => CPU_EXTENSION_RISCV_Zxcfu,
 

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -64,7 +64,6 @@ entity neorv32_SystemTop_axi4lite is
     CPU_EXTENSION_RISCV_Zfinx    : boolean := false;  -- implement 32-bit floating-point extension (using INT reg!)
     CPU_EXTENSION_RISCV_Zicntr   : boolean := true;   -- implement base counters?
     CPU_EXTENSION_RISCV_Zihpm    : boolean := false;  -- implement hardware performance monitors?
-    CPU_EXTENSION_RISCV_Zifencei : boolean := false;  -- implement instruction stream sync.?
     CPU_EXTENSION_RISCV_Zmmul    : boolean := false;  -- implement multiply-only M sub-extension?
     CPU_EXTENSION_RISCV_Zxcfu    : boolean := false;  -- implement custom (instr.) functions unit?
     -- Extension Options --
@@ -352,7 +351,6 @@ begin
     CPU_EXTENSION_RISCV_Zfinx    => CPU_EXTENSION_RISCV_Zfinx,    -- implement 32-bit floating-point extension (using INT reg!)
     CPU_EXTENSION_RISCV_Zicntr   => CPU_EXTENSION_RISCV_Zicntr,   -- implement base counters?
     CPU_EXTENSION_RISCV_Zihpm    => CPU_EXTENSION_RISCV_Zihpm,    -- implement hardware performance monitors?
-    CPU_EXTENSION_RISCV_Zifencei => CPU_EXTENSION_RISCV_Zifencei, -- implement instruction stream sync.?
     CPU_EXTENSION_RISCV_Zmmul    => CPU_EXTENSION_RISCV_Zmmul,    -- implement multiply-only M sub-extension?
     CPU_EXTENSION_RISCV_Zxcfu    => CPU_EXTENSION_RISCV_Zxcfu,    -- implement custom (instr.) functions unit?
     -- Extension Options --

--- a/rtl/system_integration/neorv32_litex_core_complex.vhd
+++ b/rtl/system_integration/neorv32_litex_core_complex.vhd
@@ -167,45 +167,44 @@ begin
   neorv32_core_complex: neorv32_top
   generic map (
     -- General --
-    CLOCK_FREQUENCY              => 0,                              -- clock frequency of clk_i in Hz [not required by the core complex]
-    HART_ID                      => hart_id_c,                      -- hardware thread ID
-    VENDOR_ID                    => jedec_id_c,                     -- vendor's JEDEC ID
+    CLOCK_FREQUENCY            => 0,                              -- clock frequency of clk_i in Hz [not required by the core complex]
+    HART_ID                    => hart_id_c,                      -- hardware thread ID
+    VENDOR_ID                  => jedec_id_c,                     -- vendor's JEDEC ID
     -- On-Chip Debugger (OCD) --
-    ON_CHIP_DEBUGGER_EN          => DEBUG,                          -- implement on-chip debugger
+    ON_CHIP_DEBUGGER_EN        => DEBUG,                          -- implement on-chip debugger
     -- RISC-V CPU Extensions --
-    CPU_EXTENSION_RISCV_C        => configs_c.riscv_c(CONFIG),      -- implement compressed extension?
-    CPU_EXTENSION_RISCV_M        => configs_c.riscv_m(CONFIG),      -- implement mul/div extension?
-    CPU_EXTENSION_RISCV_U        => configs_c.riscv_u(CONFIG),      -- implement user mode extension?
-    CPU_EXTENSION_RISCV_Zicntr   => configs_c.riscv_zicntr(CONFIG), -- implement base counters?
-    CPU_EXTENSION_RISCV_Zihpm    => configs_c.riscv_zihpm(CONFIG),  -- implement hardware performance monitors?
-    CPU_EXTENSION_RISCV_Zifencei => true,                           -- implement instruction stream sync.?
+    CPU_EXTENSION_RISCV_C      => configs_c.riscv_c(CONFIG),      -- implement compressed extension?
+    CPU_EXTENSION_RISCV_M      => configs_c.riscv_m(CONFIG),      -- implement mul/div extension?
+    CPU_EXTENSION_RISCV_U      => configs_c.riscv_u(CONFIG),      -- implement user mode extension?
+    CPU_EXTENSION_RISCV_Zicntr => configs_c.riscv_zicntr(CONFIG), -- implement base counters?
+    CPU_EXTENSION_RISCV_Zihpm  => configs_c.riscv_zihpm(CONFIG),  -- implement hardware performance monitors?
     -- Tuning Options --
-    FAST_MUL_EN                  => configs_c.fast_ops(CONFIG),     -- use DSPs for M extension's multiplier
-    FAST_SHIFT_EN                => configs_c.fast_ops(CONFIG),     -- use barrel shifter for shift operations
+    FAST_MUL_EN                => configs_c.fast_ops(CONFIG),     -- use DSPs for M extension's multiplier
+    FAST_SHIFT_EN              => configs_c.fast_ops(CONFIG),     -- use barrel shifter for shift operations
     -- Physical Memory Protection (PMP) --
-    PMP_NUM_REGIONS              => configs_c.pmp_nr(CONFIG),       -- number of regions (0..16)
-    PMP_MIN_GRANULARITY          => 4,                              -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
+    PMP_NUM_REGIONS            => configs_c.pmp_nr(CONFIG),       -- number of regions (0..16)
+    PMP_MIN_GRANULARITY        => 4,                              -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
     -- Hardware Performance Monitors (HPM) --
-    HPM_NUM_CNTS                 => configs_c.hpm_nr(CONFIG),       -- number of implemented HPM counters (0..29)
-    HPM_CNT_WIDTH                => 64,                             -- total size of HPM counters (0..64)
+    HPM_NUM_CNTS               => configs_c.hpm_nr(CONFIG),       -- number of implemented HPM counters (0..29)
+    HPM_CNT_WIDTH              => 64,                             -- total size of HPM counters (0..64)
     -- Internal Instruction Cache (iCACHE) --
-    ICACHE_EN                    => configs_c.icache_en(CONFIG),    -- implement instruction cache
-    ICACHE_NUM_BLOCKS            => configs_c.icache_nb(CONFIG),    -- i-cache: number of blocks (min 1), has to be a power of 2
-    ICACHE_BLOCK_SIZE            => configs_c.icache_bs(CONFIG),    -- i-cache: block size in bytes (min 4), has to be a power of 2
-    ICACHE_ASSOCIATIVITY         => configs_c.icache_as(CONFIG),    -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
+    ICACHE_EN                  => configs_c.icache_en(CONFIG),    -- implement instruction cache
+    ICACHE_NUM_BLOCKS          => configs_c.icache_nb(CONFIG),    -- i-cache: number of blocks (min 1), has to be a power of 2
+    ICACHE_BLOCK_SIZE          => configs_c.icache_bs(CONFIG),    -- i-cache: block size in bytes (min 4), has to be a power of 2
+    ICACHE_ASSOCIATIVITY       => configs_c.icache_as(CONFIG),    -- i-cache: associativity / number of sets (1=direct_mapped), has to be a power of 2
     -- Internal Data Cache (dCACHE) --
-    DCACHE_EN                    => configs_c.dcache_en(CONFIG),    -- implement data cache
-    DCACHE_NUM_BLOCKS            => configs_c.dcache_nb(CONFIG),    -- d-cache: number of blocks (min 1), has to be a power of 2
-    DCACHE_BLOCK_SIZE            => configs_c.dcache_bs(CONFIG),    -- d-cache: block size in bytes (min 4), has to be a power of 2
+    DCACHE_EN                  => configs_c.dcache_en(CONFIG),    -- implement data cache
+    DCACHE_NUM_BLOCKS          => configs_c.dcache_nb(CONFIG),    -- d-cache: number of blocks (min 1), has to be a power of 2
+    DCACHE_BLOCK_SIZE          => configs_c.dcache_bs(CONFIG),    -- d-cache: block size in bytes (min 4), has to be a power of 2
     -- External memory interface (WISHBONE) --
-    MEM_EXT_EN                   => true,                           -- implement external memory bus interface?
-    MEM_EXT_TIMEOUT              => wb_timeout_c,                   -- cycles after a pending bus access auto-terminates (0 = disabled)
-    MEM_EXT_PIPE_MODE            => true,                           -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
-    MEM_EXT_BIG_ENDIAN           => big_endian_c,                   -- byte order: true=big-endian, false=little-endian
-    MEM_EXT_ASYNC_RX             => true,                           -- use register buffer for RX data when false
-    MEM_EXT_ASYNC_TX             => true,                           -- use register buffer for TX data when false
+    MEM_EXT_EN                 => true,                           -- implement external memory bus interface?
+    MEM_EXT_TIMEOUT            => wb_timeout_c,                   -- cycles after a pending bus access auto-terminates (0 = disabled)
+    MEM_EXT_PIPE_MODE          => true,                           -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
+    MEM_EXT_BIG_ENDIAN         => big_endian_c,                   -- byte order: true=big-endian, false=little-endian
+    MEM_EXT_ASYNC_RX           => true,                           -- use register buffer for RX data when false
+    MEM_EXT_ASYNC_TX           => true,                           -- use register buffer for TX data when false
     -- Processor peripherals --
-    IO_MTIME_EN                  => configs_c.mtime(CONFIG)         -- implement machine system timer (MTIME)?
+    IO_MTIME_EN                => configs_c.mtime(CONFIG)         -- implement machine system timer (MTIME)?
   )
   port map (
     -- Global control --

--- a/rtl/test_setups/neorv32_test_setup_on_chip_debugger.vhd
+++ b/rtl/test_setups/neorv32_test_setup_on_chip_debugger.vhd
@@ -75,26 +75,25 @@ begin
   neorv32_top_inst: neorv32_top
   generic map (
     -- General --
-    CLOCK_FREQUENCY              => CLOCK_FREQUENCY,   -- clock frequency of clk_i in Hz
-    INT_BOOTLOADER_EN            => true,              -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
+    CLOCK_FREQUENCY            => CLOCK_FREQUENCY,   -- clock frequency of clk_i in Hz
+    INT_BOOTLOADER_EN          => true,              -- boot configuration: true = boot explicit bootloader; false = boot from int/ext (I)MEM
     -- On-Chip Debugger (OCD) --
-    ON_CHIP_DEBUGGER_EN          => true,              -- implement on-chip debugger
+    ON_CHIP_DEBUGGER_EN        => true,              -- implement on-chip debugger
     -- RISC-V CPU Extensions --
-    CPU_EXTENSION_RISCV_C        => true,              -- implement compressed extension?
-    CPU_EXTENSION_RISCV_M        => true,              -- implement mul/div extension?
-    CPU_EXTENSION_RISCV_U        => true,              -- implement user mode extension?
-    CPU_EXTENSION_RISCV_Zicntr   => true,              -- implement base counters?
-    CPU_EXTENSION_RISCV_Zifencei => true,              -- implement instruction stream sync.? (required for the on-chip debugger)
+    CPU_EXTENSION_RISCV_C      => true,              -- implement compressed extension?
+    CPU_EXTENSION_RISCV_M      => true,              -- implement mul/div extension?
+    CPU_EXTENSION_RISCV_U      => true,              -- implement user mode extension?
+    CPU_EXTENSION_RISCV_Zicntr => true,              -- implement base counters?
     -- Internal Instruction memory --
-    MEM_INT_IMEM_EN              => true,              -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE            => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes
+    MEM_INT_IMEM_EN            => true,              -- implement processor-internal instruction memory
+    MEM_INT_IMEM_SIZE          => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes
     -- Internal Data memory --
-    MEM_INT_DMEM_EN              => true,              -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE            => MEM_INT_DMEM_SIZE, -- size of processor-internal data memory in bytes
+    MEM_INT_DMEM_EN            => true,              -- implement processor-internal data memory
+    MEM_INT_DMEM_SIZE          => MEM_INT_DMEM_SIZE, -- size of processor-internal data memory in bytes
     -- Processor peripherals --
-    IO_GPIO_NUM                  => 8,                 -- number of GPIO input/output pairs (0..64)
-    IO_MTIME_EN                  => true,              -- implement machine system timer (MTIME)?
-    IO_UART0_EN                  => true               -- implement primary universal asynchronous receiver/transmitter (UART0)?
+    IO_GPIO_NUM                => 8,                 -- number of GPIO input/output pairs (0..64)
+    IO_MTIME_EN                => true,              -- implement machine system timer (MTIME)?
+    IO_UART0_EN                => true               -- implement primary universal asynchronous receiver/transmitter (UART0)?
   )
   port map (
     -- Global control --

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -233,7 +233,6 @@ begin
     CPU_EXTENSION_RISCV_Zfinx    => true,          -- implement 32-bit floating-point extension (using INT reg!)
     CPU_EXTENSION_RISCV_Zicntr   => true,          -- implement base counters?
     CPU_EXTENSION_RISCV_Zihpm    => true,          -- implement hardware performance monitors?
-    CPU_EXTENSION_RISCV_Zifencei => true,          -- implement instruction stream sync.?
     CPU_EXTENSION_RISCV_Zmmul    => false,         -- implement multiply-only M sub-extension?
     CPU_EXTENSION_RISCV_Zxcfu    => true,          -- implement custom (instr.) functions unit?
     -- Extension Options --

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -176,7 +176,6 @@ begin
     CPU_EXTENSION_RISCV_Zfinx    => true,          -- implement 32-bit floating-point extension (using INT reg!)
     CPU_EXTENSION_RISCV_Zicntr   => true,          -- implement base counters?
     CPU_EXTENSION_RISCV_Zihpm    => true,          -- implement hardware performance monitors?
-    CPU_EXTENSION_RISCV_Zifencei => true,          -- implement instruction stream sync.?
     CPU_EXTENSION_RISCV_Zmmul    => false,         -- implement multiply-only M sub-extension?
     CPU_EXTENSION_RISCV_Zxcfu    => true,          -- implement custom (instr.) functions unit?
     -- Extension Options --

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -293,9 +293,9 @@ int main() {
   cnt_test++;
 
   asm volatile ("fence"); // flush/reload d-cache
-  if (neorv32_cpu_csr_read(CSR_MXISA) & (1 << CSR_MXISA_ZIFENCEI)) {
-    asm volatile ("fence.i"); // clear instruction prefetch buffer and clear i-cache
-  }
+  asm volatile ("fence.i"); // clear instruction prefetch buffer and clear i-cache
+  asm volatile ("fence");
+  asm volatile ("fence.i");
 
   if (neorv32_cpu_csr_read(CSR_MCAUSE) == mcause_never_c) {
     test_ok();


### PR DESCRIPTION
The `Zifencei` ISA extension does not consume any relevant amount of resources plus it is mandatory for the on-chip debugger. In order to simplify configuration options this ISA extension is now always automatically enabled.