### PR TITLE
refine behaviour of CPU sleep signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 09.12.2023 | 1.9.2.3 | refine behavior of CPU's sleep state & signal | [#746](https://github.com/stnolting/neorv32/pull/746) |
 | 05.12.2023 | 1.9.2.2 | reset `mstatus.mpp` to "machine-mode" | [#745](https://github.com/stnolting/neorv32/pull/745) |
 | 02.12.2023 | 1.9.2.1 | :sparkles: add RISC-V `Zicond` ISA extension (integer conditional operations) | [#743](https://github.com/stnolting/neorv32/pull/743) |
 | 01.12.2023 | [**:rocket:1.9.2**](https://github.com/stnolting/neorv32/releases/tag/v1.9.2) | **New release** | |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -207,8 +207,8 @@ simple `nop`.
 In sleep mode all CPU-internal operations are stopped (execution, instruction fetch, counter increments, etc.).
 CPU-external modules like memories, timers and peripheral interfaces are not affected by this. Furthermore, the CPU will
 continue to buffer/enqueue incoming interrupt requests. The CPU will leave sleep mode as soon as any _enabled (via <<_mie>>)
-interrupt source becomes _pending_ or if a debug session is started. As soon as the CPU has halted **all** internal
-operations the `sleep_o` signal becomes high (see <<_cpu_top_entity_signals>>).
+interrupt source becomes _pending_ or if a debug session is started. As soon as the CPU has "parked" in a safe/resumable
+state the `sleep_o` signal becomes high (see <<_cpu_top_entity_signals>>).
 
 
 ==== Full Virtualization

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -197,17 +197,18 @@ includes the <<_control_and_status_registers_csrs>> as well as the trap controll
 ==== Sleep Mode
 
 The NEORV32 CPU provides a single sleep mode that can be entered to power-down the core reducing dynamic
-power consumption. Sleep mode in entered by executing the `wfi` instruction. When in sleep mode, all CPU-internal
-operations are stopped (execution, instruction fetch, counter increments, ...). However, this does not affect the
-operation of any peripheral/IO modules like interfaces and timers. Furthermore, the CPU will continue to buffer/enqueue
-incoming interrupt requests. The CPU will leave sleep mode as soon as any _enabled_ interrupt source becomes _pending_.
-
-[IMPORTANT]
-If sleep mode is entered without at least one enabled interrupt source the CPU will be _permanently_ halted.
+power consumption. Sleep mode is entered by executing the `wfi` ("wait for interrupt") instruction.
 
 [NOTE]
-The CPU automatically wakes up from sleep mode if a debug session is started via the on-chip debugger. `wfi` behaves as
-a simple `nop` when the CPU is _in_ debug-mode or during single-stepping.
+The `wfi` instruction will raise an illegal instruction exception when executed in user-mode
+and `TW` in <<_mstatus>> is set. When executed in debug-mode or during single-stepping `wfi` will behave as
+simple `nop`.
+
+In sleep mode all CPU-internal operations are stopped (execution, instruction fetch, counter increments, etc.).
+CPU-external modules like memories, timers and peripheral interfaces are not affected by this. Furthermore, the CPU will
+continue to buffer/enqueue incoming interrupt requests. The CPU will leave sleep mode as soon as any _enabled (via <<_mie>>)
+interrupt source becomes _pending_ or if a debug session is started. As soon as the CPU has halted **all** internal
+operations the `sleep_o` signal becomes high (see <<_cpu_top_entity_signals>>).
 
 
 ==== Full Virtualization
@@ -340,8 +341,8 @@ direction as seen from the CPU.
 4+^| **Global Signals**
 | `clk_i`      |           1 | in  | Global clock line, all registers triggering on rising edge
 | `rstn_i`     |           1 | in  | Global reset, low-active
-| `sleep_o`    |           1 | out | CPU is in sleep mode when set
-| `debug_o`    |           1 | out | CPU is in debug mode when set
+| `sleep_o`    |           1 | out | CPU is in <<_sleep_mode>> when set
+| `debug_o`    |           1 | out | CPU is in <<_cpu_debug_mode,debug mode>> when set
 | `ifence_o`   |           1 | out | instruction fence (`fence.i` instruction )
 | `dfence_o`   |           1 | out | data fence (`fence` instruction )
 4+^| **Interrupts (<<_traps_exceptions_and_interrupts>>)**

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090202"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090203"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width, do not change!
 


### PR DESCRIPTION
The CPU's `sleep_o` signal get high when
* the CPU has entered sleep mode (`wfi` instruction)
* **and** all pending bus accesses (i.e. instruction fetch) have completed
* -> the CPU is safely "parked"