### PR TITLE
:bug: fix DMA fence flag, :warning: rework CPU FIRQs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 24.03.2024 | 1.9.7.5 | :warning: **interrupt system rework**: rework CPU's FIRQ system; `mip` CSR is now read-only ; :bug: fix DMA fence configuration flag | [#864](https://github.com/stnolting/neorv32/pull/864) |
 | 23.03.2024 | 1.9.7.4 | :warning: **interrupt system rework**: rework TWI and XIRQ interrupts | [#860](https://github.com/stnolting/neorv32/pull/860) |
 | 23.03.2024 | 1.9.7.3 | :warning: **interrupt system rework**: rework ONEWIRE and GPTMR interrupts | [#859](https://github.com/stnolting/neorv32/pull/859) |
 | 23.03.2024 | 1.9.7.2 | :warning: **interrupt system rework**: removed WDT and TRNG interrupts; :bug: fix core complex clocking during sleep mode | [#858](https://github.com/stnolting/neorv32/pull/858) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -871,17 +871,13 @@ even if <<_mstatus>>.mie is cleared.
 
 .Interrupt Signal Requirements - Standard RISC-V Interrupts
 [IMPORTANT]
-All standard RISC-V interrupt request signals are **high-active**. A request has to stay at high-level
-until it is explicitly acknowledged by the CPU software (for example by writing to a specific memory-mapped register).
+All interrupt request signals are **high-active**. Once triggered, a interrupt request line should stay high
+until it is explicitly acknowledged by a source-specific mechanism (for example by writing to a specific memory-mapped register).
 
-.Interrupt Signal Requirements - NEORV32-Specific Fast Interrupt Requests
-[IMPORTANT]
-The NEORV32-specific FIRQ request lines are triggered (= becoming pending) by a one-shot high-level.
-
-.Instruction Atomicity
+.Instruction Atomicity and Forward-Progress
 [NOTE]
 All instructions execute as atomic operations - interrupts can only trigger _between_ consecutive instructions.
-Even if there is a permanent interrupt request, exactly one instruction from the interrupted program will be executed before
+Additionally, if there is a permanent interrupt request, exactly one instruction from the interrupted program will be executed before
 another interrupt handler can start. This allows program progress even if there are permanent interrupt requests.
 
 
@@ -902,9 +898,6 @@ instruction exception at all.
 As a custom extension, the NEORV32 CPU features 16 fast interrupt request (FIRQ) lines via the `firq_i` CPU top
 entity signals. These interrupts have custom configuration and status flags in the <<_mie>> and <<_mip>> CSRs and also
 provide custom trap codes in <<_mcause>>. These FIRQs are reserved for NEORV32 processor-internal usage only.
-
-Once triggered, the according FIRQ bits in <<_mip>> has to be cleared _manually_ by the FIRQ interrupt handler
-to clear/acknowledge the fast interrupt request.
 
 
 :sectnums:

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -432,7 +432,7 @@ However, any write-access will be ignored and will not cause an exception to mai
 | Address     | `0x344`
 | Reset value | `0x00000000`
 | ISA         | `Zicsr`
-| Description | The `mip` CSR shows currently _pending_ machine-mode interrupt requests.
+| Description | The `mip` CSR shows currently _pending_ machine-mode interrupt requests. Any write access to this register is ignored.
 |=======================
 
 .`mip` CSR bits
@@ -443,7 +443,7 @@ However, any write-access will be ignored and will not cause an exception to mai
 | 3     | `CSR_MIP_MSIP`                       | r/- | **MSIP**: Machine _software_ interrupt pending; _cleared by platform-defined mechanism_
 | 7     | `CSR_MIP_MTIP`                       | r/- | **MTIP**: Machine _timer_ interrupt pending; _cleared by platform-defined mechanism_
 | 11    | `CSR_MIP_MEIP`                       | r/- | **MEIP**: Machine _external_ interrupt pending; _cleared by platform-defined mechanism_
-| 31:16 | `CSR_MIP_FIRQ15P` : `CSR_MIP_FIRQ0P` | r/c | **FIRQxP**: Fast interrupt channel 15..0 pending; has to be cleared manually by writing zero; writing `1` has no effect
+| 31:16 | `CSR_MIP_FIRQ15P` : `CSR_MIP_FIRQ0P` | r/- | **FIRQxP**: Fast interrupt channel 15..0 pending; _cleared by platform-defined mechanism_
 |=======================
 
 .FIRQ Channel Mapping

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -441,18 +441,18 @@ table (the channel number also corresponds to the according FIRQ priority: 0 = h
 | Channel | Source | Description
 | 0       | - | _reserved_
 | 1       | <<_custom_functions_subsystem_cfs,CFS>> | custom functions subsystem (CFS) interrupt (user-defined)
-| 2       | <<_primary_universal_asynchronous_receiver_and_transmitter_uart0,UART0>> | UART0 RX interrupt
-| 3       | <<_primary_universal_asynchronous_receiver_and_transmitter_uart0,UART0>> | UART0 TX interrupt
-| 4       | <<_secondary_universal_asynchronous_receiver_and_transmitter_uart1,UART1>> | UART1 RX interrupt
-| 5       | <<_secondary_universal_asynchronous_receiver_and_transmitter_uart1,UART1>> | UART1 TX interrupt
-| 6       | <<_serial_peripheral_interface_controller_spi,SPI>> | SPI interrupt
-| 7       | <<_two_wire_serial_interface_controller_twi,TWI>> | TWI transmission done interrupt
+| 2       | <<_primary_universal_asynchronous_receiver_and_transmitter_uart0,UART0>> | UART0 RX FIFO level interrupt
+| 3       | <<_primary_universal_asynchronous_receiver_and_transmitter_uart0,UART0>> | UART0 TX FIFO level interrupt
+| 4       | <<_secondary_universal_asynchronous_receiver_and_transmitter_uart1,UART1>> | UART1 RX FIFO level interrupt
+| 5       | <<_secondary_universal_asynchronous_receiver_and_transmitter_uart1,UART1>> | UART1 TX FIFO level interrupt
+| 6       | <<_serial_peripheral_interface_controller_spi,SPI>> | SPI FIFO level interrupt
+| 7       | <<_two_wire_serial_interface_controller_twi,TWI>> | TWI idle interrupt
 | 8       | <<_external_interrupt_controller_xirq,XIRQ>> | External interrupt controller interrupt
-| 9       | <<_smart_led_interface_neoled,NEOLED>> | NEOLED TX buffer interrupt
+| 9       | <<_smart_led_interface_neoled,NEOLED>> | NEOLED TX FIFO level interrupt
 | 10      | <<_direct_memory_access_controller_dma,DMA>> | DMA transfer done interrupt
-| 11      | <<_serial_data_interface_controller_sdi,SDI>> | SDI interrupt
+| 11      | <<_serial_data_interface_controller_sdi,SDI>> | SDI FIFO level interrupt
 | 12      | <<_general_purpose_timer_gptmr,GPTMR>> | General purpose timer interrupt
-| 13      | <<_one_wire_serial_interface_controller_onewire,ONEWIRE>> | 1-wire operation done interrupt
+| 13      | <<_one_wire_serial_interface_controller_onewire,ONEWIRE>> | 1-wire idle interrupt
 | 14      | <<_stream_link_interface_slink,SLINK>> | SLINK FIFO level interrupt
 | 15      | - | _reserved_
 |=======================

--- a/rtl/core/neorv32_dma.vhd
+++ b/rtl/core/neorv32_dma.vhd
@@ -69,7 +69,7 @@ architecture neorv32_dma_rtl of neorv32_dma is
   -- control and status register bits --
   constant ctrl_en_c            : natural :=  0; -- r/w: DMA enable
   constant ctrl_auto_c          : natural :=  1; -- r/w: enable FIRQ-triggered transfer
-  constant ctrl_fence_c         : natural :=  3; -- r/w: issue FENCE operation when DMA is done
+  constant ctrl_fence_c         : natural :=  2; -- r/w: issue FENCE operation when DMA is done
   --
   constant ctrl_error_rd_c      : natural :=  8; -- r/-: error during read transfer
   constant ctrl_error_wr_c      : natural :=  9; -- r/-: error during write transfer
@@ -163,9 +163,7 @@ begin
       config.done  <= config.enable and (config.done or engine.done); -- set if enabled and transfer done
 
       if (bus_req_i.stb = '1') then
-
-        -- write access --
-        if (bus_req_i.rw = '1') then
+        if (bus_req_i.rw = '1') then -- write access
           if (bus_req_i.addr(3 downto 2) = "00") then -- control and status register
             config.enable    <= bus_req_i.data(ctrl_en_c);
             config.auto      <= bus_req_i.data(ctrl_auto_c);
@@ -187,9 +185,7 @@ begin
             config.endian  <= bus_req_i.data(type_endian_c);
             config.start   <= '1'; -- trigger DMA operation
           end if;
-
-        -- read access --
-        else
+        else -- read access
           case bus_req_i.addr(3 downto 2) is
             when "00" => -- control and status register
               bus_rsp_o.data(ctrl_en_c)       <= config.enable;
@@ -212,7 +208,6 @@ begin
               bus_rsp_o.data(type_endian_c)                        <= config.endian;
           end case;
         end if;
-
       end if;
     end if;
   end process bus_access;

--- a/rtl/core/neorv32_dma.vhd
+++ b/rtl/core/neorv32_dma.vhd
@@ -218,7 +218,7 @@ begin
   end process bus_access;
 
   -- transfer-done interrupt --
-  irq_o <= engine.done and config.enable; -- no interrupt if transfer was aborted by clearing config.enable
+  irq_o <= config.done;
 
 
   -- Automatic Trigger ----------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -52,7 +52,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090704"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090705"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -184,7 +184,7 @@ begin
     if ci_mode then
       -- No need to send the full expectation in one big chunk
       check_uart(net, uart1_rx_handle, nul & nul);
-      check_uart(net, uart1_rx_handle, "0/55" & cr & lf);
+      check_uart(net, uart1_rx_handle, "0/54" & cr & lf);
     end if;
 
     -- Wait until all expected data has been received

--- a/sw/example/demo_gptmr/main.c
+++ b/sw/example/demo_gptmr/main.c
@@ -93,7 +93,6 @@ int main() {
   neorv32_gptmr_setup(CLK_PRSC_8, NEORV32_SYSINFO->CLK / (8 * 2), 1);
 
   // enable interrupt
-  neorv32_cpu_csr_clr(CSR_MIP, 1 << GPTMR_FIRQ_PENDING);  // make sure there is no GPTMR IRQ pending already
   neorv32_cpu_csr_set(CSR_MIE, 1 << GPTMR_FIRQ_ENABLE);   // enable GPTMR FIRQ channel
   neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE); // enable machine-mode interrupts
 

--- a/sw/example/demo_gptmr/main.c
+++ b/sw/example/demo_gptmr/main.c
@@ -114,7 +114,7 @@ int main() {
  **************************************************************************/
 void gptmr_firq_handler(void) {
 
-  neorv32_cpu_csr_write(CSR_MIP, ~(1<<GPTMR_FIRQ_PENDING)); // clear/ack pending FIRQ
+  neorv32_gptmr_trigger_matched(); // clear timer-match interrupt
 
   neorv32_uart0_putc('.'); // send tick symbol via UART0
   neorv32_gpio_pin_toggle(0); // toggle output port bit 0

--- a/sw/example/demo_slink/main.c
+++ b/sw/example/demo_slink/main.c
@@ -184,8 +184,6 @@ int main() {
 void slink_firq_handler(void) {
 
   neorv32_uart0_printf(" <<RX data: 0x%x>> ", neorv32_slink_get());
-
-  neorv32_cpu_csr_clr(CSR_MIP, 1 << SLINK_FIRQ_PENDING); // ack/clear FIRQ *after* reading RX data
 }
 
 

--- a/sw/example/demo_spi_irq/drv/neorv32_spi_irq.c
+++ b/sw/example/demo_spi_irq/drv/neorv32_spi_irq.c
@@ -82,7 +82,6 @@ void neorv32_spi_isr(t_neorv32_spi *self) {
     neorv32_spi_cs_dis(); // deselect slave
     self->uint32Total = 0;
     self->uint8IsBusy = 0;
-    neorv32_cpu_csr_clr(CSR_MIP, 1 << SPI_FIRQ_PENDING); // ack/clear pending FIRQ
     return;
   }
 
@@ -91,7 +90,6 @@ void neorv32_spi_isr(t_neorv32_spi *self) {
   for ( ; self->uint32Write<uint32Lim; (self->uint32Write)++ ) {
     NEORV32_SPI->DATA = (uint32_t) (self->ptrSpiBuf)[self->uint32Write]; // next transfer
   }
-  neorv32_cpu_csr_clr(CSR_MIP, 1 << SPI_FIRQ_PENDING); // ack/clear pending FIRQ
   return;
 }
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1072,7 +1072,7 @@ int main() {
     NEORV32_UART0->CTRL &= ~(1 << UART_CTRL_SIM_MODE);
 
     // enable fast interrupt
-    neorv32_cpu_irq_enable(UART0_RX_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << UART0_RX_FIRQ_ENABLE);
 
     neorv32_uart0_putc(0);
     while(neorv32_uart0_tx_busy());
@@ -1121,7 +1121,7 @@ int main() {
     while(neorv32_uart0_tx_busy());
 
     // UART0 TX interrupt enable
-    neorv32_cpu_irq_enable(UART0_TX_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << UART0_TX_FIRQ_ENABLE);
 
     // wait for interrupt
     asm volatile ("nop");
@@ -1161,7 +1161,7 @@ int main() {
     NEORV32_UART1->CTRL &= ~(1 << UART_CTRL_SIM_MODE);
 
     // UART1 RX interrupt enable
-    neorv32_cpu_irq_enable(UART1_RX_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << UART1_RX_FIRQ_ENABLE);
 
     neorv32_uart1_putc(0);
     while(neorv32_uart1_tx_busy());
@@ -1207,7 +1207,7 @@ int main() {
     while(neorv32_uart1_tx_busy());
 
     // UART0 TX interrupt enable
-    neorv32_cpu_irq_enable(UART1_TX_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << UART1_TX_FIRQ_ENABLE);
 
     // wait for interrupt
     asm volatile ("nop");
@@ -1243,7 +1243,7 @@ int main() {
     neorv32_spi_setup(CLK_PRSC_8, 0, 0, 0, 1<<SPI_CTRL_IRQ_RX_AVAIL); // IRQ when RX FIFO is not empty
 
     // enable fast interrupt
-    neorv32_cpu_irq_enable(SPI_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << SPI_FIRQ_ENABLE);
 
     // trigger SPI IRQ
     neorv32_spi_trans(0); // blocking
@@ -1279,7 +1279,7 @@ int main() {
     neorv32_twi_setup(CLK_PRSC_2, 0, 0);
 
     // enable TWI FIRQ
-    neorv32_cpu_irq_enable(TWI_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << TWI_FIRQ_ENABLE);
 
     // trigger TWI IRQ
     neorv32_twi_start_trans(0xA5);
@@ -1319,7 +1319,7 @@ int main() {
     xirq_err_cnt += neorv32_xirq_install(1, xirq_trap_handler1); // install XIRQ IRQ handler channel 1
 
     // enable XIRQ FIRQ
-    neorv32_cpu_irq_enable(XIRQ_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << XIRQ_FIRQ_ENABLE);
 
     // trigger XIRQ channel 1 and 0
     neorv32_gpio_port_set(3);
@@ -1355,7 +1355,7 @@ int main() {
     cnt_test++;
 
     // enable fast interrupt
-    neorv32_cpu_irq_enable(NEOLED_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << NEOLED_FIRQ_ENABLE);
 
     // configure NEOLED, IRQ if FIFO  empty
     neorv32_neoled_setup(CLK_PRSC_4, 0, 0, 0, 0);
@@ -1394,7 +1394,7 @@ int main() {
     // enable DMA, auto-fencing and according FIRQ channel
     neorv32_dma_enable();
     neorv32_dma_fence_enable();
-    neorv32_cpu_irq_enable(DMA_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << DMA_FIRQ_ENABLE);
 
     // setup source data
     dma_src = 0x7788ee11;
@@ -1449,7 +1449,7 @@ int main() {
     neorv32_spi_setup(CLK_PRSC_4, 0, 0, 0, 0);
 
     // enable fast interrupt
-    neorv32_cpu_irq_enable(SDI_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << SDI_FIRQ_ENABLE);
 
     // write test data to SDI
     neorv32_sdi_rx_clear();
@@ -1490,7 +1490,7 @@ int main() {
     cnt_test++;
 
     // enable GPTMR FIRQ
-    neorv32_cpu_irq_enable(GPTMR_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << GPTMR_FIRQ_ENABLE);
 
     // match-interrupt after CLK_PRSC_2*THRESHOLD = 2*2 = 8 clock cycles
     neorv32_gptmr_setup(CLK_PRSC_2, 2, 1);
@@ -1529,7 +1529,7 @@ int main() {
     cnt_test++;
 
     // enable ONEWIRE FIRQ
-    neorv32_cpu_irq_enable(ONEWIRE_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << ONEWIRE_FIRQ_ENABLE);
 
     // configure interface for minimal timing
     neorv32_onewire_setup(200); // t_base = 200ns
@@ -1566,7 +1566,7 @@ int main() {
     cnt_test++;
 
     // enable SLINK FIRQ
-    neorv32_cpu_irq_enable(SLINK_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << SLINK_FIRQ_ENABLE);
 
     // configure RX data available interrupt
     neorv32_slink_setup(1 << SLINK_CTRL_IRQ_RX_NEMPTY);

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -191,7 +191,6 @@ int main() {
 
   // clear all interrupts, enable only where needed
   neorv32_cpu_csr_write(CSR_MIE, 0);
-  neorv32_cpu_csr_write(CSR_MIP, 0);
 
   // enable machine-mode interrupts
   neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE);
@@ -506,58 +505,6 @@ int main() {
   }
   else {
     test_fail();
-  }
-
-
-  // ----------------------------------------------------------
-  // Test MIP.FIRQ clear-only bits
-  // ----------------------------------------------------------
-  neorv32_cpu_csr_write(CSR_MCAUSE, mcause_never_c);
-  PRINT_STANDARD("[%i] Clear-only CSR (mip.FIRQ) ", cnt_test);
-
-  if ((NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_SPI)) && (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_GPTMR))) {
-    cnt_test++;
-
-    tmp_a = 0; // error counter
-
-    // disable all IRQ sources
-    neorv32_cpu_csr_write(CSR_MIE, 0);
-
-    // trigger two FIRQs
-    neorv32_gptmr_setup(CLK_PRSC_2, 0, -1); // fire GPTMR FIRQ
-    neorv32_spi_setup(CLK_PRSC_2, 0, 0, 0, -1); // fire SPI FIRQ
-    neorv32_gptmr_disable();
-    neorv32_spi_disable();
-
-    // both FIRQs should be pending now
-    if ((neorv32_cpu_csr_read(CSR_MIP) & 0xffff0000) != ((1 << SPI_FIRQ_PENDING) + (1 << GPTMR_FIRQ_PENDING))) {
-      tmp_a++;
-    }
-
-    // test write/set/clear access
-    neorv32_cpu_csr_write(CSR_MIP, 0xffffffff); // should have no effect at all
-    neorv32_cpu_csr_set(CSR_MIP, 0xffffffff); // should have no effect at all
-    neorv32_cpu_csr_clr(CSR_MIP, 1 << SPI_FIRQ_PENDING); // clear SPI FIRQ only
-
-    if ((neorv32_cpu_csr_read(CSR_MIP) & 0xffff0000) != (1 << GPTMR_FIRQ_PENDING)) {
-      tmp_a++;
-    }
-
-    // clear all mip.FIRQ bits
-    neorv32_cpu_csr_write(CSR_MIP, 0);
-    if ((neorv32_cpu_csr_read(CSR_MIP) & 0xffff0000) != 0) {
-      tmp_a++;
-    }
-
-    if (tmp_a == 0) {
-      test_ok();
-    }
-    else {
-      test_fail();
-    }
-  }
-  else {
-    PRINT_STANDARD("[n.a.]\n");
   }
 
 
@@ -2211,11 +2158,6 @@ void sim_irq_trigger(uint32_t sel) {
 void global_trap_handler(void) {
 
   uint32_t cause = neorv32_cpu_csr_read(CSR_MCAUSE);
-
-  // clear pending FIRQ
-  if (cause & (1<<31)) {
-    neorv32_cpu_csr_write(CSR_MIP, ~(1 << (cause & 0xf)));
-  }
 
   // hack: make "instruction access fault" exception resumable as we *exactly* know how to handle it in this case
   if (cause == TRAP_CODE_I_ACCESS) {

--- a/sw/lib/include/neorv32_cpu.h
+++ b/sw/lib/include/neorv32_cpu.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -46,8 +46,6 @@
  * @name Prototypes
  **************************************************************************/
 /**@{*/
-void     neorv32_cpu_irq_enable(int irq_sel);
-void     neorv32_cpu_irq_disable(int irq_sel);
 uint64_t neorv32_cpu_get_cycle(void);
 void     neorv32_cpu_set_mcycle(uint64_t value);
 uint64_t neorv32_cpu_get_instret(void);

--- a/sw/lib/include/neorv32_cpu_csr.h
+++ b/sw/lib/include/neorv32_cpu_csr.h
@@ -296,7 +296,7 @@ enum NEORV32_CSR_MIE_enum {
 
 
 /**********************************************************************//**
- * CPU <b>mip</b> CSR (r/c): Machine interrupt pending
+ * CPU <b>mip</b> CSR (r/-): Machine interrupt pending
  **************************************************************************/
 enum NEORV32_CSR_MIP_enum {
   CSR_MIP_MSIP    =  3, /**< CPU mip CSR  (3): MSIP - Machine software interrupt pending (r/-) */
@@ -304,22 +304,22 @@ enum NEORV32_CSR_MIP_enum {
   CSR_MIP_MEIP    = 11, /**< CPU mip CSR (11): MEIP - Machine external interrupt pending (r/-) */
 
   /* NEORV32-specific extension: Fast Interrupt Requests (FIRQ) */
-  CSR_MIP_FIRQ0P  = 16, /**< CPU mip CSR (16): FIRQ0P - Fast interrupt channel 0 pending (r/c) */
-  CSR_MIP_FIRQ1P  = 17, /**< CPU mip CSR (17): FIRQ1P - Fast interrupt channel 1 pending (r/c) */
-  CSR_MIP_FIRQ2P  = 18, /**< CPU mip CSR (18): FIRQ2P - Fast interrupt channel 2 pending (r/c) */
-  CSR_MIP_FIRQ3P  = 19, /**< CPU mip CSR (19): FIRQ3P - Fast interrupt channel 3 pending (r/c) */
-  CSR_MIP_FIRQ4P  = 20, /**< CPU mip CSR (20): FIRQ4P - Fast interrupt channel 4 pending (r/c) */
-  CSR_MIP_FIRQ5P  = 21, /**< CPU mip CSR (21): FIRQ5P - Fast interrupt channel 5 pending (r/c) */
-  CSR_MIP_FIRQ6P  = 22, /**< CPU mip CSR (22): FIRQ6P - Fast interrupt channel 6 pending (r/c) */
-  CSR_MIP_FIRQ7P  = 23, /**< CPU mip CSR (23): FIRQ7P - Fast interrupt channel 7 pending (r/c) */
-  CSR_MIP_FIRQ8P  = 24, /**< CPU mip CSR (24): FIRQ8P - Fast interrupt channel 8 pending (r/c) */
-  CSR_MIP_FIRQ9P  = 25, /**< CPU mip CSR (25): FIRQ9P - Fast interrupt channel 9 pending (r/c) */
-  CSR_MIP_FIRQ10P = 26, /**< CPU mip CSR (26): FIRQ10P - Fast interrupt channel 10 pending (r/c) */
-  CSR_MIP_FIRQ11P = 27, /**< CPU mip CSR (27): FIRQ11P - Fast interrupt channel 11 pending (r/c) */
-  CSR_MIP_FIRQ12P = 28, /**< CPU mip CSR (28): FIRQ12P - Fast interrupt channel 12 pending (r/c) */
-  CSR_MIP_FIRQ13P = 29, /**< CPU mip CSR (29): FIRQ13P - Fast interrupt channel 13 pending (r/c) */
-  CSR_MIP_FIRQ14P = 30, /**< CPU mip CSR (30): FIRQ14P - Fast interrupt channel 14 pending (r/c) */
-  CSR_MIP_FIRQ15P = 31  /**< CPU mip CSR (31): FIRQ15P - Fast interrupt channel 15 pending (r/c) */
+  CSR_MIP_FIRQ0P  = 16, /**< CPU mip CSR (16): FIRQ0P - Fast interrupt channel 0 pending (r/-) */
+  CSR_MIP_FIRQ1P  = 17, /**< CPU mip CSR (17): FIRQ1P - Fast interrupt channel 1 pending (r/-) */
+  CSR_MIP_FIRQ2P  = 18, /**< CPU mip CSR (18): FIRQ2P - Fast interrupt channel 2 pending (r/-) */
+  CSR_MIP_FIRQ3P  = 19, /**< CPU mip CSR (19): FIRQ3P - Fast interrupt channel 3 pending (r/-) */
+  CSR_MIP_FIRQ4P  = 20, /**< CPU mip CSR (20): FIRQ4P - Fast interrupt channel 4 pending (r/-) */
+  CSR_MIP_FIRQ5P  = 21, /**< CPU mip CSR (21): FIRQ5P - Fast interrupt channel 5 pending (r/-) */
+  CSR_MIP_FIRQ6P  = 22, /**< CPU mip CSR (22): FIRQ6P - Fast interrupt channel 6 pending (r/-) */
+  CSR_MIP_FIRQ7P  = 23, /**< CPU mip CSR (23): FIRQ7P - Fast interrupt channel 7 pending (r/-) */
+  CSR_MIP_FIRQ8P  = 24, /**< CPU mip CSR (24): FIRQ8P - Fast interrupt channel 8 pending (r/-) */
+  CSR_MIP_FIRQ9P  = 25, /**< CPU mip CSR (25): FIRQ9P - Fast interrupt channel 9 pending (r/-) */
+  CSR_MIP_FIRQ10P = 26, /**< CPU mip CSR (26): FIRQ10P - Fast interrupt channel 10 pending (r/-) */
+  CSR_MIP_FIRQ11P = 27, /**< CPU mip CSR (27): FIRQ11P - Fast interrupt channel 11 pending (r/-) */
+  CSR_MIP_FIRQ12P = 28, /**< CPU mip CSR (28): FIRQ12P - Fast interrupt channel 12 pending (r/-) */
+  CSR_MIP_FIRQ13P = 29, /**< CPU mip CSR (29): FIRQ13P - Fast interrupt channel 13 pending (r/-) */
+  CSR_MIP_FIRQ14P = 30, /**< CPU mip CSR (30): FIRQ14P - Fast interrupt channel 14 pending (r/-) */
+  CSR_MIP_FIRQ15P = 31  /**< CPU mip CSR (31): FIRQ15P - Fast interrupt channel 15 pending (r/-) */
 };
 
 

--- a/sw/lib/source/neorv32_cpu.c
+++ b/sw/lib/source/neorv32_cpu.c
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -43,7 +43,7 @@
 
 
 /**********************************************************************//**
- * Unavailable extensions warning.
+ * Unavailable extensions warnings.
  **************************************************************************/
 #if defined __riscv_d || (__riscv_flen == 64)
   #error Double-precision floating-point extension <D/Zdinx> is NOT supported!
@@ -60,32 +60,6 @@
 #ifdef __riscv_fsqrt
   #warning Floating-point square root instruction <FSQRT> is NOT supported yet!
 #endif
-
-
-/**********************************************************************//**
- * Enable specific interrupt channel.
- * @note This functions also tries to clear the pending flag of the interrupt.
- *
- * @param[in] irq_sel CPU interrupt select. See #NEORV32_CSR_MIE_enum.
- **************************************************************************/
-void neorv32_cpu_irq_enable(int irq_sel) {
-
-  neorv32_cpu_csr_clr(CSR_MIP, 1 << (irq_sel & 0x1f)); // clear pending
-  neorv32_cpu_csr_set(CSR_MIE, 1 << (irq_sel & 0x1f)); // enable
-}
-
-
-/**********************************************************************//**
- * Disable specific interrupt channel.
- * @note This functions also tries to clear the pending flag of the interrupt.
- *
- * @param[in] irq_sel CPU interrupt select. See #NEORV32_CSR_MIE_enum.
- **************************************************************************/
-void neorv32_cpu_irq_disable(int irq_sel) {
-
-  neorv32_cpu_csr_clr(CSR_MIE, 1 << (irq_sel & 0x1f)); // disable
-  neorv32_cpu_csr_clr(CSR_MIP, 1 << (irq_sel & 0x1f)); // clear pending
-}
 
 
 /**********************************************************************//**

--- a/sw/lib/source/neorv32_xirq.c
+++ b/sw/lib/source/neorv32_xirq.c
@@ -241,9 +241,6 @@ static void __neorv32_xirq_core(void) {
   (*handler_pnt)();
 
   NEORV32_XIRQ->ESC = 0; // acknowledge the current XIRQ interrupt
-  asm volatile("nop");
-  asm volatile("nop");
-  neorv32_cpu_csr_write(CSR_MIP, ~(1 << XIRQ_FIRQ_PENDING)); // acknowledge XIRQ FIRQ
 }
 
 


### PR DESCRIPTION
## :bug: Fix Bug in DMA's "fence" Control Register Bit

Bit 2 of the control register should be used for this but the hardware was using bit 3.

## :warning: All CPU Interrupt Request Lines are now Level-Triggered

The standard RISC-V machine interrupt (like the timer interrupt MTI) are level-triggered. With this PR the NEORV32-specific fast interrupt requests (FIRQs) now also follow this standard.

## :warning: CPU's `mip` CSR is now Read-Only

`mip` shows all current pending interrupt sources (all interrupt lines that are high). Writing to this register has no effect and is ignored by the hardware. All interrupts keep pending until the interrupt-causing source is cleared (e.g. by reading from a RX FIFO that was signaling "data available").

-----------

> [!NOTE]
> This PR is part of a series that aims to _unify_ (and simplify) the entire interrupt system of the processor.