### PR TITLE
[DMA] use FIRQ select instead of FIRQ mask

### DIFF
--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -87,12 +87,12 @@ Some interfaces (like the TWI and the 1-Wire bus) require tri-state drivers in t
 | `jtag_tms_i`     |  1 |  in | `'L'` | mode select
 5+^| **<<_processor_external_bus_interface_xbus>>**
 | `xbus_adr_o`     | 32 | out |   -   |  destination address
-| `xbus_dat_i`     | 32 |  in | `'L'` |  write data
 | `xbus_dat_o`     | 32 | out |   -   |  read data
 | `xbus_we_o`      |  1 | out |   -   |  write enable ('0' = read transfer)
 | `xbus_sel_o`     |  4 | out |   -   |  byte enable
 | `xbus_stb_o`     |  1 | out |   -   |  strobe
 | `xbus_cyc_o`     |  1 | out |   -   |  valid cycle
+| `xbus_dat_i`     | 32 |  in | `'L'` |  write data
 | `xbus_ack_i`     |  1 |  in | `'L'` |  transfer acknowledge
 | `xbus_err_i`     |  1 |  in | `'L'` |  transfer error
 5+^| **<<_stream_link_interface_slink>>**

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090803"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090804"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -816,12 +816,12 @@ package neorv32_package is
       jtag_tms_i     : in  std_ulogic := 'L';
       -- External bus interface (available if XBUS_EN = true) --
       xbus_adr_o     : out std_ulogic_vector(31 downto 0);
-      xbus_dat_i     : in  std_ulogic_vector(31 downto 0) := (others => 'L');
       xbus_dat_o     : out std_ulogic_vector(31 downto 0);
       xbus_we_o      : out std_ulogic;
       xbus_sel_o     : out std_ulogic_vector(03 downto 0);
       xbus_stb_o     : out std_ulogic;
       xbus_cyc_o     : out std_ulogic;
+      xbus_dat_i     : in  std_ulogic_vector(31 downto 0) := (others => 'L');
       xbus_ack_i     : in  std_ulogic := 'L';
       xbus_err_i     : in  std_ulogic := 'L';
       -- Stream Link Interface (available if IO_SLINK_EN = true) --

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -149,12 +149,12 @@ entity neorv32_top is
 
     -- External bus interface (available if XBUS_EN = true) --
     xbus_adr_o     : out std_ulogic_vector(31 downto 0); -- address
-    xbus_dat_i     : in  std_ulogic_vector(31 downto 0) := (others => 'L'); -- read data
     xbus_dat_o     : out std_ulogic_vector(31 downto 0); -- write data
     xbus_we_o      : out std_ulogic; -- read/write
     xbus_sel_o     : out std_ulogic_vector(03 downto 0); -- byte enable
     xbus_stb_o     : out std_ulogic; -- strobe
     xbus_cyc_o     : out std_ulogic; -- valid cycle
+    xbus_dat_i     : in  std_ulogic_vector(31 downto 0) := (others => 'L'); -- read data
     xbus_ack_i     : in  std_ulogic := 'L'; -- transfer acknowledge
     xbus_err_i     : in  std_ulogic := 'L'; -- transfer error
 

--- a/rtl/system_integration/neorv32_litex_core_complex.vhd
+++ b/rtl/system_integration/neorv32_litex_core_complex.vhd
@@ -161,12 +161,12 @@ begin
     jtag_tms_i  => jtag_tms_i,  -- mode select
     -- External bus interface --
     xbus_adr_o  => wb_adr_o,    -- address
-    xbus_dat_i  => wb_dat_i,    -- read data
     xbus_dat_o  => wb_dat_o,    -- write data
     xbus_we_o   => wb_we_o,     -- read/write
     xbus_sel_o  => wb_sel_o,    -- byte enable
     xbus_stb_o  => open,        -- strobe
     xbus_cyc_o  => wb_cyc,      -- valid cycle
