### PR TITLE
Add support for page fault exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 01.02.2024 | 1.9.4.2 | :sparkles: add support for page fault exceptions (yet unused) | [#786](https://github.com/stnolting/neorv32/pull/786) |
 | 31.01.2024 | 1.9.4.1 | fix trap priority | [#784](https://github.com/stnolting/neorv32/pull/784) |
 | 31.01.2024 | [**:rocket:1.9.4**](https://github.com/stnolting/neorv32/releases/tag/v1.9.4) | **New release** | |
 | 31.01.2024 | 1.9.3.10 | close illegal compressed instruction decoding loophole | [#783](https://github.com/stnolting/neorv32/pull/783) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -927,6 +927,7 @@ written to the according CSRs when a trap is triggered:
 * **PC** - address of instruction that caused the trap (instruction has been executed)
 * **ADR** - bad data memory access address that caused the trap
 * **INS** - the transformed/decompressed instruction word that caused the trap
+* **UND** - undefined
 * **0** - zero
 
 .NEORV32 Trap Listing
@@ -935,36 +936,39 @@ written to the according CSRs when a trap is triggered:
 |=======================
 | Prio. | `mcause`     | RTE Trap ID              | Cause                                | `mepc` | `mtval` | `mtinst`
 7+^| **Exceptions** (_synchronous_ to instruction execution)                                                 
-| 1     | `0x00000001` | `TRAP_CODE_I_ACCESS`     | instruction access fault             | I-PC   | 0       | INS
-| 2     | `0x00000002` | `TRAP_CODE_I_ILLEGAL`    | illegal instruction                  | PC     | 0       | INS
-| 3     | `0x00000000` | `TRAP_CODE_I_MISALIGNED` | instruction address misaligned       | PC     | 0       | INS
-| 4     | `0x0000000b` | `TRAP_CODE_MENV_CALL`    | environment call from M-mode         | PC     | 0       | INS
-| 5     | `0x00000008` | `TRAP_CODE_UENV_CALL`    | environment call from U-mode         | PC     | 0       | INS
-| 6     | `0x00000003` | `TRAP_CODE_BREAKPOINT`   | software breakpoint / trigger firing | PC     | 0       | INS
-| 7     | `0x00000006` | `TRAP_CODE_S_MISALIGNED` | store address misaligned             | PC     | ADR     | INS
-| 8     | `0x00000004` | `TRAP_CODE_L_MISALIGNED` | load address misaligned              | PC     | ADR     | INS
-| 9     | `0x00000007` | `TRAP_CODE_S_ACCESS`     | store access fault                   | PC     | ADR     | INS
-| 10    | `0x00000005` | `TRAP_CODE_L_ACCESS`     | load access fault                    | PC     | ADR     | INS
+| 1     | `0x0000000c` | `TRAP_CODE_I_PAGE`       | instruction page fault               | I-PC   | UND     | INS
+| 2     | `0x00000001` | `TRAP_CODE_I_ACCESS`     | instruction access fault             | I-PC   | 0       | INS
+| 3     | `0x00000002` | `TRAP_CODE_I_ILLEGAL`    | illegal instruction                  | PC     | 0       | INS
+| 4     | `0x00000000` | `TRAP_CODE_I_MISALIGNED` | instruction address misaligned       | PC     | 0       | INS
+| 5     | `0x0000000b` | `TRAP_CODE_MENV_CALL`    | environment call from M-mode         | PC     | 0       | INS
+| 6     | `0x00000008` | `TRAP_CODE_UENV_CALL`    | environment call from U-mode         | PC     | 0       | INS
+| 7     | `0x00000003` | `TRAP_CODE_BREAKPOINT`   | software breakpoint / trigger firing | PC     | 0       | INS
+| 8     | `0x00000006` | `TRAP_CODE_S_MISALIGNED` | store address misaligned             | PC     | ADR     | INS
+| 9     | `0x00000004` | `TRAP_CODE_L_MISALIGNED` | load address misaligned              | PC     | ADR     | INS
+| 10    | `0x0000000f` | `TRAP_CODE_S_PAGE`       | store page fault                     | PC     | ADR     | INS
+| 11    | `0x0000000d` | `TRAP_CODE_L_PAGE`       | load page fault                      | PC     | ADR     | INS
+| 12    | `0x00000007` | `TRAP_CODE_S_ACCESS`     | store access fault                   | PC     | ADR     | INS
+| 13    | `0x00000005` | `TRAP_CODE_L_ACCESS`     | load access fault                    | PC     | ADR     | INS
 7+^| **Interrupts** (_asynchronous_ to instruction execution)                                                
-| 11    | `0x80000010` | `TRAP_CODE_FIRQ_0`       | fast interrupt request channel 0     | I-PC   | 0       | 0
-| 12    | `0x80000011` | `TRAP_CODE_FIRQ_1`       | fast interrupt request channel 1     | I-PC   | 0       | 0
-| 13    | `0x80000012` | `TRAP_CODE_FIRQ_2`       | fast interrupt request channel 2     | I-PC   | 0       | 0
-| 14    | `0x80000013` | `TRAP_CODE_FIRQ_3`       | fast interrupt request channel 3     | I-PC   | 0       | 0
-| 15    | `0x80000014` | `TRAP_CODE_FIRQ_4`       | fast interrupt request channel 4     | I-PC   | 0       | 0
-| 16    | `0x80000015` | `TRAP_CODE_FIRQ_5`       | fast interrupt request channel 5     | I-PC   | 0       | 0
-| 17    | `0x80000016` | `TRAP_CODE_FIRQ_6`       | fast interrupt request channel 6     | I-PC   | 0       | 0
-| 18    | `0x80000017` | `TRAP_CODE_FIRQ_7`       | fast interrupt request channel 7     | I-PC   | 0       | 0
-| 19    | `0x80000018` | `TRAP_CODE_FIRQ_8`       | fast interrupt request channel 8     | I-PC   | 0       | 0
-| 20    | `0x80000019` | `TRAP_CODE_FIRQ_9`       | fast interrupt request channel 9     | I-PC   | 0       | 0
-| 21    | `0x8000001a` | `TRAP_CODE_FIRQ_10`      | fast interrupt request channel 10    | I-PC   | 0       | 0
-| 22    | `0x8000001b` | `TRAP_CODE_FIRQ_11`      | fast interrupt request channel 11    | I-PC   | 0       | 0
-| 23    | `0x8000001c` | `TRAP_CODE_FIRQ_12`      | fast interrupt request channel 12    | I-PC   | 0       | 0
-| 24    | `0x8000001d` | `TRAP_CODE_FIRQ_13`      | fast interrupt request channel 13    | I-PC   | 0       | 0
-| 25    | `0x8000001e` | `TRAP_CODE_FIRQ_14`      | fast interrupt request channel 14    | I-PC   | 0       | 0
-| 26    | `0x8000001f` | `TRAP_CODE_FIRQ_15`      | fast interrupt request channel 15    | I-PC   | 0       | 0
-| 27    | `0x8000000B` | `TRAP_CODE_MEI`          | machine external interrupt (MEI)     | I-PC   | 0       | 0
-| 28    | `0x80000003` | `TRAP_CODE_MSI`          | machine software interrupt (MSI)     | I-PC   | 0       | 0
-| 29    | `0x80000007` | `TRAP_CODE_MTI`          | machine timer interrupt (MTI)        | I-PC   | 0       | 0
+| 14    | `0x80000010` | `TRAP_CODE_FIRQ_0`       | fast interrupt request channel 0     | I-PC   | 0       | 0
+| 15    | `0x80000011` | `TRAP_CODE_FIRQ_1`       | fast interrupt request channel 1     | I-PC   | 0       | 0
+| 16    | `0x80000012` | `TRAP_CODE_FIRQ_2`       | fast interrupt request channel 2     | I-PC   | 0       | 0
+| 17    | `0x80000013` | `TRAP_CODE_FIRQ_3`       | fast interrupt request channel 3     | I-PC   | 0       | 0
+| 18    | `0x80000014` | `TRAP_CODE_FIRQ_4`       | fast interrupt request channel 4     | I-PC   | 0       | 0
+| 19    | `0x80000015` | `TRAP_CODE_FIRQ_5`       | fast interrupt request channel 5     | I-PC   | 0       | 0
+| 20    | `0x80000016` | `TRAP_CODE_FIRQ_6`       | fast interrupt request channel 6     | I-PC   | 0       | 0
+| 21    | `0x80000017` | `TRAP_CODE_FIRQ_7`       | fast interrupt request channel 7     | I-PC   | 0       | 0
+| 22    | `0x80000018` | `TRAP_CODE_FIRQ_8`       | fast interrupt request channel 8     | I-PC   | 0       | 0
+| 23    | `0x80000019` | `TRAP_CODE_FIRQ_9`       | fast interrupt request channel 9     | I-PC   | 0       | 0
+| 24    | `0x8000001a` | `TRAP_CODE_FIRQ_10`      | fast interrupt request channel 10    | I-PC   | 0       | 0
+| 25    | `0x8000001b` | `TRAP_CODE_FIRQ_11`      | fast interrupt request channel 11    | I-PC   | 0       | 0
+| 26    | `0x8000001c` | `TRAP_CODE_FIRQ_12`      | fast interrupt request channel 12    | I-PC   | 0       | 0
+| 27    | `0x8000001d` | `TRAP_CODE_FIRQ_13`      | fast interrupt request channel 13    | I-PC   | 0       | 0
+| 28    | `0x8000001e` | `TRAP_CODE_FIRQ_14`      | fast interrupt request channel 14    | I-PC   | 0       | 0
+| 29    | `0x8000001f` | `TRAP_CODE_FIRQ_15`      | fast interrupt request channel 15    | I-PC   | 0       | 0
+| 30    | `0x8000000B` | `TRAP_CODE_MEI`          | machine external interrupt (MEI)     | I-PC   | 0       | 0
+| 31    | `0x80000003` | `TRAP_CODE_MSI`          | machine software interrupt (MSI)     | I-PC   | 0       | 0
+| 32    | `0x80000007` | `TRAP_CODE_MTI`          | machine timer interrupt (MTI)        | I-PC   | 0       | 0
 |=======================
 
 .NEORV32 Trap Description
@@ -972,14 +976,17 @@ written to the according CSRs when a trap is triggered:
 [options="header",grid="rows"]
 |=======================
 | Trap ID [C] | Triggered when ...
-| `TRAP_CODE_I_MISALIGNED` | fetching a 32-bit instruction word that is not 32-bit-aligned (see note below)
+| `TRAP_CODE_I_PAGE`       | instruction page fault, **no trigger mechanism implemented yet**
 | `TRAP_CODE_I_ACCESS`     | bus timeout, bus access error or <<_pmp_isa_extension,PMP>> rule violation during instruction fetch
 | `TRAP_CODE_I_ILLEGAL`    | trying to execute an invalid instruction word (malformed or not supported) or on a privilege violation
+| `TRAP_CODE_I_MISALIGNED` | fetching a 32-bit instruction word that is not 32-bit-aligned (see note below)
 | `TRAP_CODE_MENV_CALL`    | executing `ecall` instruction in machine-mode
 | `TRAP_CODE_UENV_CALL`    | executing `ecall` instruction in user-mode
 | `TRAP_CODE_BREAKPOINT`   | executing `ebreak` instruction or if <<_trigger_module>> fires
 | `TRAP_CODE_S_MISALIGNED` | storing data to an address that is not naturally aligned to the data size (half/word)
 | `TRAP_CODE_L_MISALIGNED` | loading data from an address that is not naturally aligned to the data size  (half/word)
+| `TRAP_CODE_S_PAGE`       | store page fault, **no trigger mechanism implemented yet**
+| `TRAP_CODE_L_PAGE`       | load page fault, **no trigger mechanism implemented yet**
 | `TRAP_CODE_S_ACCESS`     | bus timeout, bus access error or <<_pmp_isa_extension,PMP>> rule violation during load data operation
 | `TRAP_CODE_L_ACCESS`     | bus timeout, bus access error or <<_pmp_isa_extension,PMP>> rule violation during store data operation
 | `TRAP_CODE_FIRQ_*`       | caused by interrupt-condition of **processor-internal modules**, see <<_neorv32_specific_fast_interrupt_requests>>

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -206,46 +206,49 @@ begin
   )
   port map (
     -- global control --
-    clk_i         => clk_i,          -- global clock, rising edge
-    clk_aux_i     => clk_aux_i,      -- always-on clock, rising edge
-    rstn_i        => rstn_i,         -- global reset, low-active, async
-    ctrl_o        => ctrl,           -- main control bus
+    clk_i          => clk_i,          -- global clock, rising edge
+    clk_aux_i      => clk_aux_i,      -- always-on clock, rising edge
+    rstn_i         => rstn_i,         -- global reset, low-active, async
+    ctrl_o         => ctrl,           -- main control bus
     -- instruction fetch interface --
-    bus_req_o     => ibus_req_o,     -- request
-    bus_rsp_i     => ibus_rsp_i,     -- response
+    bus_req_o      => ibus_req_o,     -- request
+    bus_rsp_i      => ibus_rsp_i,     -- response
     -- status input --
-    i_pmp_fault_i => pmp_ex_fault,   -- instruction fetch pmp fault
-    alu_cp_done_i => cp_done,        -- ALU iterative operation done
-    lsu_wait_i    => lsu_wait,       -- wait for data bus
-    cmp_i         => alu_cmp,        -- comparator status
+    i_page_fault_i => '0',            -- instruction fetch page fault
+    i_pmp_fault_i  => pmp_ex_fault,   -- instruction fetch pmp fault
+    alu_cp_done_i  => cp_done,        -- ALU iterative operation done
+    lsu_wait_i     => lsu_wait,       -- wait for data bus
+    cmp_i          => alu_cmp,        -- comparator status
     -- data input --
-    alu_add_i     => alu_add,        -- ALU address result
-    rs1_i         => rs1,            -- rf source 1
+    alu_add_i      => alu_add,        -- ALU address result
+    rs1_i          => rs1,            -- rf source 1
     -- data output --
-    imm_o         => imm,            -- immediate
-    fetch_pc_o    => fetch_pc,       -- instruction fetch address
-    curr_pc_o     => curr_pc,        -- current PC (corresponding to current instruction)
-    link_pc_o     => link_pc,        -- link PC (return address)
-    csr_rdata_o   => csr_rdata,      -- CSR read data
+    imm_o          => imm,            -- immediate
+    fetch_pc_o     => fetch_pc,       -- instruction fetch address
+    curr_pc_o      => curr_pc,        -- current PC (corresponding to current instruction)
+    link_pc_o      => link_pc,        -- link PC (return address)
+    csr_rdata_o    => csr_rdata,      -- CSR read data
     -- external CSR interface --
-    xcsr_we_o     => xcsr_we,        -- global write enable
-    xcsr_addr_o   => xcsr_addr,      -- address
-    xcsr_wdata_o  => xcsr_wdata,     -- write data
-    xcsr_rdata_i  => xcsr_rdata_res, -- read data
+    xcsr_we_o      => xcsr_we,        -- global write enable
+    xcsr_addr_o    => xcsr_addr,      -- address
+    xcsr_wdata_o   => xcsr_wdata,     -- write data
+    xcsr_rdata_i   => xcsr_rdata_res, -- read data
     -- debug mode (halt) request --
-    db_halt_req_i => dbi_i,
+    db_halt_req_i  => dbi_i,
     -- interrupts (risc-v compliant) --
-    msi_i         => msi_i,          -- machine software interrupt
-    mei_i         => mei_i,          -- machine external interrupt
-    mti_i         => mti_i,          -- machine timer interrupt
+    msi_i          => msi_i,          -- machine software interrupt
+    mei_i          => mei_i,          -- machine external interrupt
+    mti_i          => mti_i,          -- machine timer interrupt
     -- fast interrupts (custom) --
-    firq_i        => firq_i,         -- fast interrupt trigger
+    firq_i         => firq_i,         -- fast interrupt trigger
     -- bus access exceptions --
-    mar_i         => mar,            -- memory address register
-    ma_load_i     => ma_load,        -- misaligned load data address
-    ma_store_i    => ma_store,       -- misaligned store data address
-    be_load_i     => be_load,        -- bus error on load data access
-    be_store_i    => be_store        -- bus error on store data access
+    mar_i          => mar,            -- memory address register
+    ma_load_i      => ma_load,        -- misaligned load data address
+    ma_store_i     => ma_store,       -- misaligned store data address
+    be_load_i      => be_load,        -- bus error on load data access
+    be_store_i     => be_store,       -- bus error on store data access
+    l_page_fault_i => '0',            -- load page fault
+    s_page_fault_i => '0'             -- store page fault
   );
 
   -- external CSR read-back --

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -133,6 +133,9 @@ architecture neorv32_cpu_rtl of neorv32_cpu is
   signal link_pc      : std_ulogic_vector(XLEN-1 downto 0); -- link pc (return address)
   signal pmp_ex_fault : std_ulogic; -- PMP instruction fetch fault
   signal pmp_rw_fault : std_ulogic; -- PMP read/write access fault
+  signal i_page_fault : std_ulogic; -- instruction page fault
+  signal l_page_fault : std_ulogic; -- load page fault
+  signal s_page_fault : std_ulogic; -- store page fault
 
 begin
 
@@ -211,7 +214,7 @@ begin
     rstn_i         => rstn_i,         -- global reset, low-active, async
     ctrl_o         => ctrl,           -- main control bus
     -- instruction fetch interface --
-    i_page_fault_i => '0',            -- instruction fetch page fault
+    i_page_fault_i => i_page_fault,   -- instruction fetch page fault
     i_pmp_fault_i  => pmp_ex_fault,   -- instruction fetch pmp fault
     bus_req_o      => ibus_req_o,     -- request
     bus_rsp_i      => ibus_rsp_i,     -- response
@@ -243,8 +246,8 @@ begin
     ma_store_i     => ma_store,       -- misaligned store data address
     be_load_i      => be_load,        -- bus error on load data access
     be_store_i     => be_store,       -- bus error on store data access
-    l_page_fault_i => '0',            -- load page fault
-    s_page_fault_i => '0'             -- store page fault
+    l_page_fault_i => l_page_fault,   -- load page fault
+    s_page_fault_i => s_page_fault    -- store page fault
   );
 
   -- external CSR read-back --
@@ -389,6 +392,14 @@ begin
     pmp_ex_fault   <= '0';
     pmp_rw_fault   <= '0';
   end generate;
+
+
+  -- Memory Management/Paging Unit ----------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  -- nothing to see here yet --
+  i_page_fault <= '0'; -- instruction page fault
+  l_page_fault <= '0'; -- load page fault
+  s_page_fault <= '0'; -- store page fault
 
 
 end neorv32_cpu_rtl;

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -211,18 +211,15 @@ begin
     rstn_i         => rstn_i,         -- global reset, low-active, async
     ctrl_o         => ctrl,           -- main control bus
     -- instruction fetch interface --
-    bus_req_o      => ibus_req_o,     -- request
-    bus_rsp_i      => ibus_rsp_i,     -- response
-    -- status input --
     i_page_fault_i => '0',            -- instruction fetch page fault
     i_pmp_fault_i  => pmp_ex_fault,   -- instruction fetch pmp fault
+    bus_req_o      => ibus_req_o,     -- request
+    bus_rsp_i      => ibus_rsp_i,     -- response
+    -- data path interface --
     alu_cp_done_i  => cp_done,        -- ALU iterative operation done
-    lsu_wait_i     => lsu_wait,       -- wait for data bus
     cmp_i          => alu_cmp,        -- comparator status
-    -- data input --
     alu_add_i      => alu_add,        -- ALU address result
     rs1_i          => rs1,            -- rf source 1
-    -- data output --
     imm_o          => imm,            -- immediate
     fetch_pc_o     => fetch_pc,       -- instruction fetch address
     curr_pc_o      => curr_pc,        -- current PC (corresponding to current instruction)
@@ -233,15 +230,14 @@ begin
     xcsr_addr_o    => xcsr_addr,      -- address
     xcsr_wdata_o   => xcsr_wdata,     -- write data
     xcsr_rdata_i   => xcsr_rdata_res, -- read data
-    -- debug mode (halt) request --
-    db_halt_req_i  => dbi_i,
-    -- interrupts (risc-v compliant) --
+    -- interrupts --
+    db_halt_req_i  => dbi_i,          -- debug mode (halt) request
     msi_i          => msi_i,          -- machine software interrupt
     mei_i          => mei_i,          -- machine external interrupt
     mti_i          => mti_i,          -- machine timer interrupt
-    -- fast interrupts (custom) --
-    firq_i         => firq_i,         -- fast interrupt trigger
-    -- bus access exceptions --
+    firq_i         => firq_i,         -- fast interrupts
+    -- data access interface --
+    lsu_wait_i     => lsu_wait,       -- wait for data bus
     mar_i          => mar,            -- memory address register
     ma_load_i      => ma_load,        -- misaligned load data address
     ma_store_i     => ma_store,       -- misaligned store data address

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -88,18 +88,15 @@ entity neorv32_cpu_control is
     rstn_i         : in  std_ulogic; -- global reset, low-active, async
     ctrl_o         : out ctrl_bus_t; -- main control bus
     -- instruction fetch interface --
-    bus_req_o      : out bus_req_t;  -- request
-    bus_rsp_i      : in  bus_rsp_t;  -- response
-    -- status input --
     i_page_fault_i : in  std_ulogic; -- instruction fetch page fault
     i_pmp_fault_i  : in  std_ulogic; -- instruction fetch pmp fault
+    bus_req_o      : out bus_req_t;  -- request
+    bus_rsp_i      : in  bus_rsp_t;  -- response
+    -- data path interface --
     alu_cp_done_i  : in  std_ulogic; -- ALU iterative operation done
-    lsu_wait_i     : in  std_ulogic; -- wait for data bus
     cmp_i          : in  std_ulogic_vector(1 downto 0); -- comparator status
-    -- data input --
     alu_add_i      : in  std_ulogic_vector(XLEN-1 downto 0); -- ALU address result
     rs1_i          : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
-    -- data output --
     imm_o          : out std_ulogic_vector(XLEN-1 downto 0); -- immediate
     fetch_pc_o     : out std_ulogic_vector(XLEN-1 downto 0); -- instruction fetch address
     curr_pc_o      : out std_ulogic_vector(XLEN-1 downto 0); -- current PC (corresponding to current instruction)
@@ -116,7 +113,8 @@ entity neorv32_cpu_control is
     mei_i          : in  std_ulogic; -- machine external interrupt
     mti_i          : in  std_ulogic; -- machine timer interrupt
     firq_i         : in  std_ulogic_vector(15 downto 0); -- fast interrupts
-    -- bus access exceptions --
+    -- data access interface --
+    lsu_wait_i     : in  std_ulogic; -- wait for data bus
     mar_i          : in  std_ulogic_vector(XLEN-1 downto 0); -- memory address register
     ma_load_i      : in  std_ulogic; -- misaligned load data address
     ma_store_i     : in  std_ulogic; -- misaligned store data address

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -83,44 +83,47 @@ entity neorv32_cpu_control is
   );
   port (
     -- global control --
-    clk_i         : in  std_ulogic; -- global clock, rising edge
-    clk_aux_i     : in  std_ulogic; -- always-on clock, rising edge
-    rstn_i        : in  std_ulogic; -- global reset, low-active, async
-    ctrl_o        : out ctrl_bus_t; -- main control bus
+    clk_i          : in  std_ulogic; -- global clock, rising edge
+    clk_aux_i      : in  std_ulogic; -- always-on clock, rising edge
+    rstn_i         : in  std_ulogic; -- global reset, low-active, async
+    ctrl_o         : out ctrl_bus_t; -- main control bus
     -- instruction fetch interface --
-    bus_req_o     : out bus_req_t;  -- request
-    bus_rsp_i     : in  bus_rsp_t;  -- response
+    bus_req_o      : out bus_req_t;  -- request
+    bus_rsp_i      : in  bus_rsp_t;  -- response
     -- status input --
-    i_pmp_fault_i : in  std_ulogic; -- instruction fetch pmp fault
-    alu_cp_done_i : in  std_ulogic; -- ALU iterative operation done
-    lsu_wait_i    : in  std_ulogic; -- wait for data bus
-    cmp_i         : in  std_ulogic_vector(1 downto 0); -- comparator status
+    i_page_fault_i : in  std_ulogic; -- instruction fetch page fault
+    i_pmp_fault_i  : in  std_ulogic; -- instruction fetch pmp fault
+    alu_cp_done_i  : in  std_ulogic; -- ALU iterative operation done
+    lsu_wait_i     : in  std_ulogic; -- wait for data bus
+    cmp_i          : in  std_ulogic_vector(1 downto 0); -- comparator status
     -- data input --
-    alu_add_i     : in  std_ulogic_vector(XLEN-1 downto 0); -- ALU address result
-    rs1_i         : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+    alu_add_i      : in  std_ulogic_vector(XLEN-1 downto 0); -- ALU address result
+    rs1_i          : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
     -- data output --
-    imm_o         : out std_ulogic_vector(XLEN-1 downto 0); -- immediate
-    fetch_pc_o    : out std_ulogic_vector(XLEN-1 downto 0); -- instruction fetch address
-    curr_pc_o     : out std_ulogic_vector(XLEN-1 downto 0); -- current PC (corresponding to current instruction)
-    link_pc_o     : out std_ulogic_vector(XLEN-1 downto 0); -- link PC (return address)
-    csr_rdata_o   : out std_ulogic_vector(XLEN-1 downto 0); -- CSR read data
+    imm_o          : out std_ulogic_vector(XLEN-1 downto 0); -- immediate
+    fetch_pc_o     : out std_ulogic_vector(XLEN-1 downto 0); -- instruction fetch address
+    curr_pc_o      : out std_ulogic_vector(XLEN-1 downto 0); -- current PC (corresponding to current instruction)
+    link_pc_o      : out std_ulogic_vector(XLEN-1 downto 0); -- link PC (return address)
+    csr_rdata_o    : out std_ulogic_vector(XLEN-1 downto 0); -- CSR read data
     -- external CSR interface --
-    xcsr_we_o     : out std_ulogic; -- global write enable
-    xcsr_addr_o   : out std_ulogic_vector(11 downto 0); -- address
-    xcsr_wdata_o  : out std_ulogic_vector(XLEN-1 downto 0); -- write data
-    xcsr_rdata_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- read data
+    xcsr_we_o      : out std_ulogic; -- global write enable
+    xcsr_addr_o    : out std_ulogic_vector(11 downto 0); -- address
+    xcsr_wdata_o   : out std_ulogic_vector(XLEN-1 downto 0); -- write data
+    xcsr_rdata_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- read data
     -- interrupts --
-    db_halt_req_i : in  std_ulogic; -- debug mode (halt) request
-    msi_i         : in  std_ulogic; -- machine software interrupt
-    mei_i         : in  std_ulogic; -- machine external interrupt
-    mti_i         : in  std_ulogic; -- machine timer interrupt
-    firq_i        : in  std_ulogic_vector(15 downto 0); -- fast interrupts
+    db_halt_req_i  : in  std_ulogic; -- debug mode (halt) request
+    msi_i          : in  std_ulogic; -- machine software interrupt
+    mei_i          : in  std_ulogic; -- machine external interrupt
+    mti_i          : in  std_ulogic; -- machine timer interrupt
+    firq_i         : in  std_ulogic_vector(15 downto 0); -- fast interrupts
     -- bus access exceptions --
-    mar_i         : in  std_ulogic_vector(XLEN-1 downto 0); -- memory address register
-    ma_load_i     : in  std_ulogic; -- misaligned load data address
-    ma_store_i    : in  std_ulogic; -- misaligned store data address
-    be_load_i     : in  std_ulogic; -- bus error on load data access
-    be_store_i    : in  std_ulogic  -- bus error on store data access
+    mar_i          : in  std_ulogic_vector(XLEN-1 downto 0); -- memory address register
+    ma_load_i      : in  std_ulogic; -- misaligned load data address
+    ma_store_i     : in  std_ulogic; -- misaligned store data address
+    be_load_i      : in  std_ulogic; -- bus error on load data access
+    be_store_i     : in  std_ulogic; -- bus error on store data access
+    l_page_fault_i : in  std_ulogic; -- load page fault
+    s_page_fault_i : in  std_ulogic  -- store page fault
   );
 end neorv32_cpu_control;
 
@@ -144,7 +147,7 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
   signal fetch_engine : fetch_engine_t;
 
   -- instruction prefetch buffer (FIFO) interface --
-  type ipb_data_t is array (0 to 1) of std_ulogic_vector(16 downto 0); -- bus_error & 16-bit instruction
+  type ipb_data_t is array (0 to 1) of std_ulogic_vector(17 downto 0); -- page fault & bus_error & 16-bit instruction
   type ipb_t is record
     wdata : ipb_data_t;
     we    : std_ulogic_vector(1 downto 0); -- trigger write
@@ -162,7 +165,7 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
     align_clr : std_ulogic;
     ci_i16    : std_ulogic_vector(15 downto 0);
     ci_i32    : std_ulogic_vector(31 downto 0);
-    data      : std_ulogic_vector((2+32)-1 downto 0); -- 2-bit status + 32-bit instruction
+    data      : std_ulogic_vector((3+32)-1 downto 0); -- 3-bit status + 32-bit instruction
     valid     : std_ulogic_vector(1 downto 0); -- data word is valid
     ack       : std_ulogic;
   end record;
@@ -235,6 +238,7 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
     instr_be    : std_ulogic; -- instruction fetch bus error
     instr_ma    : std_ulogic; -- instruction fetch misaligned address
     instr_il    : std_ulogic; -- illegal instruction
+    instr_pf    : std_ulogic; -- instruction page fault
     ecall       : std_ulogic; -- ecall instruction
     ebreak      : std_ulogic; -- ebreak instruction
     hwtrig      : std_ulogic; -- hardware trigger module
@@ -415,11 +419,11 @@ begin
   bus_req_o.stb <= '1' when (fetch_engine.state = IF_REQUEST) and (ipb.free = "11") else '0';
 
   -- instruction bus response --
-  fetch_engine.resp <= '1' when (bus_rsp_i.ack = '1') or (bus_rsp_i.err = '1') else '0';
+  fetch_engine.resp <= bus_rsp_i.ack or bus_rsp_i.err or i_page_fault_i;
 
   -- IPB instruction data and status --
-  ipb.wdata(0) <= (bus_rsp_i.err or i_pmp_fault_i) & bus_rsp_i.data(15 downto 00);
-  ipb.wdata(1) <= (bus_rsp_i.err or i_pmp_fault_i) & bus_rsp_i.data(31 downto 16);
+  ipb.wdata(0) <= i_page_fault_i & (bus_rsp_i.err or i_pmp_fault_i) & bus_rsp_i.data(15 downto 00);
+  ipb.wdata(1) <= i_page_fault_i & (bus_rsp_i.err or i_pmp_fault_i) & bus_rsp_i.data(31 downto 16);
 
   -- IPB write enable --
   ipb.we(0) <= '1' when (fetch_engine.state = IF_PENDING) and (fetch_engine.resp = '1') and
@@ -514,23 +518,23 @@ begin
       issue_engine.valid     <= "00";
       -- start with LOW half-word --
       if (issue_engine.align = '0')  then
-        if (ipb.rdata(0)(1 downto 0) /= "11") then -- compressed
+        if (ipb.rdata(0)(1 downto 0) /= "11") then -- compressed, use IPB(0) entry
           issue_engine.align_set <= ipb.avail(0); -- start of next instruction word is NOT 32-bit-aligned
           issue_engine.valid(0)  <= ipb.avail(0);
-          issue_engine.data      <= '1' & ipb.rdata(0)(16) & issue_engine.ci_i32;
+          issue_engine.data      <= '1' & ipb.rdata(0)(17) & ipb.rdata(0)(16) & issue_engine.ci_i32;
         else -- aligned uncompressed; use IPB(0) status flags only
           issue_engine.valid <= (others => (ipb.avail(0) and ipb.avail(1)));
-          issue_engine.data  <= '0' & ipb.rdata(0)(16) & ipb.rdata(1)(15 downto 0) & ipb.rdata(0)(15 downto 0);
+          issue_engine.data  <= '0' & ipb.rdata(0)(17) & ipb.rdata(0)(16) & ipb.rdata(1)(15 downto 0) & ipb.rdata(0)(15 downto 0);
         end if;
       -- start with HIGH half-word --
       else
-        if (ipb.rdata(1)(1 downto 0) /= "11") then -- compressed
+        if (ipb.rdata(1)(1 downto 0) /= "11") then -- compressed, use IPB(1) entry
           issue_engine.align_clr <= ipb.avail(1); -- start of next instruction word is 32-bit-aligned again
           issue_engine.valid(1)  <= ipb.avail(1);
-          issue_engine.data      <= '1' & ipb.rdata(1)(16) & issue_engine.ci_i32;
+          issue_engine.data      <= '1' & ipb.rdata(1)(17) & ipb.rdata(1)(16) & issue_engine.ci_i32;
         else -- unaligned uncompressed; use IPB(0) status flags only
           issue_engine.valid <= (others => (ipb.avail(0) and ipb.avail(1)));
-          issue_engine.data  <= '0' & ipb.rdata(0)(16) & ipb.rdata(0)(15 downto 0) & ipb.rdata(1)(15 downto 0);
+          issue_engine.data  <= '0' & ipb.rdata(0)(17) & ipb.rdata(0)(16) & ipb.rdata(0)(15 downto 0) & ipb.rdata(1)(15 downto 0);
         end if;
       end if;
     end process issue_engine_fsm_comb;
@@ -540,7 +544,7 @@ begin
   issue_engine_disabled: -- use IPB(0) status flags only
   if not CPU_EXTENSION_RISCV_C generate
     issue_engine.valid <= (others => ipb.avail(0));
-    issue_engine.data  <= '0' & ipb.rdata(0)(16) & (ipb.rdata(1)(15 downto 0) & ipb.rdata(0)(15 downto 0));
+    issue_engine.data  <= '0' & ipb.rdata(0)(17) & ipb.rdata(0)(16) & (ipb.rdata(1)(15 downto 0) & ipb.rdata(0)(15 downto 0));
   end generate; -- /issue_engine_disabled
 
   -- update IPB FIFOs --
@@ -820,6 +824,7 @@ begin
     trap_ctrl.env_enter      <= '0';
     trap_ctrl.env_exit       <= '0';
     trap_ctrl.instr_be       <= '0';
+    trap_ctrl.instr_pf       <= '0';
     trap_ctrl.ecall          <= '0';
     trap_ctrl.ebreak         <= '0';
     trap_ctrl.hwtrig         <= '0';
@@ -872,8 +877,9 @@ begin
           execute_engine.state_nxt <= TRAP_ENTER;
         elsif (issue_engine.valid(0) = '1') or (issue_engine.valid(1) = '1') then -- new instruction word available
           issue_engine.ack         <= '1';
-          trap_ctrl.instr_be       <= issue_engine.data(32); -- bus access fault during instruction fetch
-          execute_engine.is_ci_nxt <= issue_engine.data(33); -- this is a de-compressed instruction
+          trap_ctrl.instr_be       <= issue_engine.data(32); -- access fault during instruction fetch
+          trap_ctrl.instr_pf       <= issue_engine.data(33); -- page fault during instruction fetch
+          execute_engine.is_ci_nxt <= issue_engine.data(34); -- this is a de-compressed instruction
           execute_engine.ir_nxt    <= issue_engine.data(31 downto 0); -- instruction word
           execute_engine.pc_we     <= '1'; -- pc <= next_pc
           execute_engine.state_nxt <= EXECUTE;
@@ -1041,7 +1047,8 @@ begin
         ctrl_nxt.rf_mux <= rf_mux_mem_c; -- RF input = memory read data
         if (lsu_wait_i = '0') or -- bus system has completed the transaction
            (trap_ctrl.exc_buf(exc_salign_c) = '1') or (trap_ctrl.exc_buf(exc_saccess_c) = '1') or -- store exception
-           (trap_ctrl.exc_buf(exc_lalign_c) = '1') or (trap_ctrl.exc_buf(exc_laccess_c) = '1') then -- load exception
+           (trap_ctrl.exc_buf(exc_lalign_c) = '1') or (trap_ctrl.exc_buf(exc_laccess_c) = '1') or -- load exception
+           (trap_ctrl.exc_buf(exc_lpage_c)  = '1') or (trap_ctrl.exc_buf(exc_spage_c)   = '1') then -- page exception
           if ((CPU_EXTENSION_RISCV_A = true) and (decode_aux.opcode(2) = opcode_amo_c(2))) or -- atomic operation
              (execute_engine.ir(instr_opcode_msb_c-1) = '0') then -- normal load
             ctrl_nxt.rf_wb_en <= '1'; -- allow write-back to register file (won't happen in case of exception)
@@ -1102,10 +1109,12 @@ begin
   -- -------------------------------------------------------------------------------------------
 
   -- register file --
-  ctrl_o.rf_wb_en     <= ctrl.rf_wb_en and -- inhibit write-back only for rd-writing exceptions that must not retire
-                         (not trap_ctrl.exc_buf(exc_iaccess_c)) and (not trap_ctrl.exc_buf(exc_illegal_c)) and (not trap_ctrl.exc_buf(exc_ialign_c)) and
+  ctrl_o.rf_wb_en     <= ctrl.rf_wb_en and -- inhibit write-back only for rd-updating exceptions that must not retire
+                         (not trap_ctrl.exc_buf(exc_iaccess_c)) and (not trap_ctrl.exc_buf(exc_illegal_c)) and
+                         (not trap_ctrl.exc_buf(exc_ialign_c))  and (not trap_ctrl.exc_buf(exc_ipage_c))   and
                          (not trap_ctrl.exc_buf(exc_salign_c))  and (not trap_ctrl.exc_buf(exc_lalign_c))  and
-                         (not trap_ctrl.exc_buf(exc_saccess_c)) and (not trap_ctrl.exc_buf(exc_laccess_c));
+                         (not trap_ctrl.exc_buf(exc_saccess_c)) and (not trap_ctrl.exc_buf(exc_laccess_c)) and
+                         (not trap_ctrl.exc_buf(exc_spage_c))   and (not trap_ctrl.exc_buf(exc_lpage_c));
   ctrl_o.rf_rs1       <= execute_engine.ir(instr_rs1_msb_c downto instr_rs1_lsb_c);
   ctrl_o.rf_rs2       <= execute_engine.ir(instr_rs2_msb_c downto instr_rs2_lsb_c);
   ctrl_o.rf_rs3       <= execute_engine.ir(instr_rs3_msb_c downto instr_rs3_lsb_c);
@@ -1417,10 +1426,15 @@ begin
       trap_ctrl.exc_buf(exc_salign_c) <= (trap_ctrl.exc_buf(exc_salign_c) or ma_store_i)         and (not trap_ctrl.env_enter);
       trap_ctrl.exc_buf(exc_ialign_c) <= (trap_ctrl.exc_buf(exc_ialign_c) or trap_ctrl.instr_ma) and (not trap_ctrl.env_enter);
 
-      -- load/store/instruction bus access fault --
+      -- load/store/instruction access fault --
       trap_ctrl.exc_buf(exc_laccess_c) <= (trap_ctrl.exc_buf(exc_laccess_c) or be_load_i)          and (not trap_ctrl.env_enter);
       trap_ctrl.exc_buf(exc_saccess_c) <= (trap_ctrl.exc_buf(exc_saccess_c) or be_store_i)         and (not trap_ctrl.env_enter);
       trap_ctrl.exc_buf(exc_iaccess_c) <= (trap_ctrl.exc_buf(exc_iaccess_c) or trap_ctrl.instr_be) and (not trap_ctrl.env_enter);
+
+      -- load/store/instruction page fault --
+      trap_ctrl.exc_buf(exc_lpage_c) <= (trap_ctrl.exc_buf(exc_lpage_c) or l_page_fault_i)     and (not trap_ctrl.env_enter);
+      trap_ctrl.exc_buf(exc_spage_c) <= (trap_ctrl.exc_buf(exc_spage_c) or s_page_fault_i)     and (not trap_ctrl.env_enter);
+      trap_ctrl.exc_buf(exc_ipage_c) <= (trap_ctrl.exc_buf(exc_ipage_c) or trap_ctrl.instr_pf) and (not trap_ctrl.env_enter);
 
       -- illegal instruction & environment call --
       trap_ctrl.exc_buf(exc_ecall_c)   <= (trap_ctrl.exc_buf(exc_ecall_c)   or trap_ctrl.ecall)    and (not trap_ctrl.env_enter);
@@ -1513,13 +1527,16 @@ begin
       trap_ctrl.cause <= (others => '0');
     elsif rising_edge(clk_i) then
       -- standard RISC-V exceptions --
-      if    (trap_ctrl.exc_buf(exc_iaccess_c)  = '1') then trap_ctrl.cause <= trap_iaf_c; -- instruction access fault
+      if    (trap_ctrl.exc_buf(exc_ipage_c)    = '1') then trap_ctrl.cause <= trap_ipf_c; -- instruction page fault
+      elsif (trap_ctrl.exc_buf(exc_iaccess_c)  = '1') then trap_ctrl.cause <= trap_iaf_c; -- instruction access fault
       elsif (trap_ctrl.exc_buf(exc_illegal_c)  = '1') then trap_ctrl.cause <= trap_iil_c; -- illegal instruction
       elsif (trap_ctrl.exc_buf(exc_ialign_c)   = '1') then trap_ctrl.cause <= trap_ima_c; -- instruction address misaligned
       elsif (trap_ctrl.exc_buf(exc_ecall_c)    = '1') then trap_ctrl.cause <= trap_env_c(6 downto 2) & csr.privilege & csr.privilege; -- environment call (U/M)
       elsif (trap_ctrl.exc_buf(exc_ebreak_c)   = '1') then trap_ctrl.cause <= trap_brk_c; -- environment breakpoint
       elsif (trap_ctrl.exc_buf(exc_salign_c)   = '1') then trap_ctrl.cause <= trap_sma_c; -- store address misaligned
       elsif (trap_ctrl.exc_buf(exc_lalign_c)   = '1') then trap_ctrl.cause <= trap_lma_c; -- load address misaligned
+      elsif (trap_ctrl.exc_buf(exc_spage_c)    = '1') then trap_ctrl.cause <= trap_spf_c; -- store page fault
+      elsif (trap_ctrl.exc_buf(exc_lpage_c)    = '1') then trap_ctrl.cause <= trap_lpf_c; -- load page fault
       elsif (trap_ctrl.exc_buf(exc_saccess_c)  = '1') then trap_ctrl.cause <= trap_saf_c; -- store access fault
       elsif (trap_ctrl.exc_buf(exc_laccess_c)  = '1') then trap_ctrl.cause <= trap_laf_c; -- load access fault
       -- standard RISC-V debug mode exceptions and interrupts --
@@ -1829,7 +1846,7 @@ begin
           csr.mcause <= trap_ctrl.cause(trap_ctrl.cause'left) & trap_ctrl.cause(4 downto 0); -- trap type & identifier
           csr.mepc   <= trap_ctrl.epc(XLEN-1 downto 1) & '0'; -- trap PC
           -- trap value --
-          if (trap_ctrl.cause(6) = '0') and (trap_ctrl.cause(4 downto 2) = trap_lma_c(4 downto 2)) then -- load/store misaligned/fault
+          if (trap_ctrl.cause(6) = '0') and (trap_ctrl.cause(2) = '1') then -- load/store misaligned/access/(fetch)page fault
             csr.mtval <= mar_i; -- faulting data access address
           else -- everything else including all interrupts
             csr.mtval <= (others => '0');

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1044,9 +1044,9 @@ begin
       -- ------------------------------------------------------------
         ctrl_nxt.rf_mux <= rf_mux_mem_c; -- RF input = memory read data
         if (lsu_wait_i = '0') or -- bus system has completed the transaction
-           (trap_ctrl.exc_buf(exc_salign_c) = '1') or (trap_ctrl.exc_buf(exc_saccess_c) = '1') or -- store exception
-           (trap_ctrl.exc_buf(exc_lalign_c) = '1') or (trap_ctrl.exc_buf(exc_laccess_c) = '1') or -- load exception
-           (trap_ctrl.exc_buf(exc_lpage_c)  = '1') or (trap_ctrl.exc_buf(exc_spage_c)   = '1') then -- page exception
+           (trap_ctrl.exc_buf(exc_saccess_c) = '1') or (trap_ctrl.exc_buf(exc_laccess_c) = '1') or -- access exception
+           (trap_ctrl.exc_buf(exc_salign_c) = '1')  or (trap_ctrl.exc_buf(exc_lalign_c)  = '1') or -- alignment exception
+           (trap_ctrl.exc_buf(exc_spage_c)  = '1')  or (trap_ctrl.exc_buf(exc_lpage_c)   = '1') then -- page exception
           if ((CPU_EXTENSION_RISCV_A = true) and (decode_aux.opcode(2) = opcode_amo_c(2))) or -- atomic operation
              (execute_engine.ir(instr_opcode_msb_c-1) = '0') then -- normal load
             ctrl_nxt.rf_wb_en <= '1'; -- allow write-back to register file (won't happen in case of exception)
@@ -1844,7 +1844,7 @@ begin
           csr.mcause <= trap_ctrl.cause(trap_ctrl.cause'left) & trap_ctrl.cause(4 downto 0); -- trap type & identifier
           csr.mepc   <= trap_ctrl.epc(XLEN-1 downto 1) & '0'; -- trap PC
           -- trap value --
-          if (trap_ctrl.cause(6) = '0') and (trap_ctrl.cause(2) = '1') then -- load/store misaligned/access/(fetch)page fault
+          if (trap_ctrl.cause(6) = '0') and (trap_ctrl.cause(2) = '1') then -- load/store misaligned/access/(fetch)page fault [hacky!]
             csr.mtval <= mar_i; -- faulting data access address
           else -- everything else including all interrupts
             csr.mtval <= (others => '0');

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090401"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090402"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -616,6 +616,9 @@ package neorv32_package is
   constant trap_sma_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00110"; -- 6: store address misaligned
   constant trap_saf_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00111"; -- 7: store access fault
   constant trap_env_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "010UU"; -- 8..11: environment call from u/s/h/m
+  constant trap_ipf_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "01100"; -- 12: instruction page fault
+  constant trap_lpf_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "01101"; -- 13: load page fault
+  constant trap_spf_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "01111"; -- 15: store page fault
   -- RISC-V compliant asynchronous exceptions (interrupts) --
   constant trap_msi_c      : std_ulogic_vector(6 downto 0) := "1" & "0" & "00011"; -- 3:  machine software interrupt
   constant trap_mti_c      : std_ulogic_vector(6 downto 0) := "1" & "0" & "00111"; -- 7:  machine timer interrupt
@@ -655,11 +658,14 @@ package neorv32_package is
   constant exc_lalign_c   : natural :=  6; -- load address misaligned
   constant exc_saccess_c  : natural :=  7; -- store access fault
   constant exc_laccess_c  : natural :=  8; -- load access fault
+  constant exc_ipage_c    : natural :=  9; -- instruction page fault
+  constant exc_lpage_c    : natural := 10; -- load page fault
+  constant exc_spage_c    : natural := 11; -- store page fault
   -- for debug mode only --
-  constant exc_db_break_c : natural :=  9; -- enter debug mode via ebreak instruction
-  constant exc_db_hw_c    : natural := 10; -- enter debug mode via hw trigger
+  constant exc_db_break_c : natural := 12; -- enter debug mode via ebreak instruction
+  constant exc_db_hw_c    : natural := 13; -- enter debug mode via hw trigger
   --
-  constant exc_width_c    : natural := 11; -- length of this list in bits
+  constant exc_width_c    : natural := 14; -- length of this list in bits
   -- interrupt source bits --
   constant irq_msi_irq_c  : natural :=  0; -- machine software interrupt
   constant irq_mti_irq_c  : natural :=  1; -- machine timer interrupt

--- a/sw/lib/include/neorv32_cpu_csr.h
+++ b/sw/lib/include/neorv32_cpu_csr.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -455,6 +455,9 @@ enum NEORV32_EXCEPTION_CODES_enum {
   TRAP_CODE_S_ACCESS     = 0x00000007U, /**< 0.7:  Store (bus) access fault */
   TRAP_CODE_UENV_CALL    = 0x00000008U, /**< 0.8:  Environment call from user mode (ECALL instruction) */
   TRAP_CODE_MENV_CALL    = 0x0000000bU, /**< 0.11: Environment call from machine mode (ECALL instruction) */
+  TRAP_CODE_I_PAGE       = 0x0000000cU, /**< 0.12: Instruction page fault */
+  TRAP_CODE_L_PAGE       = 0x0000000dU, /**< 0.13: Load page fault */
+  TRAP_CODE_S_PAGE       = 0x0000000fU, /**< 0.15: Store page fault */
   TRAP_CODE_MSI          = 0x80000003U, /**< 1.3:  Machine software interrupt */
   TRAP_CODE_MTI          = 0x80000007U, /**< 1.7:  Machine timer interrupt */
   TRAP_CODE_MEI          = 0x8000000bU, /**< 1.11: Machine external interrupt */

--- a/sw/lib/include/neorv32_rte.h
+++ b/sw/lib/include/neorv32_rte.h
@@ -45,42 +45,45 @@
 /**********************************************************************//**
  * NEORV32 runtime environment: Number of available traps.
  **************************************************************************/
-#define NEORV32_RTE_NUM_TRAPS 29
+#define NEORV32_RTE_NUM_TRAPS 32
 
 
 /**********************************************************************//**
  * NEORV32 runtime environment trap IDs.
  **************************************************************************/
 enum NEORV32_RTE_TRAP_enum {
-  RTE_TRAP_I_ACCESS     =  0, /**< Instruction access fault */
-  RTE_TRAP_I_ILLEGAL    =  1, /**< Illegal instruction */
-  RTE_TRAP_I_MISALIGNED =  2, /**< Instruction address misaligned */
-  RTE_TRAP_BREAKPOINT   =  3, /**< Breakpoint (EBREAK instruction) */
-  RTE_TRAP_L_MISALIGNED =  4, /**< Load address misaligned */
-  RTE_TRAP_L_ACCESS     =  5, /**< Load access fault */
-  RTE_TRAP_S_MISALIGNED =  6, /**< Store address misaligned */
-  RTE_TRAP_S_ACCESS     =  7, /**< Store access fault */
-  RTE_TRAP_UENV_CALL    =  8, /**< Environment call from user mode (ECALL instruction) */
-  RTE_TRAP_MENV_CALL    =  9, /**< Environment call from machine mode (ECALL instruction) */
-  RTE_TRAP_MSI          = 10, /**< Machine software interrupt */
-  RTE_TRAP_MTI          = 11, /**< Machine timer interrupt */
-  RTE_TRAP_MEI          = 12, /**< Machine external interrupt */
-  RTE_TRAP_FIRQ_0       = 13, /**< Fast interrupt channel 0 */
-  RTE_TRAP_FIRQ_1       = 14, /**< Fast interrupt channel 1 */
-  RTE_TRAP_FIRQ_2       = 15, /**< Fast interrupt channel 2 */
-  RTE_TRAP_FIRQ_3       = 16, /**< Fast interrupt channel 3 */
-  RTE_TRAP_FIRQ_4       = 17, /**< Fast interrupt channel 4 */
-  RTE_TRAP_FIRQ_5       = 18, /**< Fast interrupt channel 5 */
-  RTE_TRAP_FIRQ_6       = 19, /**< Fast interrupt channel 6 */
-  RTE_TRAP_FIRQ_7       = 20, /**< Fast interrupt channel 7 */
-  RTE_TRAP_FIRQ_8       = 21, /**< Fast interrupt channel 8 */
-  RTE_TRAP_FIRQ_9       = 22, /**< Fast interrupt channel 9 */
-  RTE_TRAP_FIRQ_10      = 23, /**< Fast interrupt channel 10 */
-  RTE_TRAP_FIRQ_11      = 24, /**< Fast interrupt channel 11 */
-  RTE_TRAP_FIRQ_12      = 25, /**< Fast interrupt channel 12 */
-  RTE_TRAP_FIRQ_13      = 26, /**< Fast interrupt channel 13 */
-  RTE_TRAP_FIRQ_14      = 27, /**< Fast interrupt channel 14 */
-  RTE_TRAP_FIRQ_15      = 28  /**< Fast interrupt channel 15 */
+  RTE_TRAP_I_PAGE       =  0, /**< Instruction page fault */
+  RTE_TRAP_I_ACCESS     =  1, /**< Instruction access fault */
+  RTE_TRAP_I_ILLEGAL    =  2, /**< Illegal instruction */
+  RTE_TRAP_I_MISALIGNED =  3, /**< Instruction address misaligned */
+  RTE_TRAP_BREAKPOINT   =  4, /**< Breakpoint (EBREAK instruction) */
+  RTE_TRAP_L_MISALIGNED =  5, /**< Load address misaligned */
+  RTE_TRAP_L_ACCESS     =  6, /**< Load access fault */
+  RTE_TRAP_L_PAGE       =  7, /**< Instruction page fault */
+  RTE_TRAP_S_MISALIGNED =  8, /**< Store address misaligned */
+  RTE_TRAP_S_ACCESS     =  9, /**< Store access fault */
+  RTE_TRAP_S_PAGE       = 10, /**< Instruction page fault */
+  RTE_TRAP_UENV_CALL    = 11, /**< Environment call from user mode (ECALL instruction) */
+  RTE_TRAP_MENV_CALL    = 12, /**< Environment call from machine mode (ECALL instruction) */
+  RTE_TRAP_MSI          = 13, /**< Machine software interrupt */
+  RTE_TRAP_MTI          = 14, /**< Machine timer interrupt */
+  RTE_TRAP_MEI          = 15, /**< Machine external interrupt */
+  RTE_TRAP_FIRQ_0       = 16, /**< Fast interrupt channel 0 */
+  RTE_TRAP_FIRQ_1       = 17, /**< Fast interrupt channel 1 */
+  RTE_TRAP_FIRQ_2       = 18, /**< Fast interrupt channel 2 */
+  RTE_TRAP_FIRQ_3       = 19, /**< Fast interrupt channel 3 */
+  RTE_TRAP_FIRQ_4       = 20, /**< Fast interrupt channel 4 */
+  RTE_TRAP_FIRQ_5       = 21, /**< Fast interrupt channel 5 */
+  RTE_TRAP_FIRQ_6       = 22, /**< Fast interrupt channel 6 */
+  RTE_TRAP_FIRQ_7       = 23, /**< Fast interrupt channel 7 */
+  RTE_TRAP_FIRQ_8       = 24, /**< Fast interrupt channel 8 */
+  RTE_TRAP_FIRQ_9       = 25, /**< Fast interrupt channel 9 */
+  RTE_TRAP_FIRQ_10      = 26, /**< Fast interrupt channel 10 */
+  RTE_TRAP_FIRQ_11      = 27, /**< Fast interrupt channel 11 */
+  RTE_TRAP_FIRQ_12      = 28, /**< Fast interrupt channel 12 */
+  RTE_TRAP_FIRQ_13      = 29, /**< Fast interrupt channel 13 */
+  RTE_TRAP_FIRQ_14      = 30, /**< Fast interrupt channel 14 */
+  RTE_TRAP_FIRQ_15      = 31  /**< Fast interrupt channel 15 */
 };
 
 

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -187,14 +187,17 @@ static void __attribute__((__naked__,aligned(4))) __neorv32_rte_core(void) {
   // find according trap handler base address
   uint32_t handler_base;
   switch (neorv32_cpu_csr_read(CSR_MCAUSE)) {
+    case TRAP_CODE_I_PAGE:       handler_base = __neorv32_rte_vector_lut[RTE_TRAP_I_PAGE];       break;
     case TRAP_CODE_I_ACCESS:     handler_base = __neorv32_rte_vector_lut[RTE_TRAP_I_ACCESS];     break;
     case TRAP_CODE_I_ILLEGAL:    handler_base = __neorv32_rte_vector_lut[RTE_TRAP_I_ILLEGAL];    break;
     case TRAP_CODE_I_MISALIGNED: handler_base = __neorv32_rte_vector_lut[RTE_TRAP_I_MISALIGNED]; break;
     case TRAP_CODE_BREAKPOINT:   handler_base = __neorv32_rte_vector_lut[RTE_TRAP_BREAKPOINT];   break;
     case TRAP_CODE_L_MISALIGNED: handler_base = __neorv32_rte_vector_lut[RTE_TRAP_L_MISALIGNED]; break;
     case TRAP_CODE_L_ACCESS:     handler_base = __neorv32_rte_vector_lut[RTE_TRAP_L_ACCESS];     break;
+    case TRAP_CODE_L_PAGE:       handler_base = __neorv32_rte_vector_lut[RTE_TRAP_L_PAGE];       break;
     case TRAP_CODE_S_MISALIGNED: handler_base = __neorv32_rte_vector_lut[RTE_TRAP_S_MISALIGNED]; break;
     case TRAP_CODE_S_ACCESS:     handler_base = __neorv32_rte_vector_lut[RTE_TRAP_S_ACCESS];     break;
+    case TRAP_CODE_S_PAGE:       handler_base = __neorv32_rte_vector_lut[RTE_TRAP_S_PAGE];       break;
     case TRAP_CODE_UENV_CALL:    handler_base = __neorv32_rte_vector_lut[RTE_TRAP_UENV_CALL];    break;
     case TRAP_CODE_MENV_CALL:    handler_base = __neorv32_rte_vector_lut[RTE_TRAP_MENV_CALL];    break;
     case TRAP_CODE_MSI:          handler_base = __neorv32_rte_vector_lut[RTE_TRAP_MSI];          break;
@@ -347,14 +350,17 @@ static void __neorv32_rte_debug_handler(void) {
   // cause
   uint32_t trap_cause = neorv32_cpu_csr_read(CSR_MCAUSE);
   switch (trap_cause) {
+    case TRAP_CODE_I_PAGE:       neorv32_uart0_puts("Instruction page fault"); break;
     case TRAP_CODE_I_ACCESS:     neorv32_uart0_puts("Instruction access fault"); break;
     case TRAP_CODE_I_ILLEGAL:    neorv32_uart0_puts("Illegal instruction"); break;
     case TRAP_CODE_I_MISALIGNED: neorv32_uart0_puts("Instruction address misaligned"); break;
-    case TRAP_CODE_BREAKPOINT:   neorv32_uart0_puts("Breakpoint"); break;
+    case TRAP_CODE_BREAKPOINT:   neorv32_uart0_puts("Environment breakpoint"); break;
     case TRAP_CODE_L_MISALIGNED: neorv32_uart0_puts("Load address misaligned"); break;
     case TRAP_CODE_L_ACCESS:     neorv32_uart0_puts("Load access fault"); break;
+    case TRAP_CODE_L_PAGE:       neorv32_uart0_puts("Load page fault"); break;
     case TRAP_CODE_S_MISALIGNED: neorv32_uart0_puts("Store address misaligned"); break;
     case TRAP_CODE_S_ACCESS:     neorv32_uart0_puts("Store access fault"); break;
+    case TRAP_CODE_S_PAGE:       neorv32_uart0_puts("Store page fault"); break;
     case TRAP_CODE_UENV_CALL:    neorv32_uart0_puts("Environment call from U-mode"); break;
     case TRAP_CODE_MENV_CALL:    neorv32_uart0_puts("Environment call from M-mode"); break;
     case TRAP_CODE_MSI:          neorv32_uart0_puts("Machine software IRQ"); break;
@@ -398,7 +404,7 @@ static void __neorv32_rte_debug_handler(void) {
 
   // halt if fatal exception
   if ((trap_cause == TRAP_CODE_I_ACCESS) || (trap_cause == TRAP_CODE_I_MISALIGNED)) {
-    neorv32_uart0_puts(" !!FATAL EXCEPTION!! Halting CPU. </NEORV32-RTE>\n");
+    neorv32_uart0_puts(" !!FATAL EXCEPTION!! Halting CPU </NEORV32-RTE>\n");
     neorv32_cpu_csr_write(CSR_MIE, 0);
     while(1) {
       asm volatile ("wfi");
@@ -417,14 +423,17 @@ static void __neorv32_rte_debug_handler(void) {
 void neorv32_rte_print_info(void) {
 
   const char trap_name[NEORV32_RTE_NUM_TRAPS][13] = {
+    "I_PAGE      ",
     "I_ACCESS    ",
     "I_ILLEGAL   ",
     "I_MISALIGNED",
     "BREAKPOINT  ",
     "L_MISALIGNED",
     "L_ACCESS    ",
+    "L_PAGE      ",
     "S_MISALIGNED",
     "S_ACCESS    ",
+    "S_PAGE      ",
     "UENV_CALL   ",
     "MENV_CALL   ",
     "MSI         ",


### PR DESCRIPTION
This PR adds support for three additional RISC-V exceptions:

* instruction page fault (`mcause = 0x0000000c`)
* load page fault (`mcause = 0x0000000f`)
* store page fault (`mcause = 0x0000000d`)

Right now the trigger signals for these exceptions are unused and terminated / hardwired to zero within the CPU's top entity. Hence, the hardware overhead for implementing those new trap should be zero.

I am experimenting with a very simple MMU-like paging concept but I am not really sure if this would be beneficial for any "real-world" applications. However, this might be the first step toward supervisor-mode and virtual memory support.

As always, ideas and thoughts are highly welcome. :wink: