### PR TITLE
B ISA extensions only contains Zba + Zbb + Zbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 04.04.2024 | 1.9.7.9 | RISC-V `B` ISA extension (bit-manipulation) only contains sub-extensions `Zba+Zbb+Zbs`; :warning: remove support for `Zbc` ISA extension | [#869](https://github.com/stnolting/neorv32/pull/869) |
 | 03.04.2024 | 1.9.7.8 | split SLINK interrupt into two individual FIRQs (SLINK RX and SLINK TX) | [#868](https://github.com/stnolting/neorv32/pull/868) |
 | 01.04.2024 | 1.9.7.7 | add back TWI clock stretching option | [#867](https://github.com/stnolting/neorv32/pull/867) |
 | 26.03.2024 | 1.9.7.6 | :warning: rework TWI module; add optional & configurable command/data FIFO | [#865](https://github.com/stnolting/neorv32/pull/865) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -525,7 +525,6 @@ The NEORV32 `B` ISA extension includes the following sub-extensions:
 
 * `Zba` - Address-generation instructions
 * `Zbb` - Basic bit-manipulation instructions
-* `Zbc` - Carry-less multiplication instructions
 * `Zbs` - Single-bit instructions
 
 .Instructions and Timing
@@ -533,16 +532,15 @@ The NEORV32 `B` ISA extension includes the following sub-extensions:
 [options="header", grid="rows"]
 |=======================
 | Class | Instructions | Execution cycles
-| Arithmetic/logic    | `min[u]` `max[u]` `sext.b` `sext.h` `andn` `orn` `xnor` `zext`(pack) `rev8`(grevi) `orc.b`(gorci) | 4
-| Shifts              | `clz` `ctz`                                                                                       | 3 + 1..32; FAST_SHIFT: 4
-| Shifts              | `cpop`                                                                                            | 36; FAST_SHIFT: 4
-| Shifts              | `rol` `ror[i]`                                                                                    | 4 + _shift_amount_; FAST_SHIFT: 4
-| Shifted-add         | `sh1add` `sh2add` `sh3add`                                                                        | 4
-| Single-bit          | `sbset[i]` `sbclr[i]` `sbinv[i]` `sbext[i]`                                                       | 4
-| Carry-less multiply | `clmul` `clmulh` `clmulr`                                                                         | 36
+| Arithmetic/logic | `min[u]` `max[u]` `sext.b` `sext.h` `andn` `orn` `xnor` `zext`(pack) `rev8`(grevi) `orc.b`(gorci) | 4
+| Shifts           | `clz` `ctz`                                                                                       | 3 + 1..32; FAST_SHIFT: 4
+| Shifts           | `cpop`                                                                                            | 36; FAST_SHIFT: 4
+| Shifts           | `rol` `ror[i]`                                                                                    | 4 + _shift_amount_; FAST_SHIFT: 4
+| Shifted-add      | `sh1add` `sh2add` `sh3add`                                                                        | 4
+| Single-bit       | `sbset[i]` `sbclr[i]` `sbinv[i]` `sbext[i]`                                                       | 4
 |=======================
 
-.Barrel Shifter
+.Shift Operations
 [TIP]
 Shift operations can be accelerated (at the cost of additional logic resources) by enabling the `FAST_SHIFT_EN`
 configuration option that will replace the (time-variant) bit-serial shifter by a (time-constant) barrel shifter.

--- a/docs/userguide/simulating_the_processor.adoc
+++ b/docs/userguide/simulating_the_processor.adoc
@@ -181,7 +181,6 @@ Using simulation run arguments: --stop-time=10ms <5>
 ../../rtl/core/neorv32_cpu.vhd:142:3:@0ms:(assertion note): [NEORV32] CPU ISA: rv32imabu_zicsr_zicntr_zicond_zifencei_zfinx_zihpm_zxcfu_sdext_sdtrig_smpmp
 ../../rtl/core/neorv32_cpu.vhd:163:3:@0ms:(assertion note): [NEORV32] CPU tuning options: fast_mul fast_shift
 ../../rtl/core/neorv32_cpu.vhd:170:3:@0ms:(assertion warning): [NEORV32] Assuming this is a simulation.
-../../rtl/core/neorv32_cpu_cp_bitmanip.vhd:172:3:@0ms:(assertion note): [NEORV32] Implementing bit-manipulation (B) sub-extensions Zba Zbb Zbc Zbs
 ../../rtl/core/neorv32_cpu_cp_fpu.vhd:292:3:@0ms:(assertion warning): [NEORV32] The floating-point unit (Zfinx) is still in experimental state.
 ../../rtl/core/mem/neorv32_imem.legacy.vhd:72:3:@0ms:(assertion note): [NEORV32] Implementing LEGACY processor-internal IMEM as pre-initialized ROM.
 ../../rtl/core/neorv32_wishbone.vhd:117:3:@0ms:(assertion note): [NEORV32] Ext. Bus Interface (WISHBONE) - PIPELINED Wishbone protocol, auto-timeout, LITTLE-endian byte order, registered RX, registered TX

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -728,7 +728,7 @@ begin
       end if;
       -- register-register operation --
       if ((execute_engine.ir(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0110000") and (execute_engine.ir(instr_funct3_msb_c-1 downto instr_funct3_lsb_c) = "01")) or -- ROR / ROL
-         ((execute_engine.ir(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0000101") and (execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) /= "000")) or -- MIN[U] / MAX[U] / CMUL[H/R]
+         ((execute_engine.ir(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0000101") and (execute_engine.ir(instr_funct3_msb_c) = '1')) or -- MIN[U] / MAX[U]
          ((execute_engine.ir(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0000100") and (execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = "100")) or -- ZEXTH
          ((execute_engine.ir(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0100100") and (execute_engine.ir(instr_funct3_msb_c-1 downto instr_funct3_lsb_c) = "01")) or -- BCLR / BEXT
          ((execute_engine.ir(instr_funct7_msb_c downto instr_funct7_lsb_c) = "0110100") and (execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = "001")) or -- BINV

--- a/rtl/core/neorv32_cpu_cp_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_cp_bitmanip.vhd
@@ -166,7 +166,7 @@ begin
   cmd(op_sextb_c)  <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "100") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
   cmd(op_sexth_c)  <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "101") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
   cmd(op_rol_c)    <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(02 downto 0) = "001") and (ctrl_i.ir_opcode(5) = '1') else '0';
-  cmd(op_ror_c)    <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(02 downto 0) = "101") and                                 (ctrl_i.ir_funct3(2) = '1') else '0';
+  cmd(op_ror_c)    <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(02 downto 0) = "101") and (ctrl_i.ir_funct3(2) = '1') else '0';
   cmd(op_rev8_c)   <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(02 downto 0) = "101") else '0';
 
   -- Zba - Address generation instructions --

--- a/rtl/core/neorv32_cpu_cp_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_cp_bitmanip.vhd
@@ -1,13 +1,12 @@
 -- #################################################################################################
 -- # << NEORV32 CPU - Co-Processor: Bit-Manipulation Co-Processor Unit (RISC-V "B" Extension) >>   #
 -- # ********************************************************************************************* #
--- # Supported B sub-extensions (Zb*):                                                             #
+-- # RISC-V "B" ISA Extension = Zba + Zbb + Zbs                                                    #
 -- # - Zba: Address-generation instructions                                                        #
 -- # - Zbb: Basic bit-manipulation instructions                                                    #
 -- # - Zbs: Single-bit instructions                                                                #
--- # - Zbc: Carry-less multiplication instructions                                                 #
 -- #                                                                                               #
--- # Processor/CPU configuration generic FAST_MUL_EN is also used to enable implementation of fast #
+-- # The CPU tuning option FAST_MUL_EN is also used to enable implementation of fast               #
 -- # (full-parallel) logic for all shift-related B-instructions (ROL, ROR[I], CLZ, CTZ, CPOP).     #
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
@@ -70,14 +69,6 @@ end neorv32_cpu_cp_bitmanip;
 
 architecture neorv32_cpu_cp_bitmanip_rtl of neorv32_cpu_cp_bitmanip is
 
-  -- Sub-extension configuration ----------------------------
-  -- Note that this configurations does NOT effect the CPU's (illegal) instruction decoding logic!
-  constant zbb_en_c : boolean := true;
-  constant zba_en_c : boolean := true;
-  constant zbc_en_c : boolean := true;
-  constant zbs_en_c : boolean := true;
-  -- --------------------------------------------------------
-
   -- Zbb - logic with negate --
   constant op_andn_c   : natural := 0;
   constant op_orn_c    : natural := 1;
@@ -110,15 +101,11 @@ architecture neorv32_cpu_cp_bitmanip_rtl of neorv32_cpu_cp_bitmanip is
   constant op_bext_c   : natural := 19;
   constant op_binv_c   : natural := 20;
   constant op_bset_c   : natural := 21;
-  -- Zbc - carry-less multiplication --
-  constant op_clmul_c  : natural := 22;
-  constant op_clmulh_c : natural := 23;
-  constant op_clmulr_c : natural := 24;
   --
-  constant op_width_c  : natural := 25;
+  constant op_width_c  : natural := 22;
 
   -- controller --
-  type ctrl_state_t is (S_IDLE, S_START_SHIFT, S_BUSY_SHIFT, S_START_CLMUL, S_BUSY_CLMUL);
+  type ctrl_state_t is (S_IDLE, S_START_SHIFT, S_BUSY_SHIFT);
   signal ctrl_state   : ctrl_state_t;
   signal cmd, cmd_buf : std_ulogic_vector(op_width_c-1 downto 0);
   signal valid        : std_ulogic;
@@ -155,70 +142,43 @@ architecture neorv32_cpu_cp_bitmanip_rtl of neorv32_cpu_cp_bitmanip is
   -- one-hot decoder --
   signal one_hot_core : std_ulogic_vector(XLEN-1 downto 0);
 
-  -- carry-less multiplier --
-  type clmultiplier_t is record
-    start : std_ulogic;
-    busy  : std_ulogic;
-    rs2   : std_ulogic_vector(XLEN-1 downto 0);
-    cnt   : std_ulogic_vector(index_size_f(XLEN) downto 0);
-    prod  : std_ulogic_vector(2*XLEN-1 downto 0);
-  end record;
-  signal clmul : clmultiplier_t;
-
 begin
-
-  -- Sub-Extension Configuration ------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  assert false report
-    "[NEORV32] Implementing bit-manipulation (B) sub-extensions " &
-    cond_sel_string_f(zba_en_c, "Zba ", "") &
-    cond_sel_string_f(zbb_en_c, "Zbb ", "") &
-    cond_sel_string_f(zbc_en_c, "Zbc ", "") &
-    cond_sel_string_f(zbs_en_c, "Zbs ", "") &
-    ""
-    severity note;
-
 
   -- Instruction Decoding (One-Hot) ---------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  -- A minimal decoding logic is used here just to distinguish between the different B instruction.
+  -- A "minimal" decoding logic is used here just to distinguish between the different B instructions.
   -- A more precise decoding as well as a valid-instruction-check is performed by the CPU control unit.
 
   -- Zbb - Basic bit-manipulation instructions --
-  cmd(op_andn_c)   <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(1 downto 0) = "11") else '0';
-  cmd(op_orn_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(1 downto 0) = "10") else '0';
-  cmd(op_xnor_c)   <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(1 downto 0) = "00") else '0';
+  cmd(op_andn_c)   <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(1 downto 0) = "11") else '0';
+  cmd(op_orn_c)    <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(1 downto 0) = "10") else '0';
+  cmd(op_xnor_c)   <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(1 downto 0) = "00") else '0';
   --
-  cmd(op_max_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '1') and (ctrl_i.ir_funct3(2 downto 1) = "11") else '0';
-  cmd(op_min_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '1') and (ctrl_i.ir_funct3(2 downto 1) = "10") else '0';
-  cmd(op_zexth_c)  <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '0') else '0';
+  cmd(op_max_c)    <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '1') and (ctrl_i.ir_funct3(2 downto 1) = "11") else '0';
+  cmd(op_min_c)    <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '1') and (ctrl_i.ir_funct3(2 downto 1) = "10") else '0';
+  cmd(op_zexth_c)  <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '0') else '0';
   --
-  cmd(op_orcb_c)   <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2 downto 0) = "101") else '0';
+  cmd(op_orcb_c)   <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2 downto 0) = "101") else '0';
   --
