### PR TITLE
:bug: fix GPTMR threshold = 0 configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 25.02.2024 | 1.9.5.10 | :bug: fix minor GPTMR threshold configuration issue | [#834](https://github.com/stnolting/neorv32/pull/834) |
 | 23.02.2024 | 1.9.5.9 | :bug: fix atomic write/clear/set accesses of clear-only CSR bits (re-fix of v1.9.5.6) | [#829](https://github.com/stnolting/neorv32/pull/829) |
 | 23.02.2024 | 1.9.5.8 | optimize FIFO component to improve technology mapping (inferring blockRAM for "async read" configuration); :bug: fix SLINK status flag delay | [#828](https://github.com/stnolting/neorv32/pull/828) |
 | 23.02.2024 | 1.9.5.7 | fix FIFO synthesis issue (Vivado cannot infer block RAM nor LUT-RAM) | [#827](https://github.com/stnolting/neorv32/pull/827) |

--- a/rtl/core/neorv32_gptmr.vhd
+++ b/rtl/core/neorv32_gptmr.vhd
@@ -207,7 +207,7 @@ begin
   end process counter_core;
 
   -- counter = threshold? --
-  timer.match <= '1' when (timer.count = timer.thres) else '0';
+  timer.match <= '1' when (timer.count = timer.thres) and (ctrl(ctrl_en_c) = '1') else '0';
 
   -- match edge detector --
   timer.trigger <= '1' when (timer.match_ff = '0') and (timer.match = '1') else '0';

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -53,7 +53,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090509"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090510"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -545,7 +545,7 @@ int main() {
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
     // trigger two FIRQs
-    neorv32_gptmr_setup(CLK_PRSC_2, 1, -1); // fire GPTMR FIRQ
+    neorv32_gptmr_setup(CLK_PRSC_2, 0, -1); // fire GPTMR FIRQ
     neorv32_spi_setup(CLK_PRSC_2, 0, 0, 0, -1); // fire SPI FIRQ
     neorv32_gptmr_disable();
     neorv32_spi_disable();


### PR DESCRIPTION
If the GPTMR's threshold value is set to zero (yes, this is just a corner case) it should immediately trigger an interrupt (if enabled). This PR fixes this.