### PR TITLE
Fix bug in neorv32_slink_available() function

### DIFF
--- a/sw/lib/source/neorv32_slink.c
+++ b/sw/lib/source/neorv32_slink.c
@@ -48,7 +48,7 @@
  **************************************************************************/
 int neorv32_slink_available(void) {
 
-  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_SDI)) {
+  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_SLINK)) {
     return 1;
   }
   else {


### PR DESCRIPTION
# Fix a bug in *neorv32_slink.c* library

In specific in *neorv32_slink_available()* function.

### Context:

I added a [module](https://github.com/Unike267/Practices) to NEORV32 via Stream Link interface (AXI4-Stream) and I used in *.c* program *neorv32_slink_available()* function to check if SLINK module was available. The point is that I put the *IO_SLINK_EN => true* in the top of the design and when I checked the results via UART the program crashed because *neorv32_slink_available()* return -1 when the SLINK module was available. 

![error](https://github.com/stnolting/neorv32/assets/36209778/ca580f3e-4d65-4a1f-b530-45bd527b91c1)

I checked the *neorv32_slink.c* and **I found this bug**. 

When I remade the *application_image* compiled with the fixed-up library  in local everything was good. I got the following results with CuteCom terminal:

![](https://raw.githubusercontent.com/Unike267/Photos/master/UNI-Photos/Practices/CUTECOM.png)

/cc @umarcor 

 