### PR TITLE
[fifo] fix (Vivado) synthesis issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 23.02.2024 | 1.9.5.7 | fix FIFO synthesis issue (Vivado cannot infer block RAM nor LUT-RAM) | [#827](https://github.com/stnolting/neorv32/pull/827) |
 | 20.02.2024 | 1.9.5.6 | :bug: fix bug in `mip.firq` CSR access; `mip.firq` bits are now read-write - software can trigger FIRQs by writing `1` to the according CSR bit | [#821](https://github.com/stnolting/neorv32/pull/821) |
 | 19.02.2024 | 1.9.5.5 | SLINK: add native hardware support for AXI-stream's "tlast" signal | [#815](https://github.com/stnolting/neorv32/pull/815) |
 | 19.02.2024 | 1.9.5.4 | :warning: remove support of `Smcntrpmf` ISA extension (counter privilege mode filtering) | [#814](https://github.com/stnolting/neorv32/pull/814) |

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -433,7 +433,8 @@ begin
       FIFO_DEPTH => 2,                   -- number of fifo entries; has to be a power of two, min 2
       FIFO_WIDTH => ipb.wdata(i)'length, -- size of data elements in fifo
       FIFO_RSYNC => false,               -- we NEED to read data asynchronously
-      FIFO_SAFE  => false                -- no safe access required (ensured by FIFO-external logic)
+      FIFO_SAFE  => false,               -- no safe access required (ensured by FIFO-external logic)
+      FULL_RESET => false                -- no HW reset, try to infer BRAM
     )
     port map (
       -- control --

--- a/rtl/core/neorv32_neoled.vhd
+++ b/rtl/core/neorv32_neoled.vhd
@@ -225,7 +225,8 @@ begin
     FIFO_DEPTH => FIFO_DEPTH, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 32+2,       -- size of data elements in fifo
     FIFO_RSYNC => true,       -- sync read
-    FIFO_SAFE  => true        -- safe access
+    FIFO_SAFE  => true,       -- safe access
+    FULL_RESET => false       -- no HW reset, try to infer BRAM
   )
   port map (
     -- control --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -53,7 +53,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090506"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090507"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_sdi.vhd
+++ b/rtl/core/neorv32_sdi.vhd
@@ -202,7 +202,8 @@ begin
     FIFO_DEPTH => RTX_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,        -- size of data elements in fifo (32-bit only for simulation)
     FIFO_RSYNC => true,     -- sync read
-    FIFO_SAFE  => true      -- safe access
+    FIFO_SAFE  => true,     -- safe access
+    FULL_RESET => false     -- no HW reset, try to infer BRAM
   )
   port map (
     -- control --

--- a/rtl/core/neorv32_slink.vhd
+++ b/rtl/core/neorv32_slink.vhd
@@ -217,7 +217,8 @@ begin
     FIFO_DEPTH => SLINK_RX_FIFO,
     FIFO_WIDTH => 32+1, -- data + last-flag
     FIFO_RSYNC => true, -- sync read
-    FIFO_SAFE  => true  -- safe access
+    FIFO_SAFE  => true, -- safe access
+    FULL_RESET => false -- no HW reset, try to infer BRAM
   )
   port map (
     -- control --
@@ -265,7 +266,8 @@ begin
     FIFO_DEPTH => SLINK_TX_FIFO,
     FIFO_WIDTH => 32+1, -- data + last-flag
     FIFO_RSYNC => true, -- sync read
-    FIFO_SAFE  => true  -- safe access
+    FIFO_SAFE  => true, -- safe access
+    FULL_RESET => false -- no HW reset, try to infer BRAM
   )
   port map (
     -- control --

--- a/rtl/core/neorv32_spi.vhd
+++ b/rtl/core/neorv32_spi.vhd
@@ -234,7 +234,8 @@ begin
     FIFO_DEPTH => IO_SPI_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,           -- size of data elements in fifo
     FIFO_RSYNC => true,        -- sync read
-    FIFO_SAFE  => true         -- safe access
+    FIFO_SAFE  => true,        -- safe access
+    FULL_RESET => false        -- no HW reset, try to infer BRAM
   )
   port map (
     -- control --
@@ -264,7 +265,8 @@ begin
     FIFO_DEPTH => IO_SPI_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,           -- size of data elements in fifo
     FIFO_RSYNC => true,        -- sync read
-    FIFO_SAFE  => true         -- safe access
+    FIFO_SAFE  => true,        -- safe access
+    FULL_RESET => false        -- no HW reset, try to infer BRAM
   )
   port map (
     -- control --

--- a/rtl/core/neorv32_trng.vhd
+++ b/rtl/core/neorv32_trng.vhd
@@ -195,7 +195,8 @@ begin
     FIFO_DEPTH => IO_TRNG_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,            -- size of data elements in fifo
     FIFO_RSYNC => true,         -- sync read
-    FIFO_SAFE  => true          -- safe access
+    FIFO_SAFE  => true,         -- safe access
+    FULL_RESET => false         -- no HW reset, try to infer BRAM
   )
   port map (
     -- control --

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -267,7 +267,8 @@ begin
     FIFO_DEPTH => UART_TX_FIFO,
     FIFO_WIDTH => 8,
     FIFO_RSYNC => true,
-    FIFO_SAFE  => true
+    FIFO_SAFE  => true,
+    FULL_RESET => false
   )
   port map (
     -- control --
@@ -308,7 +309,8 @@ begin
     FIFO_DEPTH => UART_RX_FIFO,
     FIFO_WIDTH => 8,
     FIFO_RSYNC => true,
-    FIFO_SAFE  => true
+    FIFO_SAFE  => true,
+    FULL_RESET => false
   )
   port map (
     clk_i   => clk_i,


### PR DESCRIPTION
Vivado was not able to infer block RAM / LUT-RAM for the FIFO memory.

@robhancocksed, @mikaelsky, @umarcor