### PR TITLE
🐛 fix bug in instruction-misaligned exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 21.11.2023 | 1.9.1.4 | :bug: fix bug in handling of "misaligned instruction exception"; [#734](https://github.com/stnolting/neorv32/pull/734) |
 | 20.11.2023 | 1.9.1.3 | :bug: fix wiring of FPU exception flags; [#733](https://github.com/stnolting/neorv32/pull/733) |
 | 18.11.2023 | 1.9.1.2 | add XIP clock divider to fine-tune SPI frequency; [#731](https://github.com/stnolting/neorv32/pull/731) |
 | 18.11.2023 | 1.9.1.1 | (re-)add SPI high-speed mode, :bug: fix bug in SPI shift register - introduced in v1.9.0.9; [#730](https://github.com/stnolting/neorv32/pull/730) |

--- a/do.py
+++ b/do.py
@@ -26,7 +26,7 @@ def task_BuildAndInstallSoftwareFrameworkTests():
             "make -C sw/bootloader clean_all info bootloader",
             # Compile and install test application, redirect UART0 TX to text.io simulation output via <UARTx_SIM_MODE> user flags
             "echo 'Compiling and installing CPU/Processor test application'",
-            "make -C sw/example/processor_check clean_all USER_FLAGS+=-DUART0_SIM_MODE USER_FLAGS+=-DUART1_SIM_MODE USER_FLAGS+=-flto EFFORT=-Os MARCH=rv32imac_zicsr_zifencei info all",
+            "make -C sw/example/processor_check clean_all USER_FLAGS+=-DUART0_SIM_MODE USER_FLAGS+=-DUART1_SIM_MODE USER_FLAGS+=-flto EFFORT=-Os MARCH=rv32ima_zicsr_zifencei info all",
         ],
         "doc": "Build all sw/example/*; install bootloader and processor check",
     }

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -363,8 +363,8 @@ The generic type "suv(x:y)" defines a `std_ulogic_vector(x downto y)`.
 |=======================
 | Name | Type | Description
 | `CPU_BOOT_ADDR`              | suv(31:0) | CPU reset address. See section <<_address_space>>.
-| `CPU_DEBUG_PARK_ADDR`        | suv(31:0) | "Park loop" entry address for the <<_on_chip_debugger_ocd>>.
-| `CPU_DEBUG_EXC_ADDR`         | suv(31:0) | "Exception" entry address for the <<_on_chip_debugger_ocd>>.
+| `CPU_DEBUG_PARK_ADDR`        | suv(31:0) | "Park loop" entry address for the <<_on_chip_debugger_ocd>>, has to be 4-byte aligned.
+| `CPU_DEBUG_EXC_ADDR`         | suv(31:0) | "Exception" entry address for the <<_on_chip_debugger_ocd>>, has to be 4-byte aligned.
 | `CPU_EXTENSION_RISCV_Sdext`  | boolean   | Implement RISC-V-compatible "debug" CPU operation mode required for the <<_on_chip_debugger_ocd>>.
 | `CPU_EXTENSION_RISCV_Sdtrig` | boolean   | Implement RISC-V-compatible trigger module. See section <<_on_chip_debugger_ocd>>.
 |=======================
@@ -864,8 +864,8 @@ written to the according CSRs when a trap is triggered:
 |=======================
 | Prio. | `mcause`     | RTE Trap ID              | Cause                                | `mepc` | `mtval` | `mtinst`
 7+^| **Exceptions** (_synchronous_ to instruction execution)                                                 
-| 1     | `0x00000000` | `TRAP_CODE_I_MISALIGNED` | instruction fetch address misaligned | I-PC   | 0       | INS
-| 2     | `0x00000001` | `TRAP_CODE_I_ACCESS`     | instruction fetch bus access fault   | I-PC   | 0       | INS
+| 1     | `0x00000000` | `TRAP_CODE_I_MISALIGNED` | instruction address misaligned       | PC     | 0       | INS
+| 2     | `0x00000001` | `TRAP_CODE_I_ACCESS`     | instruction bus access fault         | I-PC   | 0       | INS
 | 3     | `0x00000002` | `TRAP_CODE_I_ILLEGAL`    | illegal instruction                  | PC     | 0       | INS
 | 4     | `0x0000000b` | `TRAP_CODE_MENV_CALL`    | environment call from M-mode         | PC     | 0       | INS
 | 5     | `0x00000008` | `TRAP_CODE_UENV_CALL`    | environment call from U-mode         | PC     | 0       | INS

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -373,7 +373,11 @@ or entirely denied allowing access to **none** counter CSRs.
 | ISA         | `Zicsr`
 | Description | The `mepc` CSR provides the instruction address where execution has stopped/failed when
 an instruction is triggered / an exception is raised. See section <<_traps_exceptions_and_interrupts>> for a list of all legal values.
+The `mret` instruction will return to the address stored in `mepc` by automatically moving `mepc` to the program counter.
 |=======================
+
+[NOTE]
+`mepc[0]` is hardwired to zero. If IALIGN = 32 (i.e. <<_c_isa_extension>> is disabled) then `mepc[1]` is also hardwired to zero.
 
 
 {empty} +

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -631,8 +631,11 @@ Cause codes in `dcsr.cause` (highest priority first):
 | Reset value | `0x00000000`
 | ISA         | `Zicsr` & `Sdext`
 | Description | The register is used to store the current program counter when debug mode is entered. The `dret` instruction will
-return to `dpc` by automatically moving `dpc` to the program counter.
+return to the address stored in `dpc` by automatically moving `dpc` to the program counter.
 |=======================
+
+[NOTE]
+`dpc[0]` is hardwired to zero. If IALIGN = 32 (i.e. <<_c_isa_extension>> is disabled) then `dpc[1]` is also hardwired to zero.
 
 
 :sectnums!:

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1679,7 +1679,10 @@ begin
             csr.mscratch <= csr.wdata;
 
           when csr_mepc_c => -- machine exception program counter
-            csr.mepc <= csr.wdata;
+            csr.mepc <= csr.wdata(XLEN-1 downto 1) & '0';
+            if (CPU_EXTENSION_RISCV_C = false) then -- RISC-V priv. spec.: MEPC[1] is masked when IALIGN = 32
+              csr.mepc(1) <= '0';
+            end if;
 
           when csr_mcause_c => -- machine trap cause
             csr.mcause <= csr.wdata(31) & csr.wdata(4 downto 0); -- type (exception/interrupt) & identifier
@@ -1725,6 +1728,9 @@ begin
           when csr_dpc_c => -- debug mode program counter
             if (CPU_EXTENSION_RISCV_Sdext = true) then
               csr.dpc <= csr.wdata(XLEN-1 downto 1) & '0';
+              if (CPU_EXTENSION_RISCV_C = false) then -- RISC-V priv. spec.: DPC[1] is masked when IALIGN = 32
+                csr.dpc(1) <= '0';
+              end if;
             end if;
 
           when csr_dscratch0_c => -- debug mode scratch register 0
@@ -1876,12 +1882,6 @@ begin
         csr.tdata1_action <= '0';
         csr.tdata1_dmode  <= '0';
         csr.tdata2        <= (others => '0');
-      end if;
-
-      -- RISC-V priv. spec.: xPC[1] is masked when IALIGN = 32 --
-      if (CPU_EXTENSION_RISCV_C = false) then
-        csr.dpc(1)  <= '0';
-        csr.mepc(1) <= '0';
       end if;
 
     end if;

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1878,6 +1878,12 @@ begin
         csr.tdata2        <= (others => '0');
       end if;
 
+      -- RISC-V priv. spec.: xPC[1] is masked when IALIGN = 32 --
+      if (CPU_EXTENSION_RISCV_C = false) then
+        csr.dpc(1)  <= '0';
+        csr.mepc(1) <= '0';
+      end if;
+
     end if;
   end process csr_write_access;
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -59,7 +59,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090103"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090104"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -184,7 +184,7 @@ begin
     if ci_mode then
       -- No need to send the full expectation in one big chunk
       check_uart(net, uart1_rx_handle, nul & nul);
-      check_uart(net, uart1_rx_handle, "0/57" & cr & lf);
+      check_uart(net, uart1_rx_handle, "0/58" & cr & lf);
     end if;
 
     -- Wait until all expected data has been received
@@ -227,7 +227,7 @@ begin
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_A        => true,          -- implement atomic memory operations extension?
     CPU_EXTENSION_RISCV_B        => true,          -- implement bit-manipulation extension?
-    CPU_EXTENSION_RISCV_C        => true,          -- implement compressed extension?
+    CPU_EXTENSION_RISCV_C        => false,         -- implement compressed extension?
     CPU_EXTENSION_RISCV_E        => false,         -- implement embedded RF extension?
     CPU_EXTENSION_RISCV_M        => true,          -- implement mul/div extension?
     CPU_EXTENSION_RISCV_U        => true,          -- implement user mode extension?

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -184,7 +184,7 @@ begin
     if ci_mode then
       -- No need to send the full expectation in one big chunk
       check_uart(net, uart1_rx_handle, nul & nul);
-      check_uart(net, uart1_rx_handle, "0/58" & cr & lf);
+      check_uart(net, uart1_rx_handle, "0/57" & cr & lf);
     end if;
 
     -- Wait until all expected data has been received
@@ -227,7 +227,7 @@ begin
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_A        => true,          -- implement atomic memory operations extension?
     CPU_EXTENSION_RISCV_B        => true,          -- implement bit-manipulation extension?
-    CPU_EXTENSION_RISCV_C        => false,         -- implement compressed extension?
+    CPU_EXTENSION_RISCV_C        => true,          -- implement compressed extension?
     CPU_EXTENSION_RISCV_E        => false,         -- implement embedded RF extension?
     CPU_EXTENSION_RISCV_M        => true,          -- implement mul/div extension?
     CPU_EXTENSION_RISCV_U        => true,          -- implement user mode extension?

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -170,7 +170,7 @@ begin
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_A        => true,          -- implement atomic memory operations extension?
     CPU_EXTENSION_RISCV_B        => true,          -- implement bit-manipulation extension?
-    CPU_EXTENSION_RISCV_C        => true,          -- implement compressed extension?
+    CPU_EXTENSION_RISCV_C        => false,          -- implement compressed extension?
     CPU_EXTENSION_RISCV_E        => false,         -- implement embedded RF extension?
     CPU_EXTENSION_RISCV_M        => true,          -- implement mul/div extension?
     CPU_EXTENSION_RISCV_U        => true,          -- implement user mode extension?

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -170,7 +170,7 @@ begin
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_A        => true,          -- implement atomic memory operations extension?
     CPU_EXTENSION_RISCV_B        => true,          -- implement bit-manipulation extension?
-    CPU_EXTENSION_RISCV_C        => false,          -- implement compressed extension?
+    CPU_EXTENSION_RISCV_C        => false,         -- implement compressed extension?
     CPU_EXTENSION_RISCV_E        => false,         -- implement embedded RF extension?
     CPU_EXTENSION_RISCV_M        => true,          -- implement mul/div extension?
     CPU_EXTENSION_RISCV_U        => true,          -- implement user mode extension?

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -49,10 +49,10 @@
 /**@{*/
 //** UART BAUD rate */
 #define BAUD_RATE           (19200)
-//** Reachable unaligned address */
+//** Reachable but unaligned address */
 #define ADDR_UNALIGNED_1    (0x00000001UL)
-//** Reachable unaligned address */
-#define ADDR_UNALIGNED_2    (0x00000002UL)
+//** Reachable but unaligned address */
+#define ADDR_UNALIGNED_3    (0x00000003UL)
 //** Unreachable word-aligned address */
 #define ADDR_UNREACHABLE    ((uint32_t)&NEORV32_DM->SREG)
 //** Read-only word-aligned address */
@@ -583,7 +583,7 @@ int main() {
     cnt_test++;
 
     tmp_a = 0;
-    tmp_b = (uint32_t)ADDR_UNALIGNED_2;
+    tmp_b = (uint32_t)ADDR_UNALIGNED_3;
     asm volatile ("li   %[link], 0x123   \n" // initialize link register with known value
                   "jalr %[link], 0(%[addr])" // must not update link register due to exception
                   : [link] "=r" (tmp_a) : [addr] "r" (tmp_b));
@@ -2207,7 +2207,7 @@ void global_trap_handler(void) {
 
   // hack: make "instruction access fault" exception resumable as we *exactly* know how to handle it in this case
   if (cause == TRAP_CODE_I_ACCESS) {
-    neorv32_cpu_csr_write(CSR_MEPC, neorv32_cpu_csr_read(CSR_MEPC) + 4);
+    neorv32_cpu_csr_write(CSR_MEPC, (uint32_t)EXT_MEM_BASE+0);
   }
 
   // increment global trap counter

--- a/sw/example/processor_check/run_check.sh
+++ b/sw/example/processor_check/run_check.sh
@@ -3,4 +3,4 @@
 set -e
 
 echo "Starting processor check simulation..."
-make USER_FLAGS+="-DUART0_SIM_MODE -DUART1_SIM_MODE -g -flto" EFFORT=-Os MARCH=rv32imac_zicsr_zifencei clean_all all sim
+make USER_FLAGS+="-DUART0_SIM_MODE -DUART1_SIM_MODE -g -flto" EFFORT=-Os MARCH=rv32ima_zicsr_zifencei clean_all all sim


### PR DESCRIPTION
Bug identified by @mikaelsky in https://github.com/stnolting/neorv32/issues/728#issuecomment-1819638160.

The current processor version captures unaligned instruction addresses in the pipeline's front-end. Hence, any misaligned instruction will still trigger an instruction fetch and jump-and-link instruction will still update the link register. This PR aims to fix this:

* Branch instructions (unconditional branches or "taken" conditional branches) do not trigger an instruction fetch if the address is misaligned.
* Jump-and-link instruction do not write to the link register if the destination address is misaligned.
* Misaligned instruction address exception are raised by the pipeline's back end (execution) and not by the pipeline's front-end (instruction fetch).

I am not quite sure about the handling of `xRET` instructions when `xEPC` contains a misaligned address. The RISC-V priv. spec states:

> Machine Exception Program Counter (mepc)
> [...]
> If an implementation allows IALIGN to be either 16 or 32 (by changing CSR misa, for example),
> then, whenever IALIGN=32, bit mepc[1] is masked on reads so that it appears to be 0. This
> masking occurs also for the implicit read by the MRET instruction. Though masked, mepc[1]
> remains writable when IALIGN=32.

So I think `xEPC[1]` should be hardwired to zero if IALIGN=32 (i.e. the `C` extension is NOT enabled). Hence, `xRET` cannot raise a misaligned instruction exception. However, I cannot find anything regarding `dret`/`dpc` but I assume that we should expect the same behavior there. @mikaelsky can you confirm this?