### PR TITLE
minor rtl cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 01.05.2024 | 1.9.8.9 | minor rtl cleanups (cleanup boolean expressions) | [#889](https://github.com/stnolting/neorv32/pull/889) |
 | 27.04.2024 | 1.9.8.8 | fix delayed halt when single-stepping into an exception | [#887](https://github.com/stnolting/neorv32/pull/887) |
 | 24.04.2024 | 1.9.8.7 | minor RTL fixes | [#883](https://github.com/stnolting/neorv32/pull/883) |
 | 23.04.2024 | 1.9.8.6 | :bug: fix on-chip-debugger external-halt-request vs. exception concurrency | [#882](https://github.com/stnolting/neorv32/pull/882) |

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -150,7 +150,7 @@ begin
     severity note;
 
   -- simulation notifier --
-  assert not (is_simulation_c = true) report "[NEORV32] Assuming this is a simulation." severity warning;
+  assert not is_simulation_c report "[NEORV32] Assuming this is a simulation." severity warning;
 
 
   -- Control Unit ---------------------------------------------------------------------------

--- a/rtl/core/neorv32_cpu_cp_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_cp_bitmanip.vhd
@@ -169,7 +169,7 @@ begin
         when S_IDLE => -- wait for operation trigger
         -- ------------------------------------------------------------
           if (start_i = '1') then
-            if (FAST_SHIFT_EN = false) and ((cmd(op_cz_c) or cmd(op_cpop_c) or cmd(op_rot_c)) = '1') then -- multi-cycle shift operation
+            if (not FAST_SHIFT_EN) and ((cmd(op_cz_c) or cmd(op_cpop_c) or cmd(op_rot_c)) = '1') then -- multi-cycle shift operation
               shifter.start <= '1';
               ctrl_state <= S_START_SHIFT;
             else
@@ -201,7 +201,7 @@ begin
   -- Shifter Function Core (iterative: small but slow) --------------------------------------
   -- -------------------------------------------------------------------------------------------
   serial_shifter:
-  if (FAST_SHIFT_EN = false) generate
+  if not FAST_SHIFT_EN generate
 
     serial_shifter_core: process(rstn_i, clk_i)
     begin
@@ -266,7 +266,7 @@ begin
   -- Shifter Function Core (parallel: fast but large) ---------------------------------------
   -- -------------------------------------------------------------------------------------------
   barrel_shifter:
-  if (FAST_SHIFT_EN = true) generate
+  if FAST_SHIFT_EN generate
 
     -- rotator input layer: convert left-rotates to right-rotates (rotate by XLEN - N positions) --
     bs_shift <= std_ulogic_vector(unsigned(not sha_reg) + 1) when (ctrl_i.ir_funct3(2) = '0') else sha_reg;

--- a/rtl/core/neorv32_cpu_cp_fpu.vhd
+++ b/rtl/core/neorv32_cpu_cp_fpu.vhd
@@ -32,8 +32,8 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_cp_fpu is
   generic (
-    -- FPU specific options
-    FPU_SUBNORMAL_SUPPORT      : boolean := false -- Implemented sub-normal support, default false
+    -- FPU-specific options --
+    FPU_SUBNORMAL_SUPPORT : boolean := false -- Implemented sub-normal support, default false
   );
   port (
     -- global control --
@@ -77,8 +77,8 @@ architecture neorv32_cpu_cp_fpu_rtl of neorv32_cpu_cp_fpu is
   -- float-to-integer unit --
   component neorv32_cpu_cp_fpu_f2i
   generic (
-    -- FPU specific options
-    FPU_SUBNORMAL_SUPPORT      : boolean := false -- Implemented sub-normal support, default false
+    -- FPU-specific options --
+    FPU_SUBNORMAL_SUPPORT : boolean := false -- Implemented sub-normal support, default false
   );
   port (
     -- control --
@@ -103,8 +103,8 @@ architecture neorv32_cpu_cp_fpu_rtl of neorv32_cpu_cp_fpu is
   -- normalizer + rounding unit --
   component neorv32_cpu_cp_fpu_normalizer
   generic (
-    -- FPU specific options
-    FPU_SUBNORMAL_SUPPORT      : boolean := false -- Implemented sub-normal support, default false
+    -- FPU-specific options --
+    FPU_SUBNORMAL_SUPPORT : boolean := false -- Implemented sub-normal support, default false
   );
   port (
     -- control --
@@ -678,7 +678,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_cp_fpu_f2i_inst: neorv32_cpu_cp_fpu_f2i
   generic map (
-    -- FPU specific options
+    -- FPU-specific options --
     FPU_SUBNORMAL_SUPPORT => FPU_SUBNORMAL_SUPPORT -- Implemented sub-normal support, default false
   )
   port map (
@@ -1454,7 +1454,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_cp_fpu_normalizer_inst: neorv32_cpu_cp_fpu_normalizer
   generic map (
-    -- FPU specific options
+    -- FPU-specific options --
     FPU_SUBNORMAL_SUPPORT => FPU_SUBNORMAL_SUPPORT -- Implemented sub-normal support, default false
   )
   port map (
@@ -1550,8 +1550,8 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_cp_fpu_normalizer is
   generic (
-    -- FPU specific options
-    FPU_SUBNORMAL_SUPPORT      : boolean := false -- Implemented sub-normal support, default false
+    -- FPU-specific options --
+    FPU_SUBNORMAL_SUPPORT : boolean := false -- Implemented sub-normal support, default false
   );
   port (
     -- control --
@@ -1994,8 +1994,8 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_cp_fpu_f2i is
   generic (
-    -- FPU specific options
-    FPU_SUBNORMAL_SUPPORT      : boolean := false -- Implemented sub-normal support, default false
+    -- FPU-specific options --
+    FPU_SUBNORMAL_SUPPORT : boolean := false -- Implemented sub-normal support, default false
   );
   port (
     -- control --
@@ -2136,7 +2136,7 @@ begin
                ctrl.class(fp_class_snan_c)     or ctrl.class(fp_class_qnan_c)) = '1') then
             ctrl.state <= S_FINALIZE;
           -- check for denorm case if we do not support subnormals
-          elsif ((FPU_SUBNORMAL_SUPPORT = false) and
+          elsif ((not FPU_SUBNORMAL_SUPPORT) and
                 ((ctrl.class(fp_class_neg_denorm_c) or ctrl.class(fp_class_pos_denorm_c)) = '1')) then
             ctrl.state <= S_FINALIZE;
           else
@@ -2212,7 +2212,7 @@ begin
               ctrl.flags(fp_exc_nx_c) <= '0';
             elsif (ctrl.class(fp_class_neg_zero_c) = '1') or (ctrl.class(fp_class_pos_zero_c) = '1') then -- zero
               ctrl.result <= x"00000000";
-            elsif ((FPU_SUBNORMAL_SUPPORT = false) and ((ctrl.class(fp_class_neg_denorm_c) = '1') or (ctrl.class(fp_class_pos_denorm_c) = '1'))) then -- subnormal
+            elsif ((not FPU_SUBNORMAL_SUPPORT) and ((ctrl.class(fp_class_neg_denorm_c) = '1') or (ctrl.class(fp_class_pos_denorm_c) = '1'))) then -- subnormal
               ctrl.result <= x"00000000";
             elsif ((ctrl.under = '1') and (ctrl.result_tmp(0) = '0')) then -- +/- underflow
               ctrl.result <= x"00000000";
@@ -2250,7 +2250,7 @@ begin
             elsif (ctrl.class(fp_class_neg_zero_c) = '1') or (ctrl.class(fp_class_pos_zero_c) = '1') then -- zero
               ctrl.result <= x"00000000";
             -- if we do no support subnormals treat them as +/- zero
-            elsif ((FPU_SUBNORMAL_SUPPORT = false) and ((ctrl.class(fp_class_neg_denorm_c) = '1') or (ctrl.class(fp_class_pos_denorm_c) = '1'))) then -- subnormal
+            elsif ((not FPU_SUBNORMAL_SUPPORT) and ((ctrl.class(fp_class_neg_denorm_c) = '1') or (ctrl.class(fp_class_pos_denorm_c) = '1'))) then -- subnormal
               ctrl.result <= x"00000000";
             -- if underflow is set the number is too small, but the rounding mode can cause the LSB to be
             -- set and thus we still have a valid result

--- a/rtl/core/neorv32_cpu_cp_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_cp_muldiv.vhd
@@ -110,7 +110,7 @@ begin
         when S_IDLE => -- wait for start signal
           ctrl.cnt <= std_ulogic_vector(to_unsigned(XLEN-2, index_size_f(XLEN))); -- iterative cycle counter
           if (start_i = '1') then -- trigger new operation
-            if (DIVISION_EN = true) then
+            if DIVISION_EN then
               -- DIV: check relevant input signs for result sign compensation --
               if (ctrl_i.ir_funct3(1 downto 0) = op_div_c(1 downto 0)) then -- signed div operation
                 div.sign_mod <= (rs1_i(rs1_i'left) xor rs2_i(rs2_i'left)) and or_reduce_f(rs2_i); -- different signs AND divisor not zero
@@ -127,7 +127,7 @@ begin
               end if;
             end if;
             -- is fast multiplication? --
-            if (ctrl_i.ir_funct3(2) = '0') and (FAST_MUL_EN = true) then
+            if (ctrl_i.ir_funct3(2) = '0') and FAST_MUL_EN then
               ctrl.state <= S_DONE;
             else -- serial division or serial multiplication
               ctrl.state <= S_BUSY;

--- a/rtl/core/neorv32_cpu_lsu.vhd
+++ b/rtl/core/neorv32_cpu_lsu.vhd
@@ -89,7 +89,7 @@ begin
         -- privilege level --
         bus_req_o.priv <= ctrl_i.lsu_priv;
         -- reservation set operation --
-        if (AMO_LRSC_ENABLE = true) and (ctrl_i.ir_opcode(2) = opcode_amo_c(2)) then
+        if AMO_LRSC_ENABLE and (ctrl_i.ir_opcode(2) = opcode_amo_c(2)) then
           bus_req_o.rvso <= '1';
         else
           bus_req_o.rvso <= '0';

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -109,7 +109,7 @@ begin
 
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  assert not (granularity_valid_c = false) report
+  assert granularity_valid_c report
     "[NEORV32] Auto-adjusting invalid PMP granularity configuration." severity warning;
 
 
@@ -147,9 +147,9 @@ begin
           csr.cfg(i)(cfg_x_c) <= csr_wdata_i((i mod 4)*8+2); -- X (execute)
           -- A (mode) --
           mode_v := csr_wdata_i((i mod 4)*8+4 downto (i mod 4)*8+3);
-          if ((mode_v = mode_tor_c)   and (TOR_EN = false)) or -- TOR mode not implemented
-             ((mode_v = mode_na4_c)   and (NAP_EN = false)) or -- NA4 mode not implemented
-             ((mode_v = mode_napot_c) and (NAP_EN = false)) or -- NAPOT mode not implemented
+          if ((mode_v = mode_tor_c)   and (not TOR_EN)) or -- TOR mode not implemented
+             ((mode_v = mode_na4_c)   and (not NAP_EN)) or -- NA4 mode not implemented
+             ((mode_v = mode_napot_c) and (not NAP_EN)) or -- NAPOT mode not implemented
              ((mode_v = mode_na4_c)   and (granularity_c > 4)) then -- NA4 not available
             csr.cfg(i)(cfg_ah_c downto cfg_al_c) <= mode_off_c;
           else -- valid configuration

--- a/rtl/core/neorv32_dma.vhd
+++ b/rtl/core/neorv32_dma.vhd
@@ -41,17 +41,17 @@ architecture neorv32_dma_rtl of neorv32_dma is
   constant type_endian_c  : natural := 31; -- r/w: Convert Endianness when set
 
   -- control and status register bits --
-  constant ctrl_en_c            : natural :=  0; -- r/w: DMA enable
-  constant ctrl_auto_c          : natural :=  1; -- r/w: enable FIRQ-triggered transfer
-  constant ctrl_fence_c         : natural :=  2; -- r/w: issue FENCE operation when DMA is done
+  constant ctrl_en_c           : natural :=  0; -- r/w: DMA enable
+  constant ctrl_auto_c         : natural :=  1; -- r/w: enable FIRQ-triggered transfer
+  constant ctrl_fence_c        : natural :=  2; -- r/w: issue FENCE operation when DMA is done
   --
-  constant ctrl_error_rd_c      : natural :=  8; -- r/-: error during read transfer
-  constant ctrl_error_wr_c      : natural :=  9; -- r/-: error during write transfer
-  constant ctrl_busy_c          : natural := 10; -- r/-: DMA transfer in progress
-  constant ctrl_done_c          : natural := 11; -- r/c: a DMA transfer was executed/attempted
+  constant ctrl_error_rd_c     : natural :=  8; -- r/-: error during read transfer
+  constant ctrl_error_wr_c     : natural :=  9; -- r/-: error during write transfer
+  constant ctrl_busy_c         : natural := 10; -- r/-: DMA transfer in progress
+  constant ctrl_done_c         : natural := 11; -- r/c: a DMA transfer was executed/attempted
   --
-  constant ctrl_firq_sel_lsb_c  : natural := 16; -- r/w: FIRQ trigger select LSB
-  constant ctrl_firq_sel_msb_c  : natural := 19; -- r/w: FIRQ trigger select MSB
+  constant ctrl_firq_sel_lsb_c : natural := 16; -- r/w: FIRQ trigger select LSB
+  constant ctrl_firq_sel_msb_c : natural := 19; -- r/w: FIRQ trigger select MSB
 
   -- transfer quantities --
   constant qsel_b2b_c  : std_ulogic_vector(1 downto 0) := "00"; -- byte to byte

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090808"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090809"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/sw/common/common.mk
+++ b/sw/common/common.mk
@@ -210,7 +210,7 @@ $(APP_ELF): $(OBJ)
 
 # Assembly listing file (for debugging)
 $(APP_ASM): $(APP_ELF)
-	@$(OBJDUMP) -d -S -z  $< > $@
+	@$(OBJDUMP) -d -S -z $< > $@
 
 # Generate final executable from .text + .rodata + .data (in THIS order!)
 main.bin: $(APP_ELF)

--- a/sw/example/coremark/core_portme.c
+++ b/sw/example/coremark/core_portme.c
@@ -191,8 +191,8 @@ void portable_fini(core_portable *p) {
     p->portable_id = 0;
 
     neorv32_uart0_printf("\nNEORV32: Hardware Performance Monitors (low words only)\n");
-    neorv32_uart0_printf(" > Active clock cycles          : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_MCYCLE));
-    neorv32_uart0_printf(" > Retired instructions         : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_MINSTRET));
+    neorv32_uart0_printf(" > Active clock cycles         : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_MCYCLE));
+    neorv32_uart0_printf(" > Retired instructions        : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_MINSTRET));
     if (num_hpm_cnts_global == 0) {neorv32_uart0_printf("no HPMs available\n"); }
     if (num_hpm_cnts_global > 0)  {neorv32_uart0_printf(" > Compressed instructions     : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER3));  }
     if (num_hpm_cnts_global > 1)  {neorv32_uart0_printf(" > Instr. dispatch wait cycles : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_MHPMCOUNTER4));  }


### PR DESCRIPTION
Clean-up boolean expressions for better code readability:
* `(XYZ = true)` -> `xyz`
* `(xyz = false)` -> `(not xyz)`