### PR TITLE
Add menvcfg[h] CSRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,11 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 * :warning: changes that might impact compatibility with previous versions
 * :lock: security/safety-related
 * :rocket: official release
+* Date format is _dd.mm.yyyy_
 
-
-| Date (*dd.mm.yyyy*) | Version | Comment |
-|:-------------------:|:-------:|:--------|
+| Date | Version | Comment | Link |
+|:----:|:-------:|:--------|:----:|
+| 01.12.2023 | 1.9.1.9 | add `menvcfg[h]` CSRs | [#741](https://github.com/stnolting/neorv32/pull/741) |
 | 30.11.2023 | 1.9.1.8 | :sparkles: :bug: upgrade RISC-V hardware trigger module (`Sdtrig` ISA extension) to spec. version v1.0 (fixing several minor bugs); [#739](https://github.com/stnolting/neorv32/pull/739) |
 | 25.11.2023 | 1.9.1.7 | cleanup/update assertions and auto-adjusting of invalid generic configurations; [#738](https://github.com/stnolting/neorv32/pull/738) |
 | 25.11.2023 | 1.9.1.6 | :sparkles: add option for "ASIC style" register file that provides a full/dedicated hardware reset; [#736](https://github.com/stnolting/neorv32/pull/736) |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -39,6 +39,9 @@ bits can actually be modified.
 | 0x343 | <<_mtval>>    | `CSR_MTVAL`    | MRW | Machine trap value
 | 0x344 | <<_mip>>      | `CSR_MIP`      | MRW | Machine interrupt pending register
 | 0x34a | <<_mtinst>>   | `CSR_MTINST`   | MRW | Machine trap instruction
+5+^| **<<_machine_configuration_csrs>>**
+| 0x30a | <<_menvcfg>>  | `CSR_MENVCFG`  | MRW | Machine environment configuration register - low word
+| 0x31a | <<_menvcfgh>> | `CSR_MENVCFGH` | MRW | Machine environment configuration register - high word
 5+^| **<<_machine_physical_memory_protection_csrs>>**
 | 0x3a0 .. 0x303 | <<_pmpcfg, `pmpcfg0`>> .. <<_pmpcfg, `pmpcfg3`>>      | `CSR_PMPCFG0` .. `CSR_PMPCFG3`    | MRW | Physical memory protection configuration registers
 | 0x3b0 .. 0x3bf | <<_pmpaddr, `pmpaddr0`>> .. <<_pmpaddr, `pmpaddr15`>> | `CSR_PMPADDR0` .. `CSR_PMPADDR15` | MRW | Physical memory protection address registers
@@ -480,6 +483,42 @@ The RISC-V priv. spec. suggests that the instruction word written to `mtinst` by
 However, the NEORV32 `mtinst` CSR uses a simplified transformation scheme: if the trap-causing instruction is a
 standard 32-bit instruction, `mtinst` contains the exact instruction word that caused the trap. If the trap-causing
 instruction is a compressed instruction, `mtinst` contains the de-compressed 32-bit equivalent with bit 1 being cleared.
+
+
+
+<<<
+// ####################################################################################################################
+:sectnums:
+==== Machine Configuration CSRs
+
+[discrete]
+===== **`menvcfg`**
+
+[cols="<1,<8"]
+[frame="topbot",grid="none"]
+|=======================
+| Name        | Machine environment configuration register - low word
+| Address     | `0x30a`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr` & `U`
+| Description | Currently, the features of this CSR are not supported. Hence, the entire register is hardwired to all-zero.
+|=======================
+
+
+{empty} +
+[discrete]
+===== **`menvcfgh`**
+
+[cols="<1,<8"]
+[frame="topbot",grid="none"]
+|=======================
+| Name        | Machine environment configuration register - high word
+| Address     | `0x31a`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr` & `U`
+| Description | Currently, the features of this CSR are not supported. Hence, the entire register is hardwired to all-zero.
+|=======================
+
 
 
 <<<

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1168,7 +1168,8 @@ begin
         csr_reg_valid <= '1'; -- always available (but CSR might be hardwired)
 
       -- machine-controlled user-mode CSRs --
-      when csr_mcounteren_c | csr_mcyclecfg_c | csr_minstretcfg_c | csr_mcyclecfgh_c | csr_minstretcfgh_c =>
+      when csr_mcounteren_c | csr_menvcfg_c     | csr_menvcfgh_c   |
+           csr_mcyclecfg_c  | csr_minstretcfg_c | csr_mcyclecfgh_c | csr_minstretcfgh_c =>
         csr_reg_valid <= bool_to_ulogic_f(CPU_EXTENSION_RISCV_U); -- available if U-mode implemented
 
       -- physical memory protection (PMP) --
@@ -1967,6 +1968,11 @@ begin
             csr_rdata(15 downto 3) <= (others => csr.mcounteren); -- hpmcounter
           end if;
         end if;
+
+      -- machine configuration --
+      -- --------------------------------------------------------------------
+--    when csr_menvcfg_c  => csr_rdata <= (others => '0'); -- hardwired to zero
+--    when csr_menvcfgh_c => csr_rdata <= (others => '0'); -- hardwired to zero
 
       -- machine trap handling --
       -- --------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090108"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090109"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 
@@ -359,6 +359,9 @@ package neorv32_package is
   constant csr_mtvec_c          : std_ulogic_vector(11 downto 0) := x"305";
   constant csr_mcounteren_c     : std_ulogic_vector(11 downto 0) := x"306";
   constant csr_mstatush_c       : std_ulogic_vector(11 downto 0) := x"310";
+  -- machine configuration --
+  constant csr_menvcfg_c        : std_ulogic_vector(11 downto 0) := x"30a";
+  constant csr_menvcfgh_c       : std_ulogic_vector(11 downto 0) := x"31a";
   -- machine counter setup --
   constant csr_mcountinhibit_c  : std_ulogic_vector(11 downto 0) := x"320";
   constant csr_mcyclecfg_c      : std_ulogic_vector(11 downto 0) := x"321";

--- a/sw/lib/include/neorv32_cpu_csr.h
+++ b/sw/lib/include/neorv32_cpu_csr.h
@@ -62,6 +62,10 @@ enum NEORV32_CSR_enum {
   CSR_MCYCLECFG      = 0x321, /**< 0x321 - mcyclecfg:     Machine cycle counter privilege mode filtering - low word */
   CSR_MINSTRETCFG    = 0x322, /**< 0x322 - minstretcfg:   Machine instret counter privilege mode filtering - low word */
 
+  /* machine configuration */
+  CSR_MENVCFG        = 0x30a, /**< 0x30a - menvcfg:  Machine environment configuration register - low word */
+  CSR_MENVCFGH       = 0x31a, /**< 0x31a - menvcfgh: Machine environment configuration register - high word */
+
   /* hardware performance monitors - event configuration */
   CSR_MHPMEVENT3     = 0x323, /**< 0x323 - mhpmevent3:  Machine hardware performance monitor event selector 3  */
   CSR_MHPMEVENT4     = 0x324, /**< 0x324 - mhpmevent4:  Machine hardware performance monitor event selector 4  */
@@ -319,9 +323,9 @@ enum NEORV32_CSR_MIE_enum {
  * CPU <b>mip</b> CSR (r/c): Machine interrupt pending
  **************************************************************************/
 enum NEORV32_CSR_MIP_enum {
-  CSR_MIP_MSIP    =  3, /**< CPU mip CSR  (3): MSIP - Machine software interrupt pending (r/c) */
-  CSR_MIP_MTIP    =  7, /**< CPU mip CSR  (7): MTIP - Machine timer interrupt pending (r/c) */
-  CSR_MIP_MEIP    = 11, /**< CPU mip CSR (11): MEIP - Machine external interrupt pending (r/c) */
+  CSR_MIP_MSIP    =  3, /**< CPU mip CSR  (3): MSIP - Machine software interrupt pending (r/-) */
+  CSR_MIP_MTIP    =  7, /**< CPU mip CSR  (7): MTIP - Machine timer interrupt pending (r/-) */
+  CSR_MIP_MEIP    = 11, /**< CPU mip CSR (11): MEIP - Machine external interrupt pending (r/-) */
 
   /* NEORV32-specific extension: Fast Interrupt Requests (FIRQ) */
   CSR_MIP_FIRQ0P  = 16, /**< CPU mip CSR (16): FIRQ0P - Fast interrupt channel 0 pending (r/c) */


### PR DESCRIPTION
According to the RISC-V priv. spec. these CSRs seem to be mandatory (i.e. they have to be implemented if the `U` ISA extension is enabled). However, the features provided by these CSRs are not supported yet. Hence, the entire CSRs are hardwired to all-zero.