### PR TITLE
:warning: rename SLINK data interface registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Link |
 |:----:|:-------:|:--------|:----:|
+| 14.04.2024 | 1.9.8.2 | :warning: rename SLINK data interface registers; minor CPU control logic/area optimizations | [#874](https://github.com/stnolting/neorv32/pull/874) |
 | 13.04.2024 | 1.9.8.1 | minor rtl code cleanups and optimizations | [#872](https://github.com/stnolting/neorv32/pull/872) |
 | 04.04.2024 | [**:rocket:1.9.8**](https://github.com/stnolting/neorv32/releases/tag/v1.9.8) | **New release** | |
 | 04.04.2024 | 1.9.7.10 | extend SPI and SDI interrupt conditions | [#870](https://github.com/stnolting/neorv32/pull/870) |

--- a/docs/datasheet/soc_slink.adoc
+++ b/docs/datasheet/soc_slink.adoc
@@ -54,14 +54,14 @@ The interface names and the underlying protocol is compatible to the AXI4-Stream
 **Theory of Operation**
 
 The SLINK provides four interface registers. The control register (`CTRL`) is used to configure
-the module and to check its status. Three individual data registers (`RX_DATA`, `TX_DATA`, `TX_DATA_LAST`)
+the module and to check its status. Two individual data registers (`DATA` and `DATA_LAST`)
 are used to send and receive the link's actual data stream.
 
-The `RX_DATA` register provides direct access to the RX link FIFO buffer. After reading data from this register
-the control register's `SLINK_CTRL_RX_LAST` flag can be checked to determine if the according data word has been marked
-as "end of stream" via the `slink_rx_lst_i` signal (this signal is also buffered by the link's FIFO).
-
-Writing to the `TX_DATA` or `TX_DATA_LAST` register will immediately write to the TX link FIFO buffer.
+The `DATA` register provides direct access to the RX/TX FIFO buffers. Read accesses return data from the RX FIFO.
+After reading data from this register the control register's `SLINK_CTRL_RX_LAST` flag can be checked to determine
+if the according data word has been marked as "end of stream" via the `slink_rx_lst_i` signal (this signal is also
+buffered by the link's FIFO).
+Writing to the `DATA` register will immediately write to the TX link FIFO.
 When writing to the `TX_DATA_LAST` the according data word will also be marked as "end of stream" via the
 `slink_tx_lst_o` signal (this signal is also buffered by the link's FIFO).
 
@@ -121,7 +121,7 @@ interrupt-causing condition is resolved (e.g. by reading from the RX FIFO).
                                                 <| `23:22` _reserved_                                        ^| r/- <| _reserved_, read as zero
                                                 <| `27:24` `SLINK_CTRL_RX_FIFO_MSB : SLINK_CTRL_RX_FIFO_LSB` ^| r/- <| log2(RX FIFO size)
                                                 <| `31:28` `SLINK_CTRL_TX_FIFO_MSB : SLINK_CTRL_TX_FIFO_LSB` ^| r/- <| log2(TX FIFO size)
-| `0xffffec04` | `NEORV32_SLINK.RX_DATA`      | `31:0` | r/- | Read word from RX link FIFO
-| `0xffffec08` | `NEORV32_SLINK.TX_DATA`      | `31:0` | -/w | Write word to TX link FIFO
-| `0xffffec0c` | `NEORV32_SLINK.TX_DATA_LAST` | `31:0` | -/w | Write word to TX link FIFO and also set "end-of-stream" delimiter
+| `0xffffec04` | -                         | `31:0` | -/- | _reserved_
+| `0xffffec08` | `NEORV32_SLINK.DATA`      | `31:0` | r/w | Write data to TX FIFO; read data from RX FIFO
+| `0xffffec0c` | `NEORV32_SLINK.DATA_LAST` | `31:0` | r/w | Write data to TX FIFO (and also set "last" signal); read data from RX FIFO
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090801"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090802"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/system_integration/neorv32_litex_core_complex.vhd
+++ b/rtl/system_integration/neorv32_litex_core_complex.vhd
@@ -1,70 +1,31 @@
--- #################################################################################################
--- # << The NEORV32 RISC-V Processor - LiteX NEORV32 Core Complex Wrapper >>                       #
--- # ********************************************************************************************* #
--- #                                      __   _ __      _  __                                     #
--- #                                     / /  (_) /____ | |/_/                                     #
--- #                                    / /__/ / __/ -_)>  <                                       #
--- #                                   /____/_/\__/\__/_/|_|                                       #
--- #                                 Build your hardware, easily!                                  #
--- #                                                                                               #
--- # Unless otherwise noted, LiteX is copyright (C) 2012-2022 Enjoy-Digital. All rights reserved.  #
--- # LiteX HQ: https://github.com/enjoy-digital/litex                                              #
--- #                                                                                               #
--- # ********************************************************************************************* #
--- # NEORV32 Core Complex wrapper for the LiteX SoC builder framework.                             #
--- # https://github.com/enjoy-digital/litex/tree/master/litex/soc/cores/cpu/neorv32                #
--- #                                                                                               #
--- # This wrapper provides four pre-configured core complex configurations: "minimal", "lite",     #
--- # "standard" and "full". See the 'configs_c' table for more details which RISC-V ISA extensions #
--- # and module parameters are used by each of the these configurations. All configurations can be #
--- # used with the RISC-V-compatible on-chip debugger ("DEBUG").                                   #
--- #                                                                                               #
--- # === Bus Interface ===                                                                         #
--- # This wrappers uses the "pipelined" Wishbone b4 protocol for the bus interface. See the        #
--- # "global configuration" constants for further bus configuration parameters (endianness,        #
--- # timeout, etc.).                                                                               #
--- #                                                                                               #
--- # === Interrupt ====                                                                            #
--- # The external interrupt signal is delegated to the CPU as RISC-V "machine external interrupt   #
--- # (MTI)". Note that this IRQ signal is high-active - once set the signal has to stay high until #
--- # the interrupt request is explicitly acknowledged (e.g. writing to a memory-mapped register)!  #
--- #                                                                                               #
--- # === Core Complex Address Space ===                                                            #
--- # Note that the NEORV32 core complex occupies a small fraction of the total 32-bit address      #
--- # space for internal components (machine timer, on-chip-debugger, ...). This address space      #
--- # starts at address 0xffff0000 and ends at 0xffffffff. Any CPU access to this address space     #
--- # will NOT be delegated to bus interface of the core complex!                                   #
--- # ********************************************************************************************* #
--- # BSD 3-Clause License                                                                          #
--- #                                                                                               #
--- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
--- #                                                                                               #
--- # Redistribution and use in source and binary forms, with or without modification, are          #
--- # permitted provided that the following conditions are met:                                     #
--- #                                                                                               #
--- # 1. Redistributions of source code must retain the above copyright notice, this list of        #
--- #    conditions and the following disclaimer.                                                   #
--- #                                                                                               #
--- # 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
--- #    conditions and the following disclaimer in the documentation and/or other materials        #
--- #    provided with the distribution.                                                            #
--- #                                                                                               #
--- # 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
--- #    endorse or promote products derived from this software without specific prior written      #
--- #    permission.                                                                                #
--- #                                                                                               #
--- # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
--- # OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
--- # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
--- # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
--- # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
--- # GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
--- # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
--- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
--- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
--- # ********************************************************************************************* #
--- # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
--- #################################################################################################
+-- ================================================================================ --
+-- The NEORV32 RISC-V Processor - LiteX NEORV32 Core Complex Wrapper                --
+-- -------------------------------------------------------------------------------- --
+--                                __   _ __      _  __                              --
+--                               / /  (_) /____ | |/_/                              --
+--                              / /__/ / __/ -_)>  <                                --
+--                             /____/_/\__/\__/_/|_|                                --
+--                           Build your hardware, easily!                           --
+--                                                                                  --
+-- Unless otherwise noted, LiteX is copyright (C) 2012-2024 Enjoy-Digital.          --
+-- All rights reserved.                                                             --
+-- LiteX HQ: https://github.com/enjoy-digital/litex                                 --
+-- -------------------------------------------------------------------------------- --
+-- NEORV32 Core Complex wrapper for the LiteX SoC builder framework.                --
+-- https://github.com/enjoy-digital/litex/tree/master/litex/soc/cores/cpu/neorv32   --
+--                                                                                  --
+-- This wrapper provides four pre-configured core complex configurations:           --
+-- "minimal", "lite", "standard" and "full". See the 'configs_c' table for more     --
+-- details which RISC-V ISA extensions and module parameters are used by each of    --
+-- the these configurations. All configurations can be used with the                --
+--  RISC-V-compatible on-chip debugger ("DEBUG").                                   --
+-- -------------------------------------------------------------------------------- --
+-- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
+-- Copyright (c) NEORV32 contributors.                                              --
+-- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
+-- SPDX-License-Identifier: BSD-3-Clause                                            --
+-- ================================================================================ --
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/sw/lib/include/neorv32_slink.h
+++ b/sw/lib/include/neorv32_slink.h
@@ -47,10 +47,10 @@
 /**@{*/
 /** SLINK module prototype */
 typedef volatile struct __attribute__((packed,aligned(4))) {
-  uint32_t CTRL;         /**< offset 0: control register (#NEORV32_SLINK_CTRL_enum) */
-  uint32_t RX_DATA;      /**< offset 4: rx data register */
-  uint32_t TX_DATA;      /**< offset 8: tx data register */
-  uint32_t TX_DATA_LAST; /**< offset 12: tx data register + end-of-stream delimiter */
+  uint32_t CTRL;           /**< offset 0: control register (#NEORV32_SLINK_CTRL_enum) */
+  const uint32_t reserved; /**< offset 4: reserved */
+  uint32_t DATA;           /**< offset 8: RX/TX data register */
+  uint32_t DATA_LAST;      /**< offset 12: RX/TX data register (+ TX end-of-stream) */
 } neorv32_slink_t;
 
 /** SLINK module hardware access (#neorv32_slink_t) */

--- a/sw/lib/source/neorv32_slink.c
+++ b/sw/lib/source/neorv32_slink.c
@@ -131,7 +131,7 @@ int neorv32_slink_get_tx_fifo_depth(void) {
  **************************************************************************/
 inline uint32_t __attribute__((always_inline)) neorv32_slink_get(void) {
 
-  return NEORV32_SLINK->RX_DATA;
+  return NEORV32_SLINK->DATA;
 }
 
 
@@ -156,7 +156,7 @@ inline uint32_t __attribute__((always_inline)) neorv32_slink_check_last(void) {
  **************************************************************************/
 inline void __attribute__((always_inline)) neorv32_slink_put(uint32_t tx_data) {
 
-  NEORV32_SLINK->TX_DATA = tx_data;
+  NEORV32_SLINK->DATA = tx_data;
 }
 
 
@@ -168,7 +168,7 @@ inline void __attribute__((always_inline)) neorv32_slink_put(uint32_t tx_data) {
  **************************************************************************/
 inline void __attribute__((always_inline)) neorv32_slink_put_last(uint32_t tx_data) {
 
-  NEORV32_SLINK->TX_DATA_LAST = tx_data;
+  NEORV32_SLINK->DATA_LAST = tx_data;
 }
 
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -349,19 +349,13 @@
           </fields>
         </register>
         <register>
-          <name>RX_DATA</name>
-          <description>RX link receive data</description>
-           <access>read-only</access>
-          <addressOffset>0x04</addressOffset>
-        </register>
-        <register>
-          <name>TX_DATA</name>
-          <description>TX link transmit data</description>
+          <name>DATA</name>
+          <description>RX/TX data register</description>
           <addressOffset>0x08</addressOffset>
         </register>
         <register>
-          <name>TX_DATA_LAST</name>
-          <description>TX link transmit data (plus end-of-stream delimiter)</description>
+          <name>DATA_LAST</name>
+          <description>RX/TX data register (plus TX end-of-stream delimiter)</description>
           <addressOffset>0x0c</addressOffset>
         </register>
       </registers>


### PR DESCRIPTION
* :warning: rename SLINK data interface registers: only two registers are used now: `DATA` and `DATA_LAST`; reading any of these registers will return data from the RX FIFO; writing to any of these registers will write to the TX FIFO; writing `DATA_LAST` will also set the "last" identifier
* minor CPU control unit optimizations (area)
* update LiteX wrapper file header
* cleanup some CFU comments and code (for better understanding)