### PR TITLE
add additional SPI and SDI interrupt conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 04.04.2024 | 1.9.7.10 | extend SPI and SDI interrupt conditions | [#870](https://github.com/stnolting/neorv32/pull/870) |
 | 04.04.2024 | 1.9.7.9 | RISC-V `B` ISA extension (bit-manipulation) only contains sub-extensions `Zba+Zbb+Zbs`; :warning: remove support for `Zbc` ISA extension | [#869](https://github.com/stnolting/neorv32/pull/869) |
 | 03.04.2024 | 1.9.7.8 | split SLINK interrupt into two individual FIRQs (SLINK RX and SLINK TX) | [#868](https://github.com/stnolting/neorv32/pull/868) |
 | 01.04.2024 | 1.9.7.7 | add back TWI clock stretching option | [#867](https://github.com/stnolting/neorv32/pull/867) |

--- a/docs/datasheet/soc_sdi.adoc
+++ b/docs/datasheet/soc_sdi.adoc
@@ -5,16 +5,16 @@
 [cols="<3,<3,<4"]
 [frame="topbot",grid="none"]
 |=======================
-| Hardware source file(s): | neorv32_sdi.vhd |
-| Software driver file(s): | neorv32_sdi.c |
-|                          | neorv32_sdi.h |
-| Top entity port:         | `sdi_clk_i` | 1-bit serial clock input
-|                          | `sdi_dat_o` | 1-bit serial data output
-|                          | `sdi_dat_i` | 1-bit serial data input
-|                          | `sdi_csn_i` | 1-bit chip-select input (low-active)
-| Configuration generics:  | `IO_SDI_EN`   | implement SDI controller when `true`
-|                          | `IO_SDI_FIFO` | data FIFO size, has to a power of two, min 1
-| CPU interrupts:          | fast IRQ channel 11 | configurable SDI interrupt (see <<_processor_interrupts>>)
+| Hardware source files:  | neorv32_sdi.vhd |
+| Software driver files:  | neorv32_sdi.c |
+|                         | neorv32_sdi.h |
+| Top entity ports:       | `sdi_clk_i` | 1-bit serial clock input
+|                         | `sdi_dat_o` | 1-bit serial data output
+|                         | `sdi_dat_i` | 1-bit serial data input
+|                         | `sdi_csn_i` | 1-bit chip-select input (low-active)
+| Configuration generics: | `IO_SDI_EN`   | implement SDI controller when `true`
+|                         | `IO_SDI_FIFO` | data FIFO size, has to a power of two, min 1
+| CPU interrupts:         | fast IRQ channel 11 | configurable SDI interrupt (see <<_processor_interrupts>>)
 |=======================
 
 
@@ -45,6 +45,9 @@ data can be retrieved by reading the RX FIFO via the `DATA` register. The curren
 via the control register's `SDI_CTRL_RX_*` and `SDI_CTRL_TX_*` flags. The RX FIFO can be manually cleared at any time
 by setting the `SDI_CTRL_CLR_RX` bit.
 
+If no data is available in the TX FIFO while an external device performs a transmission the external device will
+read all-zero from the SDI controller.
+
 .MSB-first Only
 [NOTE]
 The NEORV32 SDI module only supports MSB-first mode.
@@ -66,7 +69,7 @@ clock domain to simplify timing behavior. However, the clock synchronization req
 **SDI Interrupt**
 
 The SDI module provides a set of programmable interrupt conditions based on the level of the RX & TX FIFOs. The different
-interrupt sources are enabled by setting the according control register's `SDI_CTRL_IRQ` bits. All enabled interrupt
+interrupt sources are enabled by setting the according control register's `SDI_CTRL_IRQ_*` bits. All enabled interrupt
 conditions are logically OR-ed so any enabled interrupt source will trigger the module's interrupt signal.
 
 Once the SDI interrupt has fired it will remain active until the actual cause of the interrupt is resolved; for
@@ -80,7 +83,7 @@ example if just the `SDI_CTRL_IRQ_RX_AVAIL` bit is set, the interrupt will keep 
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.16+<| `0xfffff700` .16+<| `CTRL` <|`0`     `SDI_CTRL_EN`                           ^| r/w <| SDI module enable
+.18+<| `0xfffff700` .18+<| `CTRL` <|`0`     `SDI_CTRL_EN`                           ^| r/w <| SDI module enable
                                   <|`1`     `SDI_CTRL_CLR_RX`                       ^| -/w <| clear RX FIFO when set, bit auto-clears
                                   <|`3:2`   _reserved_                              ^| r/- <| reserved, read as zero
                                   <|`7:4`   `SDI_CTRL_FIFO_MSB : SDI_CTRL_FIFO_LSB` ^| r/- <| FIFO depth; log2(_IO_SDI_FIFO_)
@@ -89,12 +92,14 @@ example if just the `SDI_CTRL_IRQ_RX_AVAIL` bit is set, the interrupt will keep 
                                   <|`16`    `SDI_CTRL_IRQ_RX_HALF`                  ^| r/w <| fire interrupt if RX FIFO is at least half full
                                   <|`17`    `SDI_CTRL_IRQ_RX_FULL`                  ^| r/w <| fire interrupt if if RX FIFO is full
                                   <|`18`    `SDI_CTRL_IRQ_TX_EMPTY`                 ^| r/w <| fire interrupt if TX FIFO is empty
-                                  <|`22:19` _reserved_                              ^| r/- <| reserved, read as zero
+                                  <|`19`    `SDI_CTRL_IRQ_TX_NHALF`                 ^| r/w <| fire interrupt if TX FIFO is not at least half full
+                                  <|`22:20` _reserved_                              ^| r/- <| reserved, read as zero
                                   <|`23`    `SDI_CTRL_RX_AVAIL`                     ^| r/- <| RX FIFO data available (RX FIFO not empty)
                                   <|`24`    `SDI_CTRL_RX_HALF`                      ^| r/- <| RX FIFO at least half full
                                   <|`25`    `SDI_CTRL_RX_FULL`                      ^| r/- <| RX FIFO full
                                   <|`26`    `SDI_CTRL_TX_EMPTY`                     ^| r/- <| TX FIFO empty
-                                  <|`27`    `SDI_CTRL_TX_FULL`                      ^| r/- <| TX FIFO full
-                                  <|`31:28` _reserved_                              ^| r/- <| reserved, read as zero
+                                  <|`27`    `SDI_CTRL_TX_NHALF`                     ^| r/- <| TX FIFO not at least half full
+                                  <|`28`    `SDI_CTRL_TX_FULL`                      ^| r/- <| TX FIFO full
+                                  <|`31:29` _reserved_                              ^| r/- <| reserved, read as zero
 | `0xfffff704` | `DATA` |`7:0` | r/w | receive/transmit data (FIFO)
 |=======================

--- a/docs/datasheet/soc_spi.adoc
+++ b/docs/datasheet/soc_spi.adoc
@@ -5,16 +5,16 @@
 [cols="<3,<3,<4"]
 [frame="topbot",grid="none"]
 |=======================
-| Hardware source file(s): | neorv32_spi.vhd |
-| Software driver file(s): | neorv32_spi.c |
-|                          | neorv32_spi.h |
-| Top entity port:         | `spi_clk_o` | 1-bit serial clock output
-|                          | `spi_dat_o` | 1-bit serial data output
-|                          | `spi_dat_i` | 1-bit serial data input
-|                          | `spi_csn_o` | 8-bit dedicated chip select output (low-active)
-| Configuration generics:  | `IO_SPI_EN`   | implement SPI controller when `true`
-|                          | `IO_SPI_FIFO` | FIFO depth, has to be a power of two, min 1
-| CPU interrupts:          | fast IRQ channel 6 | configurable SPI interrupt (see <<_processor_interrupts>>)
+| Hardware source files:  | neorv32_spi.vhd |
+| Software driver files:  | neorv32_spi.c |
+|                         | neorv32_spi.h |
+| Top entity ports:       | `spi_clk_o` | 1-bit serial clock output
+|                         | `spi_dat_o` | 1-bit serial data output
+|                         | `spi_dat_i` | 1-bit serial data input
+|                         | `spi_csn_o` | 8-bit dedicated chip select output (low-active)
+| Configuration generics: | `IO_SPI_EN`   | implement SPI controller when `true`
+|                         | `IO_SPI_FIFO` | FIFO depth, has to be a power of two, min 1
+| CPU interrupts:         | fast IRQ channel 6 | configurable SPI interrupt (see <<_processor_interrupts>>)
 |=======================
 
 
@@ -114,7 +114,7 @@ example if just the `SPI_CTRL_IRQ_RX_AVAIL` bit is set, the interrupt will keep 
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.19+<| `0xfffff800` .19+<| `CTRL` <|`0`     `SPI_CTRL_EN`                           ^| r/w <| SPI module enable
+.20+<| `0xfffff800` .20+<| `CTRL` <|`0`     `SPI_CTRL_EN`                           ^| r/w <| SPI module enable
                                   <|`1`     `SPI_CTRL_CPHA`                         ^| r/w <| clock phase
                                   <|`2`     `SPI_CTRL_CPOL`                         ^| r/w <| clock polarity
                                   <|`5:3`   `SPI_CTRL_CS_SEL2 : SPI_CTRL_CS_SEL0`   ^| r/w <| Direct chip-select 0..7
@@ -130,8 +130,9 @@ example if just the `SPI_CTRL_IRQ_RX_AVAIL` bit is set, the interrupt will keep 
                                   <|`20`    `SPI_CTRL_IRQ_RX_AVAIL`                 ^| r/w <| Trigger IRQ if RX FIFO not empty
                                   <|`21`    `SPI_CTRL_IRQ_TX_EMPTY`                 ^| r/w <| Trigger IRQ if TX FIFO empty
                                   <|`22`    `SPI_CTRL_IRQ_TX_NHALF`                 ^| r/w <| Trigger IRQ if TX FIFO _not_ at least half full
-                                  <|`26:23` `SPI_CTRL_FIFO_MSB : SPI_CTRL_FIFO_LSB` ^| r/- <| FIFO depth; log2(_IO_SPI_FIFO_)
-                                  <|`30:27` _reserved_                              ^| r/- <| reserved, read as zero
+                                  <|`23`    `SPI_CTRL_IRQ_IDLE`                     ^| r/w <| Trigger IRQ if TX FIFO is empty and SPI bus engine is idle
+                                  <|`27:24` `SPI_CTRL_FIFO_MSB : SPI_CTRL_FIFO_LSB` ^| r/- <| FIFO depth; log2(_IO_SPI_FIFO_)
+                                  <|`30:28` _reserved_                              ^| r/- <| reserved, read as zero
                                   <|`31`    `SPI_CTRL_BUSY`                         ^| r/- <| SPI module busy when set (serial engine operation in progress and TX FIFO not empty yet)
 | `0xfffff804` | `DATA` |`7:0` | r/w | receive/transmit data (FIFO)
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -52,7 +52,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090709"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090710"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1240,17 +1240,17 @@ int main() {
     cnt_test++;
 
     // configure SPI
-    neorv32_spi_setup(CLK_PRSC_8, 0, 0, 0, 1<<SPI_CTRL_IRQ_RX_AVAIL); // IRQ when RX FIFO is not empty
+    neorv32_spi_setup(CLK_PRSC_8, 0, 0, 0, 1<<SPI_CTRL_IRQ_IDLE); // IRQ when TX FIFO is empty and SPI bus engine is idle
+
+    // trigger SPI transmissions
+    neorv32_spi_put_nonblocking(0xab); // non-blocking
+    neorv32_spi_put_nonblocking(0xcd); // non-blocking
 
     // enable fast interrupt
     neorv32_cpu_csr_write(CSR_MIE, 1 << SPI_FIRQ_ENABLE);
 
-    // trigger SPI IRQ
-    neorv32_spi_trans(0); // blocking
-
     // wait for interrupt
-    asm volatile ("nop");
-    asm volatile ("nop");
+    asm volatile ("wfi");
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 

--- a/sw/lib/include/neorv32_sdi.h
+++ b/sw/lib/include/neorv32_sdi.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -68,12 +68,14 @@ enum NEORV32_SDI_CTRL_enum {
   SDI_CTRL_IRQ_RX_HALF  = 16, /**< SDI control register(16) (r/w): IRQ when RX FIFO at least half full */
   SDI_CTRL_IRQ_RX_FULL  = 17, /**< SDI control register(17) (r/w): IRQ when RX FIFO full */
   SDI_CTRL_IRQ_TX_EMPTY = 18, /**< SDI control register(18) (r/w): IRQ when TX FIFO empty */
+  SDI_CTRL_IRQ_TX_NHALF = 19, /**< SDI control register(19) (r/w): IRQ when TX FIFO not at least half full */
 
   SDI_CTRL_RX_AVAIL     = 23, /**< SDI control register(23) (r/-): RX FIFO not empty */
   SDI_CTRL_RX_HALF      = 24, /**< SDI control register(24) (r/-): RX FIFO at least half full */
   SDI_CTRL_RX_FULL      = 25, /**< SDI control register(25) (r/-): RX FIFO full */
   SDI_CTRL_TX_EMPTY     = 26, /**< SDI control register(26) (r/-): TX FIFO empty */
-  SDI_CTRL_TX_FULL      = 27  /**< SDI control register(27) (r/-): TX FIFO full */
+  SDI_CTRL_TX_NHALF     = 27, /**< SDI control register(27) (r/-): TX FIFO not at least half full */
+  SDI_CTRL_TX_FULL      = 28  /**< SDI control register(28) (r/-): TX FIFO full */
 };
 /**@}*/
 

--- a/sw/lib/include/neorv32_spi.h
+++ b/sw/lib/include/neorv32_spi.h
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -82,9 +82,10 @@ enum NEORV32_SPI_CTRL_enum {
   SPI_CTRL_IRQ_RX_AVAIL = 20, /**< SPI control register(20) (r/w): Fire IRQ if RX FIFO data available (RX FIFO not empty) */
   SPI_CTRL_IRQ_TX_EMPTY = 21, /**< SPI control register(21) (r/w): Fire IRQ if TX FIFO empty */
   SPI_CTRL_IRQ_TX_HALF  = 22, /**< SPI control register(22) (r/w): Fire IRQ if TX FIFO not at least half full */
+  SPI_CTRL_IRQ_IDLE     = 23, /**< SPI control register(23) (r/w): Fire IRQ if TX FIFO is empty and SPI bus engine is idle */
 
-  SPI_CTRL_FIFO_LSB     = 23, /**< SPI control register(23) (r/-): log2(FIFO size), lsb */
-  SPI_CTRL_FIFO_MSB     = 26, /**< SPI control register(26) (r/-): log2(FIFO size), msb */
+  SPI_CTRL_FIFO_LSB     = 24, /**< SPI control register(24) (r/-): log2(FIFO size), lsb */
+  SPI_CTRL_FIFO_MSB     = 27, /**< SPI control register(27) (r/-): log2(FIFO size), msb */
 
   SPI_CTRL_BUSY         = 31  /**< SPI control register(31) (r/-): SPI busy flag */
 };

--- a/sw/lib/source/neorv32_sdi.c
+++ b/sw/lib/source/neorv32_sdi.c
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -72,7 +72,7 @@ void neorv32_sdi_setup(uint32_t irq_mask) {
 
   uint32_t tmp = 0;
   tmp |= (uint32_t)(1 & 0x01) << SDI_CTRL_EN;
-  tmp |= (uint32_t)(irq_mask & (0x0f << SDI_CTRL_IRQ_RX_AVAIL));
+  tmp |= (uint32_t)(irq_mask & (0x1f << SDI_CTRL_IRQ_RX_AVAIL));
 
   NEORV32_SDI->CTRL = tmp;
 }

--- a/sw/lib/source/neorv32_spi.c
+++ b/sw/lib/source/neorv32_spi.c
@@ -3,7 +3,7 @@
 // # ********************************************************************************************* #
 // # BSD 3-Clause License                                                                          #
 // #                                                                                               #
-// # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+// # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
 // #                                                                                               #
 // # Redistribution and use in source and binary forms, with or without modification, are          #
 // # permitted provided that the following conditions are met:                                     #
@@ -79,7 +79,7 @@ void neorv32_spi_setup(int prsc, int cdiv, int clk_phase, int clk_polarity, uint
   tmp |= (uint32_t)(clk_polarity & 0x01) << SPI_CTRL_CPOL;
   tmp |= (uint32_t)(prsc         & 0x07) << SPI_CTRL_PRSC0;
   tmp |= (uint32_t)(cdiv         & 0x0f) << SPI_CTRL_CDIV0;
-  tmp |= (uint32_t)(irq_mask     & (0x07 << SPI_CTRL_IRQ_RX_AVAIL));
+  tmp |= (uint32_t)(irq_mask     & (0x0f << SPI_CTRL_IRQ_RX_AVAIL));
 
   NEORV32_SPI->CTRL = tmp;
 }
@@ -197,7 +197,7 @@ void neorv32_spi_cs_dis(void) {
 uint8_t neorv32_spi_trans(uint8_t tx_data) {
 
   NEORV32_SPI->DATA = (uint32_t)tx_data; // trigger transfer
-  while((NEORV32_SPI->CTRL & (1<<SPI_CTRL_BUSY)) != 0); // wait for current transfer to finish
+  while (neorv32_spi_busy()); // wait for current transfer to finish
 
   return (uint8_t)NEORV32_SPI->DATA;
 }
@@ -210,7 +210,7 @@ uint8_t neorv32_spi_trans(uint8_t tx_data) {
  **************************************************************************/
 void neorv32_spi_put_nonblocking(uint8_t tx_data) {
 
-  NEORV32_SPI->DATA = (uint32_t)tx_data; // trigger transfer
+  NEORV32_SPI->DATA = (uint32_t)tx_data; // put transfer into TX FIFO
 }
 
 
@@ -226,7 +226,7 @@ uint8_t neorv32_spi_get_nonblocking(void) {
 
 
 /**********************************************************************//**
- * Check if SPI transceiver is busy.
+ * Check if SPI transceiver is busy or TX FIFO not empty.
  *
  * @return 0 if idle, 1 if busy
  **************************************************************************/

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -175,6 +175,11 @@
               <description>Fire interrupt if TX FIFO is empty</description>
             </field>
             <field>
+              <name>SDI_CTRL_IRQ_TX_NHALF</name>
+              <bitRange>[19:19]</bitRange>
+              <description>Fire interrupt if TX FIFO is not at least half full</description>
+            </field>
+            <field>
               <name>SDI_CTRL_RX_AVAIL</name>
               <bitRange>[23:23]</bitRange>
               <access>read-only</access>
@@ -199,8 +204,14 @@
               <description>TX FIFO empty</description>
             </field>
             <field>
-              <name>SDI_CTRL_TX_FULL</name>
+              <name>SDI_CTRL_TX_NHALF</name>
               <bitRange>[27:27]</bitRange>
+              <access>read-only</access>
+              <description>TX FIFO not at least half full</description>
+            </field>
+            <field>
+              <name>SDI_CTRL_TX_FULL</name>
+              <bitRange>[28:28]</bitRange>
               <access>read-only</access>
               <description>TX FIFO full</description>
             </field>
@@ -1157,8 +1168,13 @@
               <description>Fire interrupt if TX FIFO is not at least half full</description>
             </field>
             <field>
+              <name>SPI_CTRL_IRQ_IDLE</name>
+              <bitRange>[23:23]</bitRange>
+              <description>Fire interrupt if TX FIFO is empty and SPI bus engine is idle</description>
+            </field>
+            <field>
               <name>SPI_CTRL_FIFO</name>
-              <bitRange>[26:23]</bitRange>
+              <bitRange>[27:24]</bitRange>
               <access>read-only</access>
               <description>log2(FIFO size)</description>
             </field>


### PR DESCRIPTION
## SPI

* add "SPI idle" interrupt condition (fire interrupt if TX FIFO is empty and SPI bus engine is idle)

## SDI

* add "TX FIFO not at least half full" interrupt condition
* add "TX FIFO not at least half full" status flag

> [!NOTE]
> This PR is part of a series that aims to _unify_ (and simplify) the entire interrupt system of the processor.