### PR TITLE
Add UART FIFO clear flags; add DMA FIRQ interrupt configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 22.06.2024 | 1.10.0.3 | UARTs: add flags to clear RX/TX FIFOs; DMA: add FIRQ trigger type configuration flag | [#930](https://github.com/stnolting/neorv32/pull/930) |
 | 21.06.2024 | 1.10.0.2 | minor code rtl clean-ups; fix some missing TOP defaults | [#929](https://github.com/stnolting/neorv32/pull/929) |
 | 17.05.2024 | 1.10.0.1 | :warning: remove (optional and redundant) JTAG reset signal `jtag_trst_i` | [#928](https://github.com/stnolting/neorv32/pull/928) |
 | 16.05.2024 | [**:rocket:1.10.0**](https://github.com/stnolting/neorv32/releases/tag/v1.10.0) | **New release** | |

--- a/docs/datasheet/soc_dma.adoc
+++ b/docs/datasheet/soc_dma.adoc
@@ -97,7 +97,7 @@ data quantity has to be set to **word** (32-bit) since all IO registers can only
 
 **Automatic Trigger**
 
-As an alternative to the manual trigger mode, the DMA can be configured to **automatic trigger mode** starting a pre-configured
+As an alternative to the manual trigger mode, the DMA can be set to **automatic trigger mode** starting a pre-configured
 transfer if a specific processor-internal peripheral issues a FIRQ interrupt request. The automatic trigger mode is enabled by
 setting the `CTRL` register's `DMA_CTRL_AUTO` bit. In this configuration _no_ transfer is started when writing to the DMA's
 `TTYPE` register.
@@ -105,6 +105,13 @@ setting the `CTRL` register's `DMA_CTRL_AUTO` bit. In this configuration _no_ tr
 The actually triggering FIRQ channel is configured via the control register's `DMA_CTRL_FIRQ_SEL` bits. Writing a 0 will
 select FIRQ channel 0, writing a 1 will select FIRQ channel 1, and so on. See section <<_processor_interrupts>>
 for a list of all FIRQ channels and their according sources.
+
+The FIRQ trigger can operate in two trigger mode configured via the `DMA_CTRL_FIRQ_TYPE` flag:
+
+* `DMA_CTRL_FIRQ_TYPE = 0`: trigger the automatic DMA transfer on a rising-edge of the selected FIRQ channel (e.g. trigger
+DMA transfer only once)
+* `DMA_CTRL_FIRQ_TYPE = 1`: trigger the automatic DMA transfer when the selected FIRQ channel is active (e.g. trigger
+DMA transfer again and again)
 
 .FIRQ Trigger
 [NOTE]
@@ -134,7 +141,7 @@ register).
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.11+<| `0xffffed00` .11+<| `CTRL` <|`0`     `DMA_CTRL_EN`                                   ^| r/w <| DMA module enable
+.12+<| `0xffffed00` .12+<| `CTRL` <|`0`     `DMA_CTRL_EN`                                   ^| r/w <| DMA module enable
                                   <|`1`     `DMA_CTRL_AUTO`                                 ^| r/w <| Enable automatic mode (FIRQ-triggered)
                                   <|`2`     `DMA_CTRL_FENCE`                                ^| r/w <| Issue a downstream FENCE operation when DMA transfer completes (without errors)
                                   <|`7:3`   _reserved_                                      ^| r/- <| reserved, read as zero
@@ -142,7 +149,8 @@ register).
                                   <|`9`     `DMA_CTRL_ERROR_WR`                             ^| r/- <| Error during write access, clears when starting a new transfer
                                   <|`10`    `DMA_CTRL_BUSY`                                 ^| r/- <| DMA transfer in progress
                                   <|`11`    `DMA_CTRL_DONE`                                 ^| r/c <| Set if a transfer was executed; auto-clears on write-access
-                                  <|`15:12` _reserved_                                      ^| r/- <| reserved, read as zero
+                                  <|`14:12` _reserved_                                      ^| r/- <| reserved, read as zero
+                                  <|`15`    `DMA_CTRL_FIRQ_TYPE`                            ^| r/w <| Trigger on rising-edge (`0`) or high-level (`1`) or selected FIRQ channel
                                   <|`19:16` `DMA_CTRL_FIRQ_SEL_MSB : DMA_CTRL_FIRQ_SEL_LSB` ^| r/w <| FIRQ trigger select (FIRQ0=0 ... FIRQ15=15)
                                   <|`31:20` _reserved_                                      ^| r/- <| reserved, read as zero
 | `0xffffed04` | `SRC_BASE` |`31:0` | r/w | Source base address (shows the last-accessed source address when read)

--- a/docs/datasheet/soc_uart.adoc
+++ b/docs/datasheet/soc_uart.adoc
@@ -34,6 +34,14 @@ and the runtime environment) use the primary UART (_UART0_) as default user cons
 is used to implement the "standard consoles" (`STDIN`, `STDOUT` and `STDERR`).
 
 
+**RX and TX FIFOs**
+
+The UART provides individual data FIFOs for RX and TX to allow data transmission without CPU intervention.
+The sizes of these FIFOs can be configured via the according configuration generics (`UART0_RX_FIFO` and `UART0_TX_FIFO`).
+Both FIFOs a re automatically cleared when disabling the module via the `UART_CTRL_EN` flag. However, the FIFOs can
+also be cleared individually by setting the `UART_CTRL_RX_CLR` / `UART_CTRL_TX_CLR` flags.
+
+
 **Theory of Operation**
 
 The module is enabled by setting the `UART_CTRL_EN` bit in the UART0 control register `CTRL`. The Baud rate
@@ -119,7 +127,7 @@ Both file are created in the simulation's home folder.
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.19+<| `0xfffff500` .19+<| `CTRL` <|`0`     `UART_CTRL_EN`                      ^| r/w <| UART enable
+.20+<| `0xfffff500` .20+<| `CTRL` <|`0`     `UART_CTRL_EN`                      ^| r/w <| UART enable
                                   <|`1`     `UART_CTRL_SIM_MODE`                ^| r/w <| enable **simulation mode**
                                   <|`2`     `UART_CTRL_HWFC_EN`                 ^| r/w <| enable RTS/CTS hardware flow-control
                                   <|`5:3`   `UART_CTRL_PRSC2 : UART_CTRL_PRSC0` ^| r/w <| Baud rate clock prescaler select
@@ -135,7 +143,9 @@ Both file are created in the simulation's home folder.
                                   <|`24`    `UART_CTRL_IRQ_RX_FULL`             ^| r/w <| fire IRQ if RX FIFO full
                                   <|`25`    `UART_CTRL_IRQ_TX_EMPTY`            ^| r/w <| fire IRQ if TX FIFO empty
                                   <|`26`    `UART_CTRL_IRQ_TX_NHALF`            ^| r/w <| fire IRQ if TX not at least half full
-                                  <|`29:27` -                                   ^| r/- <| _reserved_ read as zero
+                                  <|`27`    -                                   ^| r/- <| _reserved_ read as zero
+                                  <|`28`    `UART_CTRL_RX_CLR`                  ^| r/w <| Clear RX FIFO, flag auto-clears
+                                  <|`29`    `UART_CTRL_TX_CLR`                  ^| r/w <| Clear TX FIFO, flag auto-clears
                                   <|`30`    `UART_CTRL_RX_OVER`                 ^| r/- <| RX FIFO overflow; cleared by disabling the module
                                   <|`31`    `UART_CTRL_TX_BUSY`                 ^| r/- <| TX busy or TX FIFO not empty
 .4+<| `0xfffff504` .4+<| `DATA` <|`7:0`   `UART_DATA_RTX_MSB : UART_DATA_RTX_LSB`                   ^| r/w <| receive/transmit data

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100002"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100003"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -70,6 +70,8 @@ architecture neorv32_uart_rtl of neorv32_uart is
   constant ctrl_irq_tx_empty_c  : natural := 25; -- r/w: TX FIFO empty
   constant ctrl_irq_tx_nhalf_c  : natural := 26; -- r/w: TX FIFO not at least half-full
   --
+  constant ctrl_rx_clr_c        : natural := 28; -- r/w: Clear RX FIFO, flag auto-clears
+  constant ctrl_tx_clr_c        : natural := 29; -- r/w: Clear TX FIFO, flag auto-clears
   constant ctrl_rx_over_c       : natural := 30; -- r/-: RX FIFO overflow
   constant ctrl_tx_busy_c       : natural := 31; -- r/-: UART transmitter is busy and TX FIFO not empty
 
@@ -96,6 +98,8 @@ architecture neorv32_uart_rtl of neorv32_uart is
     irq_rx_full   : std_ulogic;
     irq_tx_empty  : std_ulogic;
     irq_tx_nhalf  : std_ulogic;
+    clr_rx        : std_ulogic;
+    clr_tx        : std_ulogic;
   end record;
   signal ctrl : ctrl_t;
 
@@ -157,15 +161,18 @@ begin
       ctrl.irq_rx_full   <= '0';
       ctrl.irq_tx_empty  <= '0';
       ctrl.irq_tx_nhalf  <= '0';
+      ctrl.clr_rx        <= '0';
+      ctrl.clr_tx        <= '0';
     elsif rising_edge(clk_i) then
-      -- bus handshake --
+      -- defaults --
       bus_rsp_o.ack  <= bus_req_i.stb;
       bus_rsp_o.err  <= '0';
       bus_rsp_o.data <= (others => '0');
+      ctrl.clr_rx    <= '0'; -- auto-clear
+      ctrl.clr_tx    <= '0'; -- auto-clear
+      -- bus access --
       if (bus_req_i.stb = '1') then
-
-        -- write access --
-        if (bus_req_i.rw = '1') then
+        if (bus_req_i.rw = '1') then -- write access
           if (bus_req_i.addr(2) = '0') then -- control register
             ctrl.enable        <= bus_req_i.data(ctrl_en_c);
             ctrl.sim_mode      <= bus_req_i.data(ctrl_sim_en_c);
@@ -178,10 +185,10 @@ begin
             ctrl.irq_rx_full   <= bus_req_i.data(ctrl_irq_rx_full_c);
             ctrl.irq_tx_empty  <= bus_req_i.data(ctrl_irq_tx_empty_c);
             ctrl.irq_tx_nhalf  <= bus_req_i.data(ctrl_irq_tx_nhalf_c);
+            ctrl.clr_rx        <= bus_req_i.data(ctrl_rx_clr_c);
+            ctrl.clr_tx        <= bus_req_i.data(ctrl_tx_clr_c);
           end if;
-
-        -- read access --
-        else
+        else -- read access
           if (bus_req_i.addr(2) = '0') then -- control register
             bus_rsp_o.data(ctrl_en_c)                        <= ctrl.enable;
             bus_rsp_o.data(ctrl_sim_en_c)                    <= ctrl.sim_mode;
@@ -244,7 +251,7 @@ begin
     avail_o => tx_fifo.avail
   );
 
