### PR TITLE
⚠️ remove redundant JTAG reset signal (TRST)

### DIFF
--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -81,7 +81,6 @@ External JTAG access is provided by the following top-level ports:
 [options="header",grid="rows"]
 |=======================
 | Name          | Width | Direction | Description
-| `jtag_trst_i` | 1     | in        | TAP reset (low-active); this signal is optional, make sure to pull it **high** if not used
 | `jtag_tck_i`  | 1     | in        | serial clock
 | `jtag_tdi_i`  | 1     | in        | serial data input
 | `jtag_tdo_o`  | 1     | out       | serial data output
@@ -93,6 +92,11 @@ External JTAG access is provided by the following top-level ports:
 All JTAG signals are synchronized to the processor's clock domain. Hence, no additional clock domain is required for the DTM.
 However, this constraints the maximal JTAG clock frequency (`jtag_tck_i`) to be less than or equal to **1/5** of the processor
 clock frequency (`clk_i`).
+
+.JTAG TAP Reset
+[NOTE]
+The NEORV32 JTAG TAP does not provide a dedicated reset signal ("TRST"). However, the missing TRST is not a problem,
+since JTAG-level resets can be triggered using with TMS signaling.
 
 .Maintaining JTAG Chain
 [NOTE]

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -80,7 +80,6 @@ Some interfaces (like the TWI and the 1-Wire bus) require tri-state drivers in t
 | `clk_i`          |  1 |  in | none  | global clock line, all registers triggering on rising edge
 | `rstn_i`         |  1 |  in | none  | global reset, asynchronous, **low-active**
 5+^| **JTAG Access Port for <<_on_chip_debugger_ocd>>**
-| `jtag_trst_i`    |  1 |  in | `'H'` | TAP reset, low-active (optional)
 | `jtag_tck_i`     |  1 |  in | `'L'` | serial clock
 | `jtag_tdi_i`     |  1 |  in | `'L'` | serial data input
 | `jtag_tdo_o`     |  1 | out |   -   | serial data output

--- a/docs/userguide/debugging_with_ocd.adoc
+++ b/docs/userguide/debugging_with_ocd.adoc
@@ -10,7 +10,7 @@ RISC-V _GNU debugger_ `gdb`.
 .TLDR
 [TIP]
 You can start a pre-configured debug session (using default `main.elf` as executable and
-`target extended-remote localhost:3333` as gdb connection configuration) by using the **gdb** makefile target
+`target extended-remote localhost:3333` as GDB connection configuration) by using the **GDB** makefile target
 (i.e. `make gdb`).
 
 .OCD Hardware Implementation
@@ -39,17 +39,17 @@ also use a FTDI-based adapter like the "FT2232H-56Q Mini Module", which is a sim
 [cols="^3,^2,^2"]
 [options="header",grid="rows"]
 |=======================
-| NEORV32 top signal | JTAG signal | FTDI port
+| NEORV32 top signal | JTAG signal | Default FTDI port
 | `jtag_tck_i`       | TCK         | D0
 | `jtag_tdi_i`       | TDI         | D1
 | `jtag_tdo_o`       | TDO         | D2
 | `jtag_tms_i`       | TMS         | D3
-| `jtag_trst_i`      | TRST        | D4
 |=======================
 
-[TIP]
-The low-active JTAG tap reset `jtag_trst_i` signals is _optional_ as a reset can also be triggered via the TAP controller
-issuing special commands. If `jtag_trst_i` is not connected make sure to pull the signal _high_.
+.JTAG TAP Reset
+[NOTE]
+The NEORV32 JTAG TAP does not provide a dedicated reset signal ("TRST"). However, the missing TRST is not a problem,
+since JTAG-level resets can be triggered using with TMS signaling.
 
 
 :sectnums:
@@ -239,7 +239,7 @@ instruction. Whenever execution reaches this instruction, debug mode is entered 
 instruction at this address to maintain original program behavior. +
  +
 When debugging programs executed from ROM _hardware-assisted_ breakpoints using the core's trigger module have to be used.
