### PR TITLE
[sim] add simulation check to sw makefiles as target 'sim-check'

### DIFF
--- a/.github/workflows/Processor.yml
+++ b/.github/workflows/Processor.yml
@@ -36,7 +36,7 @@ jobs:
     - name: '🚧 Run Processor Hardware Tests with shell script'
       uses: docker://ghcr.io/stnolting/neorv32/sim
       with:
-        args: ./sim/simple/ghdl.sh
+        args: make -C sw/example/processor_check sim-check
 
 
   VUnit-Container:

--- a/sim/simple/ghdl.run.sh
+++ b/sim/simple/ghdl.run.sh
@@ -41,6 +41,3 @@ if [ -n "$GHDL_DEVNULL" ]; then
 else
   $runcmd
 fi
-
-# verify results of processor check: sw/example/processor_check
-cat neorv32.uart0.sim_mode.text.out | grep "PROCESSOR TEST COMPLETED SUCCESSFULLY!"

--- a/sw/example/hello_world/makefile
+++ b/sw/example/hello_world/makefile
@@ -2,3 +2,6 @@
 NEORV32_HOME ?= ../../..
 
 include $(NEORV32_HOME)/sw/common/common.mk
+
+sim-check: sim
+	cat $(NEORV32_HOME)/sim/simple/neorv32.uart0.sim_mode.text.out | grep "Hello world! :)"

--- a/sw/example/processor_check/makefile
+++ b/sw/example/processor_check/makefile
@@ -2,3 +2,6 @@
 NEORV32_HOME ?= ../../..
 
 include $(NEORV32_HOME)/sw/common/common.mk
+
+sim-check: sim
+	cat $(NEORV32_HOME)/sim/simple/neorv32.uart0.sim_mode.text.out | grep "PROCESSOR TEST COMPLETED SUCCESSFULLY!"

--- a/sw/example/processor_check/run_check.sh
+++ b/sw/example/processor_check/run_check.sh
@@ -3,4 +3,4 @@
 set -e
 
 echo "Starting processor check simulation..."
-make USER_FLAGS+="-DUART0_SIM_MODE -DUART1_SIM_MODE -g -flto" EFFORT=-Os MARCH=rv32ima_zba_zbb_zbc_zbs_zicsr_zifencei_zicond clean_all all sim
+make USER_FLAGS+="-DUART0_SIM_MODE -DUART1_SIM_MODE -g -flto" EFFORT=-Os MARCH=rv32ima_zba_zbb_zbc_zbs_zicsr_zifencei_zicond clean_all all sim-check


### PR DESCRIPTION
Coming from #816, this PR moves the cat-grep assert from the simulation shell script to the Makefile of the corresponding software program. In order to do so, target `sim-check` is added, which depends on `sim`.
This approach allows us to have per-program checks. In order to showcase the feature, I added a check to `hello_world` as well.

See a successful execution https://github.com/umarcor/neorv32/actions/runs/7977125739 and failures when I changed the strings in the software on purpose: https://github.com/umarcor/neorv32/actions/runs/7977200433.