-  tx_fifo.clear <= '1' when (ctrl.enable = '0') or (ctrl.sim_mode = '1') else '0';
+  tx_fifo.clear <= '1' when (ctrl.enable = '0') or (ctrl.sim_mode = '1') or (ctrl.clr_tx = '1') else '0';
   tx_fifo.wdata <= bus_req_i.data(data_rtx_msb_c downto data_rtx_lsb_c);
   tx_fifo.we    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '1') else '0';
   tx_fifo.re    <= '1' when (tx_engine.state = "100") else '0';
@@ -285,7 +292,7 @@ begin
     avail_o => rx_fifo.avail
   );
 
-  rx_fifo.clear <= '1' when (ctrl.enable = '0') or (ctrl.sim_mode = '1') else '0';
+  rx_fifo.clear <= '1' when (ctrl.enable = '0') or (ctrl.sim_mode = '1') or (ctrl.clr_rx = '1') else '0';
   rx_fifo.wdata <= rx_engine.sreg(7 downto 0);
   rx_fifo.we    <= rx_engine.done;
   rx_fifo.re    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(2) = '1') else '0';

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1070,6 +1070,9 @@ int main() {
     neorv32_uart0_setup(BAUD_RATE, 1 << UART_CTRL_IRQ_RX_NEMPTY);
     // make sure sim mode is disabled
     NEORV32_UART0->CTRL &= ~(1 << UART_CTRL_SIM_MODE);
+    // clear FIFOs
+    neorv32_uart0_rx_clear();
+    neorv32_uart0_tx_clear();
 
     // enable fast interrupt
     neorv32_cpu_csr_write(CSR_MIE, 1 << UART0_RX_FIRQ_ENABLE);
@@ -1116,6 +1119,9 @@ int main() {
     neorv32_uart0_setup(BAUD_RATE, 1 << UART_CTRL_IRQ_TX_EMPTY);
     // make sure sim mode is disabled
     NEORV32_UART0->CTRL &= ~(1 << UART_CTRL_SIM_MODE);
+    // clear FIFOs
+    neorv32_uart0_rx_clear();
+    neorv32_uart0_tx_clear();
 
     neorv32_uart0_putc(0);
     while(neorv32_uart0_tx_busy());
@@ -1159,6 +1165,9 @@ int main() {
     neorv32_uart1_setup(BAUD_RATE, 1 << UART_CTRL_IRQ_RX_NEMPTY);
     // make sure sim mode is disabled
     NEORV32_UART1->CTRL &= ~(1 << UART_CTRL_SIM_MODE);
+    // clear FIFOs
+    neorv32_uart1_rx_clear();
+    neorv32_uart1_tx_clear();
 
     // UART1 RX interrupt enable
     neorv32_cpu_csr_write(CSR_MIE, 1 << UART1_RX_FIRQ_ENABLE);
@@ -1202,6 +1211,9 @@ int main() {
     neorv32_uart1_setup(BAUD_RATE, 1 << UART_CTRL_IRQ_TX_EMPTY);
     // make sure sim mode is disabled
     NEORV32_UART1->CTRL &= ~(1 << UART_CTRL_SIM_MODE);
+    // clear FIFOs
+    neorv32_uart1_rx_clear();
+    neorv32_uart1_tx_clear();
 
     neorv32_uart1_putc(0);
     while(neorv32_uart1_tx_busy());

--- a/sw/lib/include/neorv32_dma.h
+++ b/sw/lib/include/neorv32_dma.h
@@ -44,6 +44,7 @@ enum NEORV32_DMA_CTRL_enum {
   DMA_CTRL_BUSY         = 10, /**< DMA control register(10) (r/-): DMA busy / transfer in progress */
   DMA_CTRL_DONE         = 11, /**< DMA control register(11) (r/c): A transfer was executed when set */
 
+  DMA_CTRL_FIRQ_TYPE    = 15, /**< DMA control register(15) (r/w): Trigger on FIRQ rising-edge (0) or high-level (1) */
   DMA_CTRL_FIRQ_SEL_LSB = 16, /**< DMA control register(16) (r/w): FIRQ trigger select LSB */
   DMA_CTRL_FIRQ_SEL_MSB = 19  /**< DMA control register(19) (r/w): FIRQ trigger select MSB */
 };
@@ -102,7 +103,7 @@ void neorv32_dma_disable(void);
 void neorv32_dma_fence_enable(void);
 void neorv32_dma_fence_disable(void);
 void neorv32_dma_transfer(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config);
-void neorv32_dma_transfer_auto(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config, int firq_sel);
+void neorv32_dma_transfer_auto(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config, int firq_sel, int firq_type);
 int  neorv32_dma_status(void);
 int  neorv32_dma_done(void);
 /**@}*/

--- a/sw/lib/include/neorv32_uart.h
+++ b/sw/lib/include/neorv32_uart.h
@@ -33,6 +33,8 @@
 #define neorv32_uart0_rtscts_disable()             neorv32_uart_rtscts_disable(NEORV32_UART0)
 #define neorv32_uart0_rtscts_enable()              neorv32_uart_rtscts_enable(NEORV32_UART0)
 #define neorv32_uart0_putc(c)                      neorv32_uart_putc(NEORV32_UART0, c)
+#define neorv32_uart0_rx_clear()                   neorv32_uart_rx_clear(NEORV32_UART0)
+#define neorv32_uart0_tx_clear()                   neorv32_uart_tx_clear(NEORV32_UART0)
 #define neorv32_uart0_tx_busy()                    neorv32_uart_tx_busy(NEORV32_UART0)
 #define neorv32_uart0_getc()                       neorv32_uart_getc(NEORV32_UART0)
 #define neorv32_uart0_char_received()              neorv32_uart_char_received(NEORV32_UART0)
@@ -55,6 +57,8 @@
 #define neorv32_uart1_rtscts_disable()             neorv32_uart_rtscts_disable(NEORV32_UART1)
 #define neorv32_uart1_rtscts_enable()              neorv32_uart_rtscts_enable(NEORV32_UART1)
 #define neorv32_uart1_putc(c)                      neorv32_uart_putc(NEORV32_UART1, c)
+#define neorv32_uart1_rx_clear()                   neorv32_uart_rx_clear(NEORV32_UART1)
+#define neorv32_uart1_tx_clear()                   neorv32_uart_tx_clear(NEORV32_UART1)
 #define neorv32_uart1_tx_busy()                    neorv32_uart_tx_busy(NEORV32_UART1)
 #define neorv32_uart1_getc()                       neorv32_uart_getc(NEORV32_UART1)
 #define neorv32_uart1_char_received()              neorv32_uart_char_received(NEORV32_UART1)
@@ -113,6 +117,8 @@ enum NEORV32_UART_CTRL_enum {
   UART_CTRL_IRQ_TX_EMPTY  = 25, /**< UART control register(25) (r/w): Fire IRQ if TX FIFO empty */
   UART_CTRL_IRQ_TX_NHALF  = 26, /**< UART control register(26) (r/w): Fire IRQ if TX FIFO not at least half-full */
 
+  UART_CTRL_RX_CLR        = 28, /**< UART control register(28) (r/w): Clear RX FIFO, flag auto-clears */
+  UART_CTRL_TX_CLR        = 29, /**< UART control register(29) (r/w): Clear TX FIFO, flag auto-clears */
   UART_CTRL_RX_OVER       = 30, /**< UART control register(30) (r/-): RX FIFO overflow */
   UART_CTRL_TX_BUSY       = 31  /**< UART control register(31) (r/-): Transmitter busy or TX FIFO not empty */
 };
@@ -144,6 +150,8 @@ void neorv32_uart_disable(neorv32_uart_t *UARTx);
 void neorv32_uart_rtscts_enable(neorv32_uart_t *UARTx);
 void neorv32_uart_rtscts_disable(neorv32_uart_t *UARTx);
 void neorv32_uart_putc(neorv32_uart_t *UARTx, char c);
+void neorv32_uart_rx_clear(neorv32_uart_t *UARTx);
+void neorv32_uart_tx_clear(neorv32_uart_t *UARTx);
 int  neorv32_uart_tx_busy(neorv32_uart_t *UARTx);
 char neorv32_uart_getc(neorv32_uart_t *UARTx);
 int  neorv32_uart_char_received(neorv32_uart_t *UARTx);

--- a/sw/lib/source/neorv32_dma.c
+++ b/sw/lib/source/neorv32_dma.c
@@ -97,13 +97,15 @@ void neorv32_dma_transfer(uint32_t base_src, uint32_t base_dst, uint32_t num, ui
  * @param[in] num Number of elements to transfer (24-bit).
  * @param[in] config Transfer type configuration/commands.
  * @param[in] firq_sel FIRQ trigger select (#NEORV32_CSR_MIP_enum); only FIRQ0..FIRQ15 = 16..31.
+ * @param[in] firq_type Trigger on rising-edge (0) or high-level (1) of FIRQ channel.
  **************************************************************************/
-void neorv32_dma_transfer_auto(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config, int firq_sel) {
+void neorv32_dma_transfer_auto(uint32_t base_src, uint32_t base_dst, uint32_t num, uint32_t config, int firq_sel, int firq_type) {
 
   uint32_t tmp = NEORV32_DMA->CTRL;
   tmp |= (uint32_t)(1 << DMA_CTRL_AUTO); // automatic transfer trigger
   tmp &= ~(0xf << DMA_CTRL_FIRQ_SEL_LSB); // clear current FIRQ select
   tmp |= (uint32_t)((firq_sel & 0xf) << DMA_CTRL_FIRQ_SEL_LSB); // set new FIRQ select
+  tmp |= (uint32_t)((firq_type & 1) << DMA_CTRL_FIRQ_TYPE); // FIRQ trigger type
   NEORV32_DMA->CTRL = tmp;
 
   NEORV32_DMA->SRC_BASE = base_src;

--- a/sw/lib/source/neorv32_uart.c
+++ b/sw/lib/source/neorv32_uart.c
@@ -192,6 +192,28 @@ void neorv32_uart_putc(neorv32_uart_t *UARTx, char c) {
 
 
 /**********************************************************************//**
+ * Clear RX FIFO.
+ *
+ * @param[in,out] UARTx Hardware handle to UART register struct, #neorv32_uart_t.
+ **************************************************************************/
+void neorv32_uart_rx_clear(neorv32_uart_t *UARTx) {
+
+  UARTx->CTRL |= (uint32_t)(1 << UART_CTRL_RX_CLR);
+}
+
+
+/**********************************************************************//**
+ * Clear TX FIFO.
+ *
+ * @param[in,out] UARTx Hardware handle to UART register struct, #neorv32_uart_t.
+ **************************************************************************/
+void neorv32_uart_tx_clear(neorv32_uart_t *UARTx) {
+
+  UARTx->CTRL |= (uint32_t)(1 << UART_CTRL_TX_CLR);
+}
+
+
+/**********************************************************************//**
  * Check if UART TX is busy (transmitter busy or data left in TX buffer).
  *
  * @param[in,out] UARTx Hardware handle to UART register struct, #neorv32_uart_t.

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -440,6 +440,11 @@
               <description>DMA transfer done; auto-clears on write access</description>
             </field>
             <field>
+              <name>DMA_CTRL_FIRQ_TYPE</name>
+              <bitRange>[15:15]</bitRange>
+              <description>Trigger on rising-edge (0) or high-level (1) or selected FIRQ channel</description>
+            </field>
+            <field>
               <name>DMA_CTRL_FIRQ_SEL</name>
               <bitRange>[19:16]</bitRange>
               <description>FIRQ trigger select</description>
@@ -1047,6 +1052,16 @@
               <name>UART_CTRL_IRQ_TX_NHALF</name>
               <bitRange>[26:26]</bitRange>
               <description>Fire IRQ if TX FIFO not at least half-full</description>
+            </field>
+            <field>
+              <name>UART_CTRL_RX_CLR</name>
+              <bitRange>[28:28]</bitRange>
+              <description>Clear RX FIFO, flag auto-clears</description>
+            </field>
+            <field>
+              <name>UART_CTRL_TX_CLR</name>
+              <bitRange>[29:29]</bitRange>
+              <description>Clear TX FIFO, flag auto-clears</description>
             </field>
             <field>
               <name>UART_CTRL_RX_OVER</name>


### PR DESCRIPTION
#### UART

Add two new control register bits to manually clear the RX / TX FIFOs:

* bit 28: `UART_CTRL_RX_CLR`, flag auto-clears
* bit 29:`UART_CTRL_TX_CLR`, flag auto-clears

#### DMA

Add new FIRQ interrupt type configuration flag:

* bit 15: `DMA_CTRL_FIRQ_TYPE`
  * when `0`: trigger DMA operation on rising-edge of selected FIRQ channel (e.g. trigger only once)
  * when `1`: trigger DMA operation whenever the selected FIRQ channel is active/high (e.g. trigger again and again)