### PR TITLE
fix external debug-halt vs. exception concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 23.04.2024 | 1.9.8.6 | :bug: fix on-chip-debugger external-halt-request vs. exception concurrency | [#882](https://github.com/stnolting/neorv32/pull/882) |
 | 21.04.2024 | 1.9.8.5 | rtl cleanups and (area) optimizations | [#880](https://github.com/stnolting/neorv32/pull/880) |
 | 16.04.2024 | 1.9.8.4 | :warning: use a 4-bit FIRQ select instead of a 16-bit FIRQ mask for DMA auto-trigger configuration | [#877](https://github.com/stnolting/neorv32/pull/877) |
 | 15.04.2024 | 1.9.8.3 | :warning: simplify XBUS gateway logic and configuration generics; only "pipelined Wishbone" protocol is supported now | [#876](https://github.com/stnolting/neorv32/pull/876) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090805"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090806"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -623,7 +623,6 @@ package neorv32_package is
   constant exc_laccess_c  : natural :=  8; -- load access fault
   constant exc_db_break_c : natural :=  9; -- enter debug mode via ebreak instruction
   constant exc_db_hw_c    : natural := 10; -- enter debug mode via hw trigger
-  --
   constant exc_width_c    : natural := 11; -- length of this list in bits
   -- interrupt source bits --
   constant irq_msi_irq_c  : natural :=  0; -- machine software interrupt
@@ -647,7 +646,6 @@ package neorv32_package is
   constant irq_firq_15_c  : natural := 18; -- fast interrupt channel 15
   constant irq_db_halt_c  : natural := 19; -- enter debug mode via external halt request
   constant irq_db_step_c  : natural := 20; -- enter debug mode via single-stepping
-  --
   constant irq_width_c    : natural := 21; -- length of this list in bits
 
   -- Privilege Modes ------------------------------------------------------------------------

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -596,7 +596,7 @@ int main() {
     asm volatile (".word 0x7b200073"); // dret outside of debug mode
     asm volatile (".word 0x7b300073"); // illegal system funct12
     asm volatile (".word 0xfe000033"); // illegal add funct7
-    asm volatile (".word 0x80002063"); // illegal branch funct3
+    asm volatile (".word 0x80002163"); // illegal branch funct3 (misaligned DST if C not available)
     asm volatile (".word 0x0000200f"); // illegal fence funct3
     asm volatile (".word 0xfe002fe3"); // illegal store funct3
     asm volatile (".align 4");


### PR DESCRIPTION
Fixing #879.

The CPU can now be halted right after reset **before** the first instruction is executed. However, the on-chip debugger does not provide the "halt on reset" functionality yet (but that can be emulated by the debugger).