-  cmd(op_clz_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "000") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
-  cmd(op_ctz_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "001") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
-  cmd(op_cpop_c)   <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "010") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
-  cmd(op_sextb_c)  <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "100") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
-  cmd(op_sexth_c)  <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "101") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
-  cmd(op_rol_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(02 downto 0) = "001") and (ctrl_i.ir_opcode(5) = '1') else '0';
-  cmd(op_ror_c)    <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(02 downto 0) = "101") and                                 (ctrl_i.ir_funct3(2) = '1') else '0';
-  cmd(op_rev8_c)   <= '1' when (zbb_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(02 downto 0) = "101") else '0';
+  cmd(op_clz_c)    <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "000") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_ctz_c)    <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "001") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_cpop_c)   <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "010") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_sextb_c)  <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "100") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_sexth_c)  <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct12(2 downto 0) = "101") and (ctrl_i.ir_opcode(5) = '0') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_rol_c)    <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(02 downto 0) = "001") and (ctrl_i.ir_opcode(5) = '1') else '0';
+  cmd(op_ror_c)    <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(02 downto 0) = "101") and                                 (ctrl_i.ir_funct3(2) = '1') else '0';
+  cmd(op_rev8_c)   <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(02 downto 0) = "101") else '0';
 
   -- Zba - Address generation instructions --