+    xbus_dat_i  => wb_dat_i,    -- read data
     xbus_ack_i  => wb_ack_i,    -- transfer acknowledge
     xbus_err_i  => wb_err_i,    -- transfer error
     -- CPU Interrupts --

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -295,12 +295,12 @@ begin
     jtag_tms_i     => '0',             -- mode select
     -- External bus interface (available if XBUS_EN = true) --
     xbus_adr_o     => wb_cpu.addr,     -- address
-    xbus_dat_i     => wb_cpu.rdata,    -- read data
     xbus_dat_o     => wb_cpu.wdata,    -- write data
     xbus_we_o      => wb_cpu.we,       -- read/write
     xbus_sel_o     => wb_cpu.sel,      -- byte enable
     xbus_stb_o     => wb_cpu.stb,      -- strobe
     xbus_cyc_o     => wb_cpu.cyc,      -- valid cycle
+    xbus_dat_i     => wb_cpu.rdata,    -- read data
     xbus_ack_i     => wb_cpu.ack,      -- transfer acknowledge
     xbus_err_i     => wb_cpu.err,      -- transfer error
     -- Stream Link Interface (available if IO_SLINK_EN = true) --

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -271,12 +271,12 @@ begin
     jtag_tms_i     => '0',             -- mode select
     -- External bus interface (available if XBUS_EN = true) --
     xbus_adr_o     => wb_cpu.addr,     -- address
-    xbus_dat_i     => wb_cpu.rdata,    -- read data
     xbus_dat_o     => wb_cpu.wdata,    -- write data
     xbus_we_o      => wb_cpu.we,       -- read/write
     xbus_sel_o     => wb_cpu.sel,      -- byte enable
     xbus_stb_o     => wb_cpu.stb,      -- strobe
     xbus_cyc_o     => wb_cpu.cyc,      -- valid cycle
+    xbus_dat_i     => wb_cpu.rdata,    -- read data
     xbus_ack_i     => wb_cpu.ack,      -- transfer acknowledge
     xbus_err_i     => wb_cpu.err,      -- transfer error
     -- Stream Link Interface (available if IO_SLINK_EN = true) --

