### PR TITLE
[sw] remove unused variable RISCV_TOOLCHAIN

### DIFF
--- a/sw/common/common.mk
+++ b/sw/common/common.mk
@@ -358,7 +358,7 @@ info:
 	@echo "------------------------------------------------------"
 	@echo "-- Toolchain"
 	@echo "------------------------------------------------------"
-	@echo "Toolchain:      $(RISCV_TOLLCHAIN)"
+	@echo "Toolchain:      $(RISCV_TOOLCHAIN)"
 	@echo "CC:             $(CC)"
 	@echo "OBJDUMP:        $(OBJDUMP)"
 	@echo "OBJCOPY:        $(OBJCOPY)"

--- a/sw/common/common.mk
+++ b/sw/common/common.mk
@@ -358,7 +358,6 @@ info:
 	@echo "------------------------------------------------------"
 	@echo "-- Toolchain"
 	@echo "------------------------------------------------------"
-	@echo "Toolchain:      $(RISCV_TOOLCHAIN)"
 	@echo "CC:             $(CC)"
 	@echo "OBJDUMP:        $(OBJDUMP)"
 	@echo "OBJCOPY:        $(OBJCOPY)"

--- a/sw/ocd-firmware/makefile
+++ b/sw/ocd-firmware/makefile
@@ -242,7 +242,7 @@ info:
 	@echo "MARCH:      $(MARCH)"
 	@echo "MABI:       $(MABI)"
 	@echo "---------------- Info: Toolchain ----------------"
-	@echo "Toolchain:  $(RISCV_TOLLCHAIN)"
+	@echo "Toolchain:  $(RISCV_TOOLCHAIN)"
 	@echo "CC:         $(CC)"
 	@echo "OBJDUMP:    $(OBJDUMP)"
 	@echo "OBJCOPY:    $(OBJCOPY)"

--- a/sw/ocd-firmware/makefile
+++ b/sw/ocd-firmware/makefile
@@ -242,7 +242,6 @@ info:
 	@echo "MARCH:      $(MARCH)"
 	@echo "MABI:       $(MABI)"
 	@echo "---------------- Info: Toolchain ----------------"
-	@echo "Toolchain:  $(RISCV_TOOLCHAIN)"
 	@echo "CC:         $(CC)"
 	@echo "OBJDUMP:    $(OBJDUMP)"
 	@echo "OBJCOPY:    $(OBJCOPY)"


### PR DESCRIPTION
While trying to build and install the bootloader on MSYS2 following my notes from #55, I found the following typo: `s/RISCV_TOLLCHAIN/RISCV_TOOLCHAIN/`. So I fixed it.

However, then I found out that it seems not to be used anymore. Now `RISCV_PREFIX` is used: `RISCV_PREFIX=riscv64-unknown-elf- MARCH=rv32i make -C sw/bootloader/ install`. Therefore, I removed it. Yet, I don't know if that's correct.

@stnolting wdyt?