### PR TITLE
[revert] remove page faults support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 16.02.2024 | 1.9.5.2 | :warning: **revert** support for page faults (keep that in mmu branch for now) | [#809](https://github.com/stnolting/neorv32/pull/809) |
 | 16.02.2024 | 1.9.5.1 | :sparkles: add two new generics to exclude certain PMP modes from synthesis | [#808](https://github.com/stnolting/neorv32/pull/808) |
 | 16.02.2024 | [**:rocket:1.9.5**](https://github.com/stnolting/neorv32/releases/tag/v1.9.5) | **New release** | |
 | 15.02.2023 | 1.9.4.13 | allow the DMA to issue a FENCE operation | [#807](https://github.com/stnolting/neorv32/pull/807) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -927,7 +927,6 @@ written to the according CSRs when a trap is triggered:
 * **PC** - address of instruction that caused the trap (instruction has been executed)
 * **ADR** - bad data memory access address that caused the trap
 * **INS** - the transformed/decompressed instruction word that caused the trap
-* **UND** - undefined
 * **0** - zero
 
 .NEORV32 Trap Listing
@@ -936,39 +935,36 @@ written to the according CSRs when a trap is triggered:
 |=======================
 | Prio. | `mcause`     | RTE Trap ID              | Cause                                | `mepc` | `mtval` | `mtinst`
 7+^| **Exceptions** (_synchronous_ to instruction execution)                                                 
-| 1     | `0x0000000c` | `TRAP_CODE_I_PAGE`       | instruction page fault               | I-PC   | UND     | INS
-| 2     | `0x00000001` | `TRAP_CODE_I_ACCESS`     | instruction access fault             | I-PC   | 0       | INS
-| 3     | `0x00000002` | `TRAP_CODE_I_ILLEGAL`    | illegal instruction                  | PC     | 0       | INS
-| 4     | `0x00000000` | `TRAP_CODE_I_MISALIGNED` | instruction address misaligned       | PC     | 0       | INS
-| 5     | `0x0000000b` | `TRAP_CODE_MENV_CALL`    | environment call from M-mode         | PC     | 0       | INS
-| 6     | `0x00000008` | `TRAP_CODE_UENV_CALL`    | environment call from U-mode         | PC     | 0       | INS
-| 7     | `0x00000003` | `TRAP_CODE_BREAKPOINT`   | software breakpoint / trigger firing | PC     | 0       | INS
-| 8     | `0x00000006` | `TRAP_CODE_S_MISALIGNED` | store address misaligned             | PC     | ADR     | INS
-| 9     | `0x00000004` | `TRAP_CODE_L_MISALIGNED` | load address misaligned              | PC     | ADR     | INS
-| 10    | `0x0000000f` | `TRAP_CODE_S_PAGE`       | store page fault                     | PC     | ADR     | INS
-| 11    | `0x0000000d` | `TRAP_CODE_L_PAGE`       | load page fault                      | PC     | ADR     | INS
-| 12    | `0x00000007` | `TRAP_CODE_S_ACCESS`     | store access fault                   | PC     | ADR     | INS
-| 13    | `0x00000005` | `TRAP_CODE_L_ACCESS`     | load access fault                    | PC     | ADR     | INS
+| 1     | `0x00000001` | `TRAP_CODE_I_ACCESS`     | instruction access fault             | I-PC   | 0       | INS
+| 2     | `0x00000002` | `TRAP_CODE_I_ILLEGAL`    | illegal instruction                  | PC     | 0       | INS
+| 3     | `0x00000000` | `TRAP_CODE_I_MISALIGNED` | instruction address misaligned       | PC     | 0       | INS
+| 4     | `0x0000000b` | `TRAP_CODE_MENV_CALL`    | environment call from M-mode         | PC     | 0       | INS
+| 5     | `0x00000008` | `TRAP_CODE_UENV_CALL`    | environment call from U-mode         | PC     | 0       | INS
+| 6     | `0x00000003` | `TRAP_CODE_BREAKPOINT`   | software breakpoint / trigger firing | PC     | 0       | INS
+| 7     | `0x00000006` | `TRAP_CODE_S_MISALIGNED` | store address misaligned             | PC     | ADR     | INS
+| 8     | `0x00000004` | `TRAP_CODE_L_MISALIGNED` | load address misaligned              | PC     | ADR     | INS
+| 9     | `0x00000007` | `TRAP_CODE_S_ACCESS`     | store access fault                   | PC     | ADR     | INS
+| 10    | `0x00000005` | `TRAP_CODE_L_ACCESS`     | load access fault                    | PC     | ADR     | INS
 7+^| **Interrupts** (_asynchronous_ to instruction execution)                                                
-| 14    | `0x80000010` | `TRAP_CODE_FIRQ_0`       | fast interrupt request channel 0     | I-PC   | 0       | 0
-| 15    | `0x80000011` | `TRAP_CODE_FIRQ_1`       | fast interrupt request channel 1     | I-PC   | 0       | 0
-| 16    | `0x80000012` | `TRAP_CODE_FIRQ_2`       | fast interrupt request channel 2     | I-PC   | 0       | 0
-| 17    | `0x80000013` | `TRAP_CODE_FIRQ_3`       | fast interrupt request channel 3     | I-PC   | 0       | 0
-| 18    | `0x80000014` | `TRAP_CODE_FIRQ_4`       | fast interrupt request channel 4     | I-PC   | 0       | 0
-| 19    | `0x80000015` | `TRAP_CODE_FIRQ_5`       | fast interrupt request channel 5     | I-PC   | 0       | 0
-| 20    | `0x80000016` | `TRAP_CODE_FIRQ_6`       | fast interrupt request channel 6     | I-PC   | 0       | 0
-| 21    | `0x80000017` | `TRAP_CODE_FIRQ_7`       | fast interrupt request channel 7     | I-PC   | 0       | 0
-| 22    | `0x80000018` | `TRAP_CODE_FIRQ_8`       | fast interrupt request channel 8     | I-PC   | 0       | 0
-| 23    | `0x80000019` | `TRAP_CODE_FIRQ_9`       | fast interrupt request channel 9     | I-PC   | 0       | 0
-| 24    | `0x8000001a` | `TRAP_CODE_FIRQ_10`      | fast interrupt request channel 10    | I-PC   | 0       | 0
-| 25    | `0x8000001b` | `TRAP_CODE_FIRQ_11`      | fast interrupt request channel 11    | I-PC   | 0       | 0
-| 26    | `0x8000001c` | `TRAP_CODE_FIRQ_12`      | fast interrupt request channel 12    | I-PC   | 0       | 0
-| 27    | `0x8000001d` | `TRAP_CODE_FIRQ_13`      | fast interrupt request channel 13    | I-PC   | 0       | 0
-| 28    | `0x8000001e` | `TRAP_CODE_FIRQ_14`      | fast interrupt request channel 14    | I-PC   | 0       | 0
-| 29    | `0x8000001f` | `TRAP_CODE_FIRQ_15`      | fast interrupt request channel 15    | I-PC   | 0       | 0
-| 30    | `0x8000000B` | `TRAP_CODE_MEI`          | machine external interrupt (MEI)     | I-PC   | 0       | 0
-| 31    | `0x80000003` | `TRAP_CODE_MSI`          | machine software interrupt (MSI)     | I-PC   | 0       | 0
-| 32    | `0x80000007` | `TRAP_CODE_MTI`          | machine timer interrupt (MTI)        | I-PC   | 0       | 0
+| 11    | `0x80000010` | `TRAP_CODE_FIRQ_0`       | fast interrupt request channel 0     | I-PC   | 0       | 0
+| 12    | `0x80000011` | `TRAP_CODE_FIRQ_1`       | fast interrupt request channel 1     | I-PC   | 0       | 0
+| 13    | `0x80000012` | `TRAP_CODE_FIRQ_2`       | fast interrupt request channel 2     | I-PC   | 0       | 0
+| 14    | `0x80000013` | `TRAP_CODE_FIRQ_3`       | fast interrupt request channel 3     | I-PC   | 0       | 0
+| 15    | `0x80000014` | `TRAP_CODE_FIRQ_4`       | fast interrupt request channel 4     | I-PC   | 0       | 0
+| 16    | `0x80000015` | `TRAP_CODE_FIRQ_5`       | fast interrupt request channel 5     | I-PC   | 0       | 0
+| 17    | `0x80000016` | `TRAP_CODE_FIRQ_6`       | fast interrupt request channel 6     | I-PC   | 0       | 0
+| 18    | `0x80000017` | `TRAP_CODE_FIRQ_7`       | fast interrupt request channel 7     | I-PC   | 0       | 0
+| 19    | `0x80000018` | `TRAP_CODE_FIRQ_8`       | fast interrupt request channel 8     | I-PC   | 0       | 0
+| 20    | `0x80000019` | `TRAP_CODE_FIRQ_9`       | fast interrupt request channel 9     | I-PC   | 0       | 0
+| 21    | `0x8000001a` | `TRAP_CODE_FIRQ_10`      | fast interrupt request channel 10    | I-PC   | 0       | 0
+| 22    | `0x8000001b` | `TRAP_CODE_FIRQ_11`      | fast interrupt request channel 11    | I-PC   | 0       | 0
+| 23    | `0x8000001c` | `TRAP_CODE_FIRQ_12`      | fast interrupt request channel 12    | I-PC   | 0       | 0
+| 24    | `0x8000001d` | `TRAP_CODE_FIRQ_13`      | fast interrupt request channel 13    | I-PC   | 0       | 0
+| 25    | `0x8000001e` | `TRAP_CODE_FIRQ_14`      | fast interrupt request channel 14    | I-PC   | 0       | 0
+| 26    | `0x8000001f` | `TRAP_CODE_FIRQ_15`      | fast interrupt request channel 15    | I-PC   | 0       | 0
+| 27    | `0x8000000B` | `TRAP_CODE_MEI`          | machine external interrupt (MEI)     | I-PC   | 0       | 0
+| 28    | `0x80000003` | `TRAP_CODE_MSI`          | machine software interrupt (MSI)     | I-PC   | 0       | 0
+| 29    | `0x80000007` | `TRAP_CODE_MTI`          | machine timer interrupt (MTI)        | I-PC   | 0       | 0
 |=======================
 
 .NEORV32 Trap Description
@@ -976,7 +972,6 @@ written to the according CSRs when a trap is triggered:
 [options="header",grid="rows"]
 |=======================
 | Trap ID [C] | Triggered when ...
-| `TRAP_CODE_I_PAGE`       | instruction page fault, **no trigger mechanism implemented yet**
 | `TRAP_CODE_I_ACCESS`     | bus timeout, bus access error or <<_pmp_isa_extension,PMP>> rule violation during instruction fetch
 | `TRAP_CODE_I_ILLEGAL`    | trying to execute an invalid instruction word (malformed or not supported) or on a privilege violation
 | `TRAP_CODE_I_MISALIGNED` | fetching a 32-bit instruction word that is not 32-bit-aligned (see note below)
@@ -985,8 +980,6 @@ written to the according CSRs when a trap is triggered:
 | `TRAP_CODE_BREAKPOINT`   | executing `ebreak` instruction or if <<_trigger_module>> fires
 | `TRAP_CODE_S_MISALIGNED` | storing data to an address that is not naturally aligned to the data size (half/word)
 | `TRAP_CODE_L_MISALIGNED` | loading data from an address that is not naturally aligned to the data size  (half/word)
-| `TRAP_CODE_S_PAGE`       | store page fault, **no trigger mechanism implemented yet**
-| `TRAP_CODE_L_PAGE`       | load page fault, **no trigger mechanism implemented yet**
 | `TRAP_CODE_S_ACCESS`     | bus timeout, bus access error or <<_pmp_isa_extension,PMP>> rule violation during load data operation
 | `TRAP_CODE_L_ACCESS`     | bus timeout, bus access error or <<_pmp_isa_extension,PMP>> rule violation during store data operation
 | `TRAP_CODE_FIRQ_*`       | caused by interrupt-condition of **processor-internal modules**, see <<_neorv32_specific_fast_interrupt_requests>>

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -133,9 +133,6 @@ architecture neorv32_cpu_rtl of neorv32_cpu is
   signal link_pc      : std_ulogic_vector(XLEN-1 downto 0); -- link pc (return address)
   signal pmp_ex_fault : std_ulogic; -- PMP instruction fetch fault
   signal pmp_rw_fault : std_ulogic; -- PMP read/write access fault
-  signal i_page_fault : std_ulogic; -- instruction page fault
-  signal l_page_fault : std_ulogic; -- load page fault
-  signal s_page_fault : std_ulogic; -- store page fault
 
 begin
 
@@ -209,45 +206,42 @@ begin
   )
   port map (
     -- global control --
-    clk_i          => clk_i,          -- global clock, rising edge
-    clk_aux_i      => clk_aux_i,      -- always-on clock, rising edge
-    rstn_i         => rstn_i,         -- global reset, low-active, async
-    ctrl_o         => ctrl,           -- main control bus
+    clk_i         => clk_i,          -- global clock, rising edge
+    clk_aux_i     => clk_aux_i,      -- always-on clock, rising edge
+    rstn_i        => rstn_i,         -- global reset, low-active, async
+    ctrl_o        => ctrl,           -- main control bus
     -- instruction fetch interface --
-    i_page_fault_i => i_page_fault,   -- instruction fetch page fault
-    i_pmp_fault_i  => pmp_ex_fault,   -- instruction fetch pmp fault
-    bus_req_o      => ibus_req_o,     -- request
-    bus_rsp_i      => ibus_rsp_i,     -- response
+    i_pmp_fault_i => pmp_ex_fault,   -- instruction fetch pmp fault
+    bus_req_o     => ibus_req_o,     -- request
+    bus_rsp_i     => ibus_rsp_i,     -- response
     -- data path interface --
-    alu_cp_done_i  => cp_done,        -- ALU iterative operation done
-    cmp_i          => alu_cmp,        -- comparator status
-    alu_add_i      => alu_add,        -- ALU address result
-    rs1_i          => rs1,            -- rf source 1
-    imm_o          => imm,            -- immediate
-    fetch_pc_o     => fetch_pc,       -- instruction fetch address
-    curr_pc_o      => curr_pc,        -- current PC (corresponding to current instruction)
-    link_pc_o      => link_pc,        -- link PC (return address)
-    csr_rdata_o    => csr_rdata,      -- CSR read data
+    alu_cp_done_i => cp_done,        -- ALU iterative operation done
+    cmp_i         => alu_cmp,        -- comparator status
+    alu_add_i     => alu_add,        -- ALU address result
+    rs1_i         => rs1,            -- rf source 1
+    imm_o         => imm,            -- immediate
+    fetch_pc_o    => fetch_pc,       -- instruction fetch address
+    curr_pc_o     => curr_pc,        -- current PC (corresponding to current instruction)
+    link_pc_o     => link_pc,        -- link PC (return address)
+    csr_rdata_o   => csr_rdata,      -- CSR read data
     -- external CSR interface --
-    xcsr_we_o      => xcsr_we,        -- global write enable
-    xcsr_addr_o    => xcsr_addr,      -- address
-    xcsr_wdata_o   => xcsr_wdata,     -- write data
-    xcsr_rdata_i   => xcsr_rdata_res, -- read data
+    xcsr_we_o     => xcsr_we,        -- global write enable
+    xcsr_addr_o   => xcsr_addr,      -- address
+    xcsr_wdata_o  => xcsr_wdata,     -- write data
+    xcsr_rdata_i  => xcsr_rdata_res, -- read data
     -- interrupts --
-    db_halt_req_i  => dbi_i,          -- debug mode (halt) request
-    msi_i          => msi_i,          -- machine software interrupt
-    mei_i          => mei_i,          -- machine external interrupt
-    mti_i          => mti_i,          -- machine timer interrupt
-    firq_i         => firq_i,         -- fast interrupts
+    db_halt_req_i => dbi_i,          -- debug mode (halt) request
+    msi_i         => msi_i,          -- machine software interrupt
+    mei_i         => mei_i,          -- machine external interrupt
+    mti_i         => mti_i,          -- machine timer interrupt
+    firq_i        => firq_i,         -- fast interrupts
     -- data access interface --
-    lsu_wait_i     => lsu_wait,       -- wait for data bus
-    mar_i          => mar,            -- memory address register
-    ma_load_i      => ma_load,        -- misaligned load data address
-    ma_store_i     => ma_store,       -- misaligned store data address
-    be_load_i      => be_load,        -- bus error on load data access
-    be_store_i     => be_store,       -- bus error on store data access
-    l_page_fault_i => l_page_fault,   -- load page fault
-    s_page_fault_i => s_page_fault    -- store page fault
+    lsu_wait_i    => lsu_wait,       -- wait for data bus
+    mar_i         => mar,            -- memory address register
+    ma_load_i     => ma_load,        -- misaligned load data address
+    ma_store_i    => ma_store,       -- misaligned store data address
+    be_load_i     => be_load,        -- bus error on load data access
+    be_store_i    => be_store        -- bus error on store data access
   );
 
   -- external CSR read-back --
@@ -390,14 +384,6 @@ begin
     pmp_ex_fault   <= '0';
     pmp_rw_fault   <= '0';
   end generate;
-
-
-  -- Memory Management/Paging Unit ----------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  -- nothing to see here yet --
-  i_page_fault <= '0'; -- instruction page fault
-  l_page_fault <= '0'; -- load page fault
-  s_page_fault <= '0'; -- store page fault
 
 
 end neorv32_cpu_rtl;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -53,7 +53,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090501"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090502"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -341,7 +341,7 @@ package neorv32_package is
   constant fp_single_qnan_c     : std_ulogic_vector(31 downto 0) := x"7fc00000"; -- quiet NaN
   constant fp_single_snan_c     : std_ulogic_vector(31 downto 0) := x"7fa00000"; -- signaling NaN
   constant fp_single_pos_max_c  : std_ulogic_vector(31 downto 0) := x"7f7FFFFF"; -- positive max
-  constant fp_single_neg_max_c  : std_ulogic_vector(31 downto 0) := x"Ff7FFFFF"; -- negative max                         
+  constant fp_single_neg_max_c  : std_ulogic_vector(31 downto 0) := x"Ff7FFFFF"; -- negative max
   constant fp_single_pos_inf_c  : std_ulogic_vector(31 downto 0) := x"7f800000"; -- positive infinity
   constant fp_single_neg_inf_c  : std_ulogic_vector(31 downto 0) := x"ff800000"; -- negative infinity
   constant fp_single_pos_zero_c : std_ulogic_vector(31 downto 0) := x"00000000"; -- positive zero
@@ -615,9 +615,6 @@ package neorv32_package is
   constant trap_sma_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00110"; -- 6: store address misaligned
   constant trap_saf_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00111"; -- 7: store access fault
   constant trap_env_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "010UU"; -- 8..11: environment call from u/s/h/m
-  constant trap_ipf_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "01100"; -- 12: instruction page fault
-  constant trap_lpf_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "01101"; -- 13: load page fault
-  constant trap_spf_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "01111"; -- 15: store page fault
   -- RISC-V compliant asynchronous exceptions (interrupts) --
   constant trap_msi_c      : std_ulogic_vector(6 downto 0) := "1" & "0" & "00011"; -- 3:  machine software interrupt
   constant trap_mti_c      : std_ulogic_vector(6 downto 0) := "1" & "0" & "00111"; -- 7:  machine timer interrupt
@@ -657,14 +654,10 @@ package neorv32_package is
   constant exc_lalign_c   : natural :=  6; -- load address misaligned
   constant exc_saccess_c  : natural :=  7; -- store access fault
   constant exc_laccess_c  : natural :=  8; -- load access fault
-  constant exc_ipage_c    : natural :=  9; -- instruction page fault
-  constant exc_lpage_c    : natural := 10; -- load page fault
-  constant exc_spage_c    : natural := 11; -- store page fault
-  -- for debug mode only --
-  constant exc_db_break_c : natural := 12; -- enter debug mode via ebreak instruction
-  constant exc_db_hw_c    : natural := 13; -- enter debug mode via hw trigger
+  constant exc_db_break_c : natural :=  9; -- enter debug mode via ebreak instruction
+  constant exc_db_hw_c    : natural := 10; -- enter debug mode via hw trigger
   --
-  constant exc_width_c    : natural := 14; -- length of this list in bits
+  constant exc_width_c    : natural := 11; -- length of this list in bits
   -- interrupt source bits --
   constant irq_msi_irq_c  : natural :=  0; -- machine software interrupt
   constant irq_mti_irq_c  : natural :=  1; -- machine timer interrupt
@@ -685,7 +678,6 @@ package neorv32_package is
   constant irq_firq_13_c  : natural := 16; -- fast interrupt channel 13
   constant irq_firq_14_c  : natural := 17; -- fast interrupt channel 14
   constant irq_firq_15_c  : natural := 18; -- fast interrupt channel 15
-  -- for debug mode only --
   constant irq_db_halt_c  : natural := 19; -- enter debug mode via external halt request
   constant irq_db_step_c  : natural := 20; -- enter debug mode via single-stepping
   --

--- a/sw/lib/include/neorv32_cpu_csr.h
+++ b/sw/lib/include/neorv32_cpu_csr.h
@@ -455,9 +455,6 @@ enum NEORV32_EXCEPTION_CODES_enum {
   TRAP_CODE_S_ACCESS     = 0x00000007U, /**< 0.7:  Store (bus) access fault */
   TRAP_CODE_UENV_CALL    = 0x00000008U, /**< 0.8:  Environment call from user mode (ECALL instruction) */
   TRAP_CODE_MENV_CALL    = 0x0000000bU, /**< 0.11: Environment call from machine mode (ECALL instruction) */
-  TRAP_CODE_I_PAGE       = 0x0000000cU, /**< 0.12: Instruction page fault */
-  TRAP_CODE_L_PAGE       = 0x0000000dU, /**< 0.13: Load page fault */
-  TRAP_CODE_S_PAGE       = 0x0000000fU, /**< 0.15: Store page fault */
   TRAP_CODE_MSI          = 0x80000003U, /**< 1.3:  Machine software interrupt */
   TRAP_CODE_MTI          = 0x80000007U, /**< 1.7:  Machine timer interrupt */
   TRAP_CODE_MEI          = 0x8000000bU, /**< 1.11: Machine external interrupt */

--- a/sw/lib/include/neorv32_rte.h
+++ b/sw/lib/include/neorv32_rte.h
@@ -45,45 +45,42 @@
 /**********************************************************************//**
  * NEORV32 runtime environment: Number of available traps.
  **************************************************************************/
-#define NEORV32_RTE_NUM_TRAPS 32
+#define NEORV32_RTE_NUM_TRAPS 29
 
 
 /**********************************************************************//**
  * NEORV32 runtime environment trap IDs.
  **************************************************************************/
 enum NEORV32_RTE_TRAP_enum {
-  RTE_TRAP_I_PAGE       =  0, /**< Instruction page fault */
-  RTE_TRAP_I_ACCESS     =  1, /**< Instruction access fault */
-  RTE_TRAP_I_ILLEGAL    =  2, /**< Illegal instruction */
-  RTE_TRAP_I_MISALIGNED =  3, /**< Instruction address misaligned */
-  RTE_TRAP_BREAKPOINT   =  4, /**< Breakpoint (EBREAK instruction) */
-  RTE_TRAP_L_MISALIGNED =  5, /**< Load address misaligned */
-  RTE_TRAP_L_ACCESS     =  6, /**< Load access fault */
-  RTE_TRAP_L_PAGE       =  7, /**< Instruction page fault */
-  RTE_TRAP_S_MISALIGNED =  8, /**< Store address misaligned */
-  RTE_TRAP_S_ACCESS     =  9, /**< Store access fault */
-  RTE_TRAP_S_PAGE       = 10, /**< Instruction page fault */
-  RTE_TRAP_UENV_CALL    = 11, /**< Environment call from user mode (ECALL instruction) */
-  RTE_TRAP_MENV_CALL    = 12, /**< Environment call from machine mode (ECALL instruction) */
-  RTE_TRAP_MSI          = 13, /**< Machine software interrupt */
-  RTE_TRAP_MTI          = 14, /**< Machine timer interrupt */
-  RTE_TRAP_MEI          = 15, /**< Machine external interrupt */
-  RTE_TRAP_FIRQ_0       = 16, /**< Fast interrupt channel 0 */
-  RTE_TRAP_FIRQ_1       = 17, /**< Fast interrupt channel 1 */
-  RTE_TRAP_FIRQ_2       = 18, /**< Fast interrupt channel 2 */
-  RTE_TRAP_FIRQ_3       = 19, /**< Fast interrupt channel 3 */
-  RTE_TRAP_FIRQ_4       = 20, /**< Fast interrupt channel 4 */
-  RTE_TRAP_FIRQ_5       = 21, /**< Fast interrupt channel 5 */
-  RTE_TRAP_FIRQ_6       = 22, /**< Fast interrupt channel 6 */
-  RTE_TRAP_FIRQ_7       = 23, /**< Fast interrupt channel 7 */
-  RTE_TRAP_FIRQ_8       = 24, /**< Fast interrupt channel 8 */
-  RTE_TRAP_FIRQ_9       = 25, /**< Fast interrupt channel 9 */
-  RTE_TRAP_FIRQ_10      = 26, /**< Fast interrupt channel 10 */
-  RTE_TRAP_FIRQ_11      = 27, /**< Fast interrupt channel 11 */
-  RTE_TRAP_FIRQ_12      = 28, /**< Fast interrupt channel 12 */
-  RTE_TRAP_FIRQ_13      = 29, /**< Fast interrupt channel 13 */
-  RTE_TRAP_FIRQ_14      = 30, /**< Fast interrupt channel 14 */
-  RTE_TRAP_FIRQ_15      = 31  /**< Fast interrupt channel 15 */
+  RTE_TRAP_I_ACCESS     =  0, /**< Instruction access fault */
+  RTE_TRAP_I_ILLEGAL    =  1, /**< Illegal instruction */
+  RTE_TRAP_I_MISALIGNED =  2, /**< Instruction address misaligned */
+  RTE_TRAP_BREAKPOINT   =  3, /**< Breakpoint (EBREAK instruction) */
+  RTE_TRAP_L_MISALIGNED =  4, /**< Load address misaligned */
+  RTE_TRAP_L_ACCESS     =  5, /**< Load access fault */
+  RTE_TRAP_S_MISALIGNED =  6, /**< Store address misaligned */
+  RTE_TRAP_S_ACCESS     =  7, /**< Store access fault */
+  RTE_TRAP_UENV_CALL    =  8, /**< Environment call from user mode (ECALL instruction) */
+  RTE_TRAP_MENV_CALL    =  9, /**< Environment call from machine mode (ECALL instruction) */
+  RTE_TRAP_MSI          = 10, /**< Machine software interrupt */
+  RTE_TRAP_MTI          = 11, /**< Machine timer interrupt */
+  RTE_TRAP_MEI          = 12, /**< Machine external interrupt */
+  RTE_TRAP_FIRQ_0       = 13, /**< Fast interrupt channel 0 */
+  RTE_TRAP_FIRQ_1       = 14, /**< Fast interrupt channel 1 */
+  RTE_TRAP_FIRQ_2       = 15, /**< Fast interrupt channel 2 */
+  RTE_TRAP_FIRQ_3       = 16, /**< Fast interrupt channel 3 */
+  RTE_TRAP_FIRQ_4       = 17, /**< Fast interrupt channel 4 */
+  RTE_TRAP_FIRQ_5       = 18, /**< Fast interrupt channel 5 */
+  RTE_TRAP_FIRQ_6       = 19, /**< Fast interrupt channel 6 */
+  RTE_TRAP_FIRQ_7       = 20, /**< Fast interrupt channel 7 */
+  RTE_TRAP_FIRQ_8       = 21, /**< Fast interrupt channel 8 */
+  RTE_TRAP_FIRQ_9       = 22, /**< Fast interrupt channel 9 */
+  RTE_TRAP_FIRQ_10      = 23, /**< Fast interrupt channel 10 */
+  RTE_TRAP_FIRQ_11      = 24, /**< Fast interrupt channel 11 */
+  RTE_TRAP_FIRQ_12      = 25, /**< Fast interrupt channel 12 */
+  RTE_TRAP_FIRQ_13      = 26, /**< Fast interrupt channel 13 */
+  RTE_TRAP_FIRQ_14      = 27, /**< Fast interrupt channel 14 */
+  RTE_TRAP_FIRQ_15      = 28  /**< Fast interrupt channel 15 */
 };
 
 

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -187,17 +187,14 @@ static void __attribute__((__naked__,aligned(4))) __neorv32_rte_core(void) {
   // find according trap handler base address
   uint32_t handler_base;
   switch (neorv32_cpu_csr_read(CSR_MCAUSE)) {
-    case TRAP_CODE_I_PAGE:       handler_base = __neorv32_rte_vector_lut[RTE_TRAP_I_PAGE];       break;
     case TRAP_CODE_I_ACCESS:     handler_base = __neorv32_rte_vector_lut[RTE_TRAP_I_ACCESS];     break;
     case TRAP_CODE_I_ILLEGAL:    handler_base = __neorv32_rte_vector_lut[RTE_TRAP_I_ILLEGAL];    break;
     case TRAP_CODE_I_MISALIGNED: handler_base = __neorv32_rte_vector_lut[RTE_TRAP_I_MISALIGNED]; break;
     case TRAP_CODE_BREAKPOINT:   handler_base = __neorv32_rte_vector_lut[RTE_TRAP_BREAKPOINT];   break;
     case TRAP_CODE_L_MISALIGNED: handler_base = __neorv32_rte_vector_lut[RTE_TRAP_L_MISALIGNED]; break;
     case TRAP_CODE_L_ACCESS:     handler_base = __neorv32_rte_vector_lut[RTE_TRAP_L_ACCESS];     break;
-    case TRAP_CODE_L_PAGE:       handler_base = __neorv32_rte_vector_lut[RTE_TRAP_L_PAGE];       break;
     case TRAP_CODE_S_MISALIGNED: handler_base = __neorv32_rte_vector_lut[RTE_TRAP_S_MISALIGNED]; break;
     case TRAP_CODE_S_ACCESS:     handler_base = __neorv32_rte_vector_lut[RTE_TRAP_S_ACCESS];     break;
-    case TRAP_CODE_S_PAGE:       handler_base = __neorv32_rte_vector_lut[RTE_TRAP_S_PAGE];       break;
     case TRAP_CODE_UENV_CALL:    handler_base = __neorv32_rte_vector_lut[RTE_TRAP_UENV_CALL];    break;
     case TRAP_CODE_MENV_CALL:    handler_base = __neorv32_rte_vector_lut[RTE_TRAP_MENV_CALL];    break;
     case TRAP_CODE_MSI:          handler_base = __neorv32_rte_vector_lut[RTE_TRAP_MSI];          break;
@@ -350,17 +347,14 @@ static void __neorv32_rte_debug_handler(void) {
   // cause
   uint32_t trap_cause = neorv32_cpu_csr_read(CSR_MCAUSE);
   switch (trap_cause) {
-    case TRAP_CODE_I_PAGE:       neorv32_uart0_puts("Instruction page fault"); break;
     case TRAP_CODE_I_ACCESS:     neorv32_uart0_puts("Instruction access fault"); break;
     case TRAP_CODE_I_ILLEGAL:    neorv32_uart0_puts("Illegal instruction"); break;
     case TRAP_CODE_I_MISALIGNED: neorv32_uart0_puts("Instruction address misaligned"); break;
     case TRAP_CODE_BREAKPOINT:   neorv32_uart0_puts("Environment breakpoint"); break;
     case TRAP_CODE_L_MISALIGNED: neorv32_uart0_puts("Load address misaligned"); break;
     case TRAP_CODE_L_ACCESS:     neorv32_uart0_puts("Load access fault"); break;
-    case TRAP_CODE_L_PAGE:       neorv32_uart0_puts("Load page fault"); break;
     case TRAP_CODE_S_MISALIGNED: neorv32_uart0_puts("Store address misaligned"); break;
     case TRAP_CODE_S_ACCESS:     neorv32_uart0_puts("Store access fault"); break;
-    case TRAP_CODE_S_PAGE:       neorv32_uart0_puts("Store page fault"); break;
     case TRAP_CODE_UENV_CALL:    neorv32_uart0_puts("Environment call from U-mode"); break;
     case TRAP_CODE_MENV_CALL:    neorv32_uart0_puts("Environment call from M-mode"); break;
     case TRAP_CODE_MSI:          neorv32_uart0_puts("Machine software IRQ"); break;
@@ -422,39 +416,36 @@ static void __neorv32_rte_debug_handler(void) {
  **************************************************************************/
 void neorv32_rte_print_info(void) {
 
-  const char trap_name[NEORV32_RTE_NUM_TRAPS][13] = {
-    "I_PAGE      ",
-    "I_ACCESS    ",
-    "I_ILLEGAL   ",
-    "I_MISALIGNED",
-    "BREAKPOINT  ",
-    "L_MISALIGNED",
-    "L_ACCESS    ",
-    "L_PAGE      ",
-    "S_MISALIGNED",
-    "S_ACCESS    ",
-    "S_PAGE      ",
-    "UENV_CALL   ",
-    "MENV_CALL   ",
-    "MSI         ",
-    "MTI         ",
-    "MEI         ",
-    "FIRQ_0      ",
-    "FIRQ_1      ",
-    "FIRQ_2      ",
-    "FIRQ_3      ",
-    "FIRQ_4      ",
-    "FIRQ_5      ",
-    "FIRQ_6      ",
-    "FIRQ_7      ",
-    "FIRQ_8      ",
-    "FIRQ_9      ",
-    "FIRQ_10     ",
-    "FIRQ_11     ",
-    "FIRQ_12     ",
-    "FIRQ_13     ",
-    "FIRQ_14     ",
-    "FIRQ_15     "
+  const char trap_name[NEORV32_RTE_NUM_TRAPS][11] = {
+    "I_ACCESS  ",
+    "I_ILLEGAL ",
+    "I_MISALIGN",
+    "BREAKPOINT",
+    "L_MISALIGN",
+    "L_ACCESS  ",
+    "S_MISALIGN",
+    "S_ACCESS  ",
+    "UENV_CALL ",
+    "MENV_CALL ",
+    "MSI       ",
+    "MTI       ",
+    "MEI       ",
+    "FIRQ_0    ",
+    "FIRQ_1    ",
+    "FIRQ_2    ",
+    "FIRQ_3    ",
+    "FIRQ_4    ",
+    "FIRQ_5    ",
+    "FIRQ_6    ",
+    "FIRQ_7    ",
+    "FIRQ_8    ",
+    "FIRQ_9    ",
+    "FIRQ_10   ",
+    "FIRQ_11   ",
+    "FIRQ_12   ",
+    "FIRQ_13   ",
+    "FIRQ_14   ",
+    "FIRQ_15   "
   };
 
   if (neorv32_uart0_available() == 0) {
@@ -464,9 +455,9 @@ void neorv32_rte_print_info(void) {
   neorv32_uart0_puts("\n\n<< NEORV32 RTE Configuration >>\n\n");
 
   // header
-  neorv32_uart0_puts("---------------------------------\n");
-  neorv32_uart0_puts("Trap Name [ID]         Handler\n");
-  neorv32_uart0_puts("---------------------------------\n");
+  neorv32_uart0_puts("-------------------------------\n");
+  neorv32_uart0_puts("Trap Name [ID]       Handler\n");
+  neorv32_uart0_puts("-------------------------------\n");
 
   uint32_t i;
   for (i=0; i<NEORV32_RTE_NUM_TRAPS; i++) {
@@ -478,7 +469,7 @@ void neorv32_rte_print_info(void) {
   }
 
   // footer
-  neorv32_uart0_puts("---------------------------------\n");
+  neorv32_uart0_puts("-------------------------------\n");
   neorv32_uart0_puts("\n");
 }
 


### PR DESCRIPTION
Reverting the changes from #786. Keep support for page faults in [mmu development branch](https://github.com/stnolting/neorv32/tree/mmu_dev) for now.