--- a/sw/lib/include/neorv32_dma.h
+++ b/sw/lib/include/neorv32_dma.h
@@ -60,17 +60,17 @@ typedef volatile struct __attribute__((packed,aligned(4))) {
 
 /** DMA control and status register bits */
 enum NEORV32_DMA_CTRL_enum {
-  DMA_CTRL_EN            =  0, /**< DMA control register(0) (r/w): DMA enable */
-  DMA_CTRL_AUTO          =  1, /**< DMA control register(1) (r/w): Automatic trigger mode enable */
-  DMA_CTRL_FENCE         =  2, /**< DMA control register(2) (r/w): Issue FENCE downstream operation when DMA transfer is completed */
+  DMA_CTRL_EN           =  0, /**< DMA control register(0) (r/w): DMA enable */
+  DMA_CTRL_AUTO         =  1, /**< DMA control register(1) (r/w): Automatic trigger mode enable */
+  DMA_CTRL_FENCE        =  2, /**< DMA control register(2) (r/w): Issue FENCE downstream operation when DMA transfer is completed */
 
-  DMA_CTRL_ERROR_RD      =  8, /**< DMA control register(8)  (r/-): Error during read access; SRC_BASE shows the faulting address */
-  DMA_CTRL_ERROR_WR      =  9, /**< DMA control register(9)  (r/-): Error during write access; DST_BASE shows the faulting address */
-  DMA_CTRL_BUSY          = 10, /**< DMA control register(10) (r/-): DMA busy / transfer in progress */
-  DMA_CTRL_DONE          = 11, /**< DMA control register(11) (r/c): A transfer was executed when set */
+  DMA_CTRL_ERROR_RD     =  8, /**< DMA control register(8)  (r/-): Error during read access; SRC_BASE shows the faulting address */
+  DMA_CTRL_ERROR_WR     =  9, /**< DMA control register(9)  (r/-): Error during write access; DST_BASE shows the faulting address */
+  DMA_CTRL_BUSY         = 10, /**< DMA control register(10) (r/-): DMA busy / transfer in progress */
+  DMA_CTRL_DONE         = 11, /**< DMA control register(11) (r/c): A transfer was executed when set */
 
-  DMA_CTRL_FIRQ_MASK_LSB = 16, /**< DMA control register(16) (r/w): FIRQ trigger mask LSB */
-  DMA_CTRL_FIRQ_MASK_MSB = 31  /**< DMA control register(31) (r/w): FIRQ trigger mask MSB */
+  DMA_CTRL_FIRQ_SEL_LSB = 16, /**< DMA control register(16) (r/w): FIRQ trigger select LSB */
+  DMA_CTRL_FIRQ_SEL_MSB = 19  /**< DMA control register(19) (r/w): FIRQ trigger select MSB */
 };
 
 /** DMA transfer type bits */
@@ -127,7 +127,7 @@ void neorv32_dma_disable(void);
 void neorv32_dma_fence_enable(void);
 void neorv32_dma_fence_disable(void);
 void neorv32_dma_transfer(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config);
-void neorv32_dma_transfer_auto(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config, uint32_t firq_mask);
+void neorv32_dma_transfer_auto(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config, int firq_sel);
 int  neorv32_dma_status(void);
 int  neorv32_dma_done(void);
 /**@}*/

--- a/sw/lib/source/neorv32_dma.c
+++ b/sw/lib/source/neorv32_dma.c
@@ -121,14 +121,14 @@ void neorv32_dma_transfer(uint32_t base_src, uint32_t base_dst, uint32_t num, ui
  * @param[in] base_dst Destination base address (has to be aligned to destination data type!).
  * @param[in] num Number of elements to transfer (24-bit).
  * @param[in] config Transfer type configuration/commands.
- * @param[in] firq_mask FIRQ trigger mask (#NEORV32_CSR_MIP_enum).
+ * @param[in] firq_sel FIRQ trigger select (#NEORV32_CSR_MIP_enum); only FIRQ0..FIRQ15 = 16..31.
  **************************************************************************/
-void neorv32_dma_transfer_auto(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config, uint32_t firq_mask) {
+void neorv32_dma_transfer_auto(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config, int firq_sel) {
 
   uint32_t tmp = NEORV32_DMA->CTRL;
   tmp |= (uint32_t)(1 << DMA_CTRL_AUTO); // automatic transfer trigger
-  tmp &= 0x0000ffffUL; // clear current FIRQ mask
-  tmp |= firq_mask & 0xffff0000UL; // set new FIRQ mask
+  tmp &= ~(0xf << DMA_CTRL_FIRQ_SEL_LSB); // clear current FIRQ select
+  tmp |= (uint32_t)((firq_sel & 0xf) << DMA_CTRL_FIRQ_SEL_LSB); // set new FIRQ select
   NEORV32_DMA->CTRL = tmp;
 
   NEORV32_DMA->SRC_BASE = base_src;

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -422,9 +422,9 @@
               <description>DMA transfer done; auto-clears on write access</description>
             </field>
             <field>
-              <name>DMA_CTRL_FIRQ_MASK</name>
-              <bitRange>[31:16]</bitRange>
-              <description>FIRQ trigger mask</description>
+              <name>DMA_CTRL_FIRQ_SEL</name>
+              <bitRange>[19:16]</bitRange>
+              <description>FIRQ trigger select</description>
             </field>
           </fields>
         </register>


### PR DESCRIPTION
⚠️ The "auto-configuration" of the DMA now uses a 4-bit FIRQ select field (to select only a _single_ FIRQ trigger) instead of a 16-bit FIRQ mask (potentially selecting more than one FIRQ trigger).