### PR TITLE
minor rtl fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 24.04.2024 | 1.9.8.7 | minor RTL fixes | [#883](https://github.com/stnolting/neorv32/pull/883) |
 | 23.04.2024 | 1.9.8.6 | :bug: fix on-chip-debugger external-halt-request vs. exception concurrency | [#882](https://github.com/stnolting/neorv32/pull/882) |
 | 21.04.2024 | 1.9.8.5 | rtl cleanups and (area) optimizations | [#880](https://github.com/stnolting/neorv32/pull/880) |
 | 16.04.2024 | 1.9.8.4 | :warning: use a 4-bit FIRQ select instead of a 16-bit FIRQ mask for DMA auto-trigger configuration | [#877](https://github.com/stnolting/neorv32/pull/877) |

--- a/rtl/core/neorv32_cpu_cp_cond.vhd
+++ b/rtl/core/neorv32_cpu_cp_cond.vhd
@@ -37,7 +37,8 @@ architecture neorv32_cpu_cp_cond_rtl of neorv32_cpu_cp_cond is
 
 begin
 
-  -- conditional output --
+  -- Conditional Output ---------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
   cond_out: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then

--- a/rtl/core/neorv32_cpu_cp_fpu.vhd
+++ b/rtl/core/neorv32_cpu_cp_fpu.vhd
@@ -1153,7 +1153,7 @@ begin
               addsub.res_sign <= fpu_operands.rs1(31) xor addsub.exp_comp(0);
             end if;
           else
-            --  roundTowardNegative; under that attribute, the sign of an exact zero sum (or difference) shall be −0
+            --  roundTowardNegative; under that attribute, the sign of an exact zero sum (or difference) shall be -0
             if (fpu_operands.frm = "010") then -- round down (towards -infinity)
               addsub.res_sign <= '1'; -- set the sign to 0 to generate a +0.0 result
             else
@@ -1172,7 +1172,7 @@ begin
               addsub.res_sign <= fpu_operands.rs1(31) xor addsub.exp_comp(0);
             end if;
           else
-            --  roundTowardNegative; under that attribute, the sign of an exact zero sum (or difference) shall be −0
+            --  roundTowardNegative; under that attribute, the sign of an exact zero sum (or difference) shall be -0
             if (fpu_operands.frm = "010") then -- round down (towards -infinity)
               addsub.res_sign <= '1'; -- set the sign to 0 to generate a +0.0 result
             else

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -293,8 +293,10 @@ begin
 
     -- check region match according to configured mode --
     match_gen: process(csr, region)
+      variable tmp_v : std_ulogic_vector(1 downto 0);
     begin
-      case csr.cfg(r)(cfg_ah_c downto cfg_al_c) is
+      tmp_v := csr.cfg(r)(cfg_ah_c downto cfg_al_c);
+      case tmp_v is -- VHDL/GHDL issue: "object type is not locally static"
         when mode_off_c => -- entry disabled
           region.i_match(r) <= '0';
           region.d_match(r) <= '0';

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090806"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090807"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 


### PR DESCRIPTION
* removed non-ASCII characters from FPU comments (`neorv32_cpu_cp_fpu.vhd`)
* fixed minor VHDL/GHDL issue (only relevant for older GHDL versions) in PMP mode select (case operand: "object type is not locally static")
* fixed imprecise timing of first-transmitted UART TX bit (was not correctly synchronized with the UART baud clock)