-  cmd(op_sh1add_c) <= '1' when (zba_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(2 downto 1) = "01") else '0';
-  cmd(op_sh2add_c) <= '1' when (zba_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(2 downto 1) = "10") else '0';
-  cmd(op_sh3add_c) <= '1' when (zba_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(2 downto 1) = "11") else '0';
+  cmd(op_sh1add_c) <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(2 downto 1) = "01") else '0';
+  cmd(op_sh2add_c) <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(2 downto 1) = "10") else '0';
+  cmd(op_sh3add_c) <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '0') and (ctrl_i.ir_funct3(2 downto 1) = "11") else '0';
 
   -- Zbs - Single-bit instructions --
-  cmd(op_bclr_c)   <= '1' when (zbs_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2) = '0') else '0';
-  cmd(op_bext_c)   <= '1' when (zbs_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2) = '1') else '0';
-  cmd(op_binv_c)   <= '1' when (zbs_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2) = '0') else '0';
-  cmd(op_bset_c)   <= '1' when (zbs_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2) = '0') else '0';
-
-  -- Zbc - Carry-less multiplication instructions --
-  cmd(op_clmul_c)  <= '1' when (zbc_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '1') and (ctrl_i.ir_funct3(2 downto 0) = "001") else '0';
-  cmd(op_clmulh_c) <= '1' when (zbc_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '1') and (ctrl_i.ir_funct3(2 downto 0) = "011") else '0';
-  cmd(op_clmulr_c) <= '1' when (zbc_en_c = true) and (ctrl_i.ir_funct12(10 downto 9) = "00") and (ctrl_i.ir_funct12(5) = '1') and (ctrl_i.ir_funct3(2 downto 0) = "010") else '0';
+  cmd(op_bclr_c)   <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_bext_c)   <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "10") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2) = '1') else '0';
+  cmd(op_binv_c)   <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "11") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2) = '0') else '0';
+  cmd(op_bset_c)   <= '1' when (ctrl_i.ir_funct12(10 downto 9) = "01") and (ctrl_i.ir_funct12(7) = '1') and (ctrl_i.ir_funct3(2) = '0') else '0';
 
 
   -- Co-Processor Controller ----------------------------------------------------------------