-See section <<_hardware_breakpoints>> for more information. 
+See section <<_hardware_breakpoints>> for more information.
 
 Now execute `c` (= continue). The CPU will resume operation until it hits the break-point.
 By this we can move from one counter increment to another.

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -213,7 +213,7 @@ begin
       dm_ctrl.pbuf_en       <= '0';
       dm_ctrl.illegal_cmd   <= '0';
       dm_ctrl.illegal_state <= '0';
-      dm_ctrl.cmderr        <= "000";
+      dm_ctrl.cmderr        <= (others => '0');
     elsif rising_edge(clk_i) then
       if (dm_reg.dmcontrol_dmactive = '0') then -- DM reset / DM disabled
         dm_ctrl.state         <= CMD_IDLE;
@@ -223,7 +223,7 @@ begin
         --
         dm_ctrl.illegal_cmd   <= '0';
         dm_ctrl.illegal_state <= '0';
-        dm_ctrl.cmderr        <= "000";
+        dm_ctrl.cmderr        <= (others => '0');
       else -- DM active
 
         -- defaults --
@@ -416,8 +416,8 @@ begin
           dm_reg.halt_req           <= dmi_req_i.data(31); -- haltreq (-/w): write 1 to request halt; has to be cleared again by debugger
           dm_reg.resume_req         <= dmi_req_i.data(30); -- resumereq (-/w1): write 1 to request resume; auto-clears
           dm_reg.reset_ack          <= dmi_req_i.data(28); -- ackhavereset (-/w1): write 1 to ACK reset; auto-clears
-          dm_reg.dmcontrol_ndmreset <= dmi_req_i.data(01); -- ndmreset (r/w): SoC reset when high
-          dm_reg.dmcontrol_dmactive <= dmi_req_i.data(00); -- dmactive (r/w): DM reset when low
+          dm_reg.dmcontrol_ndmreset <= dmi_req_i.data(1);  -- ndmreset (r/w): SoC reset when high
+          dm_reg.dmcontrol_dmactive <= dmi_req_i.data(0);  -- dmactive (r/w): DM reset when low
         end if;
 
         -- write abstract command --
@@ -430,7 +430,7 @@ begin
         -- write abstract command autoexec --
         if (dmi_req_i.addr = addr_abstractauto_c) then
           if (dm_ctrl.busy = '0') then -- idle and no errors yet
-            dm_reg.abstractauto_autoexecdata       <= dmi_req_i.data(00);
+            dm_reg.abstractauto_autoexecdata       <= dmi_req_i.data(0);
             dm_reg.abstractauto_autoexecprogbuf(0) <= dmi_req_i.data(16);
             dm_reg.abstractauto_autoexecprogbuf(1) <= dmi_req_i.data(17);
           end if;
@@ -529,13 +529,13 @@ begin
           dmi_rsp_o.data(12)           <= dm_reg.dmcontrol_ndmreset; -- anyunavail (r/-): there is only one hart that is unavailable during reset
           dmi_rsp_o.data(11)           <= not dm_ctrl.hart_halted;   -- allrunning (r/-): there is only one hart that can be RUNNING or HALTED
           dmi_rsp_o.data(10)           <= not dm_ctrl.hart_halted;   -- anyrunning (r/-): there is only one hart that can be RUNNING or HALTED
