### PR TITLE
[rtl] Cleanup/update assertions and "auto-configuration"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date (*dd.mm.yyyy*) | Version | Comment |
 |:-------------------:|:-------:|:--------|
+| 25.11.2023 | 1.9.1.7 | cleanup/update assertions and auto-adjusting of invalid generic configurations; [#738](https://github.com/stnolting/neorv32/pull/738) |
 | 25.11.2023 | 1.9.1.6 | :sparkles: add option for "ASIC style" register file that provides a full/dedicated hardware reset; [#736](https://github.com/stnolting/neorv32/pull/736) |
 | 23.11.2023 | 1.9.1.5 | clean-up & rework CPU branch logic; [#735](https://github.com/stnolting/neorv32/pull/735) |
 | 21.11.2023 | 1.9.1.4 | :bug: fix bug in handling of "misaligned instruction exception"; [#734](https://github.com/stnolting/neorv32/pull/734) |

--- a/rtl/core/mem/neorv32_imem.default.vhd
+++ b/rtl/core/mem/neorv32_imem.default.vhd
@@ -71,11 +71,11 @@ begin
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   assert false report
-    "NEORV32 PROCESSOR CONFIG NOTE: Implementing DEFAULT processor-internal IMEM as " &
+    "[NEORV32] Implementing DEFAULT processor-internal IMEM as " &
     cond_sel_string_f(IMEM_AS_IROM, "pre-initialized ROM.", "blank RAM.") severity note;
 
   assert not ((IMEM_AS_IROM = true) and (imem_app_size_c > IMEM_SIZE)) report
-    "NEORV32 PROCESSOR CONFIG ERROR: Application (image = " & natural'image(imem_app_size_c) &
+    "[NEORV32] Application (image = " & natural'image(imem_app_size_c) &
     " bytes) does not fit into processor-internal IMEM (ROM = " & natural'image(IMEM_SIZE) & " bytes)!" severity error;
 
 

--- a/rtl/core/mem/neorv32_imem.legacy.vhd
+++ b/rtl/core/mem/neorv32_imem.legacy.vhd
@@ -71,11 +71,11 @@ begin
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   assert false report
-    "NEORV32 PROCESSOR CONFIG NOTE: Implementing LEGACY processor-internal IMEM as " &
+    "[NEORV32] Implementing LEGACY processor-internal IMEM as " &
     cond_sel_string_f(IMEM_AS_IROM, "pre-initialized ROM.", "blank RAM.") severity note;
 
   assert not ((IMEM_AS_IROM = true) and (imem_app_size_c > IMEM_SIZE)) report
-    "NEORV32 PROCESSOR CONFIG ERROR: Application (image = " & natural'image(imem_app_size_c) &
+    "[NEORV32] Application (image = " & natural'image(imem_app_size_c) &
     " bytes) does not fit into processor-internal IMEM (ROM = " & natural'image(IMEM_SIZE) & " bytes)!" severity error;
 
 

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -141,7 +141,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   -- CPU ISA configuration --
   assert false report
-    "NEORV32 CPU Configuration: rv32" &
+    "[NEORV32] CPU ISA: rv32" &
     cond_sel_string_f(CPU_EXTENSION_RISCV_E,      "e",         "i") &
     cond_sel_string_f(CPU_EXTENSION_RISCV_M,      "m",         "" ) &
     cond_sel_string_f(CPU_EXTENSION_RISCV_A,      "a",         "" ) &
@@ -160,9 +160,17 @@ begin
     cond_sel_string_f(pmp_enable_c,               "_smpmp",    "" )
     severity note;
 
+  -- CPU tuning options --
+  assert false report
+    "[NEORV32] CPU tuning options: " &
+    cond_sel_string_f(FAST_MUL_EN,    "fast_mul ",   "") &
+    cond_sel_string_f(FAST_SHIFT_EN,  "fast_shift ", "" ) &
+    cond_sel_string_f(REGFILE_HW_RST, "rf_hw_rst",   "" )
+    severity note;
+
   -- simulation notifier --
   assert not (is_simulation_c = true) report
-    "NEORV32 CPU WARNING! Assuming this is a simulation." severity warning;
+    "[NEORV32] Assuming this is a simulation." severity warning;
 
 
   -- Control Unit ---------------------------------------------------------------------------

--- a/rtl/core/neorv32_cpu_cp_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_cp_bitmanip.vhd
@@ -171,7 +171,7 @@ begin
   -- Sub-Extension Configuration ------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   assert false report
-    "NEORV32 CPU: Implementing bit-manipulation (B) sub-extensions " &
+    "[NEORV32] Implementing bit-manipulation (B) sub-extensions " &
     cond_sel_string_f(zba_en_c, "Zba ", "") &
     cond_sel_string_f(zbb_en_c, "Zbb ", "") &
     cond_sel_string_f(zbc_en_c, "Zbc ", "") &

--- a/rtl/core/neorv32_cpu_cp_fpu.vhd
+++ b/rtl/core/neorv32_cpu_cp_fpu.vhd
@@ -279,7 +279,7 @@ begin
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   assert false report
-    "[Zfinx] The NEORV32 floating-point unit is still in experimental state." severity warning;
+    "[NEORV32] The floating-point unit (Zfinx) is still in experimental state." severity warning;
 
 
 -- ****************************************************************************************************************************

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -224,8 +224,8 @@ begin
 
   -- Info -----------------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  assert not (LEGACY_MODE = true)  report "NEORV32 [OCD] on-chip debugger: DM compatible to debug spec. version 0.13" severity note;
-  assert not (LEGACY_MODE = false) report "NEORV32 [OCD] on-chip debugger: DM compatible to debug spec. version 1.0"  severity note;
+  assert not (LEGACY_MODE = true)  report "[NEORV32] OCD DM compatible to debug spec. version 0.13" severity note;
+  assert not (LEGACY_MODE = false) report "[NEORV32] OCD DM compatible to debug spec. version 1.0"  severity note;
 
 
   -- DMI Access -----------------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090106"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090107"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -348,7 +348,7 @@ begin
 
     -- show module configuration --
     assert false report
-      "NEORV32 Processor Configuration: " &
+      "[NEORV32] Processor Configuration: " &
       cond_sel_string_f(MEM_INT_IMEM_EN,     "IMEM ",     "") &
       cond_sel_string_f(MEM_INT_DMEM_EN,     "DMEM ",     "") &
       cond_sel_string_f(INT_BOOTLOADER_EN,   "BOOTROM ",  "") &
@@ -381,13 +381,11 @@ begin
 
     -- IMEM size --
     assert not ((imem_size_valid_c = false) and (MEM_INT_IMEM_EN = true)) report
-      "NEORV32 PROCESSOR CONFIG WARNING: Configured internal IMEM size (" & natural'image(MEM_INT_IMEM_SIZE) & " bytes) is not a power of two. " &
-      "Auto-adjusting memory size to the next power of two (" & natural'image(imem_size_c) & " bytes)" severity warning;
+      "[NEORV32] Auto-adjusting invalid IMEM size configuration." severity warning;
 
     -- DMEM size --
     assert not ((dmem_size_valid_c = false) and (MEM_INT_DMEM_EN = true)) report
-      "NEORV32 PROCESSOR CONFIG WARNING: Configured internal DMEM size (" & natural'image(MEM_INT_DMEM_SIZE) & " bytes) is not a power of two. " &
-      "Auto-adjusting memory size to the next power of two (" & natural'image(dmem_size_c) & " bytes)" severity warning;
+      "[NEORV32] Auto-adjusting invalid DMEM size configuration." severity warning;
 
   end generate; -- /sanity_checks
 

--- a/rtl/core/neorv32_wishbone.vhd
+++ b/rtl/core/neorv32_wishbone.vhd
@@ -116,7 +116,7 @@ begin
   -- Configuration Info ---------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   assert false report
-    "NEORV32 PROCESSOR CONFIG NOTE: Ext. Bus Interface - " &
+    "[NEORV32] Ext. Bus Interface (WISHBONE) - " &
     cond_sel_string_f(PIPE_MODE, "PIPELINED", "CLASSIC/STANDARD") & " Wishbone protocol, " &
     cond_sel_string_f(boolean(BUS_TIMEOUT /= 0), "auto-timeout, ", "NO auto-timeout, ") &
     cond_sel_string_f(BIG_ENDIAN, "BIG", "LITTLE") & "-endian byte order, " &
@@ -126,11 +126,11 @@ begin
 
   -- async RX override warning --
   assert not ((ASYNC_RX = true) and (async_rx_c = false)) report
-    "NEORV32 PROCESSOR CONFIG WARNING! Ext. Bus Interface - Non-pipelined/standard mode requires sync RX (auto-disabling async RX)." severity warning;
+    "[NEORV32] Ext. Bus Interface - Non-pipelined/standard mode requires sync RX (auto-disabling async RX)." severity warning;
 
   -- zero timeout warning --
   assert not (BUS_TIMEOUT = 0) report
-    "NEORV32 PROCESSOR CONFIG WARNING! Ext. Bus Interface - NO auto-timeout defined; can cause permanent CPU stall!" severity warning;
+    "[NEORV32] Ext. Bus Interface - NO auto-timeout defined; can cause permanent CPU stall!" severity warning;
 
 
   -- Bus Arbiter -----------------------------------------------------------------------------


### PR DESCRIPTION
Invalid generic configurations (for example a cache block size that is not a power of two) will no longer result in an error assertion. Instead, the invalid configuration is auto-adjusted and the user is informed with a warning. For example:

```vhdl
  assert not ((nblocks_valid_c = false) or (block_size_valid_c = false)) report
    "[NEORV32] Auto-adjusting invalid d-cache size configuration(s)." severity warning;
```