### PR TITLE
[xbus] access type identifier (tag signal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 31.05.2024 | 1.9.9.6 | add "tag" signal to XBUS to provide additional access information (compatible to the AXI4 _ARPROT_ and _AWPROT_ signals) | [#917](https://github.com/stnolting/neorv32/pull/917) |
 | 30.05.2024 | 1.9.9.5 | :bug: fix uncached-vs-cached memory accesses (do not interrupt cache bursts by direct/uncached memory accesses) | [#915](https://github.com/stnolting/neorv32/pull/915) |
 | 29.05.2024 | 1.9.9.4 | Vivado IP block: add resizing ports for GPIOs, XIRQs and PWM; split size configuration for GPIO inputs and outputs | [#913](https://github.com/stnolting/neorv32/pull/913) |
 | 27.05.2024 | 1.9.9.3 | removed `XIRQ_TRIGGER_*` generics; XIRQ trigger type is now _programmable_ by dedicated configuration registers | [#911](https://github.com/stnolting/neorv32/pull/911) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -86,15 +86,16 @@ Some interfaces (like the TWI and the 1-Wire bus) require tri-state drivers in t
 | `jtag_tdo_o`     |  1 | out |   -   | serial data output
 | `jtag_tms_i`     |  1 |  in | `'L'` | mode select
 5+^| **<<_processor_external_bus_interface_xbus>>**
-| `xbus_adr_o`     | 32 | out |   -   |  destination address
-| `xbus_dat_o`     | 32 | out |   -   |  read data
-| `xbus_we_o`      |  1 | out |   -   |  write enable ('0' = read transfer)
-| `xbus_sel_o`     |  4 | out |   -   |  byte enable
-| `xbus_stb_o`     |  1 | out |   -   |  strobe
-| `xbus_cyc_o`     |  1 | out |   -   |  valid cycle
-| `xbus_dat_i`     | 32 |  in | `'L'` |  write data
-| `xbus_ack_i`     |  1 |  in | `'L'` |  transfer acknowledge
-| `xbus_err_i`     |  1 |  in | `'L'` |  transfer error
+| `xbus_adr_o`     | 32 | out |   -   | destination address
+| `xbus_dat_o`     | 32 | out |   -   | read data
+| `xbus_tag_o`     |  3 | out |   -   | access tag
+| `xbus_we_o`      |  1 | out |   -   | write enable ('0' = read transfer)
+| `xbus_sel_o`     |  4 | out |   -   | byte enable
+| `xbus_stb_o`     |  1 | out |   -   | strobe
+| `xbus_cyc_o`     |  1 | out |   -   | valid cycle
+| `xbus_dat_i`     | 32 |  in | `'L'` | write data
+| `xbus_ack_i`     |  1 |  in | `'L'` | transfer acknowledge
+| `xbus_err_i`     |  1 |  in | `'L'` | transfer error
 5+^| **<<_stream_link_interface_slink>>**
 | `slink_rx_dat_i` | 32 |  in | `'L'` | RX data
 | `slink_rx_src_i` |  4 |  in | `'L'` | RX source routing information

--- a/docs/datasheet/soc_xbus.adoc
+++ b/docs/datasheet/soc_xbus.adoc
@@ -9,12 +9,13 @@
 |                         | neorv32_cache.vhd       | Generic cache module
 | Software driver files:  | none                    | _implicitly used_
 | Top entity ports:       | `xbus_adr_o`            | address output (32-bit)
-|                         | `xbus_dat_i`            | data input (32-bit)
 |                         | `xbus_dat_o`            | data output (32-bit)
+|                         | `xbus_tag_o`            | access tag (3-bit)
 |                         | `xbus_we_o`             | write enable (1-bit)
 |                         | `xbus_sel_o`            | byte enable (4-bit)
 |                         | `xbus_stb_o`            | bus strobe (1-bit)
 |                         | `xbus_cyc_o`            | valid cycle (1-bit)
+|                         | `xbus_dat_i`            | data input (32-bit)
 |                         | `xbus_ack_i`            | acknowledge (1-bit)
 |                         | `xbus_err_i`            | bus error (1-bit)
 | Configuration generics: | `XBUS_EN`               | enable external bus interface when `true`
@@ -92,6 +93,16 @@ An optional register stage can be added to the XBUS gateway to break up the crit
 When `XBUS_REGSTAGE_EN` is _true_ all outgoing and incoming XBUS signals are registered increasing access latency
 by two cycles. Furthermore, all outgoing signals (like the address) will be kept stable if there is no bus access
 being initiated.
+
+
+**Access Tag**
+
+The XBUS tag signal `xbus_tag_o(0)` provides additional information about the current access cycle.
+It compatible to the the AXI4 `ARPROT` and `AWPROT` signals.
+
+* `xbus_tag_o(0)` **P**: access is performed from **privileged** mode (machine-mode) when set
+* `xbus_tag_o(1)` **NS**: this bit is hardwired to `0` indicating a **secure** access
+* `xbus_tag_o(2)` **I**: access is an **instruction** fetch when set; access is a data access when cleared
 
 
 **External Bus Cache (X-CACHE)**

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090905"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01090906"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -817,6 +817,7 @@ package neorv32_package is
       -- External bus interface (available if XBUS_EN = true) --
       xbus_adr_o     : out std_ulogic_vector(31 downto 0);
       xbus_dat_o     : out std_ulogic_vector(31 downto 0);
+      xbus_tag_o     : out std_ulogic_vector(2 downto 0);
       xbus_we_o      : out std_ulogic;
       xbus_sel_o     : out std_ulogic_vector(3 downto 0);
       xbus_stb_o     : out std_ulogic;

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -148,6 +148,7 @@ entity neorv32_top is
     -- External bus interface (available if XBUS_EN = true) --
     xbus_adr_o     : out std_ulogic_vector(31 downto 0); -- address
     xbus_dat_o     : out std_ulogic_vector(31 downto 0); -- write data
+    xbus_tag_o     : out std_ulogic_vector(2 downto 0); -- access tag
     xbus_we_o      : out std_ulogic; -- read/write
     xbus_sel_o     : out std_ulogic_vector(3 downto 0); -- byte enable
     xbus_stb_o     : out std_ulogic; -- strobe
@@ -643,7 +644,7 @@ begin
     port map (
       clk_i    => clk_i,
       rstn_i   => rstn_sys,
-      a_lock_i => '0', -- no exclusive accesses for port A
+      a_lock_i => '0',        -- no exclusive accesses for port A
       a_req_i  => dcache_req, -- prioritized
       a_rsp_o  => dcache_rsp,
       b_req_i  => icache_req,
@@ -686,7 +687,7 @@ begin
     port map (
       clk_i    => clk_i,
       rstn_i   => rstn_sys,
-      a_lock_i => '0', -- no exclusive accesses for port A
+      a_lock_i => '0',      -- no exclusive accesses for port A
       a_req_i  => core_req, -- prioritized
       a_rsp_o  => core_rsp,
       b_req_i  => dma_req,
@@ -948,6 +949,7 @@ begin
         xbus_adr_o => xbus_adr_o,
         xbus_dat_i => xbus_dat_i,
         xbus_dat_o => xbus_dat_o,
+        xbus_tag_o => xbus_tag_o,
         xbus_we_o  => xbus_we_o,
         xbus_sel_o => xbus_sel_o,
         xbus_stb_o => xbus_stb_o,

--- a/rtl/core/neorv32_xbus.vhd
+++ b/rtl/core/neorv32_xbus.vhd
@@ -31,6 +31,7 @@ entity neorv32_xbus is
     xbus_adr_o : out std_ulogic_vector(31 downto 0); -- address
     xbus_dat_i : in  std_ulogic_vector(31 downto 0); -- read data
     xbus_dat_o : out std_ulogic_vector(31 downto 0); -- write data
+    xbus_tag_o : out std_ulogic_vector(2 downto 0); -- access tag
     xbus_we_o  : out std_ulogic; -- read/write
     xbus_sel_o : out std_ulogic_vector(3 downto 0); -- byte enable
     xbus_stb_o : out std_ulogic; -- strobe
@@ -122,6 +123,7 @@ begin
   xbus_sel_o <= bus_req.ben;
   xbus_stb_o <= bus_req.stb;
   xbus_cyc_o <= bus_req.stb or pending;
+  xbus_tag_o <= bus_req.src & '0' & bus_req.priv; -- instr/data, secure, privileged/unprivileged
 
   -- response gating --
   bus_rsp.data <= xbus_dat_i when (pending = '1') and (bus_rw = '0') else (others => '0'); -- no read-back if READ operation

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -295,6 +295,7 @@ begin
     -- External bus interface (available if XBUS_EN = true) --
     xbus_adr_o     => wb_cpu.addr,     -- address
     xbus_dat_o     => wb_cpu.wdata,    -- write data
+    xbus_tag_o     => open,            -- access tag
     xbus_we_o      => wb_cpu.we,       -- read/write
     xbus_sel_o     => wb_cpu.sel,      -- byte enable
     xbus_stb_o     => wb_cpu.stb,      -- strobe

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -271,6 +271,7 @@ begin
     -- External bus interface (available if XBUS_EN = true) --
     xbus_adr_o     => wb_cpu.addr,     -- address
     xbus_dat_o     => wb_cpu.wdata,    -- write data
+    xbus_tag_o     => open,            -- access tag
     xbus_we_o      => wb_cpu.we,       -- read/write
     xbus_sel_o     => wb_cpu.sel,      -- byte enable
     xbus_stb_o     => wb_cpu.stb,      -- strobe


### PR DESCRIPTION
New top signal:
```vhdl
xbus_tag_o : out std_ulogic_vector(2 downto 0); -- access tag
```

* `xbus_tag_o(0)` **P**: access is performed from **privileged** mode (machine-mode) when set
* `xbus_tag_o(1)` **NS**: this bit is hardwired to `0` indicating a **secure** access
* `xbus_tag_o(2)` **I**: access is an **instruction** fetch when set; access is a data access when cleared

> [!NOTE]
> This signal is compatible to AXI4's `ARPROT` and `AWPROT` signals.