-          dmi_rsp_o.data(09)           <= dm_ctrl.hart_halted;       -- allhalted (r/-): there is only one hart that can be RUNNING or HALTED
-          dmi_rsp_o.data(08)           <= dm_ctrl.hart_halted;       -- anyhalted (r/-): there is only one hart that can be RUNNING or HALTED
-          dmi_rsp_o.data(07)           <= '1';                       -- authenticated (r/-): authentication passed since there is no authentication
-          dmi_rsp_o.data(06)           <= '0';                       -- authbusy (r/-): always ready since there is no authentication
-          dmi_rsp_o.data(05)           <= '0';                       -- hasresethaltreq (r/-): halt-on-reset not implemented
-          dmi_rsp_o.data(04)           <= '0';                       -- confstrptrvalid (r/-): no configuration string available
-          dmi_rsp_o.data(03 downto 00) <= dm_version_c;              -- version (r/-): DM spec. version
+          dmi_rsp_o.data(9)            <= dm_ctrl.hart_halted;       -- allhalted (r/-): there is only one hart that can be RUNNING or HALTED
+          dmi_rsp_o.data(8)            <= dm_ctrl.hart_halted;       -- anyhalted (r/-): there is only one hart that can be RUNNING or HALTED
+          dmi_rsp_o.data(7)            <= '1';                       -- authenticated (r/-): authentication passed since there is no authentication
+          dmi_rsp_o.data(6)            <= '0';                       -- authbusy (r/-): always ready since there is no authentication
+          dmi_rsp_o.data(5)            <= '0';                       -- hasresethaltreq (r/-): halt-on-reset not implemented
+          dmi_rsp_o.data(4)            <= '0';                       -- confstrptrvalid (r/-): no configuration string available
+          dmi_rsp_o.data(3 downto 0)   <= dm_version_c;              -- version (r/-): DM spec. version
 
         -- debug module control --
         when addr_dmcontrol_c =>
@@ -546,12 +546,12 @@ begin
           dmi_rsp_o.data(27)           <= '0';                       -- reserved (r/-)
           dmi_rsp_o.data(26)           <= '0';                       -- hasel (r/-) - only a single hart can be selected at once
           dmi_rsp_o.data(25 downto 16) <= (others => '0');           -- hartsello (r/-) - there is only one hart
-          dmi_rsp_o.data(15 downto 06) <= (others => '0');           -- hartselhi (r/-) - there is only one hart
-          dmi_rsp_o.data(05 downto 04) <= (others => '0');           -- reserved (r/-)
-          dmi_rsp_o.data(03)           <= '0';                       -- setresethaltreq (-/w1): halt-on-reset request - halt-on-reset not implemented
-          dmi_rsp_o.data(02)           <= '0';                       -- clrresethaltreq (-/w1): halt-on-reset ack - halt-on-reset not implemented
-          dmi_rsp_o.data(01)           <= dm_reg.dmcontrol_ndmreset; -- ndmreset (r/w): soc reset
-          dmi_rsp_o.data(00)           <= dm_reg.dmcontrol_dmactive; -- dmactive (r/w): DM reset
+          dmi_rsp_o.data(15 downto 6)  <= (others => '0');           -- hartselhi (r/-) - there is only one hart
+          dmi_rsp_o.data(5 downto 4)   <= (others => '0');           -- reserved (r/-)
+          dmi_rsp_o.data(3)            <= '0';                       -- setresethaltreq (-/w1): halt-on-reset request - halt-on-reset not implemented
+          dmi_rsp_o.data(2)            <= '0';                       -- clrresethaltreq (-/w1): halt-on-reset ack - halt-on-reset not implemented
+          dmi_rsp_o.data(1)            <= dm_reg.dmcontrol_ndmreset; -- ndmreset (r/w): soc reset
+          dmi_rsp_o.data(0)            <= dm_reg.dmcontrol_dmactive; -- dmactive (r/w): DM reset
 
         -- hart info --
         when addr_hartinfo_c =>
@@ -560,7 +560,7 @@ begin
           dmi_rsp_o.data(19 downto 17) <= (others => '0');         -- reserved (r/-)
           dmi_rsp_o.data(16)           <= dataaccess_c;            -- dataaccess (r/-): 1: data registers are memory-mapped, 0: data registers are CSR-mapped
           dmi_rsp_o.data(15 downto 12) <= datasize_c;              -- datasize (r/-): number data registers in memory/CSR space
-          dmi_rsp_o.data(11 downto 00) <= dataaddr_c(11 downto 0); -- dataaddr (r/-): data registers base address (memory/CSR)
+          dmi_rsp_o.data(11 downto 0)  <= dataaddr_c(11 downto 0); -- dataaddr (r/-): data registers base address (memory/CSR)
 
         -- abstract control and status --
         when addr_abstractcs_c =>
