### PR TITLE
🐛 [FPU] fix wiring of exception flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 20.11.2023 | 1.9.1.3 | :bug: fix wiring of FPU exception flags; [#733](https://github.com/stnolting/neorv32/pull/733) |
 | 18.11.2023 | 1.9.1.2 | add XIP clock divider to fine-tune SPI frequency; [#731](https://github.com/stnolting/neorv32/pull/731) |
 | 18.11.2023 | 1.9.1.1 | (re-)add SPI high-speed mode, :bug: fix bug in SPI shift register - introduced in v1.9.0.9; [#730](https://github.com/stnolting/neorv32/pull/730) |
 | 14.11.2023 | [**:rocket:1.9.1**](https://github.com/stnolting/neorv32/releases/tag/v1.9.1) | **New release** |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -621,21 +621,16 @@ less hardware resources and features faster context changes. This also implies t
 register file-related load/store or move instructions. The `Zfinx` extension'S floating-point unit is controlled
 via dedicated <<_floating_point_csrs>>.
 
+.Fused Multiply-Add and Division Instructions
 [WARNING]
 Fused multiply-add instructions `f[n]m[add/sub].s` are not supported!
 Division `fdiv.s` and square root `fsqrt.s` instructions are not supported yet!
 
+.Subnormal Number
 [WARNING]
-Subnormal numbers ("de-normalized" numbers) are not supported by the NEORV32 FPU.
-Subnormal numbers (exponent = 0) are _flushed to zero_ setting them to +/- 0 before entering the
-FPU's processing core. If a computational instruction (like `fmul.s`) generates a subnormal result, the
-result is also flushed to zero during normalization.
-
-[WARNING]
-The `Zfinx` extension is not yet officially ratified, but is expected to stay unchanged. There is no
-software support for the `Zfinx` extension in the upstream GCC RISC-V port yet. However, an
-intrinsic library is provided to utilize the provided `Zfinx` floating-point extension from C-language
-code (see `sw/example/floating_point_test`).
+Subnormal numbers ("de-normalized" numbers, i.e. exponent = 0) are not supported by the NEORV32 FPU.
+Subnormal numbers are _flushed to zero_ setting them to +/- 0 before being processed by **any** FPU operation.
+If a computational instruction generates a subnormal result it is also flushed to zero during normalization.
 
 .Instructions and Timing
 [cols="<2,<4,<3"]

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -59,7 +59,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090102"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090103"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 
@@ -335,11 +335,11 @@ package neorv32_package is
   constant fp_class_qnan_c       : natural := 9; -- quiet NaN (qNaN)
 
   -- exception flags --
-  constant fp_exc_nv_c : natural := 0; -- invalid operation
-  constant fp_exc_dz_c : natural := 1; -- divide by zero
+  constant fp_exc_nx_c : natural := 0; -- inexact
+  constant fp_exc_uf_c : natural := 1; -- underflow
   constant fp_exc_of_c : natural := 2; -- overflow
-  constant fp_exc_uf_c : natural := 3; -- underflow
-  constant fp_exc_nx_c : natural := 4; -- inexact
+  constant fp_exc_dz_c : natural := 3; -- division by zero
+  constant fp_exc_nv_c : natural := 4; -- invalid operation
 
   -- special values (single-precision) --
   constant fp_single_qnan_c     : std_ulogic_vector(31 downto 0) := x"7fc00000"; -- quiet NaN


### PR DESCRIPTION
Triggered by #728 this PR fixes the wiring of the FPU exception flag output and the `fflags` CSR bits.