### PR TITLE
🧪 extend switchable clock domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 29.01.2024 | 1.9.3.9 | :test_tube: extend switchable clock domain (CPU bus switch, i-cache, d-cache) | [#780](https://github.com/stnolting/neorv32/pull/780) |
 | 29.01.2024 | 1.9.3.8 | top entity input ports now have default values `'L'` or `'h'` modeling a pull-down or pull-resistor in case they are not explicitly assigned during instantiation | [#779](https://github.com/stnolting/neorv32/pull/779) |
 | 28.01.2024 | 1.9.3.7 | FIFO module _NULL assertion_ fix | [#778](https://github.com/stnolting/neorv32/pull/778) |
 | 27.01.2024 | 1.9.3.6 | improve CPU's front end (instruction fetch) increasing overall performance | [#777](https://github.com/stnolting/neorv32/pull/777) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -311,9 +311,10 @@ before being further processed.
 ==== Clock Gating
 
 The single clock domain of the processor can be split into an always-on clock domain and a switchable clock domain.
-The switchable clock domain is used to clock the CPU core. This domain can be deactivated at runtime to reduce power
-consumption. The always-on clock domain is used to clock all other processor modules like peripherals, memories and IO
-devices. Hence, these modules can continue operation (e.g. a timer keeps running) even if the CPU is shut down.
+The switchable clock domain is used to clock the CPU core, the CPU's bus switch and - if implemented - the caches.
+This domain can be deactivated to reduce power consumption. The always-on clock domain is used to clock all other
+processor modules like peripherals, memories and IO devices. Hence, these modules can continue operation (e.g. a
+timer keeps running) even if the CPU is shut down.
 
 The splitting into two clock domain is enabled by the `CLOCK_GATING_EN` generic (<<_processor_top_entity_generics>>).
 When enabled, a generic clock switching gate is added to decouple the switchable clock from the always-on clock domain

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090308"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090309"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -602,7 +602,7 @@ begin
         ICACHE_UC_PBEGIN  => uncached_begin_c(31 downto 28)
       )
       port map (
-        clk_i     => clk_i,
+        clk_i     => clk_cpu,
         rstn_i    => rstn_sys,
         clear_i   => i_fence,
         cpu_req_i => cpu_i_req,
@@ -630,7 +630,7 @@ begin
         DCACHE_UC_PBEGIN  => uncached_begin_c(31 downto 28)
       )
       port map (
-        clk_i     => clk_i,
+        clk_i     => clk_cpu,
         rstn_i    => rstn_sys,
         clear_i   => d_fence,
         cpu_req_i => cpu_d_req,
@@ -655,7 +655,7 @@ begin
       PORT_B_READ_ONLY => true -- i-fetch is read-only
     )
     port map (
-      clk_i   => clk_i,
+      clk_i   => clk_cpu,
       rstn_i  => rstn_sys,
       a_req_i => dcache_req, -- prioritized
       a_rsp_o => dcache_rsp,


### PR DESCRIPTION
When the CPU is in sleep mode and clock gating is enabled the CPU itself is shut down. With this PR this switchable clock domain is extended (red box in the figure below):
- the CPU bus switched is shut down
- both caches - if implemented - are shut down

![neorv32_bus](https://github.com/stnolting/neorv32/assets/22944758/c4c929b6-7e07-40db-95a6-5028a623d8bf)