@@ -568,23 +568,23 @@ begin
           dmi_rsp_o.data(28 downto 24) <= "00010";         -- progbufsize (r/-): number of words in program buffer = 2
           dmi_rsp_o.data(12)           <= dm_ctrl.busy;    -- busy (r/-): abstract command in progress (1) / idle (0)
           dmi_rsp_o.data(11)           <= '1';             -- relaxedpriv (r/-): PMP rules are ignored when in debug-mode
-          dmi_rsp_o.data(10 downto 08) <= dm_ctrl.cmderr;  -- cmderr (r/w1c): any error during execution?
-          dmi_rsp_o.data(07 downto 04) <= (others => '0'); -- reserved (r/-)
-          dmi_rsp_o.data(03 downto 00) <= "0001";          -- datacount (r/-): number of implemented data registers = 1
+          dmi_rsp_o.data(10 downto 8)  <= dm_ctrl.cmderr;  -- cmderr (r/w1c): any error during execution?
+          dmi_rsp_o.data(7 downto 4)   <= (others => '0'); -- reserved (r/-)
+          dmi_rsp_o.data(3 downto 0)   <= "0001";          -- datacount (r/-): number of implemented data registers = 1
 
-        -- abstract command (-/w) --
-        when addr_command_c =>
-          dmi_rsp_o.data <= (others => '0'); -- register is write-only
+--      -- abstract command (-/w) --
+--      when addr_command_c =>
+--        dmi_rsp_o.data <= (others => '0'); -- register is write-only
 
         -- abstract command autoexec (r/w) --
         when addr_abstractauto_c =>
-          dmi_rsp_o.data(00) <= dm_reg.abstractauto_autoexecdata;       -- autoexecdata(0):    read/write access to data0 triggers execution of program buffer
+          dmi_rsp_o.data(0)  <= dm_reg.abstractauto_autoexecdata;       -- autoexecdata(0):    read/write access to data0 triggers execution of program buffer
           dmi_rsp_o.data(16) <= dm_reg.abstractauto_autoexecprogbuf(0); -- autoexecprogbuf(0): read/write access to progbuf0 triggers execution of program buffer
           dmi_rsp_o.data(17) <= dm_reg.abstractauto_autoexecprogbuf(1); -- autoexecprogbuf(1): read/write access to progbuf1 triggers execution of program buffer
 
-        -- next debug module (r/-) --
-        when addr_nextdm_c =>
-          dmi_rsp_o.data <= (others => '0'); -- this is the only DM
+--      -- next debug module (r/-) --
+--      when addr_nextdm_c =>
+--        dmi_rsp_o.data <= (others => '0'); -- this is the only DM
 
         -- abstract data 0 (r/w) --
         when addr_data0_c =>
@@ -596,9 +596,9 @@ begin
         when addr_progbuf1_c =>
           if (LEGACY_MODE = true) then dmi_rsp_o.data <= dm_reg.progbuf(1); else dmi_rsp_o.data <= (others => '0'); end if; -- program buffer 1
 
-        -- system bus access control and status (r/-) --
-        when addr_sbcs_c =>
-          dmi_rsp_o.data <= (others => '0'); -- system bus access not implemented
+--      -- system bus access control and status (r/-) --
+--      when addr_sbcs_c =>
+--        dmi_rsp_o.data <= (others => '0'); -- system bus access not implemented
 
         -- halt summary 0 (r/-) --
         when addr_haltsum0_c =>

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100000"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100001"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -809,7 +809,6 @@ package neorv32_package is
       clk_i          : in  std_ulogic;
       rstn_i         : in  std_ulogic;
       -- JTAG on-chip debugger interface --