@@ -232,13 +192,11 @@ begin
       rs2_reg       <= (others => '0');
       sha_reg       <= (others => '0');
       less_reg      <= '0';
-      clmul.start   <= '0';
       shifter.start <= '0';
       valid         <= '0';
     elsif rising_edge(clk_i) then
       -- defaults --
       shifter.start <= '0';
-      clmul.start   <= '0';
       valid         <= '0';
 
       -- operand registers --
@@ -259,9 +217,6 @@ begin
             if (FAST_SHIFT_EN = false) and ((cmd(op_clz_c) or cmd(op_ctz_c) or cmd(op_cpop_c) or cmd(op_ror_c) or cmd(op_rol_c)) = '1') then -- multi-cycle shift operation
               shifter.start <= '1';
               ctrl_state <= S_START_SHIFT;
-            elsif (zbc_en_c = true) and ((cmd(op_clmul_c) or cmd(op_clmulh_c) or cmd(op_clmulr_c)) = '1') then -- multi-cycle clmul operation
-              clmul.start <= '1';
-              ctrl_state  <= S_START_CLMUL;
             else
               valid      <= '1';
               ctrl_state <= S_IDLE;
@@ -275,17 +230,6 @@ begin
         when S_BUSY_SHIFT => -- wait for multi-cycle shift operation to finish
         -- ------------------------------------------------------------
           if (shifter.run = '0') or (ctrl_i.cpu_trap = '1') then -- abort on trap
-            valid      <= '1';
-            ctrl_state <= S_IDLE;
-          end if;
-
-        when S_START_CLMUL => -- one cycle delay to start clmul operation
-        -- ------------------------------------------------------------
-          ctrl_state <= S_BUSY_CLMUL;
-
-        when S_BUSY_CLMUL => -- wait for multi-cycle clmul operation to finish
-        -- ------------------------------------------------------------
-          if (clmul.busy = '0') or (ctrl_i.cpu_trap = '1') then -- abort on trap
             valid      <= '1';
             ctrl_state <= S_IDLE;
           end if;
