### PR TITLE
:warning: rework ONEWIRE and GPTMR interrupts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 23.03.2024 | 1.9.7.3 | :warning: **interrupt system rework**: rework ONEWIRE and GPTMR interrupts | [#859](https://github.com/stnolting/neorv32/pull/859) |
 | 23.03.2024 | 1.9.7.2 | :warning: **interrupt system rework**: removed WDT and TRNG interrupts; :bug: fix core complex clocking during sleep mode | [#858](https://github.com/stnolting/neorv32/pull/858) |
 | 23.03.2024 | 1.9.7.1 | CPU hardware optimization (reduced hardware footprint, shortened critical path) | [#857](https://github.com/stnolting/neorv32/pull/857) |
 | 22.03.2024 | [**:rocket:1.9.7**](https://github.com/stnolting/neorv32/releases/tag/v1.9.7) | **New release** | |

--- a/docs/datasheet/soc_onewire.adoc
+++ b/docs/datasheet/soc_onewire.adoc
@@ -163,10 +163,9 @@ time **T~base~** (and by eventually changing the hardwired timing configuration 
 
 **Interrupt**
 
-A single interrupt is provided by the ONEWIRE module to signal "operation done" condition to the CPU. Whenever the
-controller completes a "generate reset pulse", a "transfer single-bit" or a "transfer full-byte" operation the
-interrupt is triggered. Once triggered, the interrupt has to be _explicitly_ cleared again by writing zero to the
-according <<_mip>> CSR FIRQ bit.
+A single interrupt is provided by the ONEWIRE module to signal "idle" condition to the CPU. Whenever the
+controller is idle (again) the interrupt becomes active. Once triggered, the interrupt has to be _explicitly_
+cleared again by writing zero to the according <<_mip>> CSR FIRQ bit.
 
 
 **Register Map**

--- a/rtl/core/neorv32_cfs.vhd
+++ b/rtl/core/neorv32_cfs.vhd
@@ -139,9 +139,7 @@ begin
   -- Interrupt ------------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   -- The CFS features a single interrupt signal, which is connected to the CPU's "fast interrupt" channel 1 (FIRQ1).
-  -- The interrupt is triggered by a one-cycle high-level. After triggering, the interrupt appears as "pending" in the CPU's
-  -- mip CSR ready to trigger execution of the according interrupt handler. It is the task of the application to programmer
-  -- to enable/clear the CFS interrupt using the CPU's mie and mip registers when required.
+  -- The according CPU interrupt becomes pending as long as <irq_o> is high.
 
   irq_o <= '0'; -- not used for this minimal example
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -52,7 +52,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090702"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090703"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 


### PR DESCRIPTION
## :warning: Rework ONEWIRE Interrupt

The interrupt of the ONEWIRE module will now become set whenever the module is in idle state (e.g. after completing an operation).

## :warning: Rework GPTMR Interrupt

The GPTMR timer interrupt will now remain pending until explicitly cleared by writing zero to the module's `GPTMR_CTRL_TRIGM` and/or `GPTMR_CTRL_TRIGC` control register bits (depneing on the interrupt trigger configuration).

> [!NOTE]
> This PR is part of a series that aims to _unify_ (and simplify) the entire interrupt system of the processor.