-      jtag_trst_i    : in  std_ulogic := 'H';
       jtag_tck_i     : in  std_ulogic := 'L';
       jtag_tdi_i     : in  std_ulogic := 'L';
       jtag_tdo_o     : out std_ulogic;

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -139,7 +139,6 @@ entity neorv32_top is
     rstn_i         : in  std_ulogic; -- global reset, low-active, async
 
     -- JTAG on-chip debugger interface (available if ON_CHIP_DEBUGGER_EN = true) --
-    jtag_trst_i    : in  std_ulogic := 'H'; -- low-active TAP reset (optional)
     jtag_tck_i     : in  std_ulogic := 'L'; -- serial clock
     jtag_tdi_i     : in  std_ulogic := 'L'; -- serial data input
     jtag_tdo_o     : out std_ulogic; -- serial data output
@@ -1640,15 +1639,14 @@ begin
       IDCODE_MANID   => JEDEC_ID
     )
     port map (
-      clk_i        => clk_i,
-      rstn_i       => rstn_ext,
-      jtag_trst_i  => jtag_trst_i,
-      jtag_tck_i   => jtag_tck_i,
-      jtag_tdi_i   => jtag_tdi_i,
-      jtag_tdo_o   => jtag_tdo_o,
-      jtag_tms_i   => jtag_tms_i,
-      dmi_req_o    => dmi_req,
-      dmi_rsp_i    => dmi_rsp
+      clk_i      => clk_i,
+      rstn_i     => rstn_ext,
+      jtag_tck_i => jtag_tck_i,
+      jtag_tdi_i => jtag_tdi_i,
+      jtag_tdo_o => jtag_tdo_o,
+      jtag_tms_i => jtag_tms_i,
+      dmi_req_o  => dmi_req,
+      dmi_rsp_i  => dmi_rsp
     );
 
     -- On-Chip Debugger - Debug Module (DM) ---------------------------------------------------

--- a/rtl/system_integration/neorv32_litex_core_complex.vhd
+++ b/rtl/system_integration/neorv32_litex_core_complex.vhd
@@ -41,29 +41,28 @@ entity neorv32_litex_core_complex is
   );
   port (
     -- Global control --
-    clk_i       : in  std_ulogic; -- global clock, rising edge
-    rstn_i      : in  std_ulogic; -- global reset, low-active, async
+    clk_i      : in  std_ulogic; -- global clock, rising edge
+    rstn_i     : in  std_ulogic; -- global reset, low-active, async
 
     -- JTAG on-chip debugger interface --
-    jtag_trst_i : in  std_ulogic; -- low-active TAP reset (optional)
-    jtag_tck_i  : in  std_ulogic; -- serial clock
-    jtag_tdi_i  : in  std_ulogic; -- serial data input
-    jtag_tdo_o  : out std_ulogic; -- serial data output
-    jtag_tms_i  : in  std_ulogic; -- mode select
+    jtag_tck_i : in  std_ulogic; -- serial clock
+    jtag_tdi_i : in  std_ulogic; -- serial data input
+    jtag_tdo_o : out std_ulogic; -- serial data output
+    jtag_tms_i : in  std_ulogic; -- mode select
 
     -- External bus interface (Wishbone) --
-    wb_adr_o    : out std_ulogic_vector(31 downto 0); -- address
-    wb_dat_i    : in  std_ulogic_vector(31 downto 0); -- read data
-    wb_dat_o    : out std_ulogic_vector(31 downto 0); -- write data
-    wb_we_o     : out std_ulogic; -- read/write
-    wb_sel_o    : out std_ulogic_vector(3 downto 0); -- byte enable
-    wb_stb_o    : out std_ulogic; -- strobe
-    wb_cyc_o    : out std_ulogic; -- valid cycle
-    wb_ack_i    : in  std_ulogic; -- transfer acknowledge
-    wb_err_i    : in  std_ulogic; -- transfer error
+    wb_adr_o   : out std_ulogic_vector(31 downto 0); -- address
+    wb_dat_i   : in  std_ulogic_vector(31 downto 0); -- read data
+    wb_dat_o   : out std_ulogic_vector(31 downto 0); -- write data
+    wb_we_o    : out std_ulogic; -- read/write
+    wb_sel_o   : out std_ulogic_vector(3 downto 0); -- byte enable
+    wb_stb_o   : out std_ulogic; -- strobe
+    wb_cyc_o   : out std_ulogic; -- valid cycle
+    wb_ack_i   : in  std_ulogic; -- transfer acknowledge
+    wb_err_i   : in  std_ulogic; -- transfer error
 
     -- CPU interrupt --
-    mext_irq_i  : in  std_ulogic  -- RISC-V machine external interrupt (MEI)
+    mext_irq_i : in  std_ulogic  -- RISC-V machine external interrupt (MEI)
   );
 end neorv32_litex_core_complex;
 
