### PR TITLE
[SLINK] split interrupt into two FIRQs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 03.04.2024 | 1.9.7.8 | split SLINK interrupt into two individual FIRQs (SLINK RX and SLINK TX) | [#868](https://github.com/stnolting/neorv32/pull/868) |
 | 01.04.2024 | 1.9.7.7 | add back TWI clock stretching option | [#867](https://github.com/stnolting/neorv32/pull/867) |
 | 26.03.2024 | 1.9.7.6 | :warning: rework TWI module; add optional & configurable command/data FIFO | [#865](https://github.com/stnolting/neorv32/pull/865) |
 | 24.03.2024 | 1.9.7.5 | :warning: **interrupt system rework**: rework CPU's FIRQ system; `mip` CSR is now read-only ; :bug: fix DMA fence configuration flag | [#864](https://github.com/stnolting/neorv32/pull/864) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -453,8 +453,8 @@ table (the channel number also corresponds to the according FIRQ priority: 0 = h
 | 11      | <<_serial_data_interface_controller_sdi,SDI>> | SDI FIFO level interrupt
 | 12      | <<_general_purpose_timer_gptmr,GPTMR>> | General purpose timer interrupt
 | 13      | <<_one_wire_serial_interface_controller_onewire,ONEWIRE>> | 1-wire idle interrupt
-| 14      | <<_stream_link_interface_slink,SLINK>> | SLINK FIFO level interrupt
-| 15      | - | _reserved_
+| 14      | <<_stream_link_interface_slink,SLINK>> | SLINK RX FIFO level interrupt
+| 15      | <<_stream_link_interface_slink,SLINK>> | SLINK TX FIFO level interrupt
 |=======================
 
 

--- a/docs/datasheet/soc_slink.adoc
+++ b/docs/datasheet/soc_slink.adoc
@@ -5,31 +5,32 @@
 [cols="<3,<3,<4"]
 [frame="topbot",grid="none"]
 |=======================
-| Hardware source file(s): | neorv32_slink.vhd   |
-| Software driver file(s): | neorv32_slink.c     |
-|                          | neorv32_slink.h     |
-| Top entity port(s):      | `slink_rx_dat_i`    | RX link data (32-bit)
-|                          | `slink_rx_val_i`    | RX link data valid (1-bit)
-|                          | `slink_rx_lst_i`    | RX link last element of stream (1-bit)
-|                          | `slink_rx_rdy_o`    | RX link ready to receive (1-bit)
-|                          | `slink_tx_dat_o`    | TX link data (32-bit)
-|                          | `slink_tx_val_o`    | TX link data valid (1-bit)
-|                          | `slink_tx_lst_o`    | TX link last element of stream (1-bit)
-|                          | `slink_tx_rdy_i`    | TX link allowed to send (1-bit)
-| Configuration generics:  | `IO_SLINK_EN`       | implement SLINK when _true_
-|                          | `IO_SLINK_RX_FIFO`  | RX FIFO depth (1..32k), has to be a power of two
-|                          | `IO_SLINK_TX_FIFO`  | TX FIFO depth (1..32k), has to be a power of two
-| CPU interrupt:           | fast IRQ channel 14 | SLINK IRQ (see <<_processor_interrupts>>)
+| Hardware source files:  | neorv32_slink.vhd   |
+| Software driver files:  | neorv32_slink.c     |
+|                         | neorv32_slink.h     |
+| Top entity ports:       | `slink_rx_dat_i`    | RX link data (32-bit)
+|                         | `slink_rx_val_i`    | RX link data valid (1-bit)
+|                         | `slink_rx_lst_i`    | RX link last element of stream (1-bit)
+|                         | `slink_rx_rdy_o`    | RX link ready to receive (1-bit)
+|                         | `slink_tx_dat_o`    | TX link data (32-bit)
+|                         | `slink_tx_val_o`    | TX link data valid (1-bit)
+|                         | `slink_tx_lst_o`    | TX link last element of stream (1-bit)
+|                         | `slink_tx_rdy_i`    | TX link allowed to send (1-bit)
+| Configuration generics: | `IO_SLINK_EN`       | implement SLINK when _true_
+|                         | `IO_SLINK_RX_FIFO`  | RX FIFO depth (1..32k), has to be a power of two, min 1
+|                         | `IO_SLINK_TX_FIFO`  | TX FIFO depth (1..32k), has to be a power of two, min 1
+| CPU interrupts:         | fast IRQ channel 14 | RX SLINK IRQ (see <<_processor_interrupts>>)
+|                         | fast IRQ channel 15 | TX SLINK IRQ (see <<_processor_interrupts>>)
 |=======================
 
 
 **Overview**
 
-The stream link interface provides independent RX and TX channels for sending for sending and receiving
-stream data. Each channel features an internal FIFO with configurable depth to buffer stream data
+The stream link interface provides independent RX and TX channels for sending and receiving
+stream data. Each channel features a configurable internal FIFO to buffer stream data
 (`IO_SLINK_RX_FIFO` for the RX FIFO, `IO_SLINK_TX_FIFO` for the TX FIFO). The SLINK interface provides higher
 bandwidth and less latency than the external bus interface making it ideally suited for coupling custom
-stream processing units or streaming peripherals.
+stream processors or streaming peripherals.
 
 .Example Program
 [TIP]
@@ -38,51 +39,57 @@ An example program for the SLINK module is available in `sw/example/demo_slink`.
 
 **Interface & Protocol**
 
-The SLINK interface consists of four signals per channel:
+The SLINK interface consists of four signals for each channel:
 
 * `dat` contains the actual data word
 * `val` marks the current transmission cycle as valid
-* `lst` makes the current transmission cycle as the last element of a stream
-* `rdy` indicates that the receiving part is ready to receive
+* `lst` marks the current transmission cycle as the last element of a stream
+* `rdy` indicates that the receiver is ready to receive
 
 .AXI4-Stream Compatibility
 [NOTE]
-The interface names and the underlying protocol is compatible to the AXI4-Stream standard.
+The interface names and the underlying protocol is compatible to the AXI4-Stream protocol standard.
 
 
 **Theory of Operation**
 
 The SLINK provides four interface registers. The control register (`CTRL`) is used to configure
 the module and to check its status. Three individual data registers (`RX_DATA`, `TX_DATA`, `TX_DATA_LAST`)
-are used to send and received the link's actual data stream.
+are used to send and receive the link's actual data stream.
 
-The `RX_DATA` register provides direct access to the RX link FIFO buffer. After reading data from this the register
-the control register's `SLINK_CTRL_RX_LAST` can be checked to determine if the according data word has been marked
+The `RX_DATA` register provides direct access to the RX link FIFO buffer. After reading data from this register
+the control register's `SLINK_CTRL_RX_LAST` flag can be checked to determine if the according data word has been marked
 as "end of stream" via the `slink_rx_lst_i` signal (this signal is also buffered by the link's FIFO).
 
 Writing to the `TX_DATA` or `TX_DATA_LAST` register will immediately write to the TX link FIFO buffer.
-When writing to the `TX_DATA_LAST` the according data word will be marked as "end of stream" via the
+When writing to the `TX_DATA_LAST` the according data word will also be marked as "end of stream" via the
 `slink_tx_lst_o` signal (this signal is also buffered by the link's FIFO).
 
 The configured FIFO sizes can be retrieved by software via the control register's `SLINK_CTRL_RX_FIFO_*` and
 `SLINK_CTRL_TX_FIFO_*` bits.
 
 The SLINK is globally activated by setting the control register's enable bit `SLINK_CTRL_EN`. Clearing this bit will
-reset all internal logic and will also clear both FIFOs. The FIFOs can also be cleared manually at all time by
-setting the `SLINK_CTRL_RX_CLR` and `SLINK_CTRL_TX_CLR` bits (these bits will auto-clear).
+reset all internal logic and will also clear both FIFOs. The FIFOs can also be cleared manually at any time by
+setting the `SLINK_CTRL_RX_CLR` and/or `SLINK_CTRL_TX_CLR` bits (these bits will auto-clear).
 
+.FIFO Overflow
 [NOTE]
 Writing to the TX channel's FIFO while it is _full_ will have no effect. Reading from the RX channel's FIFO while it
-is _empty_ will also have no effect and will return the last received data word.
+is _empty_ will also have no effect and will return the last received data word. There is no overflow indicator
+implemented yet.
 
-The current status of the RX and TX FIFOs can be determined via the `SLINK_CTRL_RX_*` and `SLINK_CTRL_TX_*` flags.
+The current status of the RX and TX FIFOs can be determined via the control register's `SLINK_CTRL_RX_*` and
+`SLINK_CTRL_TX_*` flags.
 
 
-**Interrupt**
+**Interrupts**
 
-A single global interrupt can be programmed based on these FIFO status flags via the control register's `SLINK_CTRL_IRQ_*`
-bits. Note that all enabled interrupt conditions are logically OR-ed. If any enable interrupt conditions becomes true the
-interrupt will become pending until the interrupt-causing condition is resolved (e.g. by reading from the RX FIFO).
+The SLINK module provides two independent interrupt channels: one for RX events and one for TX events.
+The interrupt conditions are based on the according link's FIFO status flags and are configured via the control
+register's `SLINK_CTRL_IRQ_*` flags. The according interrupt will fire when the module is enabled (`SLINK_CTRL_EN`)
+and the selected interrupt conditions are met. Note that all enabled interrupt conditions are logically OR-ed per
+channel. If any enable interrupt conditions becomes active the interrupt will become pending until the
+interrupt-causing condition is resolved (e.g. by reading from the RX FIFO).
 
 
 **Register Map**
@@ -105,12 +112,12 @@ interrupt will become pending until the interrupt-causing condition is resolved 
                                                 <| `12`   `SLINK_CTRL_TX_HALF`                               ^| r/- <| TX FIFO at least half full
                                                 <| `13`   `SLINK_CTRL_TX_FULL`                               ^| r/- <| TX FIFO full
                                                 <| `15:14` _reserved_                                        ^| r/- <| _reserved_, read as zero
-                                                <| `16`   `SLINK_CTRL_IRQ_RX_NEMPTY`                         ^| r/w <| IRQ if RX FIFO not empty
-                                                <| `17`   `SLINK_CTRL_IRQ_RX_HALF`                           ^| r/w <| IRQ if RX FIFO at least half full
-                                                <| `18`   `SLINK_CTRL_IRQ_RX_FULL`                           ^| r/w <| IRQ if RX FIFO full
-                                                <| `19`   `SLINK_CTRL_IRQ_TX_EMPTY`                          ^| r/w <| IRQ if TX FIFO empty
-                                                <| `20`   `SLINK_CTRL_IRQ_TX_NHALF`                          ^| r/w <| IRQ if TX FIFO not at least half full
-                                                <| `21`   `SLINK_CTRL_IRQ_TX_NFULL`                          ^| r/w <| IRQ if TX FIFO not full
+                                                <| `16`   `SLINK_CTRL_IRQ_RX_NEMPTY`                         ^| r/w <| RX interrupt if RX FIFO not empty
+                                                <| `17`   `SLINK_CTRL_IRQ_RX_HALF`                           ^| r/w <| RX interrupt if RX FIFO at least half full
+                                                <| `18`   `SLINK_CTRL_IRQ_RX_FULL`                           ^| r/w <| RX interrupt if RX FIFO full
+                                                <| `19`   `SLINK_CTRL_IRQ_TX_EMPTY`                          ^| r/w <| TX interrupt if TX FIFO empty
+                                                <| `20`   `SLINK_CTRL_IRQ_TX_NHALF`                          ^| r/w <| TX interrupt if TX FIFO not at least half full
+                                                <| `21`   `SLINK_CTRL_IRQ_TX_NFULL`                          ^| r/w <| TX interrupt if TX FIFO not full
                                                 <| `23:22` _reserved_                                        ^| r/- <| _reserved_, read as zero
                                                 <| `27:24` `SLINK_CTRL_RX_FIFO_MSB : SLINK_CTRL_RX_FIFO_LSB` ^| r/- <| log2(RX FIFO size)
                                                 <| `31:28` `SLINK_CTRL_TX_FIFO_MSB : SLINK_CTRL_TX_FIFO_LSB` ^| r/- <| log2(TX FIFO size)

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -52,7 +52,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090707"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090708"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -184,7 +184,7 @@ begin
     if ci_mode then
       -- No need to send the full expectation in one big chunk
       check_uart(net, uart1_rx_handle, nul & nul);
-      check_uart(net, uart1_rx_handle, "0/54" & cr & lf);
+      check_uart(net, uart1_rx_handle, "0/55" & cr & lf);
     end if;
 
     -- Wait until all expected data has been received

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -309,8 +309,8 @@ begin
     IO_ONEWIRE_EN                => true,          -- implement 1-wire interface (ONEWIRE)?
     IO_DMA_EN                    => true,          -- implement direct memory access controller (DMA)?
     IO_SLINK_EN                  => true,          -- implement stream link interface (SLINK)?
-    IO_SLINK_RX_FIFO             => 2,             -- RX fifo depth, has to be a power of two, min 1
-    IO_SLINK_TX_FIFO             => 2,             -- TX fifo depth, has to be a power of two, min 1
+    IO_SLINK_RX_FIFO             => 4,             -- RX fifo depth, has to be a power of two, min 1
+    IO_SLINK_TX_FIFO             => 4,             -- TX fifo depth, has to be a power of two, min 1
     IO_CRC_EN                    => true           -- implement cyclic redundancy check unit (CRC)?
   )
   port map (

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -285,8 +285,8 @@ begin
     IO_ONEWIRE_EN                => true,          -- implement 1-wire interface (ONEWIRE)?
     IO_DMA_EN                    => true,          -- implement direct memory access controller (DMA)?
     IO_SLINK_EN                  => true,          -- implement stream link interface (SLINK)?
-    IO_SLINK_RX_FIFO             => 2,             -- RX fifo depth, has to be a power of two, min 1
-    IO_SLINK_TX_FIFO             => 2,             -- TX fifo depth, has to be a power of two, min 1
+    IO_SLINK_RX_FIFO             => 4,             -- RX fifo depth, has to be a power of two, min 1
+    IO_SLINK_TX_FIFO             => 4,             -- TX fifo depth, has to be a power of two, min 1
     IO_CRC_EN                    => true           -- implement cyclic redundancy check unit (CRC)?
   )
   port map (

--- a/sw/example/demo_slink/main.c
+++ b/sw/example/demo_slink/main.c
@@ -96,8 +96,10 @@ int main() {
                        "TX FIFO depth: %u\n\n",
                        rx_depth, tx_depth);
 
-  // setup SLINK module
-  neorv32_slink_setup(0);
+
+  // setup SLINK module, no interrupts
+  neorv32_slink_setup(0, 0);
+
 
   // TX demo
   neorv32_uart0_printf("-------- TX Demo --------\n");
@@ -149,13 +151,13 @@ int main() {
   neorv32_uart0_printf("\n------ RX IRQ Demo -------\n");
 
   // reconfigure SLINK module
-  neorv32_slink_setup(1 << SLINK_CTRL_IRQ_RX_NEMPTY); // interrupt if RX data available
+  neorv32_slink_setup(1 << SLINK_CTRL_IRQ_RX_NEMPTY, 0); // interrupt if RX data available
   neorv32_slink_rx_clear();
   neorv32_slink_tx_clear();
 
   // NEORV32 runtime environment: install SLINK FIRQ handler
-  neorv32_rte_handler_install(SLINK_RTE_ID, slink_firq_handler);
-  neorv32_cpu_csr_set(CSR_MIE, 1 << SLINK_FIRQ_ENABLE); // enable SLINK FIRQ
+  neorv32_rte_handler_install(SLINK_RX_RTE_ID, slink_firq_handler);
+  neorv32_cpu_csr_set(CSR_MIE, 1 << SLINK_RX_FIRQ_ENABLE); // enable SLINK FIRQ
   neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE); // enable machine-mode interrupts
 
   for (i=0; i<4; i++) {

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -1,5 +1,5 @@
 // #################################################################################################
-// # << NEORV32: neorv32.h - Main Core Library File >>                                             #
+// # << NEORV32: neorv32.h - Main Core Library / HAL Include File >>                               #
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
@@ -37,7 +37,7 @@
  * @file neorv32.h
  * @author Stephan Nolting
  *
- * @brief Main NEORV32 core library include file.
+ * @brief Main NEORV32 core library / HAL include file.
  **************************************************************************/
 
 #ifndef neorv32_h
@@ -161,10 +161,14 @@ enum NEORV32_CLOCK_PRSC_enum {
 /**@}*/
 /** @name Stream Link Interface (SLINK) */
 /**@{*/
-#define SLINK_FIRQ_ENABLE      CSR_MIE_FIRQ14E   /**< MIE CSR bit (#NEORV32_CSR_MIE_enum) */
-#define SLINK_FIRQ_PENDING     CSR_MIP_FIRQ14P   /**< MIP CSR bit (#NEORV32_CSR_MIP_enum) */
-#define SLINK_RTE_ID           RTE_TRAP_FIRQ_14  /**< RTE entry code (#NEORV32_RTE_TRAP_enum) */
-#define SLINK_TRAP_CODE        TRAP_CODE_FIRQ_14 /**< MCAUSE CSR trap code (#NEORV32_EXCEPTION_CODES_enum) */
+#define SLINK_RX_FIRQ_ENABLE   CSR_MIE_FIRQ14E   /**< MIE CSR bit (#NEORV32_CSR_MIE_enum) */
+#define SLINK_RX_FIRQ_PENDING  CSR_MIP_FIRQ14P   /**< MIP CSR bit (#NEORV32_CSR_MIP_enum) */
+#define SLINK_RX_RTE_ID        RTE_TRAP_FIRQ_14  /**< RTE entry code (#NEORV32_RTE_TRAP_enum) */
+#define SLINK_RX_TRAP_CODE     TRAP_CODE_FIRQ_14 /**< MCAUSE CSR trap code (#NEORV32_EXCEPTION_CODES_enum) */
+#define SLINK_TX_FIRQ_ENABLE   CSR_MIE_FIRQ15E   /**< MIE CSR bit (#NEORV32_CSR_MIE_enum) */
+#define SLINK_TX_FIRQ_PENDING  CSR_MIP_FIRQ15P   /**< MIP CSR bit (#NEORV32_CSR_MIP_enum) */
+#define SLINK_TX_RTE_ID        RTE_TRAP_FIRQ_15  /**< RTE entry code (#NEORV32_RTE_TRAP_enum) */
+#define SLINK_TX_TRAP_CODE     TRAP_CODE_FIRQ_15 /**< MCAUSE CSR trap code (#NEORV32_EXCEPTION_CODES_enum) */
 /**@}*/
 /**@}*/
 

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #

--- a/sw/lib/include/neorv32_slink.h
+++ b/sw/lib/include/neorv32_slink.h
@@ -71,12 +71,12 @@ enum NEORV32_SLINK_CTRL_enum {
   SLINK_CTRL_TX_HALF       = 12, /**< SLINK control register(12) (r/-): TX FIFO at least half full */
   SLINK_CTRL_TX_FULL       = 13, /**< SLINK control register(13) (r/-): TX FIFO full */
 
-  SLINK_CTRL_IRQ_RX_NEMPTY = 16, /**< SLINK control register(16) (r/w): IRQ if RX FIFO not empty */
-  SLINK_CTRL_IRQ_RX_HALF   = 17, /**< SLINK control register(17) (r/w): IRQ if RX FIFO at least half full */
-  SLINK_CTRL_IRQ_RX_FULL   = 18, /**< SLINK control register(18) (r/w): IRQ if RX FIFO full */
-  SLINK_CTRL_IRQ_TX_EMPTY  = 19, /**< SLINK control register(19) (r/w): IRQ if TX FIFO empty */
-  SLINK_CTRL_IRQ_TX_NHALF  = 20, /**< SLINK control register(20) (r/w): IRQ if TX FIFO not at least half full */
-  SLINK_CTRL_IRQ_TX_NFULL  = 21, /**< SLINK control register(21) (r/w): IRQ if TX FIFO not full */
+  SLINK_CTRL_IRQ_RX_NEMPTY = 16, /**< SLINK control register(16) (r/w): RX interrupt if RX FIFO not empty */
+  SLINK_CTRL_IRQ_RX_HALF   = 17, /**< SLINK control register(17) (r/w): RX interrupt if RX FIFO at least half full */
+  SLINK_CTRL_IRQ_RX_FULL   = 18, /**< SLINK control register(18) (r/w): RX interrupt if RX FIFO full */
+  SLINK_CTRL_IRQ_TX_EMPTY  = 19, /**< SLINK control register(19) (r/w): TX interrupt if TX FIFO empty */
+  SLINK_CTRL_IRQ_TX_NHALF  = 20, /**< SLINK control register(20) (r/w): TX interrupt if TX FIFO not at least half full */
+  SLINK_CTRL_IRQ_TX_NFULL  = 21, /**< SLINK control register(21) (r/w): TX interrupt if TX FIFO not full */
 
   SLINK_CTRL_RX_FIFO_LSB   = 24, /**< SLINK control register(24) (r/-): log2(RX FIFO size) LSB */
   SLINK_CTRL_RX_FIFO_MSB   = 27, /**< SLINK control register(27) (r/-): log2(RX FIFO size) MSB */
@@ -97,7 +97,7 @@ enum NEORV32_SLINK_STATUS_enum {
  **************************************************************************/
 /**@{*/
 int      neorv32_slink_available(void);
-void     neorv32_slink_setup(uint32_t irq_config);
+void     neorv32_slink_setup(uint32_t rx_irq, uint32_t tx_irq);
 void     neorv32_slink_rx_clear(void);
 void     neorv32_slink_tx_clear(void);
 int      neorv32_slink_get_rx_fifo_depth(void);

--- a/sw/lib/include/neorv32_slink.h
+++ b/sw/lib/include/neorv32_slink.h
@@ -81,7 +81,7 @@ enum NEORV32_SLINK_CTRL_enum {
   SLINK_CTRL_RX_FIFO_LSB   = 24, /**< SLINK control register(24) (r/-): log2(RX FIFO size) LSB */
   SLINK_CTRL_RX_FIFO_MSB   = 27, /**< SLINK control register(27) (r/-): log2(RX FIFO size) MSB */
   SLINK_CTRL_TX_FIFO_LSB   = 28, /**< SLINK control register(28) (r/-): log2(TX FIFO size) LSB */
-  SLINK_CTRL_TX_FIFO_MSB   = 31, /**< SLINK control register(31) (r/-): log2(TX FIFO size) MSB */
+  SLINK_CTRL_TX_FIFO_MSB   = 31  /**< SLINK control register(31) (r/-): log2(TX FIFO size) MSB */
 };
 
 enum NEORV32_SLINK_STATUS_enum {

--- a/sw/lib/source/neorv32_slink.c
+++ b/sw/lib/source/neorv32_slink.c
@@ -60,15 +60,23 @@ int neorv32_slink_available(void) {
 /**********************************************************************//**
  * Reset, enable and configure SLINK.
  *
- * @param[in] irq_config Configure RX and TX interrupt conditions (#NEORV32_SLINK_CTRL_enum).
+ * @param[in] rx_irq Configure RX interrupt conditions (#NEORV32_SLINK_CTRL_enum).
+ * @param[in] tx_irq Configure TX interrupt conditions (#NEORV32_SLINK_CTRL_enum).
  **************************************************************************/
-void neorv32_slink_setup(uint32_t irq_config) {
+void neorv32_slink_setup(uint32_t rx_irq, uint32_t tx_irq) {
 
   NEORV32_SLINK->CTRL = 0; // reset and disable
 
-  uint32_t tmp = 0;
-  tmp |= (uint32_t)(1          & 0x01) << SLINK_CTRL_EN;
-  tmp |= (uint32_t)(irq_config & 0x00ff0000);
+  const uint32_t rx_irq_mask = (1 << SLINK_CTRL_IRQ_RX_NEMPTY) |
+                               (1 << SLINK_CTRL_IRQ_RX_HALF) |
+                               (1 << SLINK_CTRL_IRQ_RX_FULL);
+  const uint32_t tx_irq_mask = (1 << SLINK_CTRL_IRQ_TX_EMPTY) |
+                               (1 << SLINK_CTRL_IRQ_TX_NHALF) |
+                               (1 << SLINK_CTRL_IRQ_TX_NFULL);
+
+  uint32_t tmp = (uint32_t)(1 << SLINK_CTRL_EN);
+  tmp |= rx_irq & rx_irq_mask;
+  tmp |= tx_irq & tx_irq_mask;
 
   NEORV32_SLINK->CTRL = tmp;
 }

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -222,7 +222,8 @@
       <groupName>SLINK</groupName>
       <baseAddress>0xFFFFEC00</baseAddress>
 
-      <interrupt><name>SLINK_FIRQ</name><value>14</value></interrupt>
+      <interrupt><name>SLINK_RX_FIRQ</name><value>14</value></interrupt>
+      <interrupt><name>SLINK_TX_FIRQ</name><value>15</value></interrupt>
 
       <addressBlock>
         <offset>0</offset>
@@ -295,32 +296,32 @@
             <field>
               <name>SLINK_CTRL_IRQ_RX_NEMPTY</name>
               <bitRange>[16:16]</bitRange>
-              <description>IRQ if RX FIFO not empty</description>
+              <description>RX interrupt if RX FIFO not empty</description>
             </field>
             <field>
               <name>SLINK_CTRL_IRQ_RX_HALF</name>
               <bitRange>[17:17]</bitRange>
-              <description>IRQ if RX FIFO at least half full</description>
+              <description>RX interrupt if RX FIFO at least half full</description>
             </field>
             <field>
               <name>SLINK_CTRL_IRQ_RX_FULL</name>
               <bitRange>[18:18]</bitRange>
-              <description>IRQ if RX FIFO full</description>
+              <description>RX interrupt if RX FIFO full</description>
             </field>
             <field>
               <name>SLINK_CTRL_IRQ_TX_EMPTY</name>
               <bitRange>[19:19]</bitRange>
-              <description>IRQ if TX FIFO empty</description>
+              <description>TX interrupt if TX FIFO empty</description>
             </field>
             <field>
               <name>SLINK_CTRL_IRQ_TX_NHALF</name>
               <bitRange>[20:20]</bitRange>
-              <description>IRQ if TX FIFO not at least half full</description>
+              <description>TX interrupt if TX FIFO not at least half full</description>
             </field>
             <field>
               <name>SLINK_CTRL_IRQ_TX_NFULL</name>
               <bitRange>[21:21]</bitRange>
-              <description>IRQ if TX FIFO not full</description>
+              <description>TX interrupt if TX FIFO not full</description>
             </field>
             <field>
               <name>SLINK_CTRL_RX_FIFO</name>


### PR DESCRIPTION
Split the SLINK interrupt into two individual interrupts:
* FIRQ14: SLINK RX interrupt (was global SLINK interrupt)
* FIRQ15: SLINK TX interrupt (was unused)