### PR TITLE
CPU RTL optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 26.03.2024 | 1.9.7.1 | CPU hardware optimization (reduced hardware footprint, shortened critical path) | [#857](https://github.com/stnolting/neorv32/pull/857) |
 | 22.03.2024 | [**:rocket:1.9.7**](https://github.com/stnolting/neorv32/releases/tag/v1.9.7) | **New release** | |
 | 18.03.2024 | 1.9.6.9 | :sparkles: update CFU example: now implementing the Extended Tiny Encryption Algorithm (XTEA) | [#855](https://github.com/stnolting/neorv32/pull/855) |
 | 16.03.2024 | 1.9.6.8 | rework cache system: L1 + L2 caches, all based on the generic cache component | [#853](https://github.com/stnolting/neorv32/pull/853) |

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -958,6 +958,7 @@ begin
     bus_req_o.ben  <= (others => '1'); -- full-word writes only
     bus_req_o.src  <= '0'; -- cache accesses are always "data" accesses
     bus_req_o.priv <= '0'; -- cache accesses are always "unprivileged" accesses
+    bus_req_o.rvso <= '0'; -- cache accesses can never be a reservation set operation
 
     -- fsm --
     case state is

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -114,8 +114,9 @@ architecture neorv32_cpu_rtl of neorv32_cpu is
   -- local signals --
   signal ctrl         : ctrl_bus_t; -- main control bus
   signal imm          : std_ulogic_vector(XLEN-1 downto 0); -- immediate
-  signal rs1, rs2     : std_ulogic_vector(XLEN-1 downto 0); -- source register 1,2
-  signal rs3, rs4     : std_ulogic_vector(XLEN-1 downto 0); -- source register 3,4
+  signal rf_wdata     : std_ulogic_vector(XLEN-1 downto 0); -- register file write data
+  signal rs1, rs2     : std_ulogic_vector(XLEN-1 downto 0); -- source registers 1 and 2
+  signal rs3, rs4     : std_ulogic_vector(XLEN-1 downto 0); -- source registers 3 and 4 (optional)
   signal alu_res      : std_ulogic_vector(XLEN-1 downto 0); -- alu result
   signal alu_add      : std_ulogic_vector(XLEN-1 downto 0); -- alu address result
   signal alu_cmp      : std_ulogic_vector(1 downto 0); -- comparator result
@@ -266,17 +267,16 @@ begin
     clk_i  => clk_i,     -- global clock, rising edge
     rstn_i => rstn_i,    -- global reset, low-active, async
     ctrl_i => ctrl,      -- main control bus
-    -- data input --
-    alu_i  => alu_res,   -- ALU result
-    mem_i  => mem_rdata, -- memory read data
-    csr_i  => csr_rdata, -- CSR read data
-    ret_i  => link_pc,   -- return address
-    -- data output --
-    rs1_o  => rs1,       -- rs1
-    rs2_o  => rs2,       -- rs2
-    rs3_o  => rs3,       -- rs3
-    rs4_o  => rs4        -- rs4
+    -- operands --
+    rd_i   => rf_wdata,  -- destination operand rd
+    rs1_o  => rs1,       -- source operand rs1
+    rs2_o  => rs2,       -- source operand rs2
+    rs3_o  => rs3,       -- source operand rs3
+    rs4_o  => rs4        -- source operand rs4
   );
+
+  -- all buses are zero unless there is an according operation --
+  rf_wdata <= alu_res or mem_rdata or csr_rdata or link_pc;
 
 
   -- ALU (Arithmetic/Logic Unit) and ALU Co-Processors --------------------------------------

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -132,7 +132,7 @@ begin
   opa_x <= (opa(opa'left) and (not ctrl_i.alu_unsigned)) & opa; -- sign-extend
   opb_x <= (opb(opb'left) and (not ctrl_i.alu_unsigned)) & opb; -- sign-extend
 
-  addsub_res <= std_ulogic_vector(unsigned(opa_x) - unsigned(opb_x)) when (ctrl_i.alu_op(0) = '1') else
+  addsub_res <= std_ulogic_vector(unsigned(opa_x) - unsigned(opb_x)) when (ctrl_i.alu_sub = '1') else
                 std_ulogic_vector(unsigned(opa_x) + unsigned(opb_x));
 
   add_o <= addsub_res(XLEN-1 downto 0); -- direct output of adder result
@@ -142,17 +142,17 @@ begin
   -- -------------------------------------------------------------------------------------------
   alu_core: process(ctrl_i, addsub_res, cp_res, rs1_i, opb)
   begin
+    res_o <= (others => '0');
     case ctrl_i.alu_op is
+      when alu_op_zero_c => res_o <= (others => '0');
       when alu_op_add_c  => res_o <= addsub_res(XLEN-1 downto 0);
-      when alu_op_sub_c  => res_o <= addsub_res(XLEN-1 downto 0);
       when alu_op_cp_c   => res_o <= cp_res;
-      when alu_op_slt_c  => res_o(XLEN-1 downto 1) <= (others => '0');
-                            res_o(0) <= addsub_res(addsub_res'left); -- carry/borrow
+      when alu_op_slt_c  => res_o(0) <= addsub_res(addsub_res'left); -- carry/borrow
       when alu_op_movb_c => res_o <= opb;
       when alu_op_xor_c  => res_o <= opb xor rs1_i;
       when alu_op_or_c   => res_o <= opb or  rs1_i;
       when alu_op_and_c  => res_o <= opb and rs1_i;
-      when others        => res_o <= addsub_res(XLEN-1 downto 0); -- don't care
+      when others        => res_o <= (others => '0');
     end case;
   end process alu_core;
 

--- a/rtl/core/neorv32_cpu_lsu.vhd
+++ b/rtl/core/neorv32_cpu_lsu.vhd
@@ -197,6 +197,8 @@ begin
           when others => -- word
             rdata_o(XLEN-1 downto 0) <= bus_rsp_i.data(XLEN-1 downto 0);
         end case;
+      else
+        rdata_o <= (others => '0'); -- output zero if there is no memory access
       end if;
     end if;
   end process mem_di_reg;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -52,7 +52,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090700"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090701"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -222,8 +222,6 @@ package neorv32_package is
   constant instr_rs1_msb_c     : natural := 19; -- source register 1 address bit 4
   constant instr_rs2_lsb_c     : natural := 20; -- source register 2 address bit 0
   constant instr_rs2_msb_c     : natural := 24; -- source register 2 address bit 4
-  constant instr_rs3_lsb_c     : natural := 27; -- source register 3 address bit 0
-  constant instr_rs3_msb_c     : natural := 31; -- source register 3 address bit 4
   constant instr_funct7_lsb_c  : natural := 25; -- funct7 bit 0
   constant instr_funct7_msb_c  : natural := 31; -- funct7 bit 6
   constant instr_funct12_lsb_c : natural := 20; -- funct12 bit 0
@@ -508,12 +506,11 @@ package neorv32_package is
     rf_wb_en     : std_ulogic; -- write back enable
     rf_rs1       : std_ulogic_vector(04 downto 0); -- source register 1 address
     rf_rs2       : std_ulogic_vector(04 downto 0); -- source register 2 address
-    rf_rs3       : std_ulogic_vector(04 downto 0); -- source register 3 address
     rf_rd        : std_ulogic_vector(04 downto 0); -- destination register address
-    rf_mux       : std_ulogic_vector(01 downto 0); -- input source select
     rf_zero_we   : std_ulogic;                     -- allow/force write access to x0
     -- alu --
-    alu_op       : std_ulogic_vector(02 downto 0); -- ALU operation select
+    alu_op       : std_ulogic_vector(02 downto 0); -- operation select
+    alu_sub      : std_ulogic;                     -- addition/subtraction control
     alu_opa_mux  : std_ulogic;                     -- operand A select (0=rs1, 1=PC)
     alu_opb_mux  : std_ulogic;                     -- operand B select (0=rs2, 1=IMM)
     alu_unsigned : std_ulogic;                     -- is unsigned ALU operation
@@ -523,7 +520,7 @@ package neorv32_package is
     lsu_rw       : std_ulogic;                     -- 0: read access, 1: write access
     lsu_mo_we    : std_ulogic;                     -- memory address and data output register write enable
     lsu_fence    : std_ulogic;                     -- fence(.i) operation
-    lsu_priv     : std_ulogic;                     -- effective privilege level for load/store
+    lsu_priv     : std_ulogic;                     -- effective privilege mode for load/store
     -- instruction word --
     ir_funct3    : std_ulogic_vector(02 downto 0); -- funct3 bit field
     ir_funct12   : std_ulogic_vector(11 downto 0); -- funct12 bit field
@@ -540,11 +537,10 @@ package neorv32_package is
     rf_wb_en     => '0',
     rf_rs1       => (others => '0'),
     rf_rs2       => (others => '0'),
-    rf_rs3       => (others => '0'),
     rf_rd        => (others => '0'),
-    rf_mux       => (others => '0'),
     rf_zero_we   => '0',
     alu_op       => (others => '0'),
+    alu_sub      => '0',
     alu_opa_mux  => '0',
     alu_opb_mux  => '0',
     alu_unsigned => '0',
@@ -577,10 +573,10 @@ package neorv32_package is
   constant cp_sel_cfu_c      : natural := 4; -- CP4: custom instructions CFU ('Zxcfu' extension)
   constant cp_sel_cond_c     : natural := 5; -- CP5: conditional operations ('Zicond' extension)
 
-  -- ALU Function Codes [DO NOT CHANGE ENCODING!] -------------------------------------------
+  -- ALU Function Codes ---------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant alu_op_add_c  : std_ulogic_vector(2 downto 0) := "000"; -- result <= A + B
-  constant alu_op_sub_c  : std_ulogic_vector(2 downto 0) := "001"; -- result <= A - B
+  constant alu_op_zero_c : std_ulogic_vector(2 downto 0) := "000"; -- result <= 0
+  constant alu_op_add_c  : std_ulogic_vector(2 downto 0) := "001"; -- result <= A + (-)B
   constant alu_op_cp_c   : std_ulogic_vector(2 downto 0) := "010"; -- result <= ALU co-processor
   constant alu_op_slt_c  : std_ulogic_vector(2 downto 0) := "011"; -- result <= A < B
   constant alu_op_movb_c : std_ulogic_vector(2 downto 0) := "100"; -- result <= B

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -762,50 +762,56 @@ begin
   -- **************************************************************************************************************************
   neorv32_bus_gateway_inst: entity neorv32.neorv32_bus_gateway
   generic map (
-    TIMEOUT     => bus_timeout_c,
-    -- IMEM port --
-    IMEM_ENABLE => MEM_INT_IMEM_EN,
-    IMEM_BASE   => mem_imem_base_c,
-    IMEM_SIZE   => imem_size_c,
-    -- DMEM port --
-    DMEM_ENABLE => MEM_INT_DMEM_EN,
-    DMEM_BASE   => mem_dmem_base_c,
-    DMEM_SIZE   => dmem_size_c,
-    -- XIP port --
-    XIP_ENABLE  => XIP_EN,
-    XIP_BASE    => mem_xip_base_c,
-    XIP_SIZE    => mem_xip_size_c,
-    -- BOOT ROM port --
-    BOOT_ENABLE => INT_BOOTLOADER_EN,
-    BOOT_BASE   => mem_boot_base_c,
-    BOOT_SIZE   => mem_boot_size_c,
-    -- IO port --
-    IO_ENABLE   => true, -- always enabled (mandatory core module)
-    IO_BASE     => mem_io_base_c,
-    IO_SIZE     => mem_io_size_c,
-    -- EXT port --
-    EXT_ENABLE  => XBUS_EN
+    TIMEOUT  => bus_timeout_c,
+    -- port A: IMEM --
+    A_ENABLE => MEM_INT_IMEM_EN,
+    A_BASE   => mem_imem_base_c,
+    A_SIZE   => imem_size_c,
+    A_TMO_EN => true,
+    -- port B: DMEM --
+    B_ENABLE => MEM_INT_DMEM_EN,
+    B_BASE   => mem_dmem_base_c,
+    B_SIZE   => dmem_size_c,
+    B_TMO_EN => true,
+    -- port C: XIP --
+    C_ENABLE => XIP_EN,
+    C_BASE   => mem_xip_base_c,
+    C_SIZE   => mem_xip_size_c,
+    C_TMO_EN => false, -- not timeout for XIP flash accesses
+    -- port D: BOOT ROM --
+    D_ENABLE => INT_BOOTLOADER_EN,
+    D_BASE   => mem_boot_base_c,
+    D_SIZE   => mem_boot_size_c,
+    D_TMO_EN => true,
+    -- port E: IO --
+    E_ENABLE => true, -- always enabled (mandatory core module)
+    E_BASE   => mem_io_base_c,
+    E_SIZE   => mem_io_size_c,
+    E_TMO_EN => true,
+    -- port X: XBUS --
+    X_ENABLE => XBUS_EN,
+    X_TMO_EN => false -- timeout handled by XBUS gateway
   )
   port map (
     -- global control --
-    clk_i      => clk_i,
-    rstn_i     => rstn_sys,
+    clk_i   => clk_i,
+    rstn_i  => rstn_sys,
     -- host port --
-    main_req_i => main2_req,
-    main_rsp_o => main2_rsp,
+    req_i   => main2_req,
+    rsp_o   => main2_rsp,
     -- section ports --
-    imem_req_o => imem_req,
-    imem_rsp_i => imem_rsp,
-    dmem_req_o => dmem_req,
-    dmem_rsp_i => dmem_rsp,
-    xip_req_o  => xip_req,
-    xip_rsp_i  => xip_rsp,
-    boot_req_o => boot_req,
-    boot_rsp_i => boot_rsp,
-    io_req_o   => io_req,
-    io_rsp_i   => io_rsp,
-    ext_req_o  => xbus_req,
-    ext_rsp_i  => xbus_rsp
+    a_req_o => imem_req,
+    a_rsp_i => imem_rsp,
+    b_req_o => dmem_req,
+    b_rsp_i => dmem_rsp,
+    c_req_o => xip_req,
+    c_rsp_i => xip_rsp,
+    d_req_o => boot_req,
+    d_rsp_i => boot_rsp,
+    e_req_o => io_req,
+    e_rsp_i => io_rsp,
+    x_req_o => xbus_req,
+    x_rsp_i => xbus_rsp
   );
 
 


### PR DESCRIPTION
* made interconnect's gateway more generic (in case someone wants to use it for building custom bus systems)
* optimize CPU data path
  * smaller hardware footprint (~5% smaller)
  * shortened critical path (134MHz, CPU-only, Cyclone 4)