### PR TITLE
🧪 [makefile] pass CC_OPTS variable as define string

### DIFF
--- a/docs/datasheet/software.adoc
+++ b/docs/datasheet/software.adoc
@@ -255,6 +255,10 @@ GDB_ARGS ?= -ex "target extended-remote localhost:3333"
 The following default compiler flags are used for compiling an application. These flags are defined via the
 `CC_OPTS` variable.
 
+[TIP]
+The makefile's `CC_OPTS` is exported as **define** to be available within a C program; for example
+`neorv32_uart0_printf("%s\n", CC_OPTS);`.
+
 [cols="<3,<9"]
 [grid="none"]
 |=======================
@@ -268,7 +272,7 @@ The following default compiler flags are used for compiling an application. Thes
 | `-mno-fdiv`           | Use built-in software functions for floating-point divisions and square roots (since the according instructions are not supported yet).
 | `-g`                  | Include debugging information/symbols in ELF.
 | `-mstrict-align`      | Unaligned memory accesses cannot be resolved by the hardware and require emulation.
-| `-mbranch-cost=...`   | Branches cost a lot cycles on a multi-cycle architecture.
+| `-mbranch-cost=10`    | Branching costs a lot of cycles.
 |=======================
 
 :sectnums:
@@ -341,7 +345,7 @@ __neorv32_ram_base = DEFINED(__neorv32_ram_base) ? __neorv32_ram_base : 0x800000
 
 The region size and base address configuration can be edited by the user - either by explicitly
 changing the default values in the linker script or by overriding them when invoking `make`:
- 
+
 .Overriding default `rom` size configuration (configuring 4096 bytes)
 [source, bash]
 ----

--- a/sw/example/coremark/core_portme.h
+++ b/sw/example/coremark/core_portme.h
@@ -33,7 +33,7 @@ Original Author: Shay Gal-on
 /************************/
 #define BAUD_RATE  (19200)
 #define ITERATIONS (2000)
-#define FLAGS_STR  "see makefile"
+#define FLAGS_STR  CC_OPTS
 
 /************************/
 /* Data types and settings */


### PR DESCRIPTION
Pass the makefile's `CC_OPTS` variable, which contains all relevant GCC flags and switches, as "define" string to the application:

```makefile
# Actual flags passed to the compiler
CC_FLAGS = $(CC_OPTS)

# Export compiler flags as define string
CC_FLAGS += -DCC_OPTS="\"$(CC_OPTS)\""
```

Application software can use this "define" to print the actual GCC configuration that was used to compile the code:

```c
neorv32_uart0_printf("%s\n", CC_OPTS);
```