### PR TITLE
Add SLINK routing information ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 21.05.2024 | 1.9.9.2 | :sparkles: add SLINK routing information ports (compatible to AXI-stream's `TID` and `TDEST` signals) | [#908](https://github.com/stnolting/neorv32/pull/908) |
 | 04.05.2024 | 1.9.9.1 | :sparkles: add NEORV32 as Vivado IP block | [#894](https://github.com/stnolting/neorv32/pull/894) |
 | 03.05.2024 | [**:rocket:1.9.9**](https://github.com/stnolting/neorv32/releases/tag/v1.9.9) | **New release** | |
 | 02.05.2024 | 1.9.8.10 | :bug: fix UART receiver bug (introduced in v1.9.8.7) | [#891](https://github.com/stnolting/neorv32/pull/891) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -97,10 +97,12 @@ Some interfaces (like the TWI and the 1-Wire bus) require tri-state drivers in t
 | `xbus_err_i`     |  1 |  in | `'L'` |  transfer error
 5+^| **<<_stream_link_interface_slink>>**
 | `slink_rx_dat_i` | 32 |  in | `'L'` | RX data
+| `slink_rx_src_i` |  4 |  in | `'L'` | RX source routing information
 | `slink_rx_val_i` |  1 |  in | `'L'` | RX data valid
 | `slink_rx_lst_i` |  1 |  in | `'L'` | RX last element of stream
 | `slink_rx_rdy_o` |  1 | out |   -   | RX ready to receive
 | `slink_tx_dat_o` | 32 | out |   -   | TX data
+| `slink_tx_dst_o` |  4 | out |   -   | TX destination routing information
 | `slink_tx_val_o` |  1 | out |   -   | TX data valid
 | `slink_tx_lst_o` |  1 | out |   -   | TX last element of stream
 | `slink_tx_rdy_i` |  1 |  in | `'L'` | TX allowed to send

--- a/docs/datasheet/soc_slink.adoc
+++ b/docs/datasheet/soc_slink.adoc
@@ -9,10 +9,12 @@
 | Software driver files:  | neorv32_slink.c     |
 |                         | neorv32_slink.h     |
 | Top entity ports:       | `slink_rx_dat_i`    | RX link data (32-bit)
+|                         | `slink_rx_src_i`    | RX routing information (4-bit)
 |                         | `slink_rx_val_i`    | RX link data valid (1-bit)
 |                         | `slink_rx_lst_i`    | RX link last element of stream (1-bit)
 |                         | `slink_rx_rdy_o`    | RX link ready to receive (1-bit)
 |                         | `slink_tx_dat_o`    | TX link data (32-bit)
+|                         | `slink_tx_dst_o`    | TX routing information (4-bit)
 |                         | `slink_tx_val_o`    | TX link data valid (1-bit)
 |                         | `slink_tx_lst_o`    | TX link last element of stream (1-bit)
 |                         | `slink_tx_rdy_i`    | TX link allowed to send (1-bit)
@@ -45,10 +47,11 @@ The SLINK interface consists of four signals for each channel:
 * `val` marks the current transmission cycle as valid
 * `lst` marks the current transmission cycle as the last element of a stream
 * `rdy` indicates that the receiver is ready to receive
+* `src` and `dst` provide source/destination routing information (optional)
 
 .AXI4-Stream Compatibility
 [NOTE]
-The interface names and the underlying protocol is compatible to the AXI4-Stream protocol standard.
+The interface names (except for `src` and `dst`) and the underlying protocol is compatible to the AXI4-Stream protocol standard.
 A processor top entity with a AXI4-Stream-compatible interfaces can be found in `rtl/system_inegration`.
 More information regarding this alternate top entity can be found in in the user guide:
 https://stnolting.github.io/neorv32/ug/#_packaging_the_processor_as_vivado_ip_block
@@ -83,6 +86,16 @@ implemented yet.
 
 The current status of the RX and TX FIFOs can be determined via the control register's `SLINK_CTRL_RX_*` and
 `SLINK_CTRL_TX_*` flags.
+
+
+**Stream Routing Information**
+
+Both stream link interface provide an optional port for routing information: `slink_tx_dst_o` (AXI stream's `TDEST`)
+can be used to set a destination address when using a switch/interconnect to access several stream sinks. `slink_rx_src_i`
+(AXI stream's `TID`) can be used to determine the source when several sources can send data via a switch/interconnect.
+The routing information can be set/read via the `ROUTE` interface registers. Note that all routing information is also
+fully buffered by the internal RX/TX FIFOs. RX routing information has to be read **after** reading the according RX
+data. Vice versa, TX routing information has to be set **before** writing the according TX data.
 
 
 **Interrupts**
@@ -124,7 +137,9 @@ interrupt-causing condition is resolved (e.g. by reading from the RX FIFO).
                                                 <| `23:22` _reserved_                                        ^| r/- <| _reserved_, read as zero
                                                 <| `27:24` `SLINK_CTRL_RX_FIFO_MSB : SLINK_CTRL_RX_FIFO_LSB` ^| r/- <| log2(RX FIFO size)
                                                 <| `31:28` `SLINK_CTRL_TX_FIFO_MSB : SLINK_CTRL_TX_FIFO_LSB` ^| r/- <| log2(TX FIFO size)
-| `0xffffec04` | -                         | `31:0` | -/- | _reserved_
+.3+<| `0xffffec04` .3+<| `NEORV32_SLINK.ROUTE` <| `3:0` | r/w | TX destination routing information (`slink_tx_dst_o`)
+                                               <| `7:4` | r/- | RX source routing information (`slink_rx_src_i`)
+                                               <| `31:8` | -/- | _reserved_
 | `0xffffec08` | `NEORV32_SLINK.DATA`      | `31:0` | r/w | Write data to TX FIFO; read data from RX FIFO
 | `0xffffec0c` | `NEORV32_SLINK.DATA_LAST` | `31:0` | r/w | Write data to TX FIFO (and also set "last" signal); read data from RX FIFO
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090901"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090902"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -119,7 +119,7 @@ package neorv32_package is
   -- Internal Memory Types ------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   type mem32_t is array (natural range <>) of std_ulogic_vector(31 downto 0); -- memory with 32-bit entries
-  type mem8_t  is array (natural range <>) of std_ulogic_vector(07 downto 0); -- memory with 8-bit entries
+  type mem8_t  is array (natural range <>) of std_ulogic_vector(7 downto 0);  -- memory with 8-bit entries
 
   -- Internal Bus Interface -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -127,7 +127,7 @@ package neorv32_package is
   type bus_req_t is record
     addr  : std_ulogic_vector(31 downto 0); -- access address
     data  : std_ulogic_vector(31 downto 0); -- write data
-    ben   : std_ulogic_vector(03 downto 0); -- byte enable
+    ben   : std_ulogic_vector(3 downto 0); -- byte enable
     stb   : std_ulogic; -- request strobe (single-shot)
     rw    : std_ulogic; -- 0=read, 1=write
     src   : std_ulogic; -- access source (1=instruction fetch, 0=data access)
@@ -167,8 +167,8 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   -- request --
   type dmi_req_t is record
-    addr : std_ulogic_vector(06 downto 0);
-    op   : std_ulogic_vector(01 downto 0);
+    addr : std_ulogic_vector(6 downto 0);
+    op   : std_ulogic_vector(1 downto 0);
     data : std_ulogic_vector(31 downto 0);
   end record;
 
@@ -483,17 +483,17 @@ package neorv32_package is
   type ctrl_bus_t is record
     -- register file --
     rf_wb_en     : std_ulogic; -- write back enable
-    rf_rs1       : std_ulogic_vector(04 downto 0); -- source register 1 address
-    rf_rs2       : std_ulogic_vector(04 downto 0); -- source register 2 address
-    rf_rd        : std_ulogic_vector(04 downto 0); -- destination register address
+    rf_rs1       : std_ulogic_vector(4 downto 0);  -- source register 1 address
+    rf_rs2       : std_ulogic_vector(4 downto 0);  -- source register 2 address
+    rf_rd        : std_ulogic_vector(4 downto 0);  -- destination register address
     rf_zero_we   : std_ulogic;                     -- allow/force write access to x0
     -- alu --
-    alu_op       : std_ulogic_vector(02 downto 0); -- operation select
+    alu_op       : std_ulogic_vector(2 downto 0);  -- operation select
     alu_sub      : std_ulogic;                     -- addition/subtraction control
     alu_opa_mux  : std_ulogic;                     -- operand A select (0=rs1, 1=PC)
     alu_opb_mux  : std_ulogic;                     -- operand B select (0=rs2, 1=IMM)
     alu_unsigned : std_ulogic;                     -- is unsigned ALU operation
-    alu_cp_trig  : std_ulogic_vector(05 downto 0); -- co-processor trigger (one-hot)
+    alu_cp_trig  : std_ulogic_vector(5 downto 0);  -- co-processor trigger (one-hot)
     -- load/store unit --
     lsu_req      : std_ulogic;                     -- trigger memory access request
     lsu_rw       : std_ulogic;                     -- 0: read access, 1: write access
@@ -501,9 +501,9 @@ package neorv32_package is
     lsu_fence    : std_ulogic;                     -- fence(.i) operation
     lsu_priv     : std_ulogic;                     -- effective privilege mode for load/store
     -- instruction word --
-    ir_funct3    : std_ulogic_vector(02 downto 0); -- funct3 bit field
+    ir_funct3    : std_ulogic_vector(2 downto 0);  -- funct3 bit field
     ir_funct12   : std_ulogic_vector(11 downto 0); -- funct12 bit field
-    ir_opcode    : std_ulogic_vector(06 downto 0); -- opcode bit field
+    ir_opcode    : std_ulogic_vector(6 downto 0);  -- opcode bit field
     -- cpu status --
     cpu_priv     : std_ulogic;                     -- effective privilege mode
     cpu_sleep    : std_ulogic;                     -- set when CPU is in sleep mode
@@ -818,7 +818,7 @@ package neorv32_package is
       xbus_adr_o     : out std_ulogic_vector(31 downto 0);
       xbus_dat_o     : out std_ulogic_vector(31 downto 0);
       xbus_we_o      : out std_ulogic;
-      xbus_sel_o     : out std_ulogic_vector(03 downto 0);
+      xbus_sel_o     : out std_ulogic_vector(3 downto 0);
       xbus_stb_o     : out std_ulogic;
       xbus_cyc_o     : out std_ulogic;
       xbus_dat_i     : in  std_ulogic_vector(31 downto 0) := (others => 'L');
@@ -826,10 +826,12 @@ package neorv32_package is
       xbus_err_i     : in  std_ulogic := 'L';
       -- Stream Link Interface (available if IO_SLINK_EN = true) --
       slink_rx_dat_i : in  std_ulogic_vector(31 downto 0) := (others => 'L');
+      slink_rx_src_i : in  std_ulogic_vector(3 downto 0) := (others => 'L');
       slink_rx_val_i : in  std_ulogic := 'L';
       slink_rx_lst_i : in  std_ulogic := 'L';
       slink_rx_rdy_o : out std_ulogic;
       slink_tx_dat_o : out std_ulogic_vector(31 downto 0);
+      slink_tx_dst_o : out std_ulogic_vector(3 downto 0);
       slink_tx_val_o : out std_ulogic;
       slink_tx_lst_o : out std_ulogic;
       slink_tx_rdy_i : in  std_ulogic := 'L';
@@ -855,7 +857,7 @@ package neorv32_package is
       spi_clk_o      : out std_ulogic;
       spi_dat_o      : out std_ulogic;
       spi_dat_i      : in  std_ulogic := 'L';
-      spi_csn_o      : out std_ulogic_vector(07 downto 0); -- SPI CS
+      spi_csn_o      : out std_ulogic_vector(7 downto 0); -- SPI CS
       -- SDI (available if IO_SDI_EN = true) --
       sdi_clk_i      : in  std_ulogic := 'L';
       sdi_dat_o      : out std_ulogic;

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -162,12 +162,14 @@ entity neorv32_vivado_ip is
     -- ------------------------------------------------------------
     -- Source --
 --  s0_axis_aclk   : in  std_ulogic := '0'; -- just to satisfy Vivado, but not actually used!
+    s0_axis_tdest  : out std_ulogic_vector(3 downto 0);
     s0_axis_tvalid : out std_ulogic;
     s0_axis_tready : in  std_ulogic := '0';
     s0_axis_tdata  : out std_ulogic_vector(31 downto 0);
     s0_axis_tlast  : out std_ulogic;
     -- Sink --
 --  s1_axis_aclk   : in  std_ulogic := '0'; -- just to satisfy Vivado, but not actually used!
+    s1_axis_tid    : in  std_ulogic_vector(3 downto 0) := x"0";
     s1_axis_tvalid : in  std_ulogic := '0';
     s1_axis_tready : out std_ulogic;
     s1_axis_tdata  : in  std_ulogic_vector(31 downto 0) := x"00000000";
@@ -387,10 +389,12 @@ begin
     xbus_err_i     => wb_core.err,
     -- Stream Link Interface (available if IO_SLINK_EN = true) --
     slink_rx_dat_i => s1_axis_tdata,
+    slink_rx_src_i => s1_axis_tid,
     slink_rx_val_i => s1_axis_tvalid,
     slink_rx_lst_i => s1_axis_tlast,
     slink_rx_rdy_o => s1_axis_tready,
     slink_tx_dat_o => s0_axis_tdata,
+    slink_tx_dst_o => s0_axis_tdest,
     slink_tx_val_o => s0_axis_tvalid,
     slink_tx_lst_o => s0_axis_tlast,
     slink_tx_rdy_i => s0_axis_tready,

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -100,6 +100,7 @@ architecture neorv32_tb_rtl of neorv32_tb is
   signal slink_val : std_ulogic;
   signal slink_lst : std_ulogic;
   signal slink_rdy : std_ulogic;
+  signal slink_id  : std_ulogic_vector(3 downto 0);
 
   -- Wishbone bus --
   type wishbone_t is record
@@ -305,12 +306,14 @@ begin
     xbus_err_i     => wb_cpu.err,      -- transfer error
     -- Stream Link Interface (available if IO_SLINK_EN = true) --
     slink_rx_dat_i => slink_dat,       -- RX input data
+    slink_rx_src_i => slink_id,        -- RX source routing information
     slink_rx_val_i => slink_val,       -- RX valid input
-    slink_rx_lst_i => slink_lst,       -- last element of stream
+    slink_rx_lst_i => slink_lst,       -- RX last element of stream
     slink_rx_rdy_o => slink_rdy,       -- RX ready to receive
     slink_tx_dat_o => slink_dat,       -- TX output data
+    slink_tx_dst_o => slink_id,        -- TX destination routing information
     slink_tx_val_o => slink_val,       -- TX valid output
-    slink_tx_lst_o => slink_lst,       -- last element of stream
+    slink_tx_lst_o => slink_lst,       -- TX last element of stream
     slink_tx_rdy_i => slink_rdy,       -- TX ready to send
     -- XIP (execute in place via SPI) signals (available if XIP_EN = true) --
     xip_csn_o      => open,            -- chip-select, low-active

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -120,6 +120,7 @@ architecture neorv32_tb_simple_rtl of neorv32_tb_simple is
   signal slink_val : std_ulogic;
   signal slink_lst : std_ulogic;
   signal slink_rdy : std_ulogic;
+  signal slink_id  : std_ulogic_vector(3 downto 0);
 
   -- Wishbone bus --
   type wishbone_t is record
@@ -281,12 +282,14 @@ begin
     xbus_err_i     => wb_cpu.err,      -- transfer error
     -- Stream Link Interface (available if IO_SLINK_EN = true) --
     slink_rx_dat_i => slink_dat,       -- RX input data
+    slink_rx_src_i => slink_id,        -- RX source routing information
     slink_rx_val_i => slink_val,       -- RX valid input
-    slink_rx_lst_i => slink_lst,       -- last element of stream
+    slink_rx_lst_i => slink_lst,       -- RX last element of stream
     slink_rx_rdy_o => slink_rdy,       -- RX ready to receive
     slink_tx_dat_o => slink_dat,       -- TX output data
+    slink_tx_dst_o => slink_id,        -- TX destination routing information
     slink_tx_val_o => slink_val,       -- TX valid output
-    slink_tx_lst_o => slink_lst,       -- last element of stream
+    slink_tx_lst_o => slink_lst,       -- TX last element of stream
     slink_tx_rdy_i => slink_rdy,       -- TX ready to send
     -- XIP (execute in place via SPI) signals (available if XIP_EN = true) --
     xip_csn_o      => open,            -- chip-select, low-active

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1578,6 +1578,7 @@ int main() {
     neorv32_cpu_csr_write(CSR_MIE, 1 << SLINK_RX_FIRQ_ENABLE);
 
     // send RX_FIFO/2 data words
+    neorv32_slink_set_dst(0b1010);
     for (tmp_b=0; tmp_b<(tmp_a/2); tmp_b++) {
       neorv32_slink_put_last(0xAABBCCDD); // mark as end-of-stream
     }
@@ -1592,6 +1593,7 @@ int main() {
     if ((neorv32_cpu_csr_read(CSR_MCAUSE) == SLINK_RX_TRAP_CODE) && // correct trap code
         (neorv32_slink_rx_status() == SLINK_FIFO_HALF) && // RX FIFO is at least half full
         (neorv32_slink_get() == 0xAABBCCDD) && // correct RX data
+        (neorv32_slink_get_src() == 0b1010) && // correct routing information
         (neorv32_slink_check_last())) { // is marked as "end of stream"
       test_ok();
     }
@@ -1621,6 +1623,7 @@ int main() {
     neorv32_cpu_csr_write(CSR_MIE, 1 << SLINK_TX_FIRQ_ENABLE);
 
     // send single data word
+    neorv32_slink_set_dst(0b1100);
     neorv32_slink_put(0x11223344);
 
     // wait for interrupt
@@ -1633,6 +1636,7 @@ int main() {
     if ((neorv32_cpu_csr_read(CSR_MCAUSE) == SLINK_TX_TRAP_CODE) && // correct trap code
         (neorv32_slink_tx_status() == SLINK_FIFO_EMPTY) && // TX FIFO is empty
         (neorv32_slink_get() == 0x11223344) && // correct RX data
+        (neorv32_slink_get_src() == 0b1100) && // correct routing information
         (neorv32_slink_check_last() == 0)) { // is NOT marked as "end of stream"
       test_ok();
     }

--- a/sw/lib/include/neorv32_slink.h
+++ b/sw/lib/include/neorv32_slink.h
@@ -62,9 +62,9 @@ enum NEORV32_SLINK_CTRL_enum {
 /** ROUTE register bits */
 enum NEORV32_SLINK_ROUTE_enum {
   SLINK_ROUTE_DST_LSB = 0, /**< SLINK routing register(0) (r/w): Destination routing information LSB */
-  SLINK_ROUTE_DST_MSB = 3, /**< SLINK routing register(3) (r/w): Destination routing information MSB */ 
+  SLINK_ROUTE_DST_MSB = 3, /**< SLINK routing register(3) (r/w): Destination routing information MSB */
   SLINK_ROUTE_SRC_LSB = 4, /**< SLINK routing register(4) (r/-): Source routing information LSB */
-  SLINK_ROUTE_SRC_MSB = 7  /**< SLINK routing register(7) (r/-): Source routing information MSB */ 
+  SLINK_ROUTE_SRC_MSB = 7  /**< SLINK routing register(7) (r/-): Source routing information MSB */
 };
 
 enum NEORV32_SLINK_STATUS_enum {

--- a/sw/lib/include/neorv32_slink.h
+++ b/sw/lib/include/neorv32_slink.h
@@ -22,10 +22,10 @@
 /**@{*/
 /** SLINK module prototype */
 typedef volatile struct __attribute__((packed,aligned(4))) {
-  uint32_t CTRL;           /**< offset 0: control register (#NEORV32_SLINK_CTRL_enum) */
-  const uint32_t reserved; /**< offset 4: reserved */
-  uint32_t DATA;           /**< offset 8: RX/TX data register */
-  uint32_t DATA_LAST;      /**< offset 12: RX/TX data register (+ TX end-of-stream) */
+  uint32_t CTRL;      /**< offset 0: control register (#NEORV32_SLINK_CTRL_enum) */
+  uint32_t ROUTE;     /**< offset 4: routing information (#NEORV32_SLINK_ROUTE_enum) */
+  uint32_t DATA;      /**< offset 8: RX/TX data register */
+  uint32_t DATA_LAST; /**< offset 12: RX/TX data register (+ TX end-of-stream) */
 } neorv32_slink_t;
 
 /** SLINK module hardware access (#neorv32_slink_t) */
@@ -59,6 +59,14 @@ enum NEORV32_SLINK_CTRL_enum {
   SLINK_CTRL_TX_FIFO_MSB   = 31  /**< SLINK control register(31) (r/-): log2(TX FIFO size) MSB */
 };
 
+/** ROUTE register bits */
+enum NEORV32_SLINK_ROUTE_enum {
+  SLINK_ROUTE_DST_LSB = 0, /**< SLINK routing register(0) (r/w): Destination routing information LSB */
+  SLINK_ROUTE_DST_MSB = 3, /**< SLINK routing register(3) (r/w): Destination routing information MSB */ 
+  SLINK_ROUTE_SRC_LSB = 4, /**< SLINK routing register(4) (r/-): Source routing information LSB */
+  SLINK_ROUTE_SRC_MSB = 7  /**< SLINK routing register(7) (r/-): Source routing information MSB */ 
+};
+
 enum NEORV32_SLINK_STATUS_enum {
   SLINK_FIFO_EMPTY = 0, /**< FIFO is empty */
   SLINK_FIFO_HALF  = 1, /**< FIFO is at least half full */
@@ -79,6 +87,8 @@ int      neorv32_slink_get_rx_fifo_depth(void);
 int      neorv32_slink_get_tx_fifo_depth(void);
 uint32_t neorv32_slink_get(void);
 uint32_t neorv32_slink_check_last(void);
+void     neorv32_slink_set_dst(uint32_t dst);
+uint32_t neorv32_slink_get_src(void);
 void     neorv32_slink_put(uint32_t tx_data);
 void     neorv32_slink_put_last(uint32_t tx_data);
 int      neorv32_slink_rx_status(void);

--- a/sw/lib/source/neorv32_slink.c
+++ b/sw/lib/source/neorv32_slink.c
@@ -128,6 +128,31 @@ inline uint32_t __attribute__((always_inline)) neorv32_slink_check_last(void) {
 
 
 /**********************************************************************//**
+ * Set TX link routing destination
+ *
+ * @param[in] dst Routing destination ID (4-bit, LSB-aligned).
+ **************************************************************************/
+inline void __attribute__((always_inline)) neorv32_slink_set_dst(uint32_t dst) {
+
+  NEORV32_SLINK->ROUTE = dst;
+}
+
+
+/**********************************************************************//**
+ * Get RX link routing source
+ *
+ * @note This needs has to be called AFTER reading the actual data word
+ * using #neorv32_slink_get(void).
+ *
+ * @return 4-bit source routing ID.
+ **************************************************************************/
+inline uint32_t __attribute__((always_inline)) neorv32_slink_get_src(void) {
+
+  return (NEORV32_SLINK->ROUTE >> SLINK_ROUTE_SRC_LSB) & 0xF;
+}
+
+
+/**********************************************************************//**
  * Write data to TX link (non-blocking)
  *
  * @param[in] tx_data Data to send to link.

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -349,6 +349,24 @@
           </fields>
         </register>
         <register>
+          <name>ROUTE</name>
+          <description>Routing information</description>
+          <addressOffset>0x04</addressOffset>
+          <fields>
+            <field>
+              <name>SLINK_ROUTE_DST</name>
+              <bitRange>[3:0]</bitRange>
+              <description>TX stream destination address/ID (TDEST)</description>
+            </field>
+            <field>
+              <name>SLINK_ROUTE_SRC</name>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+              <description>RX stream source address/ID (TID)</description>
+            </field>
+          </fields>
+        </register>
+        <register>
           <name>DATA</name>
           <description>RX/TX data register</description>
           <addressOffset>0x08</addressOffset>


### PR DESCRIPTION
This PR adds two new 4-bit ports to the SLINK module allowing the single RX/TX ports to access up to 16 stream link sources/sinks (via a switch or interconnect).

New top entity ports:
* `slink_rx_src_i`, input, 4-bit, compatible to AXI-stream's `TID` signal
* `slink_tx_dst_o`, output, 4-bit, compatible to AXI-stream's `TDEST` signal

The routing information is also fully buffered by the SLINK's internal RX/TX FIFOs.