### PR TITLE
Updated FIFO NULL assertion fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 28.01.2024 | 1.9.3.7 | FIFO module _NULL assertion_ fix | [#778](https://github.com/stnolting/neorv32/pull/778) |
 | 27.01.2024 | 1.9.3.6 | improve CPU's front end (instruction fetch) increasing overall performance | [#777](https://github.com/stnolting/neorv32/pull/777) |
 | 27.01.2024 | 1.9.3.5 | :bug: fix typo that renders the clock gating (added in v1.9.3.4) useless: CPU sleep output stuck at zero | [#776](https://github.com/stnolting/neorv32/pull/776) |
 | 24.01.2024 | 1.9.3.4 | :sparkles: add optional CPU clock gating (via new generic `CLOCK_GATING_EN`): shut down the CPU clock during sleep mode; :warning: add new HDL design file for the clock gate (`neorv32_clockgate.vhd`) | [#775](https://github.com/stnolting/neorv32/pull/775) |

--- a/rtl/core/neorv32_fifo.vhd
+++ b/rtl/core/neorv32_fifo.vhd
@@ -145,9 +145,7 @@ begin
         fifo_mem <= (others => (others => '0')); -- full reset of memory cells
       elsif rising_edge(clk_i) then
         if (we = '1') then
-          -- Added fifo_depth check to the read out path to preven a NULL assertion for
-          -- fifo_depth_c of 1.
-          if (fifo_depth_c > 1) then 
+          if (fifo_depth_c > 1) then -- prevent a NULL assertion for fifo_depth_c of 1
             fifo_mem(to_integer(unsigned(w_pnt(w_pnt'left-1 downto 0)))) <= wdata_i;
           else
             fifo_mem(0) <= wdata_i;
@@ -163,7 +161,7 @@ begin
     begin
       if rising_edge(clk_i) then
         if (we = '1') then
-          if (fifo_depth_c > 1) then 
+          if (fifo_depth_c > 1) then-- prevent a NULL assertion for fifo_depth_c of 1
             fifo_mem(to_integer(unsigned(w_pnt(w_pnt'left-1 downto 0)))) <= wdata_i;
           else
             fifo_mem(0) <= wdata_i;
@@ -178,8 +176,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   fifo_read_async: -- asynchronous read
   if not FIFO_RSYNC generate
-    -- Added fifo_depth check to the read out path to preven a NULL assertion for
-    -- fifo_depth_c of 1.
+    -- prevent a NULL assertion for fifo_depth_c of 1 --
     rdata_o <= fifo_mem(to_integer(unsigned(r_pnt(r_pnt'left-1 downto 0)))) when (fifo_depth_c > 1) else fifo_mem(0);
     -- status --
     free_o  <= free;
@@ -192,9 +189,7 @@ begin
     sync_read: process(clk_i)
     begin
       if rising_edge(clk_i) then
-        -- Added fifo_depth check to the read out path to preven a NULL assertion for
-        -- fifo_depth_c of 1.
-        if (fifo_depth_c > 1) then 
+        if (fifo_depth_c > 1) then -- prevent a NULL assertion for fifo_depth_c of 1
           rdata_o <= fifo_mem(to_integer(unsigned(r_pnt(r_pnt'left-1 downto 0))));
         else
           rdata_o <= fifo_mem(0);

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090306"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090307"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 


### PR DESCRIPTION
fifo.vhd has been updated to reflect feedback. Changes has been verified to not cause issues with assertions.
Added a tweak to the write path to make read and write symmetric allowing some flops to potentially be saved for FIFOs of size 1.