### PR TITLE
fix trap priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 31.01.2024 | 1.9.4.1 | fix trap priority | [#784](https://github.com/stnolting/neorv32/pull/784) |
 | 31.01.2024 | [**:rocket:1.9.4**](https://github.com/stnolting/neorv32/releases/tag/v1.9.4) | **New release** | |
 | 31.01.2024 | 1.9.3.10 | close illegal compressed instruction decoding loophole | [#783](https://github.com/stnolting/neorv32/pull/783) |
 | 29.01.2024 | 1.9.3.9 | :test_tube: extend switchable clock domain (CPU bus switch, i-cache, d-cache) | [#780](https://github.com/stnolting/neorv32/pull/780) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -935,16 +935,16 @@ written to the according CSRs when a trap is triggered:
 |=======================
 | Prio. | `mcause`     | RTE Trap ID              | Cause                                | `mepc` | `mtval` | `mtinst`
 7+^| **Exceptions** (_synchronous_ to instruction execution)                                                 
-| 1     | `0x00000000` | `TRAP_CODE_I_MISALIGNED` | instruction address misaligned       | PC     | 0       | INS
-| 2     | `0x00000001` | `TRAP_CODE_I_ACCESS`     | instruction bus access fault         | I-PC   | 0       | INS
-| 3     | `0x00000002` | `TRAP_CODE_I_ILLEGAL`    | illegal instruction                  | PC     | 0       | INS
+| 1     | `0x00000001` | `TRAP_CODE_I_ACCESS`     | instruction access fault             | I-PC   | 0       | INS
+| 2     | `0x00000002` | `TRAP_CODE_I_ILLEGAL`    | illegal instruction                  | PC     | 0       | INS
+| 3     | `0x00000000` | `TRAP_CODE_I_MISALIGNED` | instruction address misaligned       | PC     | 0       | INS
 | 4     | `0x0000000b` | `TRAP_CODE_MENV_CALL`    | environment call from M-mode         | PC     | 0       | INS
 | 5     | `0x00000008` | `TRAP_CODE_UENV_CALL`    | environment call from U-mode         | PC     | 0       | INS
 | 6     | `0x00000003` | `TRAP_CODE_BREAKPOINT`   | software breakpoint / trigger firing | PC     | 0       | INS
 | 7     | `0x00000006` | `TRAP_CODE_S_MISALIGNED` | store address misaligned             | PC     | ADR     | INS
 | 8     | `0x00000004` | `TRAP_CODE_L_MISALIGNED` | load address misaligned              | PC     | ADR     | INS
-| 9     | `0x00000007` | `TRAP_CODE_S_ACCESS`     | store bus access fault               | PC     | ADR     | INS
-| 10    | `0x00000005` | `TRAP_CODE_L_ACCESS`     | load bus access fault                | PC     | ADR     | INS
+| 9     | `0x00000007` | `TRAP_CODE_S_ACCESS`     | store access fault                   | PC     | ADR     | INS
+| 10    | `0x00000005` | `TRAP_CODE_L_ACCESS`     | load access fault                    | PC     | ADR     | INS
 7+^| **Interrupts** (_asynchronous_ to instruction execution)                                                
 | 11    | `0x80000010` | `TRAP_CODE_FIRQ_0`       | fast interrupt request channel 0     | I-PC   | 0       | 0
 | 12    | `0x80000011` | `TRAP_CODE_FIRQ_1`       | fast interrupt request channel 1     | I-PC   | 0       | 0

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1513,9 +1513,9 @@ begin
       trap_ctrl.cause <= (others => '0');
     elsif rising_edge(clk_i) then
       -- standard RISC-V exceptions --
-      if    (trap_ctrl.exc_buf(exc_ialign_c)   = '1') then trap_ctrl.cause <= trap_ima_c; -- instruction address misaligned
-      elsif (trap_ctrl.exc_buf(exc_iaccess_c)  = '1') then trap_ctrl.cause <= trap_iaf_c; -- instruction access fault
+      if    (trap_ctrl.exc_buf(exc_iaccess_c)  = '1') then trap_ctrl.cause <= trap_iaf_c; -- instruction access fault
       elsif (trap_ctrl.exc_buf(exc_illegal_c)  = '1') then trap_ctrl.cause <= trap_iil_c; -- illegal instruction
+      elsif (trap_ctrl.exc_buf(exc_ialign_c)   = '1') then trap_ctrl.cause <= trap_ima_c; -- instruction address misaligned
       elsif (trap_ctrl.exc_buf(exc_ecall_c)    = '1') then trap_ctrl.cause <= trap_env_c(6 downto 2) & csr.privilege & csr.privilege; -- environment call (U/M)
       elsif (trap_ctrl.exc_buf(exc_ebreak_c)   = '1') then trap_ctrl.cause <= trap_brk_c; -- environment breakpoint
       elsif (trap_ctrl.exc_buf(exc_salign_c)   = '1') then trap_ctrl.cause <= trap_sma_c; -- store address misaligned

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090400"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090401"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -610,7 +610,7 @@ package neorv32_package is
   constant trap_ima_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00000"; -- 0: instruction misaligned
   constant trap_iaf_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00001"; -- 1: instruction access fault
   constant trap_iil_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00010"; -- 2: illegal instruction
-  constant trap_brk_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00011"; -- 3: breakpoint
+  constant trap_brk_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00011"; -- 3: environment breakpoint
   constant trap_lma_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00100"; -- 4: load address misaligned
   constant trap_laf_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00101"; -- 5: load access fault
   constant trap_sma_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00110"; -- 6: store address misaligned

--- a/sw/lib/include/neorv32_rte.h
+++ b/sw/lib/include/neorv32_rte.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -52,14 +52,14 @@
  * NEORV32 runtime environment trap IDs.
  **************************************************************************/
 enum NEORV32_RTE_TRAP_enum {
-  RTE_TRAP_I_MISALIGNED =  0, /**< Instruction address misaligned */
-  RTE_TRAP_I_ACCESS     =  1, /**< Instruction (bus) access fault */
-  RTE_TRAP_I_ILLEGAL    =  2, /**< Illegal instruction */
+  RTE_TRAP_I_ACCESS     =  0, /**< Instruction access fault */
+  RTE_TRAP_I_ILLEGAL    =  1, /**< Illegal instruction */
+  RTE_TRAP_I_MISALIGNED =  2, /**< Instruction address misaligned */
   RTE_TRAP_BREAKPOINT   =  3, /**< Breakpoint (EBREAK instruction) */
   RTE_TRAP_L_MISALIGNED =  4, /**< Load address misaligned */
-  RTE_TRAP_L_ACCESS     =  5, /**< Load (bus) access fault */
+  RTE_TRAP_L_ACCESS     =  5, /**< Load access fault */
   RTE_TRAP_S_MISALIGNED =  6, /**< Store address misaligned */
-  RTE_TRAP_S_ACCESS     =  7, /**< Store (bus) access fault */
+  RTE_TRAP_S_ACCESS     =  7, /**< Store access fault */
   RTE_TRAP_UENV_CALL    =  8, /**< Environment call from user mode (ECALL instruction) */
   RTE_TRAP_MENV_CALL    =  9, /**< Environment call from machine mode (ECALL instruction) */
   RTE_TRAP_MSI          = 10, /**< Machine software interrupt */

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -448,6 +448,10 @@ void neorv32_rte_print_info(void) {
     "FIRQ_15     "
   };
 
+  if (neorv32_uart0_available() == 0) {
+    return; // cannot output anything if UART0 is not implemented
+  }
+
   neorv32_uart0_puts("\n\n<< NEORV32 RTE Configuration >>\n\n");
 
   // header

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -66,8 +66,6 @@ static void __neorv32_rte_print_hex_word(uint32_t num);
  * @note This function installs a debug handler for ALL trap sources, which
  * gives detailed information about the trap. Actual handlers can be installed afterwards
  * via neorv32_rte_handler_install(uint8_t id, void (*handler)(void)).
- *
- * @warning This function can be called from machine-mode only.
  **************************************************************************/
 void neorv32_rte_setup(void) {
 
@@ -98,13 +96,8 @@ void neorv32_rte_setup(void) {
  * @param[in] id Identifier (type) of the targeted trap. See #NEORV32_RTE_TRAP_enum.
  * @param[in] handler The actual handler function for the specified trap (function MUST be of type "void function(void);").
  * @return 0 if success, -1 if error (invalid id or targeted trap not supported).
- *
- * @warning This function can be called from machine-mode only.
  **************************************************************************/
 int neorv32_rte_handler_install(int id, void (*handler)(void)) {
-
-  // raise an exception if we're not in machine-mode
-  asm volatile ("csrr x0, mhartid");
 
   // id valid?
   uint32_t index = (uint32_t)id;
@@ -123,13 +116,8 @@ int neorv32_rte_handler_install(int id, void (*handler)(void)) {
  *
  * @param[in] id Identifier (type) of the targeted trap. See #NEORV32_RTE_TRAP_enum.
  * @return 0 if success, -1 if error (invalid id or targeted trap not supported).
- *
- * @warning This function can be called from machine-mode only.
  **************************************************************************/
 int neorv32_rte_handler_uninstall(int id) {
-
-  // raise an exception if we're not in machine-mode
-  asm volatile ("csrr x0, mhartid");
 
   // id valid?
   uint32_t index = (uint32_t)id;
@@ -199,9 +187,9 @@ static void __attribute__((__naked__,aligned(4))) __neorv32_rte_core(void) {
   // find according trap handler base address
   uint32_t handler_base;
   switch (neorv32_cpu_csr_read(CSR_MCAUSE)) {
-    case TRAP_CODE_I_MISALIGNED: handler_base = __neorv32_rte_vector_lut[RTE_TRAP_I_MISALIGNED]; break;
     case TRAP_CODE_I_ACCESS:     handler_base = __neorv32_rte_vector_lut[RTE_TRAP_I_ACCESS];     break;
     case TRAP_CODE_I_ILLEGAL:    handler_base = __neorv32_rte_vector_lut[RTE_TRAP_I_ILLEGAL];    break;
+    case TRAP_CODE_I_MISALIGNED: handler_base = __neorv32_rte_vector_lut[RTE_TRAP_I_MISALIGNED]; break;
     case TRAP_CODE_BREAKPOINT:   handler_base = __neorv32_rte_vector_lut[RTE_TRAP_BREAKPOINT];   break;
     case TRAP_CODE_L_MISALIGNED: handler_base = __neorv32_rte_vector_lut[RTE_TRAP_L_MISALIGNED]; break;
     case TRAP_CODE_L_ACCESS:     handler_base = __neorv32_rte_vector_lut[RTE_TRAP_L_ACCESS];     break;
@@ -301,8 +289,6 @@ static void __attribute__((__naked__,aligned(4))) __neorv32_rte_core(void) {
  * NEORV32 runtime environment (RTE):
  * Read register from application context.
  *
- * @warning This function can be called from machine-mode only.
- *
  * @param[in] x Register number (0..31, corresponds to register x0..x31).
  * @return Content of register x.
  **************************************************************************/
@@ -321,8 +307,6 @@ uint32_t neorv32_rte_context_get(int x) {
 /**********************************************************************//**
  * NEORV32 runtime environment (RTE):
  * Write register in application context.
- *
- * @warning This function can be called from machine-mode only.
  *
  * @param[in] x Register number (0..31, corresponds to register x0..x31).
  * @param[in] data Data to be written to register x.
@@ -363,9 +347,9 @@ static void __neorv32_rte_debug_handler(void) {
   // cause
   uint32_t trap_cause = neorv32_cpu_csr_read(CSR_MCAUSE);
   switch (trap_cause) {
-    case TRAP_CODE_I_MISALIGNED: neorv32_uart0_puts("Instruction address misaligned"); break;
     case TRAP_CODE_I_ACCESS:     neorv32_uart0_puts("Instruction access fault"); break;
     case TRAP_CODE_I_ILLEGAL:    neorv32_uart0_puts("Illegal instruction"); break;
+    case TRAP_CODE_I_MISALIGNED: neorv32_uart0_puts("Instruction address misaligned"); break;
     case TRAP_CODE_BREAKPOINT:   neorv32_uart0_puts("Breakpoint"); break;
     case TRAP_CODE_L_MISALIGNED: neorv32_uart0_puts("Load address misaligned"); break;
     case TRAP_CODE_L_ACCESS:     neorv32_uart0_puts("Load access fault"); break;
@@ -429,18 +413,13 @@ static void __neorv32_rte_debug_handler(void) {
 /**********************************************************************//**
  * NEORV32 runtime environment (RTE):
  * Print current RTE configuration via UART0.
- *
- * @warning This function can be called from machine-mode only.
  **************************************************************************/
 void neorv32_rte_print_info(void) {
 
-  // raise an exception if we're not in machine-mode
-  asm volatile ("csrr x0, mhartid");
-
   const char trap_name[NEORV32_RTE_NUM_TRAPS][13] = {
-    "I_MISALIGNED",
     "I_ACCESS    ",
     "I_ILLEGAL   ",
+    "I_MISALIGNED",
     "BREAKPOINT  ",
     "L_MISALIGNED",
     "L_ACCESS    ",
@@ -469,7 +448,7 @@ void neorv32_rte_print_info(void) {
     "FIRQ_15     "
   };
 
-  neorv32_uart0_puts("\n\n<< NEORV32 Runtime Environment (RTE) Configuration >>\n\n");
+  neorv32_uart0_puts("\n\n<< NEORV32 RTE Configuration >>\n\n");
 
   // header
   neorv32_uart0_puts("---------------------------------\n");
@@ -499,13 +478,8 @@ void neorv32_rte_print_info(void) {
 /**********************************************************************//**
  * NEORV32 runtime environment (RTE):
  * Print hardware configuration information via UART0.
- *
- * @warning This function can be called from machine-mode only.
  **************************************************************************/
 void neorv32_rte_print_hw_config(void) {
-
-  // raise an exception if we're not in machine-mode
-  asm volatile ("csrr x0, mhartid");
 
   if (neorv32_uart0_available() == 0) {
     return; // cannot output anything if UART0 is not implemented
@@ -754,8 +728,6 @@ void __neorv32_rte_print_hex_word(uint32_t num) {
 /**********************************************************************//**
  * NEORV32 runtime environment (RTE):
  * Print the processor version in human-readable format via UART0.
- *
- * @warning This function can be called from machine-mode only.
  **************************************************************************/
 void neorv32_rte_print_hw_version(void) {
 


### PR DESCRIPTION
According to the RISC-V priv. spec. "instruction access fault" has higher priority than "instruction address misaligned":

![grafik](https://github.com/stnolting/neorv32/assets/22944758/bed46062-3e2e-4e58-b0af-ff49bb947e35)

However, this is not a real bug fix since those two exceptions cannot occur at the same time.