@@ -422,42 +366,6 @@ begin
   end process shift_one_hot;
 
 
-  -- Carry-Less Multiplication Core ---------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  clmul_core: process(rstn_i, clk_i)
-  begin
-    if (rstn_i = '0') then
-      clmul.cnt  <= (others => '0');
-      clmul.prod <= (others => '0');
-    elsif rising_edge(clk_i) then
-      if (clmul.start = '1') then -- start new multiplication
-        clmul.cnt                 <= (others => '0');
-        clmul.cnt(clmul.cnt'left) <= '1';
-        clmul.prod(63 downto 32)  <= (others => '0');
-        if (cmd_buf(op_clmulr_c) = '1') then -- reverse input operands?
-          clmul.prod(31 downto 00) <= bit_rev_f(rs1_reg);
-        else
-          clmul.prod(31 downto 00) <= rs1_reg;
-        end if;
-      elsif (clmul.busy = '1') then -- processing
-        clmul.cnt <= std_ulogic_vector(unsigned(clmul.cnt) - 1);
-        if (clmul.prod(0) = '1') then
-          clmul.prod(62 downto 31) <= clmul.prod(63 downto 32) xor clmul.rs2;
-        else
-          clmul.prod(62 downto 31) <= clmul.prod(63 downto 32);
-        end if;
-        clmul.prod(30 downto 00) <= clmul.prod(31 downto 1);
-      end if;
-    end if;
-  end process clmul_core;
-
-  -- reverse input operands? --
-  clmul.rs2 <= bit_rev_f(rs2_reg) when (cmd_buf(op_clmulr_c) = '1') else rs2_reg;
-
-  -- multiplier busy? --
-  clmul.busy <= '1' when (or_reduce_f(clmul.cnt) = '1') else '0';
-
-
   -- Operation Results ----------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   -- logic with negate --
@@ -479,12 +387,12 @@ begin
   res_int(op_max_c) <= (others => '0'); -- unused/redundant
 
   -- sign-extension --
-  res_int(op_sextb_c)(XLEN-1 downto 8) <= (others => rs1_reg(7));
-  res_int(op_sextb_c)(7 downto 0) <= rs1_reg(7 downto 0); -- sign-extend byte
+  res_int(op_sextb_c)(XLEN-1 downto 8)  <= (others => rs1_reg(7));
+  res_int(op_sextb_c)(7 downto 0)       <= rs1_reg(7 downto 0); -- sign-extend byte
   res_int(op_sexth_c)(XLEN-1 downto 16) <= (others => rs1_reg(15));
-  res_int(op_sexth_c)(15 downto 0) <= rs1_reg(15 downto 0); -- sign-extend half-word
+  res_int(op_sexth_c)(15 downto 0)      <= rs1_reg(15 downto 0); -- sign-extend half-word
   res_int(op_zexth_c)(XLEN-1 downto 16) <= (others => '0');
-  res_int(op_zexth_c)(15 downto 0) <= rs1_reg(15 downto 0); -- zero-extend half-word
+  res_int(op_zexth_c)(15 downto 0)      <= rs1_reg(15 downto 0); -- zero-extend half-word
 
   -- rotate right/left --
   res_int(op_ror_c) <= shifter.sreg;
@@ -511,11 +419,6 @@ begin
   res_int(op_binv_c) <= rs1_reg xor one_hot_core;
   res_int(op_bset_c) <= rs1_reg or one_hot_core;
 
-  -- carry-less multiplication instructions --
-  res_int(op_clmul_c)  <= clmul.prod(31 downto 00);
-  res_int(op_clmulh_c) <= clmul.prod(63 downto 32);
-  res_int(op_clmulr_c) <= bit_rev_f(clmul.prod(31 downto 00));
-
 
   -- Output Selector ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -535,7 +438,7 @@ begin
   res_out(op_orcb_c)  <= res_int(op_orcb_c)  when (cmd_buf(op_orcb_c)  = '1') else (others => '0');
   res_out(op_rev8_c)  <= res_int(op_rev8_c)  when (cmd_buf(op_rev8_c)  = '1') else (others => '0');
   --
-  res_out(op_sh1add_c) <= res_int(op_sh1add_c) when ((cmd_buf(op_sh1add_c) or cmd_buf(op_sh2add_c) or cmd_buf(op_sh3add_c))  = '1') else (others => '0');
+  res_out(op_sh1add_c) <= res_int(op_sh1add_c) when ((cmd_buf(op_sh1add_c) or cmd_buf(op_sh2add_c) or cmd_buf(op_sh3add_c)) = '1') else (others => '0');
   res_out(op_sh2add_c) <= (others => '0'); -- unused/redundant
   res_out(op_sh3add_c) <= (others => '0'); -- unused/redundant
   --
@@ -543,10 +446,6 @@ begin
   res_out(op_bext_c) <= res_int(op_bext_c) when (cmd_buf(op_bext_c) = '1') else (others => '0');
   res_out(op_binv_c) <= res_int(op_binv_c) when (cmd_buf(op_binv_c) = '1') else (others => '0');
   res_out(op_bset_c) <= res_int(op_bset_c) when (cmd_buf(op_bset_c) = '1') else (others => '0');
-  --
-  res_out(op_clmul_c)  <= res_int(op_clmul_c)  when (cmd_buf(op_clmul_c)  = '1') else (others => '0');
-  res_out(op_clmulh_c) <= res_int(op_clmulh_c) when (cmd_buf(op_clmulh_c) = '1') else (others => '0');
-  res_out(op_clmulr_c) <= res_int(op_clmulr_c) when (cmd_buf(op_clmulr_c) = '1') else (others => '0');
 
 
   -- Output Gate ----------------------------------------------------------------------------
@@ -558,15 +457,14 @@ begin
     elsif rising_edge(clk_i) then
       res_o <= (others => '0'); -- default
       if (valid = '1') then
-        res_o <= res_out(op_andn_c)   or res_out(op_orn_c)    or res_out(op_xnor_c)  or
-                 res_out(op_clz_c)    or res_out(op_cpop_c)   or -- res_out(op_ctz_c) is unused here
+        res_o <= res_out(op_andn_c)   or res_out(op_orn_c)   or res_out(op_xnor_c)  or
+                 res_out(op_clz_c)    or res_out(op_cpop_c)  or -- res_out(op_ctz_c) is unused here
                  res_out(op_min_c)    or -- res_out(op_max_c) is unused here
-                 res_out(op_sextb_c)  or res_out(op_sexth_c)  or res_out(op_zexth_c) or
-                 res_out(op_ror_c)    or res_out(op_rol_c)    or
-                 res_out(op_orcb_c)   or res_out(op_rev8_c)   or
+                 res_out(op_sextb_c)  or res_out(op_sexth_c) or res_out(op_zexth_c) or
+                 res_out(op_ror_c)    or res_out(op_rol_c)   or
+                 res_out(op_orcb_c)   or res_out(op_rev8_c)  or
                  res_out(op_sh1add_c) or -- res_out(op_sh2add_c) and res_out(op_sh3add_c) are unused here
-                 res_out(op_bclr_c)   or res_out(op_bext_c)   or res_out(op_binv_c)  or res_out(op_bset_c) or
-                 res_out(op_clmul_c)  or res_out(op_clmulh_c) or res_out(op_clmulr_c);
+                 res_out(op_bclr_c)   or res_out(op_bext_c)  or res_out(op_binv_c)  or res_out(op_bset_c);
       end if;
     end if;
   end process output_gate;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -52,7 +52,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090708"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090709"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/sw/example/processor_check/run_check.sh
+++ b/sw/example/processor_check/run_check.sh
@@ -3,4 +3,4 @@
 set -e
 
 echo "Starting processor check simulation..."
-make USER_FLAGS+="-DUART0_SIM_MODE -DUART1_SIM_MODE -g -flto" EFFORT=-Os MARCH=rv32ima_zba_zbb_zbc_zbs_zicsr_zifencei_zicond clean_all all sim-check
+make USER_FLAGS+="-DUART0_SIM_MODE -DUART1_SIM_MODE -g -flto" EFFORT=-Os MARCH=rv32ima_zba_zbb_zbs_zicsr_zifencei_zicond clean_all all sim-check


### PR DESCRIPTION
Finally, the RISC-V `B` ISA extension (bit manipulation) has been frozen and is about to be ratified.

Now, `B` only contains the `Zba`, `Zbb` and `Zbs` sub-extensions but **not** the `Zbc` sub-extension (carry-less multiplication). Find more information at https://jira.riscv.org/browse/RVS-2006?src=confmacro.

⚠️ Hence, this PR removes `Zbc` support from the CPU (for now).