### PR TITLE
Fix-up the litex wrapper

### DIFF
--- a/rtl/system_integration/neorv32_litex_core_complex.vhd
+++ b/rtl/system_integration/neorv32_litex_core_complex.vhd
@@ -95,7 +95,7 @@ entity neorv32_litex_core_complex is
     wb_dat_i    : in  std_ulogic_vector(31 downto 0); -- read data
     wb_dat_o    : out std_ulogic_vector(31 downto 0); -- write data
     wb_we_o     : out std_ulogic; -- read/write
-    wb_sel_o    : out std_ulogic_vector(03 downto 0); -- byte enable
+    wb_sel_o    : out std_ulogic_vector(3 downto 0); -- byte enable
     wb_stb_o    : out std_ulogic; -- strobe
     wb_cyc_o    : out std_ulogic; -- valid cycle
     wb_ack_i    : in  std_ulogic; -- transfer acknowledge
@@ -199,7 +199,7 @@ begin
     -- External memory interface (WISHBONE) --
     MEM_EXT_EN                 => true,                           -- implement external memory bus interface?
     MEM_EXT_TIMEOUT            => wb_timeout_c,                   -- cycles after a pending bus access auto-terminates (0 = disabled)
-    MEM_EXT_PIPE_MODE          => true,                           -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
+    MEM_EXT_PIPE_MODE          => false,                           -- protocol: false=classic/standard wishbone mode, true=pipelined wishbone mode
     MEM_EXT_BIG_ENDIAN         => big_endian_c,                   -- byte order: true=big-endian, false=little-endian
     MEM_EXT_ASYNC_RX           => true,                           -- use register buffer for RX data when false
     MEM_EXT_ASYNC_TX           => true,                           -- use register buffer for TX data when false


### PR DESCRIPTION
# Fix-up Litex wrapper

+ Board: ARTY A7 35T

### Context:

I'm trying to implement the Neorv32 with Litex and with the deffault wrapper **there is a failure with the SDRAM initialization**. View enjoy-digital/litex#1802.

![SDRAM_ERROR](https://github.com/stnolting/neorv32/assets/36209778/d368fda2-e86f-4ad2-bb65-a6dfee678f4c)

I tried changing the wishbone protocol from *pipelined* to *classic*, and that seems to fix the issue.
It might have some effect in performance, but at least it works.
The following log shows that memory is correctly initialized.

![SDRAM_OK](https://github.com/stnolting/neorv32/assets/36209778/e1491cbb-74c1-40a2-9b20-5b7aee7d1e27)

Looking forward, I believe there might be some conflict in the pipelined wishbone implementations of NEORV32 and Litex. @stnolting did you try the pipelined wishbone of NEORV32 with third-party wishbone peripherals?

/cc @enjoy-digital @umarcor