@@ -151,26 +150,25 @@ begin
   )
   port map (
     -- Global control --
-    clk_i       => clk_i,       -- global clock, rising edge
-    rstn_i      => rstn_i,      -- global reset, low-active, async
+    clk_i       => clk_i,      -- global clock, rising edge
+    rstn_i      => rstn_i,     -- global reset, low-active, async
     -- JTAG on-chip debugger interface --
-    jtag_trst_i => jtag_trst_i, -- low-active TAP reset (optional)
-    jtag_tck_i  => jtag_tck_i,  -- serial clock
-    jtag_tdi_i  => jtag_tdi_i,  -- serial data input
-    jtag_tdo_o  => jtag_tdo_o,  -- serial data output
-    jtag_tms_i  => jtag_tms_i,  -- mode select
+    jtag_tck_i  => jtag_tck_i, -- serial clock
+    jtag_tdi_i  => jtag_tdi_i, -- serial data input
+    jtag_tdo_o  => jtag_tdo_o, -- serial data output
+    jtag_tms_i  => jtag_tms_i, -- mode select
     -- External bus interface --
-    xbus_adr_o  => wb_adr_o,    -- address
-    xbus_dat_o  => wb_dat_o,    -- write data
-    xbus_we_o   => wb_we_o,     -- read/write
-    xbus_sel_o  => wb_sel_o,    -- byte enable
-    xbus_stb_o  => open,        -- strobe
-    xbus_cyc_o  => wb_cyc,      -- valid cycle
-    xbus_dat_i  => wb_dat_i,    -- read data
-    xbus_ack_i  => wb_ack_i,    -- transfer acknowledge
-    xbus_err_i  => wb_err_i,    -- transfer error
+    xbus_adr_o  => wb_adr_o,   -- address
+    xbus_dat_o  => wb_dat_o,   -- write data
+    xbus_we_o   => wb_we_o,    -- read/write
+    xbus_sel_o  => wb_sel_o,   -- byte enable
+    xbus_stb_o  => open,       -- strobe
+    xbus_cyc_o  => wb_cyc,     -- valid cycle
+    xbus_dat_i  => wb_dat_i,   -- read data
+    xbus_ack_i  => wb_ack_i,   -- transfer acknowledge
+    xbus_err_i  => wb_err_i,   -- transfer error
     -- CPU Interrupts --
-    mext_irq_i  => mext_irq_i   -- machine external interrupt
+    mext_irq_i  => mext_irq_i  -- machine external interrupt
   );
 
   -- convert to "classic" Wishbone protocol (STB = CYC) --

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -176,7 +176,6 @@ entity neorv32_vivado_ip is
     -- ------------------------------------------------------------
     -- JTAG on-chip debugger interface (available if ON_CHIP_DEBUGGER_EN = true)
     -- ------------------------------------------------------------
-    jtag_trst_i    : in  std_ulogic := '1'; -- low-active; disable reset by default
     jtag_tck_i     : in  std_ulogic := '0';
     jtag_tdi_i     : in  std_ulogic := '0';
     jtag_tdo_o     : out std_ulogic := '0';
@@ -376,7 +375,6 @@ begin
     clk_i          => clk,
     rstn_i         => resetn,
     -- JTAG on-chip debugger interface (available if ON_CHIP_DEBUGGER_EN = true) --
