### PR TITLE
Fix uncached/cached access priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 30.05.2024 | 1.9.9.5 | :bug: fix uncached-vs-cached memory accesses (do not interrupt cache bursts by direct/uncached memory accesses) | [#915](https://github.com/stnolting/neorv32/pull/915) |
 | 29.05.2024 | 1.9.9.4 | Vivado IP block: add resizing ports for GPIOs, XIRQs and PWM; split size configuration for GPIO inputs and outputs | [#913](https://github.com/stnolting/neorv32/pull/913) |
 | 27.05.2024 | 1.9.9.3 | removed `XIRQ_TRIGGER_*` generics; XIRQ trigger type is now _programmable_ by dedicated configuration registers | [#911](https://github.com/stnolting/neorv32/pull/911) |
 | 21.05.2024 | 1.9.9.2 | :sparkles: add SLINK routing information ports (compatible to AXI-stream's `TID` and `TDEST` signals) | [#908](https://github.com/stnolting/neorv32/pull/908) |

--- a/docs/datasheet/soc_dcache.adoc
+++ b/docs/datasheet/soc_dcache.adoc
@@ -22,7 +22,9 @@ full-transparent accesses. The cache is direct-mapped and uses "write-allocate" 
 [NOTE]
 The data cache provides direct accesses (= uncached) to memory in order to access memory-mapped IO (like the
 processor-internal IO/peripheral modules). All accesses that target the address range from `0xF0000000` to `0xFFFFFFFF`
-will not be cached at all (see section <<_address_space>>).
+will not be cached at all (see section <<_address_space>>). Direct/uncached accesses have **lower** priority than
+cache block operations to allow continuous burst transfer and also to maintain logical instruction forward
+progress / data coherency.
 
 .Caching Internal Memories
 [NOTE]

--- a/docs/datasheet/soc_icache.adoc
+++ b/docs/datasheet/soc_icache.adoc
@@ -22,7 +22,9 @@ full-transparent accesses. The cache is direct-mapped and read-only.
 [NOTE]
 The data cache provides direct accesses (= uncached) to memory in order to access memory-mapped IO (like the
 processor-internal IO/peripheral modules). All accesses that target the address range from `0xF0000000` to `0xFFFFFFFF`
-will not be cached at all (see section <<_address_space>>).
+will not be cached at all (see section <<_address_space>>). Direct/uncached accesses have **lower** priority than
+cache block operations to allow continuous burst transfer and also to maintain logical instruction forward
+progress / data coherency.
 
 .Caching Internal Memories
 [NOTE]

--- a/docs/datasheet/soc_xbus.adoc
+++ b/docs/datasheet/soc_xbus.adoc
@@ -118,7 +118,10 @@ The **write-allocate** strategy will fetch the entire referenced block from main
 a cache write-miss. The **write-back** strategy will gather all writes locally inside the cache until the according
 cache block is about to be replaced. In this case, the entire modified cache block is written back to main memory.
 
-The x-cache also provides "direct accesses" that bypass the cache. For example, this can be used to access
-processor-external memory-mapped IO. All accesses that target the address range from `0xF0000000` to `0xFFFFFFFF`
-will always bypass the cache (see section <<_address_space>>). Furthermore, load-reservate and store conditional
-<<_atomic_accesses>> will also always bypass the cache **regardless of the accessed address**.
+.Cached/Uncached Accesses
+[NOTE]
+The data cache provides direct accesses (= uncached) to memory in order to access memory-mapped IO.
+All accesses that target the address range from `0xF0000000` to `0xFFFFFFFF`
+will not be cached at all (see section <<_address_space>>). Direct/uncached accesses have **lower** priority than
+cache block operations to allow continuous burst transfer and also to maintain logical instruction forward
+progress / data coherency.

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -381,7 +381,7 @@ end neorv32_cache_rtl;
 -- -------------------------------------------------------------------------------- --
 -- Handle host accesses to the cache (check for hit/miss) or bypass cache if        --
 -- direct/uncached access. If a cache miss occurs or a fence request is received an --
--- according command is sent to the bus interface unit.                             --                                       
+-- according command is sent to the bus interface unit.                             --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
@@ -389,7 +389,6 @@ end neorv32_cache_rtl;
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
-
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -376,42 +376,20 @@ end neorv32_cache_rtl;
 -- ###########################################################################################################################################
 
 
--- #################################################################################################
--- # << NEORV32 - Generic Cache: Host Access Controller >>                                         #
--- # ********************************************************************************************* #
--- # Handle host accesses to the cache (check for hit/miss) or bypass cache if direct/uncached     #
--- # access. If a cache miss occurs or a fence request is received an according command is sent to #
--- # the bus interface unit.                                                                       #
--- # ********************************************************************************************* #
--- # BSD 3-Clause License                                                                          #
--- #                                                                                               #
--- # The NEORV32 RISC-V Processor, https://github.com/stnolting/neorv32                            #
--- # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
--- #                                                                                               #
--- # Redistribution and use in source and binary forms, with or without modification, are          #
--- # permitted provided that the following conditions are met:                                     #
--- #                                                                                               #
--- # 1. Redistributions of source code must retain the above copyright notice, this list of        #
--- #    conditions and the following disclaimer.                                                   #
--- #                                                                                               #
--- # 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
--- #    conditions and the following disclaimer in the documentation and/or other materials        #
--- #    provided with the distribution.                                                            #
--- #                                                                                               #
--- # 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
--- #    endorse or promote products derived from this software without specific prior written      #
--- #    permission.                                                                                #
--- #                                                                                               #
--- # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
--- # OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
--- # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
--- # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
--- # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
--- # GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
--- # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
--- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
--- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
--- #################################################################################################
+-- ================================================================================ --
+-- NEORV32 CPU - Generic Cache: Host Access Controller                              --
+-- -------------------------------------------------------------------------------- --
+-- Handle host accesses to the cache (check for hit/miss) or bypass cache if        --
+-- direct/uncached access. If a cache miss occurs or a fence request is received an --
+-- according command is sent to the bus interface unit.                             --                                       
+-- -------------------------------------------------------------------------------- --
+-- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
+-- Copyright (c) NEORV32 contributors.                                              --
+-- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
+-- SPDX-License-Identifier: BSD-3-Clause                                            --
+-- ================================================================================ --
+
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -568,38 +546,15 @@ end neorv32_cache_host_rtl;
 -- ###########################################################################################################################################
 
 
--- #################################################################################################
--- # << NEORV32 - Generic Cache: Data and Status Memory (direct-mapped) >>                         #
--- # ********************************************************************************************* #
--- # BSD 3-Clause License                                                                          #
--- #                                                                                               #
--- # The NEORV32 RISC-V Processor, https://github.com/stnolting/neorv32                            #
--- # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
--- #                                                                                               #
--- # Redistribution and use in source and binary forms, with or without modification, are          #
--- # permitted provided that the following conditions are met:                                     #
--- #                                                                                               #
--- # 1. Redistributions of source code must retain the above copyright notice, this list of        #
--- #    conditions and the following disclaimer.                                                   #
--- #                                                                                               #
--- # 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
--- #    conditions and the following disclaimer in the documentation and/or other materials        #
--- #    provided with the distribution.                                                            #
--- #                                                                                               #
--- # 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
--- #    endorse or promote products derived from this software without specific prior written      #
--- #    permission.                                                                                #
--- #                                                                                               #
--- # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
--- # OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
--- # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
--- # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
--- # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
--- # GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
--- # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
--- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
--- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
--- #################################################################################################
+-- ================================================================================ --
+-- NEORV32 CPU - Generic Cache: Data and Status Memory (direct-mapped)              --
+-- -------------------------------------------------------------------------------- --
+-- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
+-- Copyright (c) NEORV32 contributors.                                              --
+-- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
+-- SPDX-License-Identifier: BSD-3-Clause                                            --
+-- ================================================================================ --
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -782,38 +737,15 @@ end neorv32_cache_memory_rtl;
 -- ###########################################################################################################################################
 
 
--- #################################################################################################
--- # << NEORV32 - Generic Cache: Bus Interface Unit >>                                             #
--- # ********************************************************************************************* #
--- # BSD 3-Clause License                                                                          #
--- #                                                                                               #
--- # The NEORV32 RISC-V Processor, https://github.com/stnolting/neorv32                            #
--- # Copyright (c) 2024, Stephan Nolting. All rights reserved.                                     #
--- #                                                                                               #
--- # Redistribution and use in source and binary forms, with or without modification, are          #
--- # permitted provided that the following conditions are met:                                     #
--- #                                                                                               #
--- # 1. Redistributions of source code must retain the above copyright notice, this list of        #
--- #    conditions and the following disclaimer.                                                   #
--- #                                                                                               #
--- # 2. Redistributions in binary form must reproduce the above copyright notice, this list of     #
--- #    conditions and the following disclaimer in the documentation and/or other materials        #
--- #    provided with the distribution.                                                            #
--- #                                                                                               #
--- # 3. Neither the name of the copyright holder nor the names of its contributors may be used to  #
--- #    endorse or promote products derived from this software without specific prior written      #
--- #    permission.                                                                                #
--- #                                                                                               #
--- # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS   #
--- # OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF               #
--- # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE    #
--- # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,     #
--- # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE #
--- # GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED    #
--- # AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING     #
--- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
--- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
--- #################################################################################################
+-- ================================================================================ --
+-- NEORV32 CPU - Generic Cache: Bus Interface Unit                                  --
+-- -------------------------------------------------------------------------------- --
+-- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
+-- Copyright (c) NEORV32 contributors.                                              --
+-- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
+-- SPDX-License-Identifier: BSD-3-Clause                                            --
+-- ================================================================================ --
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -1056,7 +1056,7 @@ begin
     end case;
   end process ctrl_engine_comb;
 
-  -- bus arbiter operation in progress (host keeps allying cache address while bus unit reports idle state) --
+  -- bus arbiter operation in progress --
   cmd_busy_o <= '0' when (state = S_IDLE) else '1';
 
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090904"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090905"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -641,14 +641,15 @@ begin
       PORT_B_READ_ONLY => true -- i-fetch is read-only
     )
     port map (
-      clk_i   => clk_i,
-      rstn_i  => rstn_sys,
-      a_req_i => dcache_req, -- prioritized
-      a_rsp_o => dcache_rsp,
-      b_req_i => icache_req,
-      b_rsp_o => icache_rsp,
-      x_req_o => core_req,
-      x_rsp_i => core_rsp
+      clk_i    => clk_i,
+      rstn_i   => rstn_sys,
+      a_lock_i => '0', -- no exclusive accesses for port A
+      a_req_i  => dcache_req, -- prioritized
+      a_rsp_o  => dcache_rsp,
+      b_req_i  => icache_req,
+      b_rsp_o  => icache_rsp,
+      x_req_o  => core_req,
+      x_rsp_i  => core_rsp
     );
 
   end generate; -- /core_complex
@@ -683,14 +684,15 @@ begin
       PORT_B_READ_ONLY => false
     )
     port map (
-      clk_i   => clk_i,
-      rstn_i  => rstn_sys,
-      a_req_i => core_req, -- prioritized
-      a_rsp_o => core_rsp,
-      b_req_i => dma_req,
-      b_rsp_o => dma_rsp,
-      x_req_o => main_req,
-      x_rsp_i => main_rsp
+      clk_i    => clk_i,
+      rstn_i   => rstn_sys,
+      a_lock_i => '0', -- no exclusive accesses for port A
+      a_req_i  => core_req, -- prioritized
+      a_rsp_o  => core_rsp,
+      b_req_i  => dma_req,
+      b_rsp_o  => dma_rsp,
+      x_req_o  => main_req,
+      x_rsp_i  => main_rsp
     );
 
   end generate; -- /neorv32_dma_complex_true

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1901,8 +1901,6 @@ int main() {
     // [NOTE] LR/SC operations bypass the data cache so we need to flush/reload
     //        it before/after making "normal" load/store operations
 
-    neorv32_cpu_invalidate_reservations(); // invalidate all current reservations
-
     amo_var = 0x00cafe00; // initialize
     asm volatile ("fence"); // flush/reload d-cache
 
@@ -1943,8 +1941,6 @@ int main() {
 
     // [NOTE] LR/SC operations bypass the data cache so we need to flush/reload
     //        it before/after making "normal" load/store operations
-
-    neorv32_cpu_invalidate_reservations(); // invalidate all current reservations
 
     amo_var = 0x00abba00; // initialize
     asm volatile ("fence"); // flush/reload d-cache

--- a/sw/lib/include/neorv32_cpu.h
+++ b/sw/lib/include/neorv32_cpu.h
@@ -348,19 +348,6 @@ inline uint32_t __attribute__ ((always_inline)) neorv32_cpu_store_conditional_wo
 }
 
 
-/**********************************************************************//**
- * Atomic memory access: invalidate (all) current reservation sets
- *
- * @warning This function requires the A ISA extension.
- **************************************************************************/
-inline void __attribute__ ((always_inline)) neorv32_cpu_invalidate_reservations(void) {
-
-#if defined __riscv_atomic
-  asm volatile ("sc.w zero, zero, (zero)");
-#endif
-}
-
-
 // #################################################################################################
 // CSR access helpers
 // #################################################################################################


### PR DESCRIPTION
With this PR the caches ensure that uncached accesses always have **lower** priority than cache block operation. Thus, cache block operations will never be interrupted allowing continuous burst transfers. Furthermore, uncached/direct memory accesses will be stalled until all cache operations are completed to ensure memory coherency.