### PR TITLE
[SLINK] add AXI-stream-compatible "tlast" signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 19.02.2024 | 1.9.5.5 | SLINK: add native hardware support for AXI-stream's "tlast" signal | [#815](https://github.com/stnolting/neorv32/pull/815) |
 | 19.02.2024 | 1.9.5.4 | :warning: remove support of `Smcntrpmf` ISA extension (counter privilege mode filtering) | [#814](https://github.com/stnolting/neorv32/pull/814) |
 | 17.02.2024 | 1.9.5.3 | :warning: reworked CPU's hardware performance monitor (HPMs) events | [#811](https://github.com/stnolting/neorv32/pull/811) |
 | 16.02.2024 | 1.9.5.2 | :warning: **revert** support for page faults (keep that in mmu branch for now) | [#809](https://github.com/stnolting/neorv32/pull/809) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -101,9 +101,11 @@ Some interfaces (like the TWI and the 1-Wire bus) require tri-state drivers in t
 5+^| **<<_stream_link_interface_slink>>**
 | `slink_rx_dat_i` | 32 |  in | `'L'` | RX data
 | `slink_rx_val_i` |  1 |  in | `'L'` | RX data valid
+| `slink_rx_lst_i` |  1 |  in | `'L'` | RX last element of stream
 | `slink_rx_rdy_o` |  1 | out |   -   | RX ready to receive
 | `slink_tx_dat_o` | 32 | out |   -   | TX data
 | `slink_tx_val_o` |  1 | out |   -   | TX data valid
+| `slink_tx_lst_o` |  1 | out |   -   | TX last element of stream
 | `slink_tx_rdy_i` |  1 |  in | `'L'` | TX allowed to send
 5+^| **<<_execute_in_place_module_xip>>**
 | `xip_csn_o`      |  1 | out |   -   | chip select, low-active

--- a/docs/datasheet/soc_slink.adoc
+++ b/docs/datasheet/soc_slink.adoc
@@ -8,12 +8,14 @@
 | Hardware source file(s): | neorv32_slink.vhd   |
 | Software driver file(s): | neorv32_slink.c     |
 |                          | neorv32_slink.h     |
-| Top entity port:         | `slink_rx_dat_i`    | RX data (32-bit)
-|                          | `slink_rx_val_i`    | RX data valid (1-bit)
-|                          | `slink_rx_rdy_o`    | RX ready to receive (1-bit)
-|                          | `slink_tx_dat_o`    | TX data (32-bit)
-|                          | `slink_tx_val_o`    | TX data valid (1-bit)
-|                          | `slink_tx_rdy_i`    | TX allowed to send (1-bit)
+| Top entity port(s):      | `slink_rx_dat_i`    | RX link data (32-bit)
+|                          | `slink_rx_val_i`    | RX link data valid (1-bit)
+|                          | `slink_rx_lst_i`    | RX link last element of stream (1-bit)
+|                          | `slink_rx_rdy_o`    | RX link ready to receive (1-bit)
+|                          | `slink_tx_dat_o`    | TX link data (32-bit)
+|                          | `slink_tx_val_o`    | TX link data valid (1-bit)
+|                          | `slink_tx_lst_o`    | TX link last element of stream (1-bit)
+|                          | `slink_tx_rdy_i`    | TX link allowed to send (1-bit)
 | Configuration generics:  | `IO_SLINK_EN`       | implement SLINK when _true_
 |                          | `IO_SLINK_RX_FIFO`  | RX FIFO depth (1..32k), has to be a power of two
 |                          | `IO_SLINK_TX_FIFO`  | TX FIFO depth (1..32k), has to be a power of two
@@ -25,7 +27,7 @@
 
 The stream link interface provides independent RX and TX channels for sending for sending and receiving
 stream data. Each channel features an internal FIFO with configurable depth to buffer stream data
-(`IO_SLINK_RX_FIFO` for the RX FIFO, `IO_SLINK_TX_FIFO` for the TX FIFO). The interface provides higher
+(`IO_SLINK_RX_FIFO` for the RX FIFO, `IO_SLINK_TX_FIFO` for the TX FIFO). The SLINK interface provides higher
 bandwidth and less latency than the external bus interface making it ideally suited for coupling custom
 stream processing units or streaming peripherals.
 
@@ -36,10 +38,11 @@ An example program for the SLINK module is available in `sw/example/demo_slink`.
 
 **Interface & Protocol**
 
-The SLINK interface consists of three signals `dat`, `val` and `rdy` per channel.
+The SLINK interface consists of four signals per channel:
 
 * `dat` contains the actual data word
 * `val` marks the current transmission cycle as valid
+* `lst` makes the current transmission cycle as the last element of a stream
 * `rdy` indicates that the receiving part is ready to receive
 
 .AXI4-Stream Compatibility
@@ -49,11 +52,20 @@ The interface names and the underlying protocol is compatible to the AXI4-Stream
 
 **Theory of Operation**
 
-The SLINK provides two interface registers: `CTRL` and `DATA`. The control register (`CTRL`) is used to configure
-the module and to check its status. The data register (`DATA`) is sued to send data (by writing to it) or to read
-received data (by reading from it). Note that accessing the data register will actually access the internal FIFOs.
+The SLINK provides four interface registers. The control register (`CTRL`) is used to configure
+the module and to check its status. Three individual data registers (`RX_DATA`, `TX_DATA`, `TX_DATA_LAST`)
+are used to send and received the link's actual data stream.
 
-The configured FIFO sizes can be retrieved by software via the `SLINK_CTRL_RX_FIFO_*` and `SLINK_CTRL_TX_FIFO_*` bits.
+The `RX_DATA` register provides direct access to the RX link FIFO buffer. After reading data from this the register
+the control register's `SLINK_CTRL_RX_LAST` can be checked to determine if the according data word has been marked
+as "end of stream" via the `slink_rx_lst_i` signal (this signal is also buffered by the link's FIFO).
+
+Writing to the `TX_DATA` or `TX_DATA_LAST` register will immediately write to the TX link FIFO buffer.
+When writing to the `TX_DATA_LAST` the according data word will be marked as "end of stream" via the
+`slink_tx_lst_o` signal (this signal is also buffered by the link's FIFO).
+
+The configured FIFO sizes can be retrieved by software via the control register's `SLINK_CTRL_RX_FIFO_*` and
+`SLINK_CTRL_TX_FIFO_*` bits.
 
 The SLINK is globally activated by setting the control register's enable bit `SLINK_CTRL_EN`. Clearing this bit will
 reset all internal logic and will also clear both FIFOs. The FIFOs can also be cleared manually at all time by
@@ -76,10 +88,12 @@ it has to be explicitly cleared again by writing zero to the according <<_mip>> 
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s) | R/W | Function
-.20+<| `0xffffec00` .20+<| `NEORV32_SLINK.CTRL` <| `0`    `SLINK_CTRL_EN`                                    ^| r/w <| SLINK global enable
-                                                <| `1`    `SLINK_CTRL_RX_CLR`                                ^| -/w <| Clear RX FIFO (bit auto-clears)
-                                                <| `2`    `SLINK_CTRL_TX_CLR`                                ^| -/w <| Clear TX FIFO (bit auto-clears)
-                                                <| `7:3`  _reserved_                                         ^| r/- <| _reserved_, read as zero
+.22+<| `0xffffec00` .22+<| `NEORV32_SLINK.CTRL` <| `0`    `SLINK_CTRL_EN`                                    ^| r/w <| SLINK global enable
+                                                <| `1`    `SLINK_CTRL_RX_CLR`                                ^| -/w <| Clear RX FIFO when set (bit auto-clears)
+                                                <| `2`    `SLINK_CTRL_TX_CLR`                                ^| -/w <| Clear TX FIFO when set (bit auto-clears)
+                                                <| `3`    _reserved_                                         ^| r/- <| _reserved_, read as zero
+                                                <| `4`    `SLINK_CTRL_RX_LAST`                               ^| r/- <| Last word read from `RX_DATA` is marked as "end of stream"
+                                                <| `7:5`  _reserved_                                         ^| r/- <| _reserved_, read as zero
                                                 <| `8`    `SLINK_CTRL_RX_EMPTY`                              ^| r/- <| RX FIFO empty
                                                 <| `9`    `SLINK_CTRL_RX_HALF`                               ^| r/- <| RX FIFO at least half full
                                                 <| `10`   `SLINK_CTRL_RX_FULL`                               ^| r/- <| RX FIFO full
@@ -87,7 +101,7 @@ it has to be explicitly cleared again by writing zero to the according <<_mip>> 
                                                 <| `12`   `SLINK_CTRL_TX_HALF`                               ^| r/- <| TX FIFO at least half full
                                                 <| `13`   `SLINK_CTRL_TX_FULL`                               ^| r/- <| TX FIFO full
                                                 <| `15:14` _reserved_                                        ^| r/- <| _reserved_, read as zero
-                                                <| `16`   `SLINK_CTRL_IRQ_RX_NEMPTY`                         ^| r/w <| IRQ if RX FIFO not empty 
+                                                <| `16`   `SLINK_CTRL_IRQ_RX_NEMPTY`                         ^| r/w <| IRQ if RX FIFO not empty
                                                 <| `17`   `SLINK_CTRL_IRQ_RX_HALF`                           ^| r/w <| IRQ if RX FIFO at least half full
                                                 <| `18`   `SLINK_CTRL_IRQ_RX_FULL`                           ^| r/w <| IRQ if RX FIFO full
                                                 <| `19`   `SLINK_CTRL_IRQ_TX_EMPTY`                          ^| r/w <| IRQ if TX FIFO empty
@@ -96,5 +110,7 @@ it has to be explicitly cleared again by writing zero to the according <<_mip>> 
                                                 <| `23:22` _reserved_                                        ^| r/- <| _reserved_, read as zero
                                                 <| `27:24` `SLINK_CTRL_RX_FIFO_MSB : SLINK_CTRL_RX_FIFO_LSB` ^| r/- <| log2(RX FIFO size)
                                                 <| `31:28` `SLINK_CTRL_TX_FIFO_MSB : SLINK_CTRL_TX_FIFO_LSB` ^| r/- <| log2(TX FIFO size)
-| `0xffffec04` | `NEORV32_SLINK.DATA` | `31:0` | r/w | RX/TX data
+| `0xffffec04` | `NEORV32_SLINK.RX_DATA`      | `31:0` | r/- | Read word from RX link FIFO
+| `0xffffec08` | `NEORV32_SLINK.TX_DATA`      | `31:0` | -/w | Write word to TX link FIFO
+| `0xffffec0c` | `NEORV32_SLINK.TX_DATA_LAST` | `31:0` | -/w | Write word to TX link FIFO and also set "end-of-stream" delimiter
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -53,7 +53,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090504"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090505"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -856,9 +856,11 @@ package neorv32_package is
       -- Stream Link Interface (available if IO_SLINK_EN = true) --
       slink_rx_dat_i : in  std_ulogic_vector(31 downto 0) := (others => 'L');
       slink_rx_val_i : in  std_ulogic := 'L';
+      slink_rx_lst_i : in  std_ulogic := 'L';
       slink_rx_rdy_o : out std_ulogic;
       slink_tx_dat_o : out std_ulogic_vector(31 downto 0);
       slink_tx_val_o : out std_ulogic;
+      slink_tx_lst_o : out std_ulogic;
       slink_tx_rdy_i : in  std_ulogic := 'L';
       -- XIP (execute in-place via SPI) signals (available if XIP_EN = true) --
       xip_csn_o      : out std_ulogic;

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -185,9 +185,11 @@ entity neorv32_top is
     -- Stream Link Interface (available if IO_SLINK_EN = true) --
     slink_rx_dat_i : in  std_ulogic_vector(31 downto 0) := (others => 'L'); -- RX input data
     slink_rx_val_i : in  std_ulogic := 'L'; -- RX valid input
+    slink_rx_lst_i : in  std_ulogic := 'L'; -- last element of stream
     slink_rx_rdy_o : out std_ulogic; -- RX ready to receive
     slink_tx_dat_o : out std_ulogic_vector(31 downto 0); -- TX output data
     slink_tx_val_o : out std_ulogic; -- TX valid output
+    slink_tx_lst_o : out std_ulogic; -- last element of stream
     slink_tx_rdy_i : in  std_ulogic := 'L'; -- TX ready to send
 
     -- XIP (execute in place via SPI) signals (available if XIP_EN = true) --
@@ -1479,10 +1481,12 @@ begin
         -- RX stream interface --
         slink_rx_data_i  => slink_rx_dat_i,
         slink_rx_valid_i => slink_rx_val_i,
+        slink_rx_last_i  => slink_rx_lst_i,
         slink_rx_ready_o => slink_rx_rdy_o,
         -- TX stream interface --
         slink_tx_data_o  => slink_tx_dat_o,
         slink_tx_valid_o => slink_tx_val_o,
+        slink_tx_last_o  => slink_tx_lst_o,
         slink_tx_ready_i => slink_tx_rdy_i
       );
     end generate;

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -1498,6 +1498,7 @@ begin
       slink_rx_rdy_o         <= '0';
       slink_tx_dat_o         <= (others => '0');
       slink_tx_val_o         <= '0';
+      slink_tx_lst_o         <= '0';
     end generate;
 
 

--- a/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
+++ b/rtl/system_integration/neorv32_SystemTop_axi4lite.vhd
@@ -1,7 +1,7 @@
 -- #################################################################################################
 -- # << NEORV32 - Processor Top Entity with AXI4-Lite Compatible Host Interface >>                 #
 -- # ********************************************************************************************* #
--- # (c) "AXI", "AXI4" and "AXI4-Lite" are trademarks of ARM Holdings plc.                         #
+-- # (c) "AXI", "AXI4", "AXI4-Lite" and "AXI-Stream" are trademarks of ARM Holdings plc.           #
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
@@ -169,10 +169,12 @@ entity neorv32_SystemTop_axi4lite is
     -- Source --
     s0_axis_tdata  : out std_logic_vector(31 downto 0);
     s0_axis_tvalid : out std_logic;
+    s0_axis_tlast  : out std_logic;
     s0_axis_tready : in  std_logic;
     -- Sink --
     s1_axis_tdata  : in  std_logic_vector(31 downto 0);
     s1_axis_tvalid : in  std_logic;
+    s1_axis_tlast  : in  std_logic;
     s1_axis_tready : out std_logic;
     -- ------------------------------------------------------------
     -- JTAG on-chip debugger interface (available if ON_CHIP_DEBUGGER_EN = true) --
@@ -246,12 +248,14 @@ architecture neorv32_SystemTop_axi4lite_rtl of neorv32_SystemTop_axi4lite is
   --
   signal clk_i_int          : std_ulogic;
   signal rstn_i_int         : std_ulogic;
-  -- 
+  --
   signal s0_axis_tdata_int  : std_ulogic_vector(31 downto 0);
   signal s0_axis_tvalid_int : std_ulogic;
+  signal s0_axis_tlast_int  : std_ulogic;
   signal s0_axis_tready_int : std_ulogic;
   signal s1_axis_tdata_int  : std_ulogic_vector(31 downto 0);
   signal s1_axis_tvalid_int : std_ulogic;
+  signal s1_axis_tlast_int : std_ulogic;
   signal s1_axis_tready_int : std_ulogic;
   --
   signal jtag_trst_i_int    : std_ulogic;
@@ -454,9 +458,11 @@ begin
     -- Stream Link Interface (available if IO_SLINK_EN = true) --
     slink_rx_dat_i => s1_axis_tdata_int,  -- RX input data
     slink_rx_val_i => s1_axis_tvalid_int, -- RX valid input
+    slink_rx_lst_i => s1_axis_tlast_int,  -- last element of stream
     slink_rx_rdy_o => s1_axis_tready_int, -- RX ready to receive
     slink_tx_dat_o => s0_axis_tdata_int,  -- TX output data
     slink_tx_val_o => s0_axis_tvalid_int, -- TX valid output
+    slink_tx_lst_o => s0_axis_tlast_int,  -- last element of stream
     slink_tx_rdy_i => s0_axis_tready_int, -- TX ready to send
     -- XIP (execute in place via SPI) signals (available if IO_XIP_EN = true) --
     xip_csn_o      => xip_csn_o_int,   -- chip-select, low-active
@@ -507,9 +513,11 @@ begin
   -- type conversion --
   s0_axis_tdata      <= std_logic_vector(s0_axis_tdata_int);
   s0_axis_tvalid     <= std_logic(s0_axis_tvalid_int);
+  s0_axis_tlast      <= std_logic(s0_axis_tlast_int);
   s0_axis_tready_int <= std_ulogic(s0_axis_tready);
   s1_axis_tdata_int  <= std_ulogic_vector(s1_axis_tdata);
   s1_axis_tvalid_int <= std_ulogic(s1_axis_tvalid);
+  s1_axis_tvalid_int <= std_ulogic(s1_axis_tlast);
   s1_axis_tready     <= std_logic(s1_axis_tready_int);
 
   xip_csn_o          <= std_logic(xip_csn_o_int);

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -126,6 +126,7 @@ architecture neorv32_tb_rtl of neorv32_tb is
   -- SLINK echo --
   signal slink_dat : std_ulogic_vector(31 downto 0);
   signal slink_val : std_ulogic;
+  signal slink_lst : std_ulogic;
   signal slink_rdy : std_ulogic;
 
   -- Wishbone bus --
@@ -334,9 +335,11 @@ begin
     -- Stream Link Interface (available if IO_SLINK_EN = true) --
     slink_rx_dat_i => slink_dat,       -- RX input data
     slink_rx_val_i => slink_val,       -- RX valid input
+    slink_rx_lst_i => slink_lst,       -- last element of stream
     slink_rx_rdy_o => slink_rdy,       -- RX ready to receive
     slink_tx_dat_o => slink_dat,       -- TX output data
     slink_tx_val_o => slink_val,       -- TX valid output
+    slink_tx_lst_o => slink_lst,       -- last element of stream
     slink_tx_rdy_i => slink_rdy,       -- TX ready to send
     -- XIP (execute in place via SPI) signals (available if XIP_EN = true) --
     xip_csn_o      => open,            -- chip-select, low-active

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -117,6 +117,7 @@ architecture neorv32_tb_simple_rtl of neorv32_tb_simple is
   -- SLINK echo --
   signal slink_dat : std_ulogic_vector(31 downto 0);
   signal slink_val : std_ulogic;
+  signal slink_lst : std_ulogic;
   signal slink_rdy : std_ulogic;
 
   -- Wishbone bus --
@@ -282,9 +283,11 @@ begin
     -- Stream Link Interface (available if IO_SLINK_EN = true) --
     slink_rx_dat_i => slink_dat,       -- RX input data
     slink_rx_val_i => slink_val,       -- RX valid input
+    slink_rx_lst_i => slink_lst,       -- last element of stream
     slink_rx_rdy_o => slink_rdy,       -- RX ready to receive
     slink_tx_dat_o => slink_dat,       -- TX output data
     slink_tx_val_o => slink_val,       -- TX valid output
+    slink_tx_lst_o => slink_lst,       -- last element of stream
     slink_tx_rdy_i => slink_rdy,       -- TX ready to send
     -- XIP (execute in place via SPI) signals (available if XIP_EN = true) --
     xip_csn_o      => open,            -- chip-select, low-active

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1616,8 +1616,8 @@ int main() {
     // configure RX data available interrupt
     neorv32_slink_setup(1 << SLINK_CTRL_IRQ_RX_NEMPTY);
 
-    // send data word
-    neorv32_slink_put(0xAABBCCDD);
+    // send data word and mark as end-of-stream
+    neorv32_slink_put_last(0xAABBCCDD);
 
     // wait for interrupt
     asm volatile ("nop");
@@ -1626,8 +1626,9 @@ int main() {
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
     // check if IRQ
-    if ((neorv32_cpu_csr_read(CSR_MCAUSE) == SLINK_TRAP_CODE) &&
-        (neorv32_slink_get() == 0xAABBCCDD)) {
+    if ((neorv32_cpu_csr_read(CSR_MCAUSE) == SLINK_TRAP_CODE) && // correct trap code
+        (neorv32_slink_get() == 0xAABBCCDD) && // correct RX data
+        (neorv32_slink_check_last() != 0)) { // is marked as "end of stream"
       test_ok();
     }
     else {

--- a/sw/lib/include/neorv32_slink.h
+++ b/sw/lib/include/neorv32_slink.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -47,8 +47,10 @@
 /**@{*/
 /** SLINK module prototype */
 typedef volatile struct __attribute__((packed,aligned(4))) {
-  uint32_t CTRL;  /**< offset 0: control register (#NEORV32_SLINK_CTRL_enum) */
-  uint32_t DATA;  /**< offset 4: data register */
+  uint32_t CTRL;         /**< offset 0: control register (#NEORV32_SLINK_CTRL_enum) */
+  uint32_t RX_DATA;      /**< offset 4: rx data register */
+  uint32_t TX_DATA;      /**< offset 8: rx data register */
+  uint32_t TX_DATA_LAST; /**< offset 12: rx data register + end-of-stream delimiter */
 } neorv32_slink_t;
 
 /** SLINK module hardware access (#neorv32_slink_t) */
@@ -59,6 +61,8 @@ enum NEORV32_SLINK_CTRL_enum {
   SLINK_CTRL_EN            =  0, /**< SLINK control register(0)  (r/w): SLINK unit enable */
   SLINK_CTRL_RX_CLR        =  1, /**< SLINK control register(1)  (-/w): Clear RX FIFO, auto-clears */
   SLINK_CTRL_TX_CLR        =  2, /**< SLINK control register(2)  (-/w): Clear TX FIFO, auto-clears */
+
+  SLINK_CTRL_RX_LAST       =  4, /**< SLINK control register(4)  (r/-): RX end-of-stream delimiter */
 
   SLINK_CTRL_RX_EMPTY      =  8, /**< SLINK control register(8)  (r/-): RX FIFO empty */
   SLINK_CTRL_RX_HALF       =  9, /**< SLINK control register(9)  (r/-): RX FIFO at least half full */
@@ -99,7 +103,9 @@ void     neorv32_slink_tx_clear(void);
 int      neorv32_slink_get_rx_fifo_depth(void);
 int      neorv32_slink_get_tx_fifo_depth(void);
 uint32_t neorv32_slink_get(void);
+uint32_t neorv32_slink_check_last(void);
 void     neorv32_slink_put(uint32_t tx_data);
+void     neorv32_slink_put_last(uint32_t tx_data);
 int      neorv32_slink_rx_status(void);
 int      neorv32_slink_tx_status(void);
 /**@}*/

--- a/sw/lib/source/neorv32_slink.c
+++ b/sw/lib/source/neorv32_slink.c
@@ -123,7 +123,21 @@ int neorv32_slink_get_tx_fifo_depth(void) {
  **************************************************************************/
 inline uint32_t __attribute__((always_inline)) neorv32_slink_get(void) {
 
-  return NEORV32_SLINK->DATA;
+  return NEORV32_SLINK->RX_DATA;
+}
+
+
+/**********************************************************************//**
+ * Check if last RX word has "end-of-stream" delimiter.
+ *
+ * @note This needs has to be called AFTER reading the actual data word
+ * using #neorv32_slink_get(void).
+ *
+ * @return 0 if not end of stream, !=0 if end of stream.
+ **************************************************************************/
+inline uint32_t __attribute__((always_inline)) neorv32_slink_check_last(void) {
+
+  return NEORV32_SLINK->CTRL & (1 << SLINK_CTRL_RX_LAST);
 }
 
 
@@ -134,7 +148,19 @@ inline uint32_t __attribute__((always_inline)) neorv32_slink_get(void) {
  **************************************************************************/
 inline void __attribute__((always_inline)) neorv32_slink_put(uint32_t tx_data) {
 
-  NEORV32_SLINK->DATA = tx_data;
+  NEORV32_SLINK->TX_DATA = tx_data;
+}
+
+
+/**********************************************************************//**
+ * Write data to TX link (non-blocking) and set "last" (end-of-stream)
+ * delimiter.
+ *
+ * @param[in] tx_data Data to send to link.
+ **************************************************************************/
+inline void __attribute__((always_inline)) neorv32_slink_put_last(uint32_t tx_data) {
+
+  NEORV32_SLINK->TX_DATA_LAST = tx_data;
 }
 
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -226,7 +226,7 @@
 
       <addressBlock>
         <offset>0</offset>
-        <size>0x08</size>
+        <size>0x10</size>
         <usage>registers</usage>
       </addressBlock>
 
@@ -250,6 +250,11 @@
               <name>SLINK_CTRL_TX_CLR</name>
               <bitRange>[2:2]</bitRange>
               <description>Clear TX FIFO (auto-clears)</description>
+            </field>
+            <field>
+              <name>SLINK_CTRL_RX_LAST</name>
+              <bitRange>[4:4]</bitRange>
+              <description>RX link end-of-stream delimiter</description>
             </field>
             <field>
               <name>SLINK_CTRL_RX_EMPTY</name>
@@ -332,9 +337,20 @@
           </fields>
         </register>
         <register>
-          <name>DATA</name>
-          <description>RX/TX data</description>
+          <name>RX_DATA</name>
+          <description>RX link receive data</description>
+           <access>read-only</access>
           <addressOffset>0x04</addressOffset>
+        </register>
+        <register>
+          <name>TX_DATA</name>
+          <description>TX link transmit data</description>
+          <addressOffset>0x08</addressOffset>
+        </register>
+        <register>
+          <name>TX_DATA_LAST</name>
+          <description>TX link transmit data (plus end-of-stream delimiter)</description>
+          <addressOffset>0x0c</addressOffset>
         </register>
       </registers>
     </peripheral>


### PR DESCRIPTION
Add native hardware support for the AXI-stream-compatible `tlast` signals that are used to identify the last data word of a stream.

Add new top signals:
```vhdl
  slink_rx_lst_i : in  std_ulogic := 'L'; -- last element of stream
  slink_tx_lst_o : out std_ulogic; -- last element of stream
```

⚠️ Reworked SLINK low-level driver / HAL. The SLINK module now uses four memory-mapped interface registers for control and data transfers. See the updated documentation.

ℹ️ The updated HAL is fully backwards-compatible.

🚀 Discussed in https://github.com/stnolting/neorv32/discussions/795; triggered by @Giorgio122.