### PR TITLE
Minor rtl edits/cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 23.06.2024 | 1.10.0.4 | minor rtl edits/cleanups | [#931](https://github.com/stnolting/neorv32/pull/931) |
 | 22.06.2024 | 1.10.0.3 | UARTs: add flags to clear RX/TX FIFOs; DMA: add FIRQ trigger type configuration flag | [#930](https://github.com/stnolting/neorv32/pull/930) |
 | 21.06.2024 | 1.10.0.2 | minor code rtl clean-ups; fix some missing TOP defaults | [#929](https://github.com/stnolting/neorv32/pull/929) |
 | 17.05.2024 | 1.10.0.1 | :warning: remove (optional and redundant) JTAG reset signal `jtag_trst_i` | [#928](https://github.com/stnolting/neorv32/pull/928) |

--- a/rtl/core/mem/README.md
+++ b/rtl/core/mem/README.md
@@ -1,14 +1,18 @@
-# Processor Memory Source Files
+## Processor Memory Source Files
 
 This folder provides the architecture-only VHDL sources for the processor-internal memories
-(instruction memory "IMEM", data memory "DMEM"). Different implementations are available - but
-only **one** version of each (IMEM and DMEM) has to be added as actual source files.
+(instruction memory "IMEM", data memory "DMEM"). Different implementations are available, but
+only **one** version of each (IMEM and DMEM) should be added as actual source files.
 
-For the first implementation the `*.default.vhd` files should be selected. The HDL style for describing
-memories used by these files has proven **platform-independence** across several FPGA architectures and toolchains.
+For an initial setup the `*.default.vhd` files should be selected. The HDL style for describing
+memories used by these files has proven quite good platform-independence across several FPGA
+architectures and toolchains.
 
-If synthesis fails to infer actual block RAM resources from these default files, try the legacy `*.legacy.vhd` files, which
-provide a different HDL style. These files are intended for legacy support of older Intel/Altera Quartus versions (13.0 and older). However,
-these files do **not** use platform-specific macros or primitives - so they might also work for other FPGAs and toolchains.
+If synthesis fails to infer block RAM resources from these default files, try the legacy
+`*.legacy.vhd` files, which provide a different HDL style. These files are also intended for
+legacy support of older Intel/Altera Quartus versions (13.0 and older). However, these files
+still do not use platform-specific macros or primitives - so they might also work for other
+FPGAs and toolchains.
 
-:warning: Make sure to add the selected files from this folder also to the `neorv32` design library.
+> [!IMPORTANT]
+> Make sure to add the selected files from this folder also to the `neorv32` design library.

--- a/rtl/core/mem/neorv32_imem.default.vhd
+++ b/rtl/core/mem/neorv32_imem.default.vhd
@@ -26,10 +26,6 @@ architecture neorv32_imem_rtl of neorv32_imem is
   signal rden  : std_ulogic;
   signal addr  : std_ulogic_vector(index_size_f(IMEM_SIZE/4)-1 downto 0);
 
-  -- --------------------------- --
-  -- IMEM as pre-initialized ROM --
-  -- --------------------------- --
-
   -- application (image) size in bytes --
   constant imem_app_size_c : natural := (application_init_image'length)*4;
 

--- a/rtl/core/mem/neorv32_imem.legacy.vhd
+++ b/rtl/core/mem/neorv32_imem.legacy.vhd
@@ -26,10 +26,6 @@ architecture neorv32_imem_rtl of neorv32_imem is
   signal rden          : std_ulogic;
   signal addr, addr_ff : std_ulogic_vector(index_size_f(IMEM_SIZE/4)-1 downto 0);
 
-  -- --------------------------- --
-  -- IMEM as pre-initialized ROM --
-  -- --------------------------- --
-
   -- application (image) size in bytes --
   constant imem_app_size_c : natural := (application_init_image'length)*4;
 

--- a/rtl/core/neorv32_fifo.vhd
+++ b/rtl/core/neorv32_fifo.vhd
@@ -222,12 +222,7 @@ begin
     -- just 1 FIFO entry --
     fifo_read_sync_small:
     if (fifo_depth_c = 1) generate
-      sync_read_small: process(clk_i)
-      begin
-        if rising_edge(clk_i) then
-          rdata_o <= fifo_reg;
-        end if;
-      end process sync_read_small;
+      rdata_o <= fifo_reg;
     end generate;
 
     -- more than 1 FIFO entry --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100003"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100004"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -672,7 +672,7 @@ package neorv32_package is
   constant hpmcnt_event_wait_lsu_c : natural := 10; -- load-store unit memory wait cycle
   constant hpmcnt_event_trap_c     : natural := 11; -- entered trap
   --
-  constant hpmcnt_event_size_c     : natural := 12; -- length of this list
+  constant hpmcnt_event_width_c    : natural := 12; -- length of this list
 
 -- **********************************************************************************************************
 -- Helper Functions


### PR DESCRIPTION
* clean-up rtl code (CPU control)
* remove redundant output register from FIFO (when using the SYNC read configuration with just a single FIFO entry)