### PR TITLE
[cpu] fix minor bug in instruction request bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 03.02.2024 | 1.9.4.3 | :bug: fix minor bug: CPU instruction bus privilege signal was hardwired to "user-mode" | [#790](https://github.com/stnolting/neorv32/pull/790) |
 | 01.02.2024 | 1.9.4.2 | :sparkles: add support for page fault exceptions (yet unused) | [#786](https://github.com/stnolting/neorv32/pull/786) |
 | 31.01.2024 | 1.9.4.1 | fix trap priority | [#784](https://github.com/stnolting/neorv32/pull/784) |
 | 31.01.2024 | [**:rocket:1.9.4**](https://github.com/stnolting/neorv32/releases/tag/v1.9.4) | **New release** | |

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -429,7 +429,7 @@ begin
   ipb.we(1) <= '1' when (fetch_engine.state = IF_PENDING) and (fetch_engine.resp = '1') else '0';
 
   -- bus access type --
-  bus_req_o.priv <= ctrl.cpu_priv; -- current privilege mode
+  bus_req_o.priv <= csr.privilege_eff; -- current effective privilege level
   bus_req_o.data <= (others => '0'); -- read-only
   bus_req_o.ben  <= (others => '0'); -- read-only
   bus_req_o.rw   <= '0'; -- read-only
@@ -1045,8 +1045,8 @@ begin
         ctrl_nxt.rf_mux <= rf_mux_mem_c; -- RF input = memory read data
         if (lsu_wait_i = '0') or -- bus system has completed the transaction
            (trap_ctrl.exc_buf(exc_saccess_c) = '1') or (trap_ctrl.exc_buf(exc_laccess_c) = '1') or -- access exception
-           (trap_ctrl.exc_buf(exc_salign_c) = '1')  or (trap_ctrl.exc_buf(exc_lalign_c)  = '1') or -- alignment exception
-           (trap_ctrl.exc_buf(exc_spage_c)  = '1')  or (trap_ctrl.exc_buf(exc_lpage_c)   = '1') then -- page exception
+           (trap_ctrl.exc_buf(exc_salign_c)  = '1') or (trap_ctrl.exc_buf(exc_lalign_c)  = '1') or -- alignment exception
+           (trap_ctrl.exc_buf(exc_spage_c)   = '1') or (trap_ctrl.exc_buf(exc_lpage_c)   = '1') then -- page exception
           if ((CPU_EXTENSION_RISCV_A = true) and (decode_aux.opcode(2) = opcode_amo_c(2))) or -- atomic operation
              (execute_engine.ir(instr_opcode_msb_c-1) = '0') then -- normal load
             ctrl_nxt.rf_wb_en <= '1'; -- allow write-back to register file (won't happen in case of exception)

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -56,7 +56,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090402"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090403"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -461,7 +461,7 @@ package neorv32_package is
   constant csr_mhpmcounter15h_c : std_ulogic_vector(11 downto 0) := x"b8f";
   -- user counters/timers --
   constant csr_cycle_c          : std_ulogic_vector(11 downto 0) := x"c00";
-  constant csr_time_c           : std_ulogic_vector(11 downto 0) := x"c01";
+--constant csr_time_c           : std_ulogic_vector(11 downto 0) := x"c01";
   constant csr_instret_c        : std_ulogic_vector(11 downto 0) := x"c02";
   constant csr_hpmcounter3_c    : std_ulogic_vector(11 downto 0) := x"c03";
   constant csr_hpmcounter4_c    : std_ulogic_vector(11 downto 0) := x"c04";
@@ -478,7 +478,7 @@ package neorv32_package is
   constant csr_hpmcounter15_c   : std_ulogic_vector(11 downto 0) := x"c0f";
   --
   constant csr_cycleh_c         : std_ulogic_vector(11 downto 0) := x"c80";
-  constant csr_timeh_c          : std_ulogic_vector(11 downto 0) := x"c81";
+--constant csr_timeh_c          : std_ulogic_vector(11 downto 0) := x"c81";
   constant csr_instreth_c       : std_ulogic_vector(11 downto 0) := x"c82";
   constant csr_hpmcounter3h_c   : std_ulogic_vector(11 downto 0) := x"c83";
   constant csr_hpmcounter4h_c   : std_ulogic_vector(11 downto 0) := x"c84";


### PR DESCRIPTION
The privilege level signal `.priv` of the CPU's instruction request bus was hardwired so it always showed "user-mode" instead of the actual privilege mode.