### PR TITLE
Fix UART receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 02.05.2024 | 1.9.8.10 | :bug: fix UART receiver bug (introduced in v1.9.8.7) | [#891](https://github.com/stnolting/neorv32/pull/891) |
 | 01.05.2024 | 1.9.8.9 | minor rtl cleanups (cleanup boolean expressions) | [#889](https://github.com/stnolting/neorv32/pull/889) |
 | 27.04.2024 | 1.9.8.8 | fix delayed halt when single-stepping into an exception | [#887](https://github.com/stnolting/neorv32/pull/887) |
 | 24.04.2024 | 1.9.8.7 | minor RTL fixes | [#883](https://github.com/stnolting/neorv32/pull/883) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090809"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090810"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -286,7 +286,7 @@ begin
   );
 
   rx_fifo.clear <= '1' when (ctrl.enable = '0') or (ctrl.sim_mode = '1') else '0';
-  rx_fifo.wdata <= rx_engine.sreg(8 downto 1);
+  rx_fifo.wdata <= rx_engine.sreg(7 downto 0);
   rx_fifo.we    <= rx_engine.done;
   rx_fifo.re    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(2) = '1') else '0';
 


### PR DESCRIPTION
According to #890
[bug] uart issue after #883 upd

The change is in neorv32_uart.vhd file
On line 289:
From rx_engine.sreg(8 downto 1) to rx_engine.sreg(7 downto 0)