### PR TITLE
[rtl/core] add again mtime_o to top entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 10.01.2024 | 1.9.2.10 | re-add MTIME system time output to processor top (`mtime_time_o`) | [#762](https://github.com/stnolting/neorv32/pull/762) |
 | 08.01.2024 | 1.9.2.9 | minor rtl code cleanups | [#760](https://github.com/stnolting/neorv32/pull/760) |
 | 06.01.2024 | 1.9.2.8 | :sparkles: add timer-capture mode to General Purpose Timer (GPTMR); :warning: remove "single-shot" mode, change control register layout | [#759](https://github.com/stnolting/neorv32/pull/759) |
 | 19.12.2023 | 1.9.2.7 | minor rtl code cleanups, edits and optimization; :lock: reset `mtvec`, `mepc` and `dpc` CSRs to CPU boot address (`CPU_BOOT_ADDR` CPU generic) | [#755](https://github.com/stnolting/neorv32/pull/755) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -150,6 +150,8 @@ Some interfaces (like the TWI and the 1-Wire bus) require tri-state drivers in t
 | `cfs_out_o`      | 32 | out | custom CFS output signal conduit
 4+^| **<<_smart_led_interface_neoled>>**
 | `neoled_o`       |  1 | out | asynchronous serial data output
+4+^| **<<_machine_system_timer_mtime>>**
+| `mtime_time_o`   | 64 | out | MTIME system time output
 4+^| **<<_general_purpose_timer_gptmr>>**
 | `gptmr_trig_i`   |  1 |  in | timer capture input
 4+^| **<<_external_interrupt_controller_xirq>>**

--- a/docs/datasheet/soc_mtime.adoc
+++ b/docs/datasheet/soc_mtime.adoc
@@ -5,31 +5,32 @@
 [cols="<3,<3,<4"]
 [frame="topbot",grid="none"]
 |=======================
-| Hardware source file(s): | neorv32_mtime.vhd | 
+| Hardware source file(s): | neorv32_mtime.vhd |
 | Software driver file(s): | neorv32_mtime.c |
 |                          | neorv32_mtime.h |
-| Top entity port:         | `mtime_irq_i` | RISC-V machine timer IRQ if internal one is **not** implemented
+| Top entity port:         | `mtime_irq_i`  | RISC-V machine timer IRQ if internal one is **not** implemented
+|                          | `mtime_time_o` | Current system time (`TIME` register)
 | Configuration generics:  | `IO_MTIME_EN` | implement machine timer when `true`
 | CPU interrupts:          | `MTI` | machine timer interrupt (see <<_processor_interrupts>>)
 |=======================
 
-The MTIME module implements a memory-mapped MTIME machine system timer that is compatible to the RISC-V
-privileged specifications. The 64-bit system time is accessed via the  memory-mapped `TIME_LO` and
-`TIME_HI` registers. A 64-bit time compare register, which is accessible via the memory-mapped `TIMECMP_LO`
-and `TIMECMP_HI` registers, can be used to configure the CPU's `MTI` (machine timer interrupt). The interrupt
+The MTIME module implements a memory-mapped machine system timer that is compatible to the RISC-V
+privileged specifications. The 64-bit system time is accessed via individual `TIME_LO` and
+`TIME_HI` registers. A 64-bit time compare register, which is accessible via individual `TIMECMP_LO`
+and `TIMECMP_HI` registers, can be used to configure the CPU's machine timer interrupt (`MTI`)). The interrupt
 is triggered whenever `TIME` (high & low part) is greater than or equal to `TIMECMP` (high & low part).
-The interrupt remains active (=pending) until `TIME` becomes less `TIMECMP` again (either by modifying
-`TIME` or `TIMECMP`).
+The interrupt remains active (=pending) until `TIME` becomes less than `TIMECMP` again (either by modifying
+`TIME` or `TIMECMP`). The current system time is available for other SoC modules via the top's `mtime_time_o` signal.
 
-.Reset
+.Hardware Reset
 [NOTE]
 After a hardware reset the `TIME` and `TIMECMP` register are reset to all-zero.
 
 .External MTIME Interrupt
-[IMPORTANT]
-If the internal MTIME module is disabled (`IO_MTIME_EN` = `false`) the machine timer interrupt becomes available as external signal.
-The `mtime_irq_i` signal is level-triggered and high-active. Once set the signal has to stay high until
-the interrupt request is explicitly acknowledged (e.g. writing to a memory-mapped register).
+[NOTE]
+If the internal MTIME module is disabled (`IO_MTIME_EN` = `false`) the machine timer interrupt becomes available
+as external signal. The `mtime_irq_i` signal is level-triggered and high-active. Once set the signal has to stay
+high until the interrupt request is explicitly acknowledged (e.g. writing to a user-defined memory-mapped register).
 
 
 **Register Map**
@@ -39,8 +40,8 @@ the interrupt request is explicitly acknowledged (e.g. writing to a memory-mappe
 [options="header",grid="all"]
 |=======================
 | Address      | Name [C]     | Bits | R/W | Function
-| `0xfffff400` | `TIME_LO`    | 31:0 | r/w | machine system time, low word
-| `0xfffff404` | `TIME_HI`    | 31:0 | r/w | machine system time, high word
+| `0xfffff400` | `TIME_LO`    | 31:0 | r/w | system time, low word
+| `0xfffff404` | `TIME_HI`    | 31:0 | r/w | system time, high word
 | `0xfffff408` | `TIMECMP_LO` | 31:0 | r/w | time compare, low word
 | `0xfffff40c` | `TIMECMP_HI` | 31:0 | r/w | time compare, high word
 |=======================

--- a/rtl/core/neorv32_mtime.vhd
+++ b/rtl/core/neorv32_mtime.vhd
@@ -48,6 +48,7 @@ entity neorv32_mtime is
     rstn_i    : in  std_ulogic; -- global reset line, low-active, async
     bus_req_i : in  bus_req_t;  -- bus request
     bus_rsp_o : out bus_rsp_t;  -- bus response
+    time_o    : out std_ulogic_vector(63 downto 0); -- current system time
     irq_o     : out std_ulogic  -- interrupt request
   );
 end neorv32_mtime;
@@ -134,6 +135,8 @@ begin
   -- mtime.time_LO increment --
   mtime_lo_nxt <= std_ulogic_vector(unsigned('0' & mtime_lo) + 1);
 
+  -- system time output for cpu --
+  time_o <= mtime_hi & mtime_lo; -- NOTE: low and high words are not synchronized here!
 
   -- Comparator -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_mtime.vhd
+++ b/rtl/core/neorv32_mtime.vhd
@@ -6,7 +6,7 @@
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -135,8 +135,9 @@ begin
   -- mtime.time_LO increment --
   mtime_lo_nxt <= std_ulogic_vector(unsigned('0' & mtime_lo) + 1);
 
-  -- system time output for cpu --
+  -- system time output --
   time_o <= mtime_hi & mtime_lo; -- NOTE: low and high words are not synchronized here!
+
 
   -- Comparator -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -908,6 +908,8 @@ package neorv32_package is
       cfs_out_o      : out std_ulogic_vector(IO_CFS_OUT_SIZE-1 downto 0);
       -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
       neoled_o       : out std_ulogic;
+      -- System time (available if IO_MTIME_EN = true) --
+      mtime_o        : out std_ulogic_vector(63 downto 0);
       -- GPTMR timer capture (available if IO_GPTMR_EN = true) --
       gptmr_trig_i   : in  std_ulogic := 'L';
       -- External platform interrupts (available if XIRQ_NUM_CH > 0) --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090209"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090210"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -908,8 +908,8 @@ package neorv32_package is
       cfs_out_o      : out std_ulogic_vector(IO_CFS_OUT_SIZE-1 downto 0);
       -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
       neoled_o       : out std_ulogic;
-      -- System time (available if IO_MTIME_EN = true) --
-      mtime_o        : out std_ulogic_vector(63 downto 0);
+      -- Machine timer system time (available if IO_MTIME_EN = true) --
+      mtime_time_o   : out std_ulogic_vector(63 downto 0);
       -- GPTMR timer capture (available if IO_GPTMR_EN = true) --
       gptmr_trig_i   : in  std_ulogic := 'L';
       -- External platform interrupts (available if XIRQ_NUM_CH > 0) --

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -377,6 +377,8 @@ begin
     cfs_out_o      => open,            -- custom CFS outputs
     -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
     neoled_o       => open,            -- async serial data line
+    -- Machine timer system time (available if IO_MTIME_EN = true) --
+    mtime_time_o   => open,
     -- GPTMR timer capture (available if IO_GPTMR_EN = true) --
     gptmr_trig_i   => gpio(63),        -- capture trigger
     -- External platform interrupts (available if XIRQ_NUM_CH > 0) --

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -325,6 +325,8 @@ begin
     cfs_out_o      => open,            -- custom CFS outputs
     -- NeoPixel-compatible smart LED interface (available if IO_NEOLED_EN = true) --
     neoled_o       => open,            -- async serial data line
+    -- Machine timer system time (available if IO_MTIME_EN = true) --
+    mtime_time_o   => open,
     -- GPTMR timer capture (available if IO_GPTMR_EN = true) --
     gptmr_trig_i   => gpio(63),        -- capture trigger
     -- External platform interrupts (available if XIRQ_NUM_CH > 0) --


### PR DESCRIPTION
This PR adds again `mtime_o` to the top entity to retain the ability to retrieve the wall clock time (mtime) from the HDL gateware. (#761)