### PR TITLE
:warning: rework TWI interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 23.03.2024 | 1.9.7.4 | :warning: **interrupt system rework**: rework TWI and XIRQ interrupts | [#860](https://github.com/stnolting/neorv32/pull/860) |
 | 23.03.2024 | 1.9.7.3 | :warning: **interrupt system rework**: rework ONEWIRE and GPTMR interrupts | [#859](https://github.com/stnolting/neorv32/pull/859) |
 | 23.03.2024 | 1.9.7.2 | :warning: **interrupt system rework**: removed WDT and TRNG interrupts; :bug: fix core complex clocking during sleep mode | [#858](https://github.com/stnolting/neorv32/pull/858) |
 | 23.03.2024 | 1.9.7.1 | CPU hardware optimization (reduced hardware footprint, shortened critical path) | [#857](https://github.com/stnolting/neorv32/pull/857) |

--- a/docs/datasheet/soc_dma.adoc
+++ b/docs/datasheet/soc_dma.adoc
@@ -124,7 +124,7 @@ This automatic fencing is enabled by the setting the control register's `DMA_CTR
 
 The DMA features a single CPU interrupt that is triggered when the programmed transfer has completed. This
 interrupt is also triggered if the DMA encounters a bus error during operation. An active DMA interrupt has to be
-explicitly cleared again by writing zero to the according <<_mip>> CSR bit.
+explicitly cleared again by clearing `DMA_CTRL_DONE` and also by writing zero to the according <<_mip>> CSR bit.
 
 
 **Register Map**

--- a/docs/datasheet/soc_twi.adoc
+++ b/docs/datasheet/soc_twi.adoc
@@ -112,10 +112,8 @@ is currently claimed.
 
 **TWI Interrupt**
 
-The TWI module provides a single interrupt to signal "transmission done" to the CPU. Whenever the TWI
-module completes the current transmission of one byte the interrupt is triggered. Note the the interrupt
-is **not** triggered when completing a START or STOP condition. Once triggered, the interrupt has to be
-explicitly cleared again by writing zero to the according <<_mip>> CSR bit.
+The TWI module provides a single interrupt to signal "idle condition" (i.e. controller is ready for a new operation) to the CPU.
+Once triggered, the interrupt has to be explicitly cleared again by writing zero to the according <<_mip>> CSR bit.
 
 
 **Register Map**

--- a/docs/datasheet/soc_xirq.adoc
+++ b/docs/datasheet/soc_xirq.adoc
@@ -59,9 +59,9 @@ the interrupt source register `ESC`. This register provides a 5-bit wide ID (0..
 Writing _any_ value to this register will acknowledge the _current_ XIRQ interrupt (so the XIRQ controller can issue a new CPU interrupt).
 
 In order to acknowledge an XIRQ interrupt, the interrupt handler has to...
-* clear the pending CPU FIRQ by clearing the according <<_mip>> CSR bit
 * clear the pending XIRQ channel by clearing the according `EIP` bit
 * writing _any_ value to `ESC` to acknowledge the XIRQ interrupt
+* clear the pending CPU FIRQ by clearing the according <<_mip>> CSR bit
 
 
 **Register Map**

--- a/rtl/core/neorv32_dma.vhd
+++ b/rtl/core/neorv32_dma.vhd
@@ -217,6 +217,9 @@ begin
     end if;
   end process bus_access;
 
+  -- transfer-done interrupt --
+  irq_o <= engine.done and config.enable; -- no interrupt if transfer was aborted by clearing config.enable
+
 
   -- Automatic Trigger ----------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -324,9 +327,6 @@ begin
 
   -- transfer in progress? --
   engine.busy <= '0' when (engine.state = S_IDLE) else '1';
-
-  -- transfer-done interrupt --
-  irq_o <= engine.done and config.enable; -- no interrupt if transfer was aborted
 
   -- bus output --
   dma_req_o.priv  <= priv_mode_m_c; -- privileged access

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -52,7 +52,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090703"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090704"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_xirq.vhd
+++ b/rtl/core/neorv32_xirq.vhd
@@ -69,9 +69,7 @@ architecture neorv32_xirq_rtl of neorv32_xirq is
   signal irq_source   : std_ulogic_vector(4 downto 0); -- r/w: source IRQ, ACK on write
 
   -- interrupt trigger --
-  signal irq_sync  : std_ulogic_vector(XIRQ_NUM_CH-1 downto 0);
-  signal irq_sync2 : std_ulogic_vector(XIRQ_NUM_CH-1 downto 0);
-  signal irq_trig  : std_ulogic_vector(XIRQ_NUM_CH-1 downto 0);
+  signal irq_sync, irq_sync2, irq_trig : std_ulogic_vector(XIRQ_NUM_CH-1 downto 0);
 
   -- interrupt buffer --
   signal irq_pending : std_ulogic_vector(XIRQ_NUM_CH-1 downto 0);
@@ -196,15 +194,12 @@ begin
   irq_arbiter: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      cpu_irq_o  <= '0';
       irq_active <= '0';
       irq_source <= (others => '0');
     elsif rising_edge(clk_i) then
-      cpu_irq_o <= '0';
       if (irq_active = '0') then -- no active IRQ
         irq_source <= irq_source_nxt; -- get IRQ source that has highest priority
         if (irq_fire = '1') then
-          cpu_irq_o  <= '1';
           irq_active <= '1';
         end if;
       elsif (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(3 downto 2) = "10") then -- acknowledge on write access
@@ -212,6 +207,9 @@ begin
       end if;
     end if;
   end process irq_arbiter;
+
+  -- CPU interrupt --
+  cpu_irq_o <= irq_active;
 
 
 end neorv32_xirq_rtl;

--- a/sw/lib/source/neorv32_xirq.c
+++ b/sw/lib/source/neorv32_xirq.c
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -228,8 +228,6 @@ int neorv32_xirq_uninstall(int channel) {
  **************************************************************************/
 static void __neorv32_xirq_core(void) {
 
-  neorv32_cpu_csr_write(CSR_MIP, ~(1 << XIRQ_FIRQ_PENDING)); // acknowledge XIRQ FIRQ
-
   // get highest-priority XIRQ channel
   uint32_t src = NEORV32_XIRQ->ESC;
 
@@ -243,6 +241,9 @@ static void __neorv32_xirq_core(void) {
   (*handler_pnt)();
 
   NEORV32_XIRQ->ESC = 0; // acknowledge the current XIRQ interrupt
+  asm volatile("nop");
+  asm volatile("nop");
+  neorv32_cpu_csr_write(CSR_MIP, ~(1 << XIRQ_FIRQ_PENDING)); // acknowledge XIRQ FIRQ
 }
 
 


### PR DESCRIPTION
## :warning: Rework TWI Interrupt

The interrupt of the TWI module will now become set whenever the module is in idle state (e.g. after completing an operation).

## XIRQ Interrupt

The CPU interrupt of the XIRQ module will now _stay_ high until explicitly acknowledge by writing to the module's `ESC` register.

> [!NOTE]
> This PR is part of a series that aims to _unify_ (and simplify) the entire interrupt system of the processor.