-    jtag_trst_i    => jtag_trst_i,
     jtag_tck_i     => jtag_tck_i,
     jtag_tdi_i     => jtag_tdi_i,
     jtag_tdo_o     => jtag_tdo_o,

--- a/rtl/test_setups/neorv32_test_setup_on_chip_debugger.vhd
+++ b/rtl/test_setups/neorv32_test_setup_on_chip_debugger.vhd
@@ -27,7 +27,6 @@ entity neorv32_test_on_chip_debugger is
     clk_i       : in  std_ulogic; -- global clock, rising edge
     rstn_i      : in  std_ulogic; -- global reset, low-active, async
     -- JTAG on-chip debugger interface --
-    jtag_trst_i : in  std_ulogic; -- low-active TAP reset (optional)
     jtag_tck_i  : in  std_ulogic; -- serial clock
     jtag_tdi_i  : in  std_ulogic; -- serial data input
     jtag_tdo_o  : out std_ulogic; -- serial data output
@@ -76,7 +75,6 @@ begin
     clk_i       => clk_i,       -- global clock, rising edge
     rstn_i      => rstn_i,      -- global reset, low-active, async
     -- JTAG on-chip debugger interface (available if ON_CHIP_DEBUGGER_EN = true) --
-    jtag_trst_i => jtag_trst_i, -- low-active TAP reset (optional)
     jtag_tck_i  => jtag_tck_i,  -- serial clock
     jtag_tdi_i  => jtag_tdi_i,  -- serial data input
     jtag_tdo_o  => jtag_tdo_o,  -- serial data output

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -287,7 +287,6 @@ begin
     clk_i          => clk_gen,         -- global clock, rising edge
     rstn_i         => rst_gen,         -- global reset, low-active, async
     -- JTAG on-chip debugger interface (available if ON_CHIP_DEBUGGER_EN = true) --
-    jtag_trst_i    => '1',             -- low-active TAP reset (optional)
     jtag_tck_i     => '0',             -- serial clock
     jtag_tdi_i     => '0',             -- serial data input
     jtag_tdo_o     => open,            -- serial data output

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -263,7 +263,6 @@ begin
     clk_i          => clk_gen,         -- global clock, rising edge
     rstn_i         => rst_gen,         -- global reset, low-active, async
     -- JTAG on-chip debugger interface (available if ON_CHIP_DEBUGGER_EN = true) --
-    jtag_trst_i    => '1',             -- low-active TAP reset (optional)
     jtag_tck_i     => '0',             -- serial clock
     jtag_tdi_i     => '0',             -- serial data input
     jtag_tdo_o     => open,            -- serial data output

--- a/sw/openocd/openocd_neorv32.cfg
+++ b/sw/openocd/openocd_neorv32.cfg
@@ -1,22 +1,12 @@
-# NEORV32 on-chip debugger openOCD configuration file
+# NEORV32 on-chip debugger OpenOCD configuration file
 
 # ----------------------------------------------
 # Physical interface configuration
-# -> ADJUST THIS FOR YOUR ADAPTER / SETUP
 # ----------------------------------------------
-
-# Default: FT2232H breakout board
-# TCK:  D0
-# TDI:  D1
-# TDO:  D2
-# TMS:  D3
-# TRST: D4 (low-active, optional - pull input pin high if not used)
-
 adapter driver ftdi
 ftdi vid_pid 0x0403 0x6010
 ftdi channel 0
 ftdi layout_init 0x0038 0x003b
-ftdi layout_signal nTRST -ndata 0x0010 -noe 0x0040
 
 adapter speed 4000
 transport select jtag


### PR DESCRIPTION
This PR removes the reset signal of the on-chip debugger's JTAG tap. This signal was optional and also redundant (and not used by the OpenOCD configuration file at all).

According to the OpenOCD user guide (and the JTAG spec.):

> The missing TRST is not a problem, since JTAG-level resets can be triggered using with TMS signaling.