### PR TITLE
[rtl] fix single-step halting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 27.04.2024 | 1.9.8.8 | fix delayed halt when single-stepping into an exception | [#887](https://github.com/stnolting/neorv32/pull/887) |
 | 24.04.2024 | 1.9.8.7 | minor RTL fixes | [#883](https://github.com/stnolting/neorv32/pull/883) |
 | 23.04.2024 | 1.9.8.6 | :bug: fix on-chip-debugger external-halt-request vs. exception concurrency | [#882](https://github.com/stnolting/neorv32/pull/882) |
 | 21.04.2024 | 1.9.8.5 | rtl cleanups and (area) optimizations | [#880](https://github.com/stnolting/neorv32/pull/880) |

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1539,7 +1539,7 @@ begin
   -- debug-entry single-step interrupt? --
   trap_ctrl.irq_fire(2) <= '1' when
     ((execute_engine.state = EXECUTE) or -- trigger single-step in EXECUTE state
-     ((trap_ctrl.env_entered = '1') and (execute_engine.state = BRANCHED))) and -- also allow triggering when entering a system trap (#)
+     ((trap_ctrl.env_entered = '1') and (execute_engine.state = BRANCHED))) and -- also allow triggering when entering a system trap (#887)
     (trap_ctrl.irq_buf(irq_db_step_c) = '1') -- pending single-step halt
     else '0';
 

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -199,6 +199,7 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
     --
     env_pending : std_ulogic; -- start of trap environment if pending
     env_enter   : std_ulogic; -- enter trap environment
+    env_entered : std_ulogic; -- trap environment has just been entered
     env_exit    : std_ulogic; -- leave trap environment
     wakeup      : std_ulogic; -- wakeup from sleep due to an enabled pending IRQ
     --
@@ -1496,7 +1497,9 @@ begin
   begin
     if (rstn_i = '0') then
       trap_ctrl.env_pending <= '0';
+      trap_ctrl.env_entered <= '0';
     elsif rising_edge(clk_i) then
+      -- pending trap environment --
       if (trap_ctrl.env_pending = '0') then -- no pending trap environment yet
         if (trap_ctrl.exc_fire = '1') or (or_reduce_f(trap_ctrl.irq_fire) = '1') then
           trap_ctrl.env_pending <= '1'; -- execute engine can start trap handling
@@ -1505,6 +1508,12 @@ begin
         if (trap_ctrl.env_enter = '1') then -- start of trap environment acknowledged by execute engine
           trap_ctrl.env_pending <= '0';
         end if;
+      end if;
+      -- trap environment has just been entered --
+      if (execute_engine.state = EXECUTE) then -- first instruction of trap environment is executing
+        trap_ctrl.env_entered <= '0';
+      elsif (trap_ctrl.env_enter = '1') then
+        trap_ctrl.env_entered <= '1';
       end if;
     end if;
   end process trap_controller;
@@ -1529,7 +1538,8 @@ begin
 
   -- debug-entry single-step interrupt? --
   trap_ctrl.irq_fire(2) <= '1' when
-    (execute_engine.state = EXECUTE) and -- trigger system IRQ only in EXECUTE state
+    ((execute_engine.state = EXECUTE) or -- trigger single-step in EXECUTE state
+     ((trap_ctrl.env_entered = '1') and (execute_engine.state = BRANCHED))) and -- also allow triggering when entering a system trap (#)
     (trap_ctrl.irq_buf(irq_db_step_c) = '1') -- pending single-step halt
     else '0';
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090807"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090808"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 


### PR DESCRIPTION
Allow the debugger's single-stepping to intercept exception entry (halt right after trap entry).

Fixing #885 