### PR TITLE
:warning: rework TWI module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 26.03.2024 | 1.9.7.6 | :warning: rework TWI module; add configurable command/data FIFO | [#865](https://github.com/stnolting/neorv32/pull/865) |
 | 24.03.2024 | 1.9.7.5 | :warning: **interrupt system rework**: rework CPU's FIRQ system; `mip` CSR is now read-only ; :bug: fix DMA fence configuration flag | [#864](https://github.com/stnolting/neorv32/pull/864) |
 | 23.03.2024 | 1.9.7.4 | :warning: **interrupt system rework**: rework TWI and XIRQ interrupts | [#860](https://github.com/stnolting/neorv32/pull/860) |
 | 23.03.2024 | 1.9.7.3 | :warning: **interrupt system rework**: rework ONEWIRE and GPTMR interrupts | [#859](https://github.com/stnolting/neorv32/pull/859) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
-| 26.03.2024 | 1.9.7.6 | :warning: rework TWI module; add configurable command/data FIFO | [#865](https://github.com/stnolting/neorv32/pull/865) |
+| 26.03.2024 | 1.9.7.6 | :warning: rework TWI module; add optional & configurable command/data FIFO | [#865](https://github.com/stnolting/neorv32/pull/865) |
 | 24.03.2024 | 1.9.7.5 | :warning: **interrupt system rework**: rework CPU's FIRQ system; `mip` CSR is now read-only ; :bug: fix DMA fence configuration flag | [#864](https://github.com/stnolting/neorv32/pull/864) |
 | 23.03.2024 | 1.9.7.4 | :warning: **interrupt system rework**: rework TWI and XIRQ interrupts | [#860](https://github.com/stnolting/neorv32/pull/860) |
 | 23.03.2024 | 1.9.7.3 | :warning: **interrupt system rework**: rework ONEWIRE and GPTMR interrupts | [#859](https://github.com/stnolting/neorv32/pull/859) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -280,6 +280,7 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `IO_SDI_EN`             | boolean   | false      | Implement the <<_serial_data_interface_controller_sdi>>.
 | `IO_SDI_FIFO`           | natural   | 1          | Depth of the <<_serial_data_interface_controller_sdi>> FIFO. Has to be a power of two, min 1, max 32768.
 | `IO_TWI_EN`             | boolean   | false      | Implement the <<_two_wire_serial_interface_controller_twi>>.
+| `IO_TWI_FIFO`           | natural   | 1          | Depth of the <<_two_wire_serial_interface_controller_twi>> FIFO. Has to be a power of two, min 1, max 32768.
 | `IO_PWM_NUM_CH`         | natural   | 0          | Number of channels of the <<_pulse_width_modulation_controller_pwm>> to implement (0..12).
 | `IO_WDT_EN`             | boolean   | false      | Implement the <<_watchdog_timer_wdt>>.
 | `IO_TRNG_EN`            | boolean   | false      | Implement the <<_true_random_number_generator_trng>>.
@@ -446,7 +447,7 @@ table (the channel number also corresponds to the according FIRQ priority: 0 = h
 | 4       | <<_secondary_universal_asynchronous_receiver_and_transmitter_uart1,UART1>> | UART1 RX FIFO level interrupt
 | 5       | <<_secondary_universal_asynchronous_receiver_and_transmitter_uart1,UART1>> | UART1 TX FIFO level interrupt
 | 6       | <<_serial_peripheral_interface_controller_spi,SPI>> | SPI FIFO level interrupt
-| 7       | <<_two_wire_serial_interface_controller_twi,TWI>> | TWI idle interrupt
+| 7       | <<_two_wire_serial_interface_controller_twi,TWI>> | TWI FIFO level interrupt
 | 8       | <<_external_interrupt_controller_xirq,XIRQ>> | External interrupt controller interrupt
 | 9       | <<_smart_led_interface_neoled,NEOLED>> | NEOLED TX FIFO level interrupt
 | 10      | <<_direct_memory_access_controller_dma,DMA>> | DMA transfer done interrupt

--- a/docs/datasheet/soc_twi.adoc
+++ b/docs/datasheet/soc_twi.adoc
@@ -5,48 +5,58 @@
 [cols="<3,<3,<4"]
 [frame="topbot",grid="none"]
 |=======================
-| Hardware source file(s): | neorv32_twi.vhd | 
-| Software driver file(s): | neorv32_twi.c |
-|                          | neorv32_twi.h |
-| Top entity port:         | `twi_sda_i` | 1-bit serial data line sense input
-|                          | `twi_sda_o` | 1-bit serial data line output (pull low only)
-|                          | `twi_scl_i` | 1-bit serial clock line sense input
-|                          | `twi_scl_o` | 1-bit serial clock line output (pull low only)
-| Configuration generics:  | `IO_TWI_EN` | implement TWI controller when `true`
-| CPU interrupts:          | fast IRQ channel 7 | transmission done interrupt (see <<_processor_interrupts>>)
+| Hardware source files:  | neorv32_twi.vhd    |
+| Software driver files:  | neorv32_twi.c      |
+|                         | neorv32_twi.h      |
+| Top entity ports:       | `twi_sda_i`        | 1-bit serial data line sense input
+|                         | `twi_sda_o`        | 1-bit serial data line output (pull low only)
+|                         | `twi_scl_i`        | 1-bit serial clock line sense input
+|                         | `twi_scl_o`        | 1-bit serial clock line output (pull low only)
+| Configuration generics: | `IO_TWI_EN`        | implement TWI controller when `true`
+|                         | `IO_TWI_FIFO`      | FIFO depth, has to be a power of two, min 1
+| CPU interrupts:         | fast IRQ channel 7 | FIFO empty and module idle interrupt (see <<_processor_interrupts>>)
 |=======================
 
 
 **Overview**
 
-The NEORV32 TWI implements a **TWI controller**. Currently, **no multi-controller support** is available.
-Furthermore, the NEORV32 TWI unit cannot operate in peripheral mode.
+The NEORV32 TWI implements an I2C-compatible host controller to communicate with arbitrary I2C-devices.
+Note that peripheral-mode (controller acts as a device) and multi-controller mode are not supported yet.
 
-[IMPORTANT]
-The serial clock (SCL) and the serial data (SDA) lines can only be actively driven low by the
-controller. Hence, external pull-up resistors are required for these lines.
+The TWI controller provides two memory-mapped registers that are used for configuring the module and
+for triggering operation: `CTRL` is the control and status register, `DCMD` is the command and data register.
 
 
-**Tri-State Drivers**
+Key features:
 
-The TWI module requires two tri-state drivers (actually: open-drain) for the SDA and SCL lines, which have to be
-implemented in the top module of the setup. A generic VHDL example is given below (`sda` and `scl` are the actual TWI
-bus signal, which are of type `std_logic`).
+* Programmable clock speed
+* Generate START / repeated-START and STOP conditions
+* Sending & receiving 8 data bits including ACK/NACK
+* Generating a host-ACK (ACK send by the TWI controller)
+* Configurable data/command FIFO to "program" large TWI sequences without further involvement of the CPU
 
-.TWI VHDL tri-state driver example
+
+**Tristate Drivers**
+
+The TWI module requires two tristate drivers (actually: open-drain drivers; signals can only be actively driven low) for
+the SDA and SCL lines, which have to be implemented by the user in the setup's top module / IO ring. A generic VHDL example
+is shown below (here, `sda_io` and `scl_io` are the actual TWI bus lines, which are of type `std_logic`).
+
+.TWI VHDL Tristate Driver Example
 [source,VHDL]
 ----
-sda       <= '0' when (twi_sda_o = '0') else 'Z'; -- drive
-scl       <= '0' when (twi_scl_o = '0') else 'Z'; -- drive
-twi_sda_i <= std_ulogic(sda); -- sense
-twi_scl_i <= std_ulogic(scl); -- sense
+sda_io    <= '0' when (twi_sda_o = '0') else 'Z'; -- drive
+scl_io    <= '0' when (twi_scl_o = '0') else 'Z'; -- drive
+twi_sda_i <= std_ulogic(sda_io); -- sense
+twi_scl_i <= std_ulogic(scl_io); -- sense
 ----
 
 
 **TWI Clock Speed**
 
-The TWI clock frequency is programmed by the 3-bit `TWI_CTRL_PRSCx` clock prescaler for a coarse selection
-and a 4-bit clock divider `TWI_CTRL_CDIVx` for a fine selection.
+The TWI clock frequency is programmed by two bit-fields in the device's control register `CTRL`: a 3-bit `TWI_CTRL_PRSCx`
+clock prescaler is sued for a coarse clock configuration and a 4-bit clock divider `TWI_CTRL_CDIVx` is used for a fine
+clock configuration.
 
 .TWI prescaler configuration
 [cols="<4,^1,^1,^1,^1,^1,^1,^1,^1"]
@@ -56,64 +66,51 @@ and a 4-bit clock divider `TWI_CTRL_CDIVx` for a fine selection.
 | Resulting `clock_prescaler` |       2 |       4 |       8 |      64 |     128 |    1024 |    2048 |    4096
 |=======================
 
-Based on the the clock configuration, the actual TWI clock frequency f~SCL~ is derived
+Based on the clock configuration, the actual TWI clock frequency f~SCL~ is derived
 from the processor's main clock f~main~ according to the following equation:
 
 _**f~SCL~**_ = _f~main~[Hz]_ / (4 * `clock_prescaler` * (1 + TWI_CTRL_CDIV))
 
 Hence, the maximum TWI clock is f~main~ / 8 and the lowest TWI clock is f~main~ / 262144. The generated TWI clock is
-always symmetric having a duty cycle of exactly 50%. However, an accessed peripheral can "slow down" the bus clock
-by using **clock stretching** (= actively driving the SCL line low). The controller will pause operation in this case
-if clock stretching is enabled via the `TWI_CTRL_CSEN` bit of the unit's control register `CTRL`
+always symmetric having a duty cycle of exactly 50%.
 
 
 **TWI Transfers**
 
-The TWI is enabled via the `TWI_CTRL_EN` bit in the `CTRL` control register. The user program can start / stop a
-transmission by issuing a START or STOP condition. These conditions are generated by setting the
-according bits (`TWI_CTRL_START` or `TWI_CTRL_STOP`) in the control register.
+The TWI is enabled via the `TWI_CTRL_EN` bit in the `CTRL` control register. All TWI operations are controlled by
+the `DCMD` register. The actual operation is selected by a 2-bit value that is written to the register's `TWI_DCMD_CMD_*`
+bit-field:
 
-Data is transferred via the TWI bus by writing a byte to the `DATA` register. The written byte is send via the TWI bus
-and the received byte from the bus is also available in this register after the transmission is completed. 
+* `00`: NOP (no-operation); all further bit-fields in `DCMD` are ignored
+* `01`: Generate a (repeated) START conditions; all further bit-fields in `DCMD` are ignored
+* `10`: Generate a STOP conditions; all further bit-fields in `DCMD` are ignored
+* `11`: Trigger a data transmission; the data to be send has to be written to the register's `TWI_DCMD_MSB : TWI_DCMD_LSB`
+bit-field; if `TWI_DCMD_ACK` is set the controller will send a host-ACK in the ACK/NACK time slot; after the transmission
+is completed `TWI_DCMD_MSB : TWI_DCMD_LSB` contains the RX data and `TWI_DCMD_ACK` the device's response if no host-ACK was
+configured (`0` = ACK, `1` = ACK)
 
-The TWI operation (transmitting data or performing a START or STOP condition) is in progress as long as the
-control register's `TWI_CTRL_BUSY` bit is set.
+All operations/data written to the `DCMD` register are buffered by a configurable data/command FIFO. The depth of the FIFO is
+configured by the `IO_TWI_FIFO` top generic. Software can retrieve this size by reading the control register's `TWI_CTRL_FIFO` bits.
+
+The command/data FIFO is internally split into a TX FIFO and a RX FIFO. Writing to `DCMD` will write to the TX FIFO while reading from
+`DCMD` will read from the RX FIFO. The TX FIFO is full when the `TWI_CTRL_TX_FULL` flag is set. Accordingly, the RX FIFO contains valid
+data when the `TWI_CTRL_RX_AVAIL` flag is set.
+
+The control register's busy flag `TWI_CTRL_BUSY` is set as long as the TX FIFO contains valid data (i.e. programmed TWI operations
+that have not been executed yet) or of the TWI bus engine is still processing an operation.
 
 [TIP]
-A transmission can be terminated at any time by disabling the TWI module
-by clearing the _TWI_CTRL_EN_ control register bit. This will also reset the whole module.
+An active transmission can be terminated at any time by disabling the TWI module. This will also clear the data/command FIFO.
 
 [NOTE]
 When reading data from a device, an all-one byte (`0xFF`) has to be written to TWI data register `NEORV32_TWI.DATA`
 so the accessed device can actively pull-down SDA when required.
 
 
-**TWI ACK/NACK and MACK**
-
-An accessed TWI peripheral has to acknowledge each transferred byte. When the `TWI_CTRL_ACK` bit is set after a
-completed transmission the accessed peripheral has send an ACKNOWLEDGE (ACK). If this bit is cleared after a completed
-transmission, the peripheral has send a_NOT-ACKNOWLEDGE (NACK).
-
-The NEORV32 TWI controller can also send an ACK generated by itself ("controller acknowledge / MACK") right after
-transmitting a byte by driving SDA low during the ACK time slot. Some TWI modules require this MACK to acknowledge
-certain data movement operations.
-
-The control register's `TWI_CTRL_MACK` bit has to be set to make the TWI module automatically generate a MACK after
-the byte transmission has been completed. If this bit is cleared, the ACK/NACK generated by the peripheral is sampled
-in this time slot instead (normal mode).
-
-
-**TWI Bus Status**
-
-The TWI controller can check if the TWI bus is currently claimed (SCL and SDA both low). The bus can be claimed by the
-NEORV32 TWI itself or by any other controller. Bit `TWI_CTRL_CLAIME` of the control register will be set if the bus
-is currently claimed.
-
-
 **TWI Interrupt**
 
-The TWI module provides a single interrupt to signal "idle condition" (i.e. controller is ready for a new operation) to the CPU.
-Once triggered, the interrupt has to be explicitly cleared again by writing zero to the according <<_mip>> CSR bit.
+The TWI module provides a single interrupt to signal "idle condition" to the CPU. The interrupt becomes active when the
+TWI module is enabled (`TWI_CTRL_EN` = `1`) and the TX FIFO is empty and the TWI bus engine is idle.
 
 
 **Register Map**
@@ -123,16 +120,16 @@ Once triggered, the interrupt has to be explicitly cleared again by writing zero
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.10+<| `0xfffff900` .10+<| `CTRL` <|`0`     `TWI_CTRL_EN`                     ^| r/w <| TWI enable, reset if cleared
-                                  <|`1`     `TWI_CTRL_START`                  ^| -/w <| generate START condition, auto-clears
-                                  <|`2`     `TWI_CTRL_STOP`                   ^| -/w <| generate STOP condition, auto-clears
-                                  <|`3`     `TWI_CTRL_MACK`                   ^| r/w <| generate controller-ACK for each transmission ("MACK")
-                                  <|`4`     `TWI_CTRL_CSEN`                   ^| r/w <| allow clock stretching when set
-                                  <|`7:5`   `TWI_CTRL_PRSC2 : TWI_CTRL_PRSC0` ^| r/w <| 3-bit clock prescaler select
-                                  <|`11:8`  `TWI_CTRL_CDIV3 : TWI_CTRL_CDIV0` ^| r/w <| 4-bit clock divider
-                                  <|`28:12` -                                 ^| r/- <| _reserved_, read as zero
-                                  <|`29`    `TWI_CTRL_CLAIMED`                ^| r/- <| set if the TWI bus is claimed by any controller
-                                  <|`30`    `TWI_CTRL_ACK`                    ^| r/- <| ACK received when set, NACK received when cleared
-                                  <|`31`    `TWI_CTRL_BUSY`                   ^| r/- <| transfer/START/STOP in progress when set
-| `0xfffff904` | `DATA` |`7:0` | r/w | receive/transmit data
+.9+<| `0xfffff900` .9+<| `CTRL` <|`0`     `TWI_CTRL_EN`                           ^| r/w <| TWI enable, reset if cleared
+                                <|`3:1`   `TWI_CTRL_PRSC2 : TWI_CTRL_PRSC0`       ^| r/w <| 3-bit clock prescaler select
+                                <|`7:4`   `TWI_CTRL_CDIV3 : TWI_CTRL_CDIV0`       ^| r/w <| 4-bit clock divider
+                                <|`14:8`   -                                      ^| r/- <| _reserved_, read as zero
+                                <|`18:15` `TWI_CTRL_FIFO_MSB : TWI_CTRL_FIFO_LSB` ^| r/- <| FIFO depth; log2(`IO_TWI_FIFO`)
+                                <|`28:12`  -                                      ^| r/- <| _reserved_, read as zero
+                                <|`29`    `TWI_CTRL_TX_FULL`                      ^| r/- <| set if the TWI bus is claimed by any controller
+                                <|`30`    `TWI_CTRL_RX_AVAIL`                     ^| r/- <| RX FIFO data available
+                                <|`31`    `TWI_CTRL_BUSY`                         ^| r/- <| TWI bus engine busy or TX FIFO not empty
+.3+<| `0xfffff904` .3+<| `DCMD` <|`7:0`   `TWI_DCMD_MSB : TWI_DCMD_LSB`           ^| r/w <| RX/TX data byte
+                                <|`8`     `TWI_DCMD_ACK`                          ^| r/w <| write: ACK bit sent by controller; read: `1` = device NACK, `0` = device ACK
+                                <|`10:9`  `TWI_DCMD_CMD_HI : TWI_DCMD_CMD_LO`     ^| r/w <| TWI operation (`00` = NOP, `01` = START conditions, `10` = STOP condition, `11` = data transmission)
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -52,7 +52,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090705"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090706"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -810,6 +810,7 @@ package neorv32_package is
       IO_SDI_EN                  : boolean                        := false;
       IO_SDI_FIFO                : natural range 1 to 2**15       := 1;
       IO_TWI_EN                  : boolean                        := false;
+      IO_TWI_FIFO                : natural range 1 to 2**15       := 1;
       IO_PWM_NUM_CH              : natural range 0 to 12          := 0;
       IO_WDT_EN                  : boolean                        := false;
       IO_TRNG_EN                 : boolean                        := false;

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -141,6 +141,7 @@ entity neorv32_top is
     IO_SDI_EN                  : boolean                        := false;       -- implement serial data interface (SDI)?
     IO_SDI_FIFO                : natural range 1 to 2**15       := 1;           -- RTX fifo depth, has to be zero or a power of two, min 1
     IO_TWI_EN                  : boolean                        := false;       -- implement two-wire interface (TWI)?
+    IO_TWI_FIFO                : natural range 1 to 2**15       := 1;           -- RTX fifo depth, has to be zero or a power of two, min 1
     IO_PWM_NUM_CH              : natural range 0 to 12          := 0;           -- number of PWM channels to implement (0..12); 0 = disabled
     IO_WDT_EN                  : boolean                        := false;       -- implement watch dog timer (WDT)?
     IO_TRNG_EN                 : boolean                        := false;       -- implement true random number generator (TRNG)?
@@ -1346,6 +1347,9 @@ begin
     neorv32_twi_inst_true:
     if IO_TWI_EN generate
       neorv32_twi_inst: entity neorv32.neorv32_twi
+      generic map (
+        IO_TWI_FIFO => IO_TWI_FIFO
+      )
       port map (
         clk_i       => clk_i,
         rstn_i      => rstn_sys,

--- a/rtl/core/neorv32_twi.vhd
+++ b/rtl/core/neorv32_twi.vhd
@@ -1,10 +1,12 @@
 -- #################################################################################################
 -- # << NEORV32 - Two-Wire Interface Controller (TWI) >>                                           #
 -- # ********************************************************************************************* #
--- # Supports START and STOP conditions, 8 bit data + ACK/NACK transfers and clock stretching.     #
--- # Supports ACKs by the controller. 8 clock pre-scalers + 4-bit clock divider for bus clock      #
--- # configuration. No multi-controller support and no peripheral mode support yet. The interrupt  #
--- # is triggered whenever the module is in idle state.                                            #
+-- # Supports START, repeated-START and STOP conditions, 8 bit data transfers, optional ACK issued #
+-- # by the controller, 8 clock pre-scalers and a 4-bit clock divider for bus clock configuration. #
+-- # A configurable FIFO can be used to program arbitrary TWI sequences.                           #
+-- #                                                                                               #
+-- # No multi-controller support and no peripheral mode support yet.                               #
+-- # The interrupt fires whenever the data/command FIFO is empty and no bus operation is pending.  #
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
@@ -44,6 +46,9 @@ library neorv32;
 use neorv32.neorv32_package.all;
 
 entity neorv32_twi is
+  generic (
+    IO_TWI_FIFO : natural range 1 to 2**15 -- TWI RTX fifo depth, has to be a power of two, min 1
+  );
   port (
     clk_i       : in  std_ulogic; -- global clock line
     rstn_i      : in  std_ulogic; -- global reset line, low-active, async
@@ -55,74 +60,83 @@ entity neorv32_twi is
     twi_sda_o   : out std_ulogic; -- serial data line output
     twi_scl_i   : in  std_ulogic; -- serial clock line input
     twi_scl_o   : out std_ulogic; -- serial clock line output
-    irq_o       : out std_ulogic  -- CPU IRQ
+    irq_o       : out std_ulogic  -- interrupt
   );
 end neorv32_twi;
 
 architecture neorv32_twi_rtl of neorv32_twi is
 
   -- control register --
-  constant ctrl_en_c      : natural :=  0; -- r/w: TWI enable
-  constant ctrl_start_c   : natural :=  1; -- -/w: Generate START condition
-  constant ctrl_stop_c    : natural :=  2; -- -/w: Generate STOP condition
-  constant ctrl_mack_c    : natural :=  3; -- r/w: generate ACK by controller for transmission
-  constant ctrl_csen_c    : natural :=  4; -- r/w: allow clock stretching when set
-  constant ctrl_prsc0_c   : natural :=  5; -- r/w: CLK prsc bit 0
-  constant ctrl_prsc1_c   : natural :=  6; -- r/w: CLK prsc bit 1
-  constant ctrl_prsc2_c   : natural :=  7; -- r/w: CLK prsc bit 2
-  constant ctrl_cdiv0_c   : natural :=  8; -- r/w: clock divider bit 0
-  constant ctrl_cdiv1_c   : natural :=  9; -- r/w: clock divider bit 1
-  constant ctrl_cdiv2_c   : natural := 10; -- r/w: clock divider bit 2
-  constant ctrl_cdiv3_c   : natural := 11; -- r/w: clock divider bit 3
+  constant ctrl_en_c         : natural :=  0; -- r/w: module enable (reset when zero)
+  constant ctrl_prsc0_c      : natural :=  1; -- r/w: CLK prsc bit 0
+  constant ctrl_prsc1_c      : natural :=  2; -- r/w: CLK prsc bit 1
+  constant ctrl_prsc2_c      : natural :=  3; -- r/w: CLK prsc bit 2
+  constant ctrl_cdiv0_c      : natural :=  4; -- r/w: clock divider bit 0
+  constant ctrl_cdiv1_c      : natural :=  5; -- r/w: clock divider bit 1
+  constant ctrl_cdiv2_c      : natural :=  6; -- r/w: clock divider bit 2
+  constant ctrl_cdiv3_c      : natural :=  7; -- r/w: clock divider bit 3
   --
-  constant ctrl_claimed_c : natural := 29; -- r/-: Set if bus is still claimed
-  constant ctrl_ack_c     : natural := 30; -- r/-: Set if ACK received
-  constant ctrl_busy_c    : natural := 31; -- r/-: Set if TWI unit is busy
+  constant ctrl_fifo_size0_c : natural := 15; -- r/-: log2(fifo size), bit 0 (lsb)
+  constant ctrl_fifo_size1_c : natural := 16; -- r/-: log2(fifo size), bit 1
+  constant ctrl_fifo_size2_c : natural := 17; -- r/-: log2(fifo size), bit 2
+  constant ctrl_fifo_size3_c : natural := 18; -- r/-: log2(fifo size), bit 3 (msb)
+  --
+  constant ctrl_tx_full_c    : natural := 29; -- r/-: TX FIFO full
+  constant ctrl_rx_avail_c   : natural := 30; -- r/-: RX FIFO data available
+  constant ctrl_busy_c       : natural := 31; -- r/-: Set if TWI unit is busy
+
+  -- data/command register --
+  constant data_lsb_c    : natural :=  0; -- r/w: data byte LSB
+  constant data_msb_c    : natural :=  7; -- r/w: data byte MSB
+  constant data_ack_c    : natural :=  8; -- r/w: ACK/NACK/MACK
+  constant data_cmd_lo_c : natural :=  9; -- -/w: operation command; 00=NOP, 01=START
+  constant data_cmd_hi_c : natural := 10; -- -/w: operation command; 10=STOP, 11=DATA
 
   -- control register --
   type ctrl_t is record
     enable : std_ulogic;
-    mack   : std_ulogic;
-    csen   : std_ulogic;
     prsc   : std_ulogic_vector(2 downto 0);
     cdiv   : std_ulogic_vector(3 downto 0);
   end record;
   signal ctrl : ctrl_t;
 
-  -- operation triggers --
-  signal trig_start, trig_stop, trig_data : std_ulogic;
+  -- FIFO interface --
+  type fifo_t is record
+    clear              : std_ulogic; -- sync reset, high-active
+    rx_we,    tx_we    : std_ulogic; -- write enable
+    rx_re,    tx_re    : std_ulogic; -- read enable
+    rx_wdata, rx_rdata : std_ulogic_vector(8 downto 0); -- RX read/write data
+    tx_wdata, tx_rdata : std_ulogic_vector(10 downto 0); -- TX read/write data
+    rx_avail, tx_avail : std_ulogic; -- data available?
+    rx_free,  tx_free  : std_ulogic; -- free entry available?
+  end record;
+  signal fifo : fifo_t;
 
   -- clock generator --
   type clk_gen_t is record
     cnt          : std_ulogic_vector(3 downto 0); -- clock divider
-    tick         : std_ulogic; -- actual TWI "clock"
+    tick         : std_ulogic; -- actual TWI clock tick
     phase_gen    : std_ulogic_vector(3 downto 0); -- clock phase generator
     phase_gen_ff : std_ulogic_vector(3 downto 0);
     phase        : std_ulogic_vector(3 downto 0);
-    halt         : std_ulogic; -- active clock stretching
   end record;
   signal clk_gen : clk_gen_t;
 
-  -- arbiter --
-  type arbiter_t is record
-    state     : std_ulogic_vector(2 downto 0);
-    state_nxt : std_ulogic_vector(1 downto 0);
-    bitcnt    : std_ulogic_vector(3 downto 0);
-    rtx_sreg  : std_ulogic_vector(8 downto 0); -- main rx/tx shift reg
-    rtx_done  : std_ulogic; -- transmission done
-    busy      : std_ulogic;
-    claimed   : std_ulogic; -- bus is currently claimed by _this_ controller
+  -- bus engine --
+  type engine_t is record
+    state  : std_ulogic_vector(2 downto 0); -- FSM state
+    bitcnt : std_ulogic_vector(3 downto 0); -- bit counter
+    sreg   : std_ulogic_vector(8 downto 0); -- main rx/tx shift reg
+    done   : std_ulogic; -- data transmission done
+    busy   : std_ulogic; -- bus operation in progress
   end record;
-  signal arbiter : arbiter_t;
+  signal engine : engine_t;
 
-  -- tri-state I/O control --
+  -- tristate I/O control --
   type io_con_t is record
-    sda_in_ff : std_ulogic_vector(1 downto 0); -- SDA input sync
-    scl_in_ff : std_ulogic_vector(1 downto 0); -- SCL input sync
-    sda_in    : std_ulogic;
-    scl_in    : std_ulogic;
-    sda_out   : std_ulogic;
-    scl_out   : std_ulogic;
+    sda_in_ff, scl_in_ff : std_ulogic_vector(1 downto 0); -- input sync
+    sda_in,    scl_in    : std_ulogic;
+    sda_out,   scl_out   : std_ulogic;
   end record;
   signal io_con : io_con_t;
 
@@ -137,51 +151,34 @@ begin
       bus_rsp_o.err  <= '0';
       bus_rsp_o.data <= (others => '0');
       ctrl.enable    <= '0';
-      ctrl.mack      <= '0';
-      ctrl.csen      <= '0';
       ctrl.prsc      <= (others => '0');
       ctrl.cdiv      <= (others => '0');
-      trig_start     <= '0';
-      trig_stop      <= '0';
-      trig_data      <= '0';
     elsif rising_edge(clk_i) then
-      -- bus handshake --
+      -- bus handshake defaults --
       bus_rsp_o.ack  <= bus_req_i.stb;
       bus_rsp_o.err  <= '0';
       bus_rsp_o.data <= (others => '0');
-
-      -- defaults --
-      trig_start <= '0';
-      trig_stop  <= '0';
-      trig_data  <= '0';
-
       -- read/write access --
       if (bus_req_i.stb = '1') then
         if (bus_req_i.rw = '1') then -- write access
           if (bus_req_i.addr(2) = '0') then -- control register
             ctrl.enable <= bus_req_i.data(ctrl_en_c);
-            ctrl.mack   <= bus_req_i.data(ctrl_mack_c);
-            ctrl.csen   <= bus_req_i.data(ctrl_csen_c);
             ctrl.prsc   <= bus_req_i.data(ctrl_prsc2_c downto ctrl_prsc0_c);
             ctrl.cdiv   <= bus_req_i.data(ctrl_cdiv3_c downto ctrl_cdiv0_c);
-            trig_start  <= bus_req_i.data(ctrl_start_c); -- issue START condition
-            trig_stop   <= bus_req_i.data(ctrl_stop_c); -- issue STOP condition
-          else -- data register
-            trig_data <= '1'; -- start data transmission
           end if;
         else -- read access
           if (bus_req_i.addr(2) = '0') then -- control register
             bus_rsp_o.data(ctrl_en_c)                        <= ctrl.enable;
-            bus_rsp_o.data(ctrl_mack_c)                      <= ctrl.mack;
-            bus_rsp_o.data(ctrl_csen_c)                      <= ctrl.csen;
             bus_rsp_o.data(ctrl_prsc2_c downto ctrl_prsc0_c) <= ctrl.prsc;
             bus_rsp_o.data(ctrl_cdiv3_c downto ctrl_cdiv0_c) <= ctrl.cdiv;
             --
-            bus_rsp_o.data(ctrl_claimed_c) <= arbiter.claimed;
-            bus_rsp_o.data(ctrl_ack_c)     <= not arbiter.rtx_sreg(0);
-            bus_rsp_o.data(ctrl_busy_c)    <= arbiter.busy;
-          else -- data register
-            bus_rsp_o.data(7 downto 0) <= arbiter.rtx_sreg(8 downto 1);
+            bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(index_size_f(IO_TWI_FIFO), 4));
+            --
+            bus_rsp_o.data(ctrl_tx_full_c)  <= not fifo.tx_free;
+            bus_rsp_o.data(ctrl_rx_avail_c) <= fifo.rx_avail;
+            bus_rsp_o.data(ctrl_busy_c)     <= engine.busy or fifo.tx_avail; -- bus engine busy or TX FIFO not empty
+          else -- RX FIFO
+            bus_rsp_o.data(8 downto 0) <= fifo.rx_rdata; -- ACK + data
           end if;
         end if;
       end if;
@@ -189,7 +186,85 @@ begin
   end process bus_access;
 
 
-  -- Clock Generation -----------------------------------------------------------------------
+  -- Data FIFO ("Ring Buffer") --------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+
+  -- global FIFO clear --
+  fifo.clear <= not ctrl.enable;
+
+
+  -- TX FIFO --
+  tx_fifo_inst: entity neorv32.neorv32_fifo
+  generic map (
+    FIFO_DEPTH => IO_TWI_FIFO,
+    FIFO_WIDTH => 11, -- command, MACK, data
+    FIFO_RSYNC => true,
+    FIFO_SAFE  => true,
+    FULL_RESET => false
+  )
+  port map (
+    -- control --
+    clk_i   => clk_i,
+    rstn_i  => rstn_i,
+    clear_i => fifo.clear,
+    half_o  => open,
+    -- write port --
+    wdata_i => fifo.tx_wdata,
+    we_i    => fifo.tx_we,
+    free_o  => fifo.tx_free,
+    -- read port --
+    re_i    => fifo.tx_re,
+    rdata_o => fifo.tx_rdata,
+    avail_o => fifo.tx_avail
+  );
+
+  fifo.tx_we    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '1') else '0';
+  fifo.tx_wdata <= bus_req_i.data(data_cmd_hi_c downto data_lsb_c);
+  fifo.tx_re    <= '1' when (engine.busy = '0') and (fifo.tx_avail = '1') and (clk_gen.tick = '1') else '0';
+
+
+  -- RX FIFO --
+  rx_fifo_inst: entity neorv32.neorv32_fifo
+  generic map (
+    FIFO_DEPTH => IO_TWI_FIFO,
+    FIFO_WIDTH => 9, -- ACK + data
+    FIFO_RSYNC => true,
+    FIFO_SAFE  => true,
+    FULL_RESET => false
+  )
+  port map (
+    -- control --
+    clk_i   => clk_i,
+    rstn_i  => rstn_i,
+    clear_i => fifo.clear,
+    half_o  => open,
+    -- write port --
+    wdata_i => fifo.rx_wdata,
+    we_i    => fifo.rx_we,
+    free_o  => fifo.rx_free,
+    -- read port --
+    re_i    => fifo.rx_re,
+    rdata_o => fifo.rx_rdata,
+    avail_o => fifo.rx_avail
+  );
+
+  fifo.rx_wdata <= engine.sreg(0) & engine.sreg(8 downto 1); -- ACK + data
+  fifo.rx_we    <= engine.done;
+  fifo.rx_re    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(2) = '1') else '0';
+
+
+  -- IRQ if enabled and TX FIFO is empty and bus engine is idle --
+  irq_generator: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      irq_o <= '0';
+    elsif rising_edge(clk_i) then
+      irq_o <= ctrl.enable and (not fifo.tx_avail) and (not engine.busy);
+    end if;
+  end process irq_generator;
+
+
+  -- TWI Clock Generator --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   clock_generator: process(rstn_i, clk_i)
   begin
@@ -214,9 +289,6 @@ begin
     end if;
   end process clock_generator;
 
-  -- clock generator enable --
-  clkgen_en_o <= ctrl.enable;
-
   -- generate four non-overlapping clock phases --
   phase_generator: process(rstn_i, clk_i)
   begin
@@ -225,12 +297,10 @@ begin
       clk_gen.phase_gen_ff <= (others => '0');
     elsif rising_edge(clk_i) then
       clk_gen.phase_gen_ff <= clk_gen.phase_gen;
-      if (arbiter.state(2) = '0') or (arbiter.state(1 downto 0) = "00") then -- offline or idle
-        clk_gen.phase_gen <= "0001"; -- make sure to start with a new phase
-      else
-        if (clk_gen.tick = '1') and (clk_gen.halt = '0') then -- clock tick and no clock stretching detected
-          clk_gen.phase_gen <= clk_gen.phase_gen(2 downto 0) & clk_gen.phase_gen(3); -- rotate left
-        end if;
+      if (ctrl.enable = '0') or (engine.busy = '0') then -- disabled or idle
+        clk_gen.phase_gen <= "0001"; -- make sure to start with a new phase beginning
+      elsif (clk_gen.tick = '1') then
+        clk_gen.phase_gen <= clk_gen.phase_gen(2 downto 0) & clk_gen.phase_gen(3); -- rotate left
       end if;
     end if;
   end process phase_generator;
@@ -241,28 +311,11 @@ begin
   clk_gen.phase(2) <= clk_gen.phase_gen_ff(2) and (not clk_gen.phase_gen(2));
   clk_gen.phase(3) <= clk_gen.phase_gen_ff(3) and (not clk_gen.phase_gen(3)); -- last step
 
-  -- Clock Stretching Detector --
-  -- controller wants to pull SCL high, but SCL is pulled low by peripheral --
-  clk_gen.halt <= '1' when (io_con.scl_out = '1') and (io_con.scl_in_ff(1) = '0') and (ctrl.csen = '1') else '0';
+  -- global clock generator enable --
+  clkgen_en_o <= ctrl.enable;
 
 
-  -- Interrupt Generator --------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  irq_generator: process(rstn_i, clk_i)
-  begin
-    if (rstn_i = '0') then
-      irq_o <= '0';
-    elsif rising_edge(clk_i) then
-      if (arbiter.state = "100") then -- enabled but idle
-        irq_o <= '1';
-      else
-        irq_o <= '0';
-      end if;
-    end if;
-  end process irq_generator;
-
-
-  -- TWI Transceiver ------------------------------------------------------------------------
+  -- TWI Bus Engine -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   twi_engine: process(rstn_i, clk_i)
   begin
@@ -271,41 +324,32 @@ begin
       io_con.scl_in_ff  <= (others => '0');
       io_con.sda_out    <= '0';
       io_con.scl_out    <= '0';
-      arbiter.state     <= (others => '0');
-      arbiter.bitcnt    <= (others => '0');
-      arbiter.state_nxt <= (others => '0');
-      arbiter.rtx_sreg  <= (others => '0');
+      engine.state      <= (others => '0');
+      engine.bitcnt     <= (others => '0');
+      engine.sreg       <= (others => '0');
+      engine.done       <= '0';
     elsif rising_edge(clk_i) then
       -- input synchronizer --
       io_con.sda_in_ff <= io_con.sda_in_ff(0) & io_con.sda_in;
       io_con.scl_in_ff <= io_con.scl_in_ff(0) & io_con.scl_in;
 
+      -- defaults --
+      engine.done <= '0';
+
       -- serial engine --
-      arbiter.state(2) <= ctrl.enable; -- module enabled?
-      case arbiter.state is
+      engine.state(2) <= ctrl.enable; -- module enabled?
+      case engine.state is
 
         when "100" => -- IDLE: waiting for operation requests
         -- ------------------------------------------------------------
-          arbiter.bitcnt <= (others => '0');
-          if (trig_start = '1') then -- issue START condition
-            arbiter.state_nxt <= "01";
-          elsif (trig_stop = '1') then  -- issue STOP condition
-            arbiter.state_nxt <= "10";
-          elsif (trig_data = '1') then -- start a data transmission
-            -- one bit extra for ACK: issued by controller if ctrl_mack_c is set,
-            -- sampled from peripheral if ctrl_mack_c is cleared
-            -- data_i will stay unchanged for min. 1 cycle after WREN has returned to low again
-            arbiter.rtx_sreg  <= bus_req_i.data(7 downto 0) & (not ctrl.mack);
-            arbiter.state_nxt <= "11";
-          end if;
-          -- start operation on next TWI clock pulse --
-          if (arbiter.state_nxt /= "00") and (clk_gen.tick = '1') then
-            arbiter.state(1 downto 0) <= arbiter.state_nxt;
+          engine.bitcnt <= (others => '0');
+          engine.sreg   <= fifo.tx_rdata(data_msb_c downto data_lsb_c) & (not fifo.tx_rdata(data_ack_c)); -- data + HOST ACK
+          if (fifo.tx_avail = '1') and (clk_gen.tick = '1') then -- trigger new operation on next TWI clock pulse
+            engine.state(1 downto 0) <= fifo.tx_rdata(data_cmd_hi_c downto data_cmd_lo_c);
           end if;
 
         when "101" => -- START: generate (repeated) START condition
         -- ------------------------------------------------------------
-          arbiter.state_nxt <= "00"; -- no operation pending anymore
           if (clk_gen.phase(0) = '1') then
             io_con.sda_out <= '1';
           elsif (clk_gen.phase(1) = '1') then
@@ -316,17 +360,16 @@ begin
             io_con.scl_out <= '1';
           elsif (clk_gen.phase(3) = '1') then
             io_con.scl_out <= '0';
-            arbiter.state(1 downto 0) <= "00"; -- go back to IDLE
+            engine.state(1 downto 0) <= "00"; -- go back to IDLE
           end if;
 
         when "110" => -- STOP: generate STOP condition
         -- ------------------------------------------------------------
-          arbiter.state_nxt <= "00"; -- no operation pending anymore
           if (clk_gen.phase(0) = '1') then
             io_con.sda_out <= '0';
           elsif (clk_gen.phase(3) = '1') then
             io_con.sda_out <= '1';
-            arbiter.state(1 downto 0) <= "00"; -- go back to IDLE
+            engine.state(1 downto 0) <= "00"; -- go back to IDLE
           end if;
           --
           if (clk_gen.phase(0) = '1') then
@@ -337,7 +380,6 @@ begin
 
         when "111" => -- TRANSMISSION: send/receive byte + ACK/NACK/MACK
         -- ------------------------------------------------------------
-          arbiter.state_nxt <= "00"; -- no operation pending anymore
           -- SCL clocking --
           if (clk_gen.phase(0) = '1') or (clk_gen.phase(3) = '1') then
             io_con.scl_out <= '0'; -- set SCL low after transmission to keep bus claimed
@@ -345,48 +387,40 @@ begin
             io_con.scl_out <= '1';
           end if;
           -- SDA output --
-          if (arbiter.rtx_done = '1') then
+          if (engine.bitcnt = "1001") and (clk_gen.phase(0) = '1') then
             io_con.sda_out <= '0'; -- set SDA low after transmission to keep bus claimed
           elsif (clk_gen.phase(0) = '1') then
-            io_con.sda_out <= arbiter.rtx_sreg(8); -- MSB first
+            io_con.sda_out <= engine.sreg(8); -- MSB first
           end if;
           -- SDA input --
           if (clk_gen.phase(2) = '1') then
-            arbiter.rtx_sreg <= arbiter.rtx_sreg(7 downto 0) & io_con.sda_in_ff(1); -- sample SDA input and shift left
+            engine.sreg <= engine.sreg(7 downto 0) & io_con.sda_in_ff(1); -- sample SDA input and shift left
           end if;
           -- bit counter --
           if (clk_gen.phase(3) = '1') then
-            arbiter.bitcnt <= std_ulogic_vector(unsigned(arbiter.bitcnt) + 1);
+            engine.bitcnt <= std_ulogic_vector(unsigned(engine.bitcnt) + 1);
           end if;
           -- transmission done --
-          if (arbiter.rtx_done = '1') then
-            arbiter.state(1 downto 0) <= "00"; -- go back to IDLE
+          if (engine.bitcnt = "1001") and (clk_gen.phase(0) = '1') then
+            engine.done              <= '1';
+            engine.state(1 downto 0) <= "00"; -- go back to IDLE
           end if;
 
-        when others => -- "0--" OFFLINE: TWI deactivated, bus unclaimed
+        when others => -- "0---" OFFLINE: TWI deactivated, bus unclaimed
         -- ------------------------------------------------------------
-          io_con.scl_out            <= '1'; -- SCL driven by pull-up resistor
-          io_con.sda_out            <= '1'; -- SDA driven by pull-up resistor
-          arbiter.rtx_sreg          <= (others => '0'); -- make DATA and ACK _defined_ after reset
-          arbiter.state_nxt         <= "00"; -- no operation pending anymore
-          arbiter.state(1 downto 0) <= "00"; -- stay here, go to IDLE when activated
+          io_con.scl_out           <= '1'; -- SCL driven by pull-up resistor
+          io_con.sda_out           <= '1'; -- SDA driven by pull-up resistor
+          engine.state(1 downto 0) <= "00"; -- stay here, go to IDLE when activated
 
       end case;
     end if;
   end process twi_engine;
 
-  -- transmit 8 data bits + 1 ACK bit and wait for another clock phase --
-  arbiter.rtx_done <= '1' when (arbiter.bitcnt = "1001") and (clk_gen.phase(0) = '1') else '0';
-
-  -- arbiter busy? --
-  arbiter.busy <= arbiter.state(1) or arbiter.state(0) or -- operation in progress
-                  arbiter.state_nxt(1) or arbiter.state_nxt(0); -- pending operation
-
-  -- check if the TWI bus is currently claimed (by this module or any other controller) --
-  arbiter.claimed <= '1' when (arbiter.busy = '1') or ((io_con.sda_in_ff(1) = '0') and (io_con.scl_in_ff(1) = '0')) else '0';
+  -- bus operation in progress --
+  engine.busy <= '1' when (engine.state(2) = '1') and (engine.state(1 downto 0) /= "00") else '0';
 
 
-  -- Tri-State Driver Interface -------------------------------------------------------------
+  -- Tristate Driver Interface --------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   twi_sda_o     <= io_con.sda_out; -- NOTE: signal lines can only be actively driven low
   twi_scl_o     <= io_con.scl_out;

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -294,6 +294,7 @@ begin
     IO_SDI_EN                    => true,          -- implement serial data interface (SDI)?
     IO_SDI_FIFO                  => 4,             -- SDI RTX fifo depth, has to be zero or a power of two
     IO_TWI_EN                    => true,          -- implement two-wire interface (TWI)?
+    IO_TWI_FIFO                  => 4,             -- RTX fifo depth, has to be zero or a power of two, min 1
     IO_PWM_NUM_CH                => 12,            -- number of PWM channels to implement (0..12); 0 = disabled
     IO_WDT_EN                    => true,          -- implement watch dog timer (WDT)?
     IO_TRNG_EN                   => true,          -- implement true random number generator (TRNG)?

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -270,6 +270,7 @@ begin
     IO_SDI_EN                    => true,          -- implement serial data interface (SDI)?
     IO_SDI_FIFO                  => 4,             -- SDI RTX fifo depth, has to be zero or a power of two
     IO_TWI_EN                    => true,          -- implement two-wire interface (TWI)?
+    IO_TWI_FIFO                  => 4,             -- RTX fifo depth, has to be zero or a power of two, min 1
     IO_PWM_NUM_CH                => 12,            -- number of PWM channels to implement (0..12); 0 = disabled
     IO_WDT_EN                    => true,          -- implement watch dog timer (WDT)?
     IO_TRNG_EN                   => true,          -- implement true random number generator (TRNG)?

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1278,9 +1278,11 @@ int main() {
     // configure TWI with fastest clock
     neorv32_twi_setup(CLK_PRSC_2, 0);
 
-    // start 2 TWI operations, after they are done the interrupt will be fired
+    // issue some TWI operations, after they are done the interrupt will be fired
+    neorv32_twi_generate_start_nonblocking();
     neorv32_twi_send_nonblocking(0xA5, 0);
     neorv32_twi_send_nonblocking(0x12, 0);
+    neorv32_twi_generate_stop_nonblocking();
 
     // enable TWI FIRQ
     neorv32_cpu_csr_write(CSR_MIE, 1 << TWI_FIRQ_ENABLE);

--- a/sw/lib/include/neorv32_twi.h
+++ b/sw/lib/include/neorv32_twi.h
@@ -3,7 +3,8 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+// # The NEORV32 RISC-V Processor, https://github.com/stnolting/neorv32                            #
+// # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -28,8 +29,6 @@
 // # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
 // # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
 // # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
-// # ********************************************************************************************* #
-// # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
 // #################################################################################################
 
 
@@ -50,7 +49,7 @@
 /** TWI module prototype */
 typedef volatile struct __attribute__((packed,aligned(4))) {
   uint32_t CTRL;  /**< offset 0: control register (#NEORV32_TWI_CTRL_enum) */
-  uint32_t DATA;  /**< offset 4: data register (#NEORV32_TWI_DATA_enum) */
+  uint32_t DCMD;  /**< offset 4: data/cmd register (#NEORV32_TWI_DCMD_enum) */
 } neorv32_twi_t;
 
 /** TWI module hardware access (#neorv32_twi_t) */
@@ -58,29 +57,41 @@ typedef volatile struct __attribute__((packed,aligned(4))) {
 
 /** TWI control register bits */
 enum NEORV32_TWI_CTRL_enum {
-  TWI_CTRL_EN      =  0, /**< TWI control register(0)  (r/w): TWI enable */
-  TWI_CTRL_START   =  1, /**< TWI control register(1)  (-/w): Generate START condition, auto-clears */
-  TWI_CTRL_STOP    =  2, /**< TWI control register(2)  (-/w): Generate STOP condition, auto-clears */
-  TWI_CTRL_MACK    =  3, /**< TWI control register(3)  (r/w): Generate ACK by controller for each transmission */
-  TWI_CTRL_CSEN    =  4, /**< TWI control register(4)  (r/w): Allow clock stretching when set */
-  TWI_CTRL_PRSC0   =  5, /**< TWI control register(5)  (r/w): Clock prescaler select bit 0 */
-  TWI_CTRL_PRSC1   =  6, /**< TWI control register(6)  (r/w): Clock prescaler select bit 1 */
-  TWI_CTRL_PRSC2   =  7, /**< TWI control register(7)  (r/w): Clock prescaler select bit 2 */
-  TWI_CTRL_CDIV0   =  8, /**< TWI control register(8)  (r/w): Clock divider bit 0 */
-  TWI_CTRL_CDIV1   =  9, /**< TWI control register(9)  (r/w): Clock divider bit 1 */
-  TWI_CTRL_CDIV2   = 10, /**< TWI control register(10) (r/w): Clock divider bit 2 */
-  TWI_CTRL_CDIV3   = 11, /**< TWI control register(11) (r/w): Clock divider bit 3 */
+  TWI_CTRL_EN       =  0, /**< TWI control register(0)  (r/w): TWI enable */
+  TWI_CTRL_PRSC0    =  1, /**< TWI control register(1)  (r/w): Clock prescaler select bit 0 */
+  TWI_CTRL_PRSC1    =  2, /**< TWI control register(2)  (r/w): Clock prescaler select bit 1 */
+  TWI_CTRL_PRSC2    =  3, /**< TWI control register(3)  (r/w): Clock prescaler select bit 2 */
+  TWI_CTRL_CDIV0    =  4, /**< TWI control register(4)  (r/w): Clock divider bit 0 */
+  TWI_CTRL_CDIV1    =  5, /**< TWI control register(5)  (r/w): Clock divider bit 1 */
+  TWI_CTRL_CDIV2    =  6, /**< TWI control register(6)  (r/w): Clock divider bit 2 */
+  TWI_CTRL_CDIV3    =  7, /**< TWI control register(7)  (r/w): Clock divider bit 3 */
 
-  TWI_CTRL_CLAIMED = 29, /**< TWI control register(29) (r/-): Set if the TWI bus is currently claimed by any controller */
-  TWI_CTRL_ACK     = 30, /**< TWI control register(30) (r/-): ACK received when set */
-  TWI_CTRL_BUSY    = 31  /**< TWI control register(31) (r/-): Transfer in progress, busy flag */
+  TWI_CTRL_FIFO_LSB = 15, /**< SPI control register(15) (r/-): log2(FIFO size), lsb */
+  TWI_CTRL_FIFO_MSB = 18, /**< SPI control register(18) (r/-): log2(FIFO size), msb */
+
+  TWI_CTRL_TX_FULL  = 29, /**< TWI control register(29) (r/-): TX FIFO full */
+  TWI_CTRL_RX_AVAIL = 30, /**< TWI control register(30) (r/-): RX FIFO data available */
+  TWI_CTRL_BUSY     = 31  /**< TWI control register(31) (r/-): Bus engine busy or TX FIFO not empty */
 };
 
-/** TWI receive/transmit data register bits */
-enum NEORV32_TWI_DATA_enum {
-  TWI_DATA_LSB = 0, /**< TWI data register(0) (r/w): Receive/transmit data (8-bit) LSB */
-  TWI_DATA_MSB = 7  /**< TWI data register(7) (r/w): Receive/transmit data (8-bit) MSB */
+/** TWI command/data register bits */
+enum NEORV32_TWI_DCMD_enum {
+  TWI_DCMD_LSB    =  0, /**< TWI data register(0)  (r/w): Receive/transmit data (8-bit) LSB */
+  TWI_DCMD_MSB    =  7, /**< TWI data register(7)  (r/w): Receive/transmit data (8-bit) MSB */
+  TWI_DCMD_ACK    =  8, /**< TWI data register(8)  (r/w): RX = ACK/NACK, TX = MACK */
+  TWI_DCMD_CMD_LO =  9, /**< TWI data register(9)  (r/w): CMD lsb */
+  TWI_DCMD_CMD_HI = 10  /**< TWI data register(10) (r/w): CMD msb */
 };
+/**@}*/
+
+/**********************************************************************//**
+ * @name TWI commands
+ **************************************************************************/
+/**@{*/
+#define TWI_CMD_NOP   (0b00) // no operation
+#define TWI_CMD_START (0b01) // generate start condition
+#define TWI_CMD_STOP  (0b10) // generate stop condition
+#define TWI_CMD_RTX   (0b11) // transmit+receive data byte
 /**@}*/
 
 
@@ -88,19 +99,22 @@ enum NEORV32_TWI_DATA_enum {
  * @name Prototypes
  **************************************************************************/
 /**@{*/
-int     neorv32_twi_available(void);
-void    neorv32_twi_setup(int prsc, int cdiv, int csen);
-void    neorv32_twi_disable(void);
-void    neorv32_twi_enable(void);
-void    neorv32_twi_mack_enable(void);
-void    neorv32_twi_mack_disable(void);
-int     neorv32_twi_busy(void);
-int     neorv32_twi_start_trans(uint8_t a);
-int     neorv32_twi_trans(uint8_t d);
-uint8_t neorv32_twi_get_data(void);
-void    neorv32_twi_generate_stop(void);
-void    neorv32_twi_generate_start(void);
-int     neorv32_twi_bus_claimed(void);
+int  neorv32_twi_available(void);
+void neorv32_twi_setup(int prsc, int cdiv);
+int  neorv32_twi_get_fifo_depth(void);
+void neorv32_twi_disable(void);
+void neorv32_twi_enable(void);
+
+int  neorv32_twi_busy(void);
+int  neorv32_twi_get(uint8_t *data);
+
+int  neorv32_twi_trans(uint8_t *data, int mack);
+void neorv32_twi_generate_stop(void);
+void neorv32_twi_generate_start(void);
+
+void neorv32_twi_send_nonblocking(uint8_t data, int mack);
+void neorv32_twi_generate_stop_nonblocking(void);
+void neorv32_twi_generate_start_nonblocking(void);
 /**@}*/
 
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -1205,64 +1205,60 @@
               <description>TWI enable flag</description>
             </field>
             <field>
-              <name>TWI_CTRL_START</name>
-              <bitRange>[1:1]</bitRange>
-              <description>Generate START condition, auto-clears</description>
-            </field>
-            <field>
-              <name>TWI_CTRL_STOP</name>
-              <bitRange>[2:2]</bitRange>
-              <description>Generate STOP condition, auto-clears</description>
-            </field>
-            <field>
-              <name>TWI_CTRL_MACK</name>
-              <bitRange>[3:3]</bitRange>
-              <description>Generate ACK by controller for each transmission</description>
-            </field>
-            <field>
-              <name>TWI_CTRL_CSEN</name>
-              <bitRange>[4:4]</bitRange>
-              <description>Allow clock stretching when set</description>
-            </field>
-            <field>
               <name>TWI_CTRL_PRSC</name>
-              <bitRange>[7:5]</bitRange>
+              <bitRange>[3:1]</bitRange>
               <description>Clock prescaler select</description>
             </field>
             <field>
               <name>TWI_CTRL_CDIV</name>
-              <bitRange>[11:8]</bitRange>
+              <bitRange>[7:4]</bitRange>
               <description>TWI clock divider</description>
             </field>
             <field>
-              <name>TWI_CTRL_CLAIMED</name>
-              <bitRange>[29:29]</bitRange>
+              <name>TWI_CTRL_FIFO</name>
+              <bitRange>[18:15]</bitRange>
               <access>read-only</access>
-              <description>Set if the TWI bus is currently claimed by any controller</description>
+              <description>log2(TWI FIFO size)</description>
             </field>
             <field>
-              <name>TWI_CTRL_ACK</name>
+              <name>TWI_CTRL_TX_FULL</name>
+              <bitRange>[29:29]</bitRange>
+              <access>read-only</access>
+              <description>TX FIFO full</description>
+            </field>
+            <field>
+              <name>TWI_CTRL_RX_AVAIL</name>
               <bitRange>[30:30]</bitRange>
               <access>read-only</access>
-              <description>ACK received when set</description>
+              <description>RX FIFO not empty (data available)</description>
             </field>
             <field>
               <name>TWI_CTRL_BUSY</name>
               <bitRange>[31:31]</bitRange>
               <access>read-only</access>
-              <description>Transfer in progress, busy flag</description>
+              <description>Bus engine busy of TX FIFO not empty</description>
             </field>
           </fields>
         </register>
         <register>
-          <name>DATA</name>
-          <description>RX/TX data register</description>
+          <name>DCMD</name>
+          <description>RX/TX data/command register</description>
           <addressOffset>0x04</addressOffset>
           <fields>
             <field>
-              <name>TWI_DATA</name>
+              <name>TWI_DCMD</name>
               <bitRange>[7:0]</bitRange>
               <description>RX/TX data</description>
+            </field>
+            <field>
+              <name>TWI_DCMD_ACK</name>
+              <bitRange>[8:8]</bitRange>
+              <description>RX = ACK/NACK, TX = MACK</description>
+            </field>
+            <field>
+              <name>TWI_DCMD_CMD</name>
+              <bitRange>[10:9]</bitRange>
+              <description>Operation command</description>
             </field>
           </fields>
         </register>


### PR DESCRIPTION
## ✨ Add Configurable TWI FIFO

An optional FIFO is implemented that can be used to "program" long sequences of TWI operations (START conditions, repeated START conditions, STOP conditions, data transmissions) without further interaction of the CPU. The FIFO is configured by a new top generic:

```vhdl
IO_TWI_FIFO : natural range 1 to 2**15 := 1;
```

## :warning: Rework TWI Core

* remove support for clock-stretching
* remove bus state sensing
* rework low-level interface / HAL
* interrupt will fire when the FIFO is empty and no bus operation is pending