### PR TITLE
Update neorv32_sdi.vhd - Minor typo correction

### DIFF
--- a/rtl/core/neorv32_sdi.vhd
+++ b/rtl/core/neorv32_sdi.vhd
@@ -211,7 +211,8 @@ begin
     FIFO_DEPTH => RTX_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,        -- size of data elements in fifo (32-bit only for simulation)
     FIFO_RSYNC => true,     -- sync read
-    FIFO_SAFE  => true      -- safe access
+    FIFO_SAFE  => true,      -- safe access
+    FULL_RESET => false     -- no HW reset, try to infer BRAM
   )
   port map (
     -- control --


### PR DESCRIPTION
RX FIFO misses the value setting for FULL_RESET generic completly. I suppose then it falls back to the default value, since that one is false too in the neorv32_fifo.vhd this commit isn't leading to any different behavior in RTL, but should be added just for consisentcy issues