### PR TITLE
Support tool-specific standard flags in makefile

### DIFF
--- a/docs/datasheet/software.adoc
+++ b/docs/datasheet/software.adoc
@@ -224,6 +224,14 @@ MABI  ?= ilp32
 USER_FLAGS ?=
 # User libraries (will be included by linker)
 USER_LIBS ?=
+# Language specific compiler flags: C
+CFLAGS ?=
+# C++
+CXXFLAGS ?=
+# Assembly
+ASFLAGS ?=
+# Flags passed only to the linker
+LDFLAGS ?=
 # Relative or absolute path to the NEORV32 home folder
 NEORV32_HOME ?= ../../..
 # GDB arguments
@@ -244,6 +252,10 @@ GDB_ARGS ?= -ex "target extended-remote localhost:3333"
 | `MABI`           | Application binary interface (default: 32-bit integer ABI `ilp32`)
 | `USER_FLAGS`     | Additional flags that will be forwarded to the compiler tools
 | `USER_LIBS`      | Additional libraries to include during linking (`*.a`)
+| `CFLAGS`         | Additional flags that will be forwarded to the C compiler
+| `CXXFLAGS`       | Additional flags that will be forwarded to the C++ compiler
+| `ASFLAGS`        | Additional flags that will be forwarded to the assembler
+| `LDFLAGS`        | Additional flags that will be forwarded to the linker
 | `NEORV32_HOME`   | Relative or absolute path to the NEORV32 project home folder; adapt this if the makefile/project is not in the project's default `sw/example` folder
 | `GDB_ARGS`       | Default GDB arguments when running the `gdb` target
 | `GHDL_RUN_FLAGS` | GHDL run arguments (e.g. `--stop-time=1ms`)

--- a/sw/common/common.mk
+++ b/sw/common/common.mk
@@ -143,6 +143,12 @@ CC_FLAGS = $(CC_OPTS)
 # Export compiler flags as define string
 CC_FLAGS += -DCC_OPTS="\"$(CC_OPTS)\""
 
+# Allow users to use tool-specific flags
+# Uses naming from https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
+NEO_CFLAGS = $(CC_FLAGS) $(CFLAGS)
+NEO_CXXFLAGS = $(CC_FLAGS) $(CXXFLAGS)
+NEO_LDFLAGS = $(CC_FLAGS) $(LDFLAGS)
+NEO_ASFLAGS = $(CC_FLAGS) $(ASFLAGS)
 
 # -----------------------------------------------------------------------------
 # Application output definitions
@@ -182,23 +188,23 @@ $(IMAGE_GEN): $(NEORV32_EXG_PATH)/image_gen.c
 # -----------------------------------------------------------------------------
 # Compile app *.s sources (assembly)
 %.s.o: %.s
-	@$(CC) -c $(CC_FLAGS) -I $(NEORV32_INC_PATH) $(ASM_INC) $< -o $@
+	@$(CC) -c $(NEO_ASFLAGS) -I $(NEORV32_INC_PATH) $(ASM_INC) $< -o $@
 
 # Compile app *.S sources (assembly + C pre-processor)
 %.S.o: %.S
-	@$(CC) -c $(CC_FLAGS) -I $(NEORV32_INC_PATH) $(ASM_INC) $< -o $@
+	@$(CC) -c $(NEO_ASFLAGS) -I $(NEORV32_INC_PATH) $(ASM_INC) $< -o $@
 
 # Compile app *.c sources
 %.c.o: %.c
-	@$(CC) -c $(CC_FLAGS) -I $(NEORV32_INC_PATH) $(APP_INC) $< -o $@
+	@$(CC) -c $(NEO_CFLAGS) -I $(NEORV32_INC_PATH) $(APP_INC) $< -o $@
 
 # Compile app *.cpp sources
 %.cpp.o: %.cpp
-	@$(CC) -c $(CC_FLAGS) -I $(NEORV32_INC_PATH) $(APP_INC) $< -o $@
+	@$(CC) -c $(NEO_CXXFLAGS) -I $(NEORV32_INC_PATH) $(APP_INC) $< -o $@
 
 # Link object files and show memory utilization
 $(APP_ELF): $(OBJ)
-	@$(CC) $(CC_FLAGS) -T $(LD_SCRIPT) $(OBJ) $(LD_LIBS) -o $@
+	@$(CC) $(NEO_LDFLAGS) -T $(LD_SCRIPT) $(OBJ) $(LD_LIBS) -o $@
 	@echo "Memory utilization:"
 	@$(SIZE) $(APP_ELF)
 


### PR DESCRIPTION
This introduces the following new makefile variables: `CFLAGS` for C, `CXXFLAGS` for C++, `ASFLAGS` for Assembler and `LDFLAGS` for the linker. Names follow  conventions from  https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html

These variables can then be set either in the user application makefile (before including `common.mk`) or on the command line when calling make.

Fixes #856 