### PR TITLE
:warning: rework CFU interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 29.06.2024 | 1.10.0.5 | :warning: rework and optimize custom functions unit (CFU) interface; simplified illegal RVC decoding | [#932](https://github.com/stnolting/neorv32/pull/932) |
 | 23.06.2024 | 1.10.0.4 | minor rtl edits/cleanups | [#931](https://github.com/stnolting/neorv32/pull/931) |
 | 22.06.2024 | 1.10.0.3 | UARTs: add flags to clear RX/TX FIFOs; DMA: add FIRQ trigger type configuration flag | [#930](https://github.com/stnolting/neorv32/pull/930) |
 | 21.06.2024 | 1.10.0.2 | minor code rtl clean-ups; fix some missing TOP defaults | [#929](https://github.com/stnolting/neorv32/pull/929) |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -476,7 +476,8 @@ However, any write-access will be ignored and will not cause an exception to mai
 The RISC-V priv. spec. suggests that the instruction word written to `mtinst` by the hardware should be "transformed".
 However, the NEORV32 `mtinst` CSR uses a simplified transformation scheme: if the trap-causing instruction is a
 standard 32-bit instruction, `mtinst` contains the exact instruction word that caused the trap. If the trap-causing
-instruction is a compressed instruction, `mtinst` contains the de-compressed 32-bit equivalent with bit 1 being cleared.
+instruction is a compressed instruction, `mtinst` contains the de-compressed 32-bit equivalent with bit 1 being cleared
+while all remaining bits represent the pre-decoded 32-bit instruction equivalent.
 
 
 

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -432,8 +432,8 @@ begin
   if CPU_EXTENSION_RISCV_C generate
     neorv32_cpu_decompressor_inst: entity neorv32.neorv32_cpu_decompressor
     port map (
-      ci_instr16_i => issue_engine.ci_i16,
-      ci_instr32_o => issue_engine.ci_i32
+      instr16_i => issue_engine.ci_i16,
+      instr32_o => issue_engine.ci_i32
     );
   end generate;
 

--- a/rtl/core/neorv32_cpu_cp_cfu.vhd
+++ b/rtl/core/neorv32_cpu_cp_cfu.vhd
@@ -1,9 +1,9 @@
 -- ================================================================================ --
 -- NEORV32 CPU - Co-Processor: Custom (RISC-V Instructions) Functions Unit (CFU)    --
 -- -------------------------------------------------------------------------------- --
--- For custom/user-defined RISC-V instructions (R3-type, R4-type and R5-type        --
--- formats). See the  CPU's documentation for more information. Also take a look at --
--- the "software-counterpart" this default CFU hardware in 'sw/example/demo_cfu'.   --
+-- For custom/user-defined RISC-V instructions See the  CPU's documentation for     --
+-- more information. Also take a look at the "software-counterpart" this default    --
+-- CFU hardware in 'sw/example/demo_cfu'.                                           --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
@@ -11,6 +11,101 @@
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
+
+  -- **************************************************************************************************************************
+  -- CFU Interface Documentation
+  -- **************************************************************************************************************************
+
+  -- ----------------------------------------------------------------------------------------
+  -- Input Operands
+  -- ----------------------------------------------------------------------------------------
+  -- rs1_i    (input, 32-bit): source register 1; selected by instruction word's <rs1> bit-field
+  -- rs2_i    (input, 32-bit): source register 2; selected by instruction word's <rs2> bit-field
+  -- rs3_i    (input, 32-bit): source register 3; selected by instruction word's <rs3> bit-field
+  -- rs4_i    (input, 32-bit): source register 4; selected by instruction word's <rs4> bit-field
+  -- rtype_i  (input,  2-bit): instruction R-type; driven by instruction word's OPCODE
+  -- funct3_i (input,  3-bit): 3-bit function select / immediate value; driven by instruction word's <funct3> bit-field
+  -- funct7_i (input,  7-bit): 7-bit function select / immediate value; driven by instruction word's <funct7> bit-field
+  --
+  -- The general instruction type is identified by the <rtype_i> input.
+  -- r3type_c  (= 00) - R3-type instructions  (custom-0 opcode): 'rs1', 'rs2' and 'funct7' and 'funct3'
+  -- r4type_c  (= 01) - R4-type instructions  (custom-1 opcode): 'rs1', 'rs2', 'rs3' and 'funct3'
+  -- r5typeA_c (= 10) - R5-type instruction A (custom-2 opcode): 'rs1', 'rs2', 'rs3', 'rs4', no immediates
+  -- r5typeB_c (= 11) - R5-type instruction B (custom-3 opcode): 'rs1', 'rs2', 'rs3', 'rs4', no immediates
+  --
+  -- The four signals <rs1_i>, <rs2_i>, <rs3_i> and <rs4_i> provide the source operand data read from the CPU's register
+  -- file. The source registers are adressed by the custom instruction word's <rs1>, <rs2>, <rs3> and <rs4> bit-fields.
+  --
+  -- [TIP] <rs1_i>, <rs2_i>, <rs3_i> and <rs4_i> are directly driven by the register file (e.g. block RAM). For complex CFU
+  --       designs it is recommended to buffer these signals using CFU-internal registers before actually using them.
+  --
+  -- [NOTE] The R4-type instructions and R5-type instruction provide additional source register. When used, this will
+  --        increase the hardware requirements of the register file.
+  --
+  -- The actual CFU operation can be defined by using the <funct3_i> and/or <funct7_i> signals (depending on the R-type).
+  -- Both signals are driven by the according bit-fields of the custom instruction word. These immediates can be used to
+  -- select the actual function or to provide small literals for certain operations (like shift amounts, offsets, ...).
+  --
+  -- [NOTE] All input operand signals remain stable during CFU operation.
+
+  -- ----------------------------------------------------------------------------------------
+  -- Processing Interface
+  -- ----------------------------------------------------------------------------------------
+  -- rstn_i   (input,   1-bit): asynchronous reset, low-active
+  -- clk_i    (input,   1-bit): main clock, interface signals updated on the rising edge
+  -- start_i  (input,   1-bit): operation trigger (start processing, high for one cycle)
+  -- active_i (input,   1-bit): operation in progress while (optional signal)
+  -- result_o (output, 32-bit): processing result
+  -- valid_o  (output,  1-bit): set high when processing is done
+  --
+  -- The start of a new CFU operation is indicated by <start_i> being high for exactly one cycle. The CFU may operate while
+  -- <active_i> is high and should stop all internal operations when it clears again. However, using this signal is optional.
+  --
+  -- When the CFU has completed computation, the data send via the <result_o> signal will be written to the CPU's register
+  -- file (indexed by the "rd" register). The CPU pipeline samples this signal exactly one cycle after <valid_o> has been set.
+  --
+  -- [TIP] For complex CFU designs it is highly recommended to register <result_o> in order to keep the CPU's critical
+  --       path as short as possible.
+  --
+  -- The <valid_o> signal is used to signal the completion of the CFU operation. For pure-combinatorial instructions
+  -- (completing within 1 clock cycle) <valid_o> can be tied to 1. If the CFU requires several clock cycles for completion
+  -- the <valid_o> signal has to be set high for one cycle EXACTLY ONE CYCLE before <result_o> is valid.
+  --
+  -- Example interface timing for a multi-cycle CFU operation ("D" represents the processing result in the output phase):
+  -- clk_i    ____/----\____/----\____/----\____/----\____/----\____
+  -- start_i  ____/---------\_______________________________________ trigger is high for one cycle
+  -- active_i ____/-----------------------------\___________________ cease processing when low
+  -- valid_o  ________________________/---------\___________________ set one cycle before output phase, zero otherwise
+  -- result_o dddddddddddddddddddddddddddddddddd|DDDDDDDDD|ddddddddd don't care except for output phase
+  --
+  -- [NOTE] If the <valid_o> signal is not set within a bound time window (default = 512 cycles; see "monitor_mc_tmo_c"
+  --        constant in the main NEORV32 package file) the CFU operation is automatically terminated by the hardware
+  --        (clearing <active_i>) and an illegal instruction exception is raised.
+
+  -- ----------------------------------------------------------------------------------------
+  -- CFU-Internal Control and Status Registers (CFU-CSRs)
+  -- ----------------------------------------------------------------------------------------
+  -- csr_we_i    (input,   1-bit): set to indicate a valid CFU CSR write access, high for one cycle
+  -- csr_addr_i  (input,   2-bit): CSR address
+  -- csr_wdata_i (input,  32-bit): CSR write data
+  -- csr_rdata_i (output, 32-bit): CSR read data
+  --
+  -- The NEORV32 provides four directly accessible CSRs for custom use inside the CFU. These registers can be used to pass
+  -- further operands, to check the unit's status or to configure operation modes.
+  --
+  -- [TIP] If more than four CFU-internal CSRs are required the designer can implement an "indirect access mechanism" based
+  --       on just two of the default CSRs: one CSR is used to configure the index while the other is used as an alias to
+  --       exchange data with the indexed CFU-internal CSR.
+
+  -- **************************************************************************************************************************
+  -- Actual CFU User Logic Example: XTEA - Extended Tiny Encryption Algorithm (replace this with your custom logic)
+  -- **************************************************************************************************************************
+
+  -- This CFU example implements the Extended Tiny Encryption Algorithm (XTEA).
+  -- The CFU provides 5 custom instructions to accelerate encryption and decryption using dedicated hardware.
+  -- The RTL code is not optimized (not for area, not for clock speed, not for performance) and was
+  -- implemented according to an open-source software C reference:
+  -- https://de.wikipedia.org/wiki/Extended_Tiny_Encryption_Algorithm
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -24,37 +119,29 @@ entity neorv32_cpu_cp_cfu is
     -- global control --
     clk_i       : in  std_ulogic; -- global clock, rising edge
     rstn_i      : in  std_ulogic; -- global reset, low-active, async
-    ctrl_i      : in  ctrl_bus_t; -- main control bus
-    start_i     : in  std_ulogic; -- trigger operation
+    -- operation control --
+    start_i     : in std_ulogic; -- operation trigger/strobe
+    active_i    : in std_ulogic; -- operation in progress
+    rtype_i     : in std_ulogic_vector(1 downto 0); -- instruction type, see constants below
+    funct3_i    : in std_ulogic_vector(2 downto 0); -- "funct3" bit-field from custom instruction word
+    funct7_i    : in std_ulogic_vector(6 downto 0); -- "funct7" bit-field from custom instruction word
     -- CSR interface --
     csr_we_i    : in  std_ulogic; -- write enable
     csr_addr_i  : in  std_ulogic_vector(1 downto 0); -- address
-    csr_wdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- write data
-    csr_rdata_o : out std_ulogic_vector(XLEN-1 downto 0) := (others => '0'); -- read data
-    -- data input --
-    rs1_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
-    rs2_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
-    rs3_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 3
-    rs4_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 4
+    csr_wdata_i : in  std_ulogic_vector(31 downto 0); -- write data
+    csr_rdata_o : out std_ulogic_vector(31 downto 0) := (others => '0'); -- read data
+    -- operands --
+    rs1_i       : in  std_ulogic_vector(31 downto 0); -- rf source 1
+    rs2_i       : in  std_ulogic_vector(31 downto 0); -- rf source 2
+    rs3_i       : in  std_ulogic_vector(31 downto 0); -- rf source 3
+    rs4_i       : in  std_ulogic_vector(31 downto 0); -- rf source 4
     -- result and status --
-    res_o       : out std_ulogic_vector(XLEN-1 downto 0) := (others => '0'); -- operation result
-    valid_o     : out std_ulogic := '0' -- data output valid
+    result_o    : out std_ulogic_vector(31 downto 0) := (others => '0'); -- operation result
+    valid_o     : out std_ulogic := '0' -- data output valid (one cycle ahead); operation done
   );
 end neorv32_cpu_cp_cfu;
 
 architecture neorv32_cpu_cp_cfu_rtl of neorv32_cpu_cp_cfu is
-
-  -- CFU Control ---------------------------------------------
-  -- ------------------------------------------------------------
-  type control_t is record
-    busy   : std_ulogic; -- CFU is busy
-    done   : std_ulogic; -- set to '1' when processing is done
-    result : std_ulogic_vector(XLEN-1 downto 0); -- CFU processing result (for write-back to register file)
-    rtype  : std_ulogic_vector(1 downto 0); -- instruction type, see constants below
-    funct3 : std_ulogic_vector(2 downto 0); -- "funct3" bit-field from custom instruction word
-    funct7 : std_ulogic_vector(6 downto 0); -- "funct7" bit-field from custom instruction word
-  end record;
-  signal control : control_t;
 
   -- instruction format types --
   constant r3type_c  : std_ulogic_vector(1 downto 0) := "00"; -- R3-type instructions (custom-0 opcode)
@@ -62,25 +149,23 @@ architecture neorv32_cpu_cp_cfu_rtl of neorv32_cpu_cp_cfu is
   constant r5typeA_c : std_ulogic_vector(1 downto 0) := "10"; -- R5-type instruction A (custom-2 opcode)
   constant r5typeB_c : std_ulogic_vector(1 downto 0) := "11"; -- R5-type instruction B (custom-3 opcode)
 
-  -- User-Defined Logic --------------------------------------
-  -- ------------------------------------------------------------
-  -- xtea instructions (funct3 bit-field) --
+  -- instruction identifiers (funct3 bit-field) --
   constant xtea_enc_v0_c : std_ulogic_vector(2 downto 0) := "000";
   constant xtea_enc_v1_c : std_ulogic_vector(2 downto 0) := "001";
   constant xtea_dec_v0_c : std_ulogic_vector(2 downto 0) := "010";
   constant xtea_dec_v1_c : std_ulogic_vector(2 downto 0) := "011";
   constant xtea_init_c   : std_ulogic_vector(2 downto 0) := "100";
 
-  -- xtea round-key adjusting --
+  -- round-key update --
   constant xtea_delta_c : std_ulogic_vector(31 downto 0) := x"9e3779b9";
 
-  -- xtea key storage (accessed via CFU CSRs) --
+  -- key storage (accessed via CFU CSRs) --
   type key_mem_t is array (0 to 3) of std_ulogic_vector(31 downto 0);
   signal key_mem : key_mem_t;
 
-  -- xtea processing logic --
+  -- processing logic --
   type xtea_t is record
-    done : std_ulogic_vector(1 downto 0);  -- multi-cycle operation SREG
+    done : std_ulogic; -- multi-cycle done shift register
     opa  : std_ulogic_vector(31 downto 0); -- input operand a
     opb  : std_ulogic_vector(31 downto 0); -- input operand b
     sum  : std_ulogic_vector(31 downto 0); -- round key buffer
@@ -88,158 +173,10 @@ architecture neorv32_cpu_cp_cfu_rtl of neorv32_cpu_cp_cfu is
   end record;
   signal xtea : xtea_t;
 
-  -- xtea helper --
+  -- helpers --
   signal tmp_a, tmp_b, tmp_x, tmp_y, tmp_z, tmp_r : std_ulogic_vector(31 downto 0);
 
 begin
-
-  -- **************************************************************************************************************************
-  -- This controller is required to handle the CFU-CPU interface.
-  -- **************************************************************************************************************************
-
-  -- CFU Controller -------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  -- The <control> record acts as proxy logic that ensures correct communication with the
-  -- CPU pipeline. However, this control instance adds one additional cycle of latency.
-  -- Advanced users can remove this default control instance to obtain maximum throughput.
-  cfu_control: process(rstn_i, clk_i)
-  begin
-    if (rstn_i = '0') then
-      res_o        <= (others => '0');
-      control.busy <= '0';
-    elsif rising_edge(clk_i) then
-      res_o <= (others => '0'); -- default; all CPU co-processor outputs are logically OR-ed
-      if (control.busy = '0') then -- CFU is idle
-        control.busy <= start_i; -- trigger new CFU operation
-      else -- CFU operation in progress
-        res_o <= control.result; -- output result only if CFU is processing; has to be all-zero otherwise
-        if (control.done = '1') or (ctrl_i.cpu_trap = '1') then -- operation done or abort if trap (exception)
-          control.busy <= '0';
-        end if;
-      end if;
-    end if;
-  end process cfu_control;
-
-  -- CPU feedback --
-  valid_o <= control.busy and control.done; -- set one cycle before result data
-
-  -- pack user-defined instruction type/function bits --
-  control.rtype  <= ctrl_i.ir_opcode(6 downto 5);
-  control.funct3 <= ctrl_i.ir_funct3;
-  control.funct7 <= ctrl_i.ir_funct12(11 downto 5);
-
-
-  -- **************************************************************************************************************************
-  -- CFU Hardware Documentation
-  -- **************************************************************************************************************************
-
-  -- ----------------------------------------------------------------------------------------
-  -- CFU Instruction Formats
-  -- ----------------------------------------------------------------------------------------
-  -- The CFU supports three instruction types:
-  --
-  -- Up to 1024 RISC-V R3-Type Instructions (RISC-V standard):
-  -- This format consists of two source registers ('rs1', 'rs2'), a destination register ('rd') and two "immediate" bit-fields
-  -- ('funct7' and 'funct3').
-  --
-  -- Up to 8 RISC-V R4-Type Instructions (RISC-V standard):
-  -- This format consists of three source registers ('rs1', 'rs2', 'rs3'), a destination register ('rd') and one "immediate"
-  -- bit-field ('funct3').
-  --
-  -- Two individual RISC-V R5-Type Instructions (NEORV32-specific):
-  -- This format consists of four source registers ('rs1', 'rs2', 'rs3', 'rs4') and a destination register ('rd'). There are
-  -- no immediate fields.
-
-  -- ----------------------------------------------------------------------------------------
-  -- Input Operands
-  -- ----------------------------------------------------------------------------------------
-  -- > rs1_i          (input, 32-bit): source register 1; selected by 'rs1' bit-field
-  -- > rs2_i          (input, 32-bit): source register 2; selected by 'rs2' bit-field
-  -- > rs3_i          (input, 32-bit): source register 3; selected by 'rs3' bit-field
-  -- > rs4_i          (input, 32-bit): source register 4; selected by 'rs4' bit-field
-  -- > control.rtype  (input,  2-bit): defining the R-type; driven by OPCODE
-  -- > control.funct3 (input,  3-bit): 3-bit function select / immediate value; driven by instruction word's 'funct3' bit-field
-  -- > control.funct7 (input,  7-bit): 7-bit function select / immediate value; driven by instruction word's 'funct7' bit-field
-  --
-  -- [NOTE] The set of usable signals depends on the actual R-type of the instruction.
-  --
-  -- The general instruction type is identified by the <control.rtype>.
-  -- > r3type_c  - R3-type instructions (custom-0 opcode)
-  -- > r4type_c  - R4-type instructions (custom-1 opcode)
-  -- > r5typeA_c - R5-type instruction A (custom-2 opcode)
-  -- > r5typeB_c - R5-type instruction B (custom-3 opcode)
-  --
-  -- The four signals <rs1_i>, <rs2_i>, <rs3_i> and <rs4_i> provide the source operand data read from the CPU's register file.
-  -- The source registers are adressed by the custom instruction word's 'rs1', 'rs2', 'rs3' and 'rs4' bit-fields.
-  --
-  -- The actual CFU operation can be defined by using the <control.funct3> and/or <control.funct7> signals (if available for a
-  -- certain R-type instruction). Both signals are directly driven by the according bit-fields of the custom instruction word.
-  -- These immediates can be used to select the actual function or to provide small literals for certain operations (like shift
-  -- amounts, offsets, multiplication factors, ...).
-  --
-  -- [NOTE] <rs1_i>, <rs2_i>, <rs3_i> and <rs4_i> are directly driven by the register file (e.g. block RAM). For complex CFU
-  --        designs it is recommended to buffer these signals using CFU-internal registers before actually using them.
-  --
-  -- [NOTE] The R4-type instructions and R5-type instruction provide additional source register. When used, this will increase
-  --        the hardware requirements of the register file.
-
-  -- ----------------------------------------------------------------------------------------
-  -- Result Output
-  -- ----------------------------------------------------------------------------------------
-  -- > control.result (output, 32-bit): processing result
-  --
-  -- When the CFU has completed computations, the data send via the <control.result> signal will be written to the CPU's register
-  -- file. The destination register is addressed by the <rd> bit-field in the instruction word. The CFU result output is registered
-  -- in the CFU controller (see above) - so do not worry too much about increasing the CPU's critical path with your custom
-  -- logic.
-
-  -- ----------------------------------------------------------------------------------------
-  -- Processing Control
-  -- ----------------------------------------------------------------------------------------
-  -- > rstn_i       (input,  1-bit): asynchronous reset, low-active
-  -- > clk_i        (input,  1-bit): main clock, triggering on rising edge
-  -- > start_i      (input,  1-bit): operation trigger (start processing, high for one cycle)
-  -- > control.done (output, 1-bit): set high when processing is done
-  --
-  -- For pure-combinatorial instructions (completing within 1 clock cycle) <control.done> can be tied to 1. If the CFU requires
-  -- several clock cycles for internal processing, the <start_i> signal can be used to *start* a new iterative operation. As soon
-  -- as all internal computations have completed, the <control.done> signal has to be set to indicate completion. This will
-  -- complete CFU instruction operation and will also write the processing result <control.result> back to the CPU register file.
-
-  -- ----------------------------------------------------------------------------------------
-  -- CFU Exception
-  -- ----------------------------------------------------------------------------------------
-  -- The CFU does not provide a dedicated exception mechanism. However, if the <control.done> signal is not set within a bound
-  -- time window (default = 512 cycles; see "monitor_mc_tmo_c" constant in the main NEORV32 package file) the CFU operation is
-  -- automatically terminated by the hardware and an **illegal instruction exception** is raised. This default mechanism combined
-  -- with according software handling can be used to "emulate" dedicated CFU exceptions.
-
-  -- ----------------------------------------------------------------------------------------
-  -- CFU-Internal Control and Status Registers (CFU-CSRs)
-  -- ----------------------------------------------------------------------------------------
-  -- > csr_we_i    (input,   1-bit): set to indicate a valid CFU CSR write access
-  -- > csr_addr_i  (input,   2-bit): CSR address
-  -- > csr_wdata_i (input,  32-bit): CSR write data
-  -- > csr_rdata_i (output, 32-bit): CSR read data
-  --
-  -- The NEORV32 provides four directly accessible CSRs for custom use inside the CFU. These registers can be used to pass
-  -- further operands, to check the unit's status or to configure operation modes. For instance, a 128-bit wide key could be
-  -- passed to an encryption system.
-  --
-  -- If more than four CFU-internal CSRs are required the designer can implement an "indirect access mechanism" based on just
-  -- two of the default CSRs: one CSR is used to configure the index while the other is used as an alias to exchange data with
-  -- the indexed CFU-internal CSR - this concept is similar to the RISC-V Indirect CSR Access Extension Specification (Smcsrind).
-
-
-  -- **************************************************************************************************************************
-  -- Actual CFU User Logic Example: XTEA - Extended Tiny Encryption Algorithm (replace this with your custom logic)
-  -- **************************************************************************************************************************
-
-  -- This CFU example implements the Extended Tiny Encryption Algorithm (XTEA).
-  -- The CFU provides 5 custom instructions to accelerate encryption and decryption using dedicated hardware.
-  -- The RTL code is not optimized (not for area, not for clock speed, not for performance) and was
-  -- implemented according to a software C reference (https://de.wikipedia.org/wiki/Extended_Tiny_Encryption_Algorithm).
-
 
   -- CFU-Internal Control and Status Registers (CFU-CSRs): 128-Bit Key Storage --------------
   -- -------------------------------------------------------------------------------------------
@@ -264,36 +201,33 @@ begin
   xtea_core: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      xtea.done <= (others => '0');
+      xtea.done <= '0';
       xtea.opa  <= (others => '0');
       xtea.opb  <= (others => '0');
       xtea.sum  <= (others => '0');
       xtea.res  <= (others => '0');
     elsif rising_edge(clk_i) then
 
-      -- shift register for computation delay --
-      xtea.done(0) <= '0'; -- default
-      xtea.done(1) <= xtea.done(0);
-
       -- trigger new operation --
-      if (start_i = '1') and (control.rtype = r3type_c) then -- execution trigger and correct instruction type
-        xtea.opa     <= rs1_i; -- buffer input operand rs1 (for improved physical timing)
-        xtea.opb     <= rs2_i; -- buffer input operand rs2 (for improved physical timing)
-        xtea.done(0) <= '1';   -- result is available in the 2nd cycle
+      xtea.done <= '0'; -- default
+      if (start_i = '1') and (rtype_i = r3type_c) then -- execution trigger and correct instruction type
+        xtea.opa  <= rs1_i; -- buffer input operand rs1 (for improved physical timing)
+        xtea.opb  <= rs2_i; -- buffer input operand rs2 (for improved physical timing)
+        xtea.done <= '1'; -- result is available in the 2nd cycle
       end if;
 
       -- data processing --
-      if (xtea.done(0) = '1') then -- second-stage execution trigger
+      if (xtea.done = '1') then -- second-stage execution trigger
         -- update "sum" round key --
-        if (control.funct3(2) = '1') then -- initialize
+        if (funct3_i(2) = '1') then -- initialize
           xtea.sum <= xtea.opa; -- set initial round key
-        elsif (control.funct3(1 downto 0) = xtea_enc_v0_c(1 downto 0)) then -- encrypt v0
+        elsif (funct3_i(1 downto 0) = xtea_enc_v0_c(1 downto 0)) then -- encrypt v0
           xtea.sum <= std_ulogic_vector(unsigned(xtea.sum) + unsigned(xtea_delta_c));
-        elsif (control.funct3(1 downto 0) = xtea_dec_v1_c(1 downto 0)) then -- decrypt v1
+        elsif (funct3_i(1 downto 0) = xtea_dec_v1_c(1 downto 0)) then -- decrypt v1
           xtea.sum <= std_ulogic_vector(unsigned(xtea.sum) - unsigned(xtea_delta_c));
         end if;
         -- process "v" operands --
-        if (control.funct3(1) = '0') then -- encrypt
+        if (funct3_i(1) = '0') then -- encrypt
           xtea.res <= std_ulogic_vector(unsigned(tmp_b) + unsigned(tmp_r));
         else -- decrypt
           xtea.res <= std_ulogic_vector(unsigned(tmp_b) - unsigned(tmp_r));
@@ -304,58 +238,59 @@ begin
   end process xtea_core;
 
   -- helpers --
-  tmp_a <= xtea.opb when (control.funct3(0) = '0') else xtea.opa; -- v1 / v0 select
-  tmp_b <= xtea.opa when (control.funct3(0) = '0') else xtea.opb; -- v0 / v1 select
-  tmp_x <= xtea.opb(27 downto 0) & "0000"  when (control.funct3(0) = '0') else xtea.opa(27 downto 0) & "0000";  -- v << 4
-  tmp_y <= "00000" & xtea.opb(31 downto 5) when (control.funct3(0) = '0') else "00000" & xtea.opa(31 downto 5); -- v >> 5
-  tmp_z <= key_mem(to_integer(unsigned(xtea.sum(1 downto 0)))) when (control.funct3(0) = '0') else -- key[sum & 3]
+  tmp_a <= xtea.opb when (funct3_i(0) = '0') else xtea.opa; -- v1 / v0 select
+  tmp_b <= xtea.opa when (funct3_i(0) = '0') else xtea.opb; -- v0 / v1 select
+  tmp_x <= xtea.opb(27 downto 0) & "0000"  when (funct3_i(0) = '0') else xtea.opa(27 downto 0) & "0000";  -- v << 4
+  tmp_y <= "00000" & xtea.opb(31 downto 5) when (funct3_i(0) = '0') else "00000" & xtea.opa(31 downto 5); -- v >> 5
+  tmp_z <= key_mem(to_integer(unsigned(xtea.sum(1 downto 0)))) when (funct3_i(0) = '0') else -- key[sum & 3]
            key_mem(to_integer(unsigned(xtea.sum(12 downto 11)))); -- key[(sum >> 11) & 3]
   tmp_r <= std_ulogic_vector(unsigned(tmp_x xor tmp_y) + unsigned(tmp_a)) xor std_ulogic_vector(unsigned(xtea.sum) + unsigned(tmp_z));
 
 
   -- Function Result Select -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  result_select: process(control, xtea)
+  result_select: process(rtype_i, funct3_i, xtea)
   begin
-    case control.rtype is
+    -- defaults --
+    result_o <= (others => '0');
+    valid_o  <= '0';
 
-      when r3type_c => -- R3-type instructions; function select via "funct7" and "funct3"
+    -- check instruction type --
+    case rtype_i is
+
+      when r3type_c => -- R3-type instructions; function select via "funct3" and ""funct7
       -- ----------------------------------------------------------------------
-        case control.funct3 is -- Just check "funct3" here; "funct7" bit-field is ignored
+        case funct3_i is -- Just check "funct3" here; "funct7" bit-field is ignored
           when xtea_enc_v0_c | xtea_enc_v1_c | xtea_dec_v0_c | xtea_dec_v1_c => -- encryption/decryption
-            control.result <= xtea.res; -- processing result
-            control.done   <= xtea.done(xtea.done'left); -- multi-cycle processing done when set
+            result_o <= xtea.res; -- processing result
+            valid_o  <= xtea.done; -- multi-cycle processing done when set
           when xtea_init_c => -- initialization
-            control.result <= (others => '0'); -- just output zero
-            control.done   <= '1'; -- pure-combinatorial, so we are done "immediately"
+            result_o <= (others => '0'); -- just output zero
+            valid_o  <= '1'; -- pure-combinatorial, so we are done "immediately"
           when others => -- all unspecified operations
-            control.result <= (others => '0'); -- no logic implemented
-            control.done   <= '0'; -- this will cause an illegal instruction exception after timeout
+            result_o <= (others => '0'); -- no logic implemented
+            valid_o  <= '0'; -- this will cause an illegal instruction exception after timeout
         end case;
 
       when r4type_c => -- R4-type instructions; function select via "funct3"
       -- ----------------------------------------------------------------------
-        control.result <= (others => '0'); -- no logic implemented
-        control.done   <= '0'; -- this will cause an illegal instruction exception after timeout
+        result_o <= (others => '0'); -- no logic implemented
+        valid_o  <= '0'; -- this will cause an illegal instruction exception after timeout
 
-      when r5typeA_c => -- R5-type instruction A
+      when r5typeA_c => -- R5-type instruction A; only one function
       -- ----------------------------------------------------------------------
-        -- No function/immediate bit-fields are available for this instruction type.
-        -- Hence, there is just one operation that can be implemented.
-        control.result <= (others => '0'); -- no logic implemented
-        control.done   <= '0'; -- this will cause an illegal instruction exception after timeout
+        result_o <= (others => '0'); -- no logic implemented
+        valid_o  <= '0'; -- this will cause an illegal instruction exception after timeout
 
-      when r5typeB_c => -- R5-type instruction B
+      when r5typeB_c => -- R5-type instruction B; only one function
       -- ----------------------------------------------------------------------
-        -- No function/immediate bit-fields are available for this instruction type.
-        -- Hence, there is just one operation that can be implemented.
-        control.result <= (others => '0'); -- no logic implemented
-        control.done   <= '0'; -- this will cause an illegal instruction exception after timeout
+        result_o <= (others => '0'); -- no logic implemented
+        valid_o  <= '0'; -- this will cause an illegal instruction exception after timeout
 
       when others => -- undefined
       -- ----------------------------------------------------------------------
-        control.result <= (others => '0'); -- no logic implemented
-        control.done   <= '0'; -- this will cause an illegal instruction exception after timeout
+        result_o <= (others => '0'); -- no logic implemented
+        valid_o  <= '0'; -- this will cause an illegal instruction exception after timeout
 
     end case;
   end process result_select;

--- a/rtl/core/neorv32_cpu_decompressor.vhd
+++ b/rtl/core/neorv32_cpu_decompressor.vhd
@@ -1,9 +1,6 @@
 -- ================================================================================ --
 -- NEORV32 CPU - Compressed Instructions Decoder (RISC-V "C" Extension)             --
 -- -------------------------------------------------------------------------------- --
--- Compressed instructions decoder compatible to the RISC-V C ISA extension.        --
--- Illegal compressed instructions are output "as-is" but zero-extended.            --
--- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
 -- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
@@ -20,8 +17,8 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_decompressor is
   port (
-    ci_instr16_i : in  std_ulogic_vector(15 downto 0); -- compressed instruction
-    ci_instr32_o : out std_ulogic_vector(31 downto 0)  -- decompressed instruction
+    instr16_i : in  std_ulogic_vector(15 downto 0); -- compressed instruction
+    instr32_o : out std_ulogic_vector(31 downto 0)  -- decompressed instruction
   );
 end neorv32_cpu_decompressor;
 
@@ -60,62 +57,62 @@ begin
 
   -- 22-bit sign-extended immediate for J/JAL --
   imm20(0)  <= '0';
-  imm20(1)  <= ci_instr16_i(3);
-  imm20(2)  <= ci_instr16_i(4);
-  imm20(3)  <= ci_instr16_i(5);
-  imm20(4)  <= ci_instr16_i(11);
-  imm20(5)  <= ci_instr16_i(2);
-  imm20(6)  <= ci_instr16_i(7);
-  imm20(7)  <= ci_instr16_i(6);
-  imm20(8)  <= ci_instr16_i(9);
-  imm20(9)  <= ci_instr16_i(10);
-  imm20(10) <= ci_instr16_i(8);
-  imm20(20 downto 11) <= (others => ci_instr16_i(12)); -- sign extension
+  imm20(1)  <= instr16_i(3);
+  imm20(2)  <= instr16_i(4);
+  imm20(3)  <= instr16_i(5);
+  imm20(4)  <= instr16_i(11);
+  imm20(5)  <= instr16_i(2);
+  imm20(6)  <= instr16_i(7);
+  imm20(7)  <= instr16_i(6);
+  imm20(8)  <= instr16_i(9);
+  imm20(9)  <= instr16_i(10);
+  imm20(10) <= instr16_i(8);
+  imm20(20 downto 11) <= (others => instr16_i(12)); -- sign extension
 
   -- 12-bit sign-extended immediate for branches --
   imm12(0) <= '0';
-  imm12(1) <= ci_instr16_i(3);
-  imm12(2) <= ci_instr16_i(4);
-  imm12(3) <= ci_instr16_i(10);
-  imm12(4) <= ci_instr16_i(11);
-  imm12(5) <= ci_instr16_i(2);
-  imm12(6) <= ci_instr16_i(5);
-  imm12(7) <= ci_instr16_i(6);
-  imm12(12 downto 8) <= (others => ci_instr16_i(12)); -- sign extension
+  imm12(1) <= instr16_i(3);
+  imm12(2) <= instr16_i(4);
+  imm12(3) <= instr16_i(10);
+  imm12(4) <= instr16_i(11);
+  imm12(5) <= instr16_i(2);
+  imm12(6) <= instr16_i(5);
+  imm12(7) <= instr16_i(6);
+  imm12(12 downto 8) <= (others => instr16_i(12)); -- sign extension
 
 
   -- Compressed Instruction Decoder ---------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  decompressor: process(ci_instr16_i, imm20, imm12)
+  decompressor: process(instr16_i, imm20, imm12)
   begin
     -- defaults --
     illegal <= '0';
-    decoded <= (others => '0');
+    decoded <= x"00000003"; -- empty rv32 instruction
 
     -- actual decoder --
-    case ci_instr16_i(ci_opcode_msb_c downto ci_opcode_lsb_c) is
+    case instr16_i(ci_opcode_msb_c downto ci_opcode_lsb_c) is
 
       when "00" => -- C0: Register-Based Loads and Stores
-        case ci_instr16_i(ci_funct3_msb_c downto ci_funct3_lsb_c) is
+        case instr16_i(ci_funct3_msb_c downto ci_funct3_lsb_c) is
 
           when "000" => -- Illegal_instruction, C.ADDI4SPN
           -- ----------------------------------------------------------------------------------------------------------
             decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_alui_c;
             decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= "00010"; -- stack pointer
-            decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= "01" & ci_instr16_i(ci_rd_3_msb_c downto ci_rd_3_lsb_c);
+            decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= "01" & instr16_i(ci_rd_3_msb_c downto ci_rd_3_lsb_c);
             decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_subadd_c;
             decoded(instr_imm12_msb_c downto instr_imm12_lsb_c)   <= (others => '0'); -- zero extend
             decoded(instr_imm12_lsb_c + 0)                        <= '0';
             decoded(instr_imm12_lsb_c + 1)                        <= '0';
-            decoded(instr_imm12_lsb_c + 2)                        <= ci_instr16_i(6);
-            decoded(instr_imm12_lsb_c + 3)                        <= ci_instr16_i(5);
-            decoded(instr_imm12_lsb_c + 4)                        <= ci_instr16_i(11);
-            decoded(instr_imm12_lsb_c + 5)                        <= ci_instr16_i(12);
-            decoded(instr_imm12_lsb_c + 6)                        <= ci_instr16_i(7);
-            decoded(instr_imm12_lsb_c + 7)                        <= ci_instr16_i(8);
-            decoded(instr_imm12_lsb_c + 8)                        <= ci_instr16_i(9);
-            decoded(instr_imm12_lsb_c + 9)                        <= ci_instr16_i(10);
-            if (ci_instr16_i(12 downto 5) = "00000000") then -- canonical illegal C instruction or C.ADDI4SPN with nzuimm = 0
+            decoded(instr_imm12_lsb_c + 2)                        <= instr16_i(6);
+            decoded(instr_imm12_lsb_c + 3)                        <= instr16_i(5);
+            decoded(instr_imm12_lsb_c + 4)                        <= instr16_i(11);
+            decoded(instr_imm12_lsb_c + 5)                        <= instr16_i(12);
+            decoded(instr_imm12_lsb_c + 6)                        <= instr16_i(7);
+            decoded(instr_imm12_lsb_c + 7)                        <= instr16_i(8);
+            decoded(instr_imm12_lsb_c + 8)                        <= instr16_i(9);
+            decoded(instr_imm12_lsb_c + 9)                        <= instr16_i(10);
+            if (instr16_i(12 downto 5) = "00000000") then -- canonical illegal C instruction or C.ADDI4SPN with nzuimm = 0
               illegal <= '1';
             end if;
 
@@ -123,29 +120,29 @@ begin
           -- ----------------------------------------------------------------------------------------------------------
             decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_load_c;
             decoded(21 downto 20)                                 <= "00";
-            decoded(22)                                           <= ci_instr16_i(6);
-            decoded(23)                                           <= ci_instr16_i(10);
-            decoded(24)                                           <= ci_instr16_i(11);
-            decoded(25)                                           <= ci_instr16_i(12);
-            decoded(26)                                           <= ci_instr16_i(5);
+            decoded(22)                                           <= instr16_i(6);
+            decoded(23)                                           <= instr16_i(10);
+            decoded(24)                                           <= instr16_i(11);
+            decoded(25)                                           <= instr16_i(12);
+            decoded(26)                                           <= instr16_i(5);
             decoded(31 downto 27)                                 <= (others => '0');
             decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_lw_c;
-            decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= "01" & ci_instr16_i(ci_rs1_3_msb_c downto ci_rs1_3_lsb_c); -- x8 - x15
-            decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= "01" & ci_instr16_i(ci_rd_3_msb_c downto ci_rd_3_lsb_c);   -- x8 - x15
+            decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= "01" & instr16_i(ci_rs1_3_msb_c downto ci_rs1_3_lsb_c); -- x8 - x15
+            decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= "01" & instr16_i(ci_rd_3_msb_c downto ci_rd_3_lsb_c);   -- x8 - x15
 
           when "110" => -- C.SW
           -- ----------------------------------------------------------------------------------------------------------
             decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_store_c;
             decoded(8 downto 7)                                   <= "00";
-            decoded(9)                                            <= ci_instr16_i(6);
-            decoded(10)                                           <= ci_instr16_i(10);
-            decoded(11)                                           <= ci_instr16_i(11);
-            decoded(25)                                           <= ci_instr16_i(12);
-            decoded(26)                                           <= ci_instr16_i(5);
+            decoded(9)                                            <= instr16_i(6);
+            decoded(10)                                           <= instr16_i(10);
+            decoded(11)                                           <= instr16_i(11);
+            decoded(25)                                           <= instr16_i(12);
+            decoded(26)                                           <= instr16_i(5);
             decoded(31 downto 27)                                 <= (others => '0');
             decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_sw_c;
-            decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= "01" & ci_instr16_i(ci_rs1_3_msb_c downto ci_rs1_3_lsb_c); -- x8 - x15
-            decoded(instr_rs2_msb_c downto instr_rs2_lsb_c)       <= "01" & ci_instr16_i(ci_rs2_3_msb_c downto ci_rs2_3_lsb_c); -- x8 - x15
+            decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= "01" & instr16_i(ci_rs1_3_msb_c downto ci_rs1_3_lsb_c); -- x8 - x15
+            decoded(instr_rs2_msb_c downto instr_rs2_lsb_c)       <= "01" & instr16_i(ci_rs2_3_msb_c downto ci_rs2_3_lsb_c); -- x8 - x15
 
           when others => -- "011": C.FLW, "111": C.FSW, "001": C.FLS / C.LQ, "100": reserved, "101": C.FSD / C.SQ
           -- ----------------------------------------------------------------------------------------------------------
@@ -155,10 +152,10 @@ begin
 
       when "01" => -- C1: Control Transfer Instructions, Integer Constant-Generation Instructions
 
-        case ci_instr16_i(ci_funct3_msb_c downto ci_funct3_lsb_c) is
+        case instr16_i(ci_funct3_msb_c downto ci_funct3_lsb_c) is
           when "101" | "001" => -- C.J, C.JAL
           -- ----------------------------------------------------------------------------------------------------------
-            if (ci_instr16_i(ci_funct3_msb_c) = '1') then -- C.J
+            if (instr16_i(ci_funct3_msb_c) = '1') then -- C.J
               decoded(instr_rd_msb_c downto instr_rd_lsb_c) <= "00000"; -- discard return address
             else -- C.JAL
               decoded(instr_rd_msb_c downto instr_rd_lsb_c) <= "00001"; -- save return address to link register
@@ -171,13 +168,13 @@ begin
 
           when "110" | "111" => -- C.BEQ, C.BNEZ
           -- ----------------------------------------------------------------------------------------------------------
-            if (ci_instr16_i(ci_funct3_lsb_c) = '0') then -- C.BEQ
+            if (instr16_i(ci_funct3_lsb_c) = '0') then -- C.BEQ
               decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_beq_c;
             else -- C.BNEZ
               decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_bne_c;
             end if;
             decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_branch_c;
-            decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= "01" & ci_instr16_i(ci_rs1_3_msb_c downto ci_rs1_3_lsb_c);
+            decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= "01" & instr16_i(ci_rs1_3_msb_c downto ci_rs1_3_lsb_c);
             decoded(instr_rs2_msb_c downto instr_rs2_lsb_c)       <= "00000"; -- x0
             decoded(7)                                            <= imm12(11);
             decoded(11 downto 8)                                  <= imm12(4 downto 1);
@@ -189,46 +186,46 @@ begin
             decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_alui_c;
             decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_subadd_c;
             decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= "00000"; -- x0
-            decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= ci_instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
-            decoded(instr_imm12_msb_c downto instr_imm12_lsb_c)   <= (others => ci_instr16_i(12)); -- sign extend
-            decoded(instr_imm12_lsb_c + 0)                        <= ci_instr16_i(2);
-            decoded(instr_imm12_lsb_c + 1)                        <= ci_instr16_i(3);
-            decoded(instr_imm12_lsb_c + 2)                        <= ci_instr16_i(4);
-            decoded(instr_imm12_lsb_c + 3)                        <= ci_instr16_i(5);
-            decoded(instr_imm12_lsb_c + 4)                        <= ci_instr16_i(6);
-            decoded(instr_imm12_lsb_c + 5)                        <= ci_instr16_i(12);
+            decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
+            decoded(instr_imm12_msb_c downto instr_imm12_lsb_c)   <= (others => instr16_i(12)); -- sign extend
+            decoded(instr_imm12_lsb_c + 0)                        <= instr16_i(2);
+            decoded(instr_imm12_lsb_c + 1)                        <= instr16_i(3);
+            decoded(instr_imm12_lsb_c + 2)                        <= instr16_i(4);
+            decoded(instr_imm12_lsb_c + 3)                        <= instr16_i(5);
+            decoded(instr_imm12_lsb_c + 4)                        <= instr16_i(6);
+            decoded(instr_imm12_lsb_c + 5)                        <= instr16_i(12);
 
           when "011" => -- C.LUI / C.ADDI16SP
           -- ----------------------------------------------------------------------------------------------------------
-            if (ci_instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c) = "00010") then -- C.ADDI16SP
+            if (instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c) = "00010") then -- C.ADDI16SP
               decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_alui_c;
               decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_subadd_c;
-              decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= ci_instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
+              decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
               decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= "00010"; -- stack pointer
               decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= "00010"; -- stack pointer
-              decoded(instr_imm12_msb_c downto instr_imm12_lsb_c)   <= (others => ci_instr16_i(12)); -- sign extend
+              decoded(instr_imm12_msb_c downto instr_imm12_lsb_c)   <= (others => instr16_i(12)); -- sign extend
               decoded(instr_imm12_lsb_c + 0)                        <= '0';
               decoded(instr_imm12_lsb_c + 1)                        <= '0';
               decoded(instr_imm12_lsb_c + 2)                        <= '0';
               decoded(instr_imm12_lsb_c + 3)                        <= '0';
-              decoded(instr_imm12_lsb_c + 4)                        <= ci_instr16_i(6);
-              decoded(instr_imm12_lsb_c + 5)                        <= ci_instr16_i(2);
-              decoded(instr_imm12_lsb_c + 6)                        <= ci_instr16_i(5);
-              decoded(instr_imm12_lsb_c + 7)                        <= ci_instr16_i(3);
-              decoded(instr_imm12_lsb_c + 8)                        <= ci_instr16_i(4);
-              decoded(instr_imm12_lsb_c + 9)                        <= ci_instr16_i(12);
+              decoded(instr_imm12_lsb_c + 4)                        <= instr16_i(6);
+              decoded(instr_imm12_lsb_c + 5)                        <= instr16_i(2);
+              decoded(instr_imm12_lsb_c + 6)                        <= instr16_i(5);
+              decoded(instr_imm12_lsb_c + 7)                        <= instr16_i(3);
+              decoded(instr_imm12_lsb_c + 8)                        <= instr16_i(4);
+              decoded(instr_imm12_lsb_c + 9)                        <= instr16_i(12);
             else -- C.LUI
               decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_lui_c;
-              decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= ci_instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
-              decoded(instr_imm20_msb_c downto instr_imm20_lsb_c)   <= (others => ci_instr16_i(12)); -- sign extend
-              decoded(instr_imm20_lsb_c + 0)                        <= ci_instr16_i(2);
-              decoded(instr_imm20_lsb_c + 1)                        <= ci_instr16_i(3);
-              decoded(instr_imm20_lsb_c + 2)                        <= ci_instr16_i(4);
-              decoded(instr_imm20_lsb_c + 3)                        <= ci_instr16_i(5);
-              decoded(instr_imm20_lsb_c + 4)                        <= ci_instr16_i(6);
-              decoded(instr_imm20_lsb_c + 5)                        <= ci_instr16_i(12);
+              decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
+              decoded(instr_imm20_msb_c downto instr_imm20_lsb_c)   <= (others => instr16_i(12)); -- sign extend
+              decoded(instr_imm20_lsb_c + 0)                        <= instr16_i(2);
+              decoded(instr_imm20_lsb_c + 1)                        <= instr16_i(3);
+              decoded(instr_imm20_lsb_c + 2)                        <= instr16_i(4);
+              decoded(instr_imm20_lsb_c + 3)                        <= instr16_i(5);
+              decoded(instr_imm20_lsb_c + 4)                        <= instr16_i(6);
+              decoded(instr_imm20_lsb_c + 5)                        <= instr16_i(12);
             end if;
-            if (ci_instr16_i(6 downto 2) = "00000") and (ci_instr16_i(12) = '0') then -- reserved if nzimm = 0
+            if (instr16_i(6 downto 2) = "00000") and (instr16_i(12) = '0') then -- reserved if nzimm = 0
               illegal <= '1';
             end if;
 
@@ -236,51 +233,51 @@ begin
           -- ----------------------------------------------------------------------------------------------------------
             decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_alui_c;
             decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_subadd_c;
-            decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= ci_instr16_i(ci_rs1_5_msb_c downto ci_rs1_5_lsb_c);
-            decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= ci_instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
-            decoded(instr_imm12_msb_c downto instr_imm12_lsb_c)   <= (others => ci_instr16_i(12)); -- sign extend
-            decoded(instr_imm12_lsb_c + 0)                        <= ci_instr16_i(2);
-            decoded(instr_imm12_lsb_c + 1)                        <= ci_instr16_i(3);
-            decoded(instr_imm12_lsb_c + 2)                        <= ci_instr16_i(4);
-            decoded(instr_imm12_lsb_c + 3)                        <= ci_instr16_i(5);
-            decoded(instr_imm12_lsb_c + 4)                        <= ci_instr16_i(6);
-            decoded(instr_imm12_lsb_c + 5)                        <= ci_instr16_i(12);
+            decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= instr16_i(ci_rs1_5_msb_c downto ci_rs1_5_lsb_c);
+            decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
+            decoded(instr_imm12_msb_c downto instr_imm12_lsb_c)   <= (others => instr16_i(12)); -- sign extend
+            decoded(instr_imm12_lsb_c + 0)                        <= instr16_i(2);
+            decoded(instr_imm12_lsb_c + 1)                        <= instr16_i(3);
+            decoded(instr_imm12_lsb_c + 2)                        <= instr16_i(4);
+            decoded(instr_imm12_lsb_c + 3)                        <= instr16_i(5);
+            decoded(instr_imm12_lsb_c + 4)                        <= instr16_i(6);
+            decoded(instr_imm12_lsb_c + 5)                        <= instr16_i(12);
 
           when others => -- 100: C.SRLI, C.SRAI, C.ANDI, C.SUB, C.XOR, C.OR, C.AND, reserved
           -- ----------------------------------------------------------------------------------------------------------
-            decoded(instr_rd_msb_c downto instr_rd_lsb_c)   <= "01" & ci_instr16_i(ci_rs1_3_msb_c downto ci_rs1_3_lsb_c);
-            decoded(instr_rs1_msb_c downto instr_rs1_lsb_c) <= "01" & ci_instr16_i(ci_rs1_3_msb_c downto ci_rs1_3_lsb_c);
-            decoded(instr_rs2_msb_c downto instr_rs2_lsb_c) <= "01" & ci_instr16_i(ci_rs2_3_msb_c downto ci_rs2_3_lsb_c);
-            case ci_instr16_i(11 downto 10) is
+            decoded(instr_rd_msb_c downto instr_rd_lsb_c)   <= "01" & instr16_i(ci_rs1_3_msb_c downto ci_rs1_3_lsb_c);
+            decoded(instr_rs1_msb_c downto instr_rs1_lsb_c) <= "01" & instr16_i(ci_rs1_3_msb_c downto ci_rs1_3_lsb_c);
+            decoded(instr_rs2_msb_c downto instr_rs2_lsb_c) <= "01" & instr16_i(ci_rs2_3_msb_c downto ci_rs2_3_lsb_c);
+            case instr16_i(11 downto 10) is
               when "00" | "01" => -- C.SRLI, C.SRAI
-                if (ci_instr16_i(10) = '0') then -- C.SRLI
+                if (instr16_i(10) = '0') then -- C.SRLI
                   decoded(instr_funct7_msb_c downto instr_funct7_lsb_c) <= "0000000";
                 else -- C.SRAI
                   decoded(instr_funct7_msb_c downto instr_funct7_lsb_c) <= "0100000";
                 end if;
                 decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_alui_c;
                 decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_sr_c;
-                decoded(instr_imm12_lsb_c + 0)                        <= ci_instr16_i(2);
-                decoded(instr_imm12_lsb_c + 1)                        <= ci_instr16_i(3);
-                decoded(instr_imm12_lsb_c + 2)                        <= ci_instr16_i(4);
-                decoded(instr_imm12_lsb_c + 3)                        <= ci_instr16_i(5);
-                decoded(instr_imm12_lsb_c + 4)                        <= ci_instr16_i(6);
-                if (ci_instr16_i(12) = '1') then -- nzuimm[5] = 1 -> RV32 custom / illegal
+                decoded(instr_imm12_lsb_c + 0)                        <= instr16_i(2);
+                decoded(instr_imm12_lsb_c + 1)                        <= instr16_i(3);
+                decoded(instr_imm12_lsb_c + 2)                        <= instr16_i(4);
+                decoded(instr_imm12_lsb_c + 3)                        <= instr16_i(5);
+                decoded(instr_imm12_lsb_c + 4)                        <= instr16_i(6);
+                if (instr16_i(12) = '1') then -- nzuimm[5] = 1 -> RV32 custom / illegal
                   illegal <= '1';
                 end if;
               when "10" => -- C.ANDI
                 decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_alui_c;
                 decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_and_c;
-                decoded(instr_imm12_msb_c downto instr_imm12_lsb_c)   <= (others => ci_instr16_i(12)); -- sign extend
-                decoded(instr_imm12_lsb_c + 0)                        <= ci_instr16_i(2);
-                decoded(instr_imm12_lsb_c + 1)                        <= ci_instr16_i(3);
-                decoded(instr_imm12_lsb_c + 2)                        <= ci_instr16_i(4);
-                decoded(instr_imm12_lsb_c + 3)                        <= ci_instr16_i(5);
-                decoded(instr_imm12_lsb_c + 4)                        <= ci_instr16_i(6);
-                decoded(instr_imm12_lsb_c + 5)                        <= ci_instr16_i(12);
+                decoded(instr_imm12_msb_c downto instr_imm12_lsb_c)   <= (others => instr16_i(12)); -- sign extend
+                decoded(instr_imm12_lsb_c + 0)                        <= instr16_i(2);
+                decoded(instr_imm12_lsb_c + 1)                        <= instr16_i(3);
+                decoded(instr_imm12_lsb_c + 2)                        <= instr16_i(4);
+                decoded(instr_imm12_lsb_c + 3)                        <= instr16_i(5);
+                decoded(instr_imm12_lsb_c + 4)                        <= instr16_i(6);
+                decoded(instr_imm12_lsb_c + 5)                        <= instr16_i(12);
               when others => -- "11" = register-register operation
                 decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_alu_c;
-                case ci_instr16_i(6 downto 5) is
+                case instr16_i(6 downto 5) is
                   when "00" => -- C.SUB
                     decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_subadd_c;
                     decoded(instr_funct7_msb_c downto instr_funct7_lsb_c) <= "0100000";
@@ -294,7 +291,7 @@ begin
                     decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_and_c;
                     decoded(instr_funct7_msb_c downto instr_funct7_lsb_c) <= "0000000";
                 end case;
-                if (ci_instr16_i(12) = '1') then -- reserved instruction space.
+                if (instr16_i(12) = '1') then -- reserved instruction space.
                   illegal <= '1';
                 end if;
             end case;
@@ -302,21 +299,21 @@ begin
         end case;
 
       when others => -- C2: Stack-Pointer-Based Loads and Stores, Control Transfer Instructions (or C3, which is not a RVC instruction)
-        case ci_instr16_i(ci_funct3_msb_c downto ci_funct3_lsb_c) is
+        case instr16_i(ci_funct3_msb_c downto ci_funct3_lsb_c) is
 
           when "000" => -- C.SLLI
           -- ----------------------------------------------------------------------------------------------------------
             decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_alui_c;
-            decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= ci_instr16_i(ci_rs1_5_msb_c downto ci_rs1_5_lsb_c);
-            decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= ci_instr16_i(ci_rs1_5_msb_c downto ci_rs1_5_lsb_c);
+            decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= instr16_i(ci_rs1_5_msb_c downto ci_rs1_5_lsb_c);
+            decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= instr16_i(ci_rs1_5_msb_c downto ci_rs1_5_lsb_c);
             decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_sll_c;
             decoded(instr_funct7_msb_c downto instr_funct7_lsb_c) <= "0000000";
-            decoded(instr_imm12_lsb_c + 0)                        <= ci_instr16_i(2);
-            decoded(instr_imm12_lsb_c + 1)                        <= ci_instr16_i(3);
-            decoded(instr_imm12_lsb_c + 2)                        <= ci_instr16_i(4);
-            decoded(instr_imm12_lsb_c + 3)                        <= ci_instr16_i(5);
-            decoded(instr_imm12_lsb_c + 4)                        <= ci_instr16_i(6);
-            if (ci_instr16_i(12) = '1') then -- nzuimm[5] = 1 -> RV32 custom
+            decoded(instr_imm12_lsb_c + 0)                        <= instr16_i(2);
+            decoded(instr_imm12_lsb_c + 1)                        <= instr16_i(3);
+            decoded(instr_imm12_lsb_c + 2)                        <= instr16_i(4);
+            decoded(instr_imm12_lsb_c + 3)                        <= instr16_i(5);
+            decoded(instr_imm12_lsb_c + 4)                        <= instr16_i(6);
+            if (instr16_i(12) = '1') then -- nzuimm[5] = 1 -> RV32 custom
               illegal <= '1';
             end if;
 
@@ -324,18 +321,18 @@ begin
           -- ----------------------------------------------------------------------------------------------------------
             decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_load_c;
             decoded(21 downto 20)                                 <= "00";
-            decoded(22)                                           <= ci_instr16_i(4);
-            decoded(23)                                           <= ci_instr16_i(5);
-            decoded(24)                                           <= ci_instr16_i(6);
-            decoded(25)                                           <= ci_instr16_i(12);
-            decoded(26)                                           <= ci_instr16_i(2);
-            decoded(27)                                           <= ci_instr16_i(3);
+            decoded(22)                                           <= instr16_i(4);
+            decoded(23)                                           <= instr16_i(5);
+            decoded(24)                                           <= instr16_i(6);
+            decoded(25)                                           <= instr16_i(12);
+            decoded(26)                                           <= instr16_i(2);
+            decoded(27)                                           <= instr16_i(3);
             decoded(31 downto 28)                                 <= (others => '0');
             decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_lw_c;
             decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= "00010"; -- stack pointer
-            decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= ci_instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
-            if (ci_instr16_i(ci_funct3_lsb_c) = '1') or -- C.FLWSP -> illegal
-               (ci_instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c) = "00000") then -- rd = 0 -> reserved
+            decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
+            if (instr16_i(ci_funct3_lsb_c) = '1') or -- C.FLWSP -> illegal
+               (instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c) = "00000") then -- rd = 0 -> reserved
               illegal <= '1';
             end if;
 
@@ -343,57 +340,57 @@ begin
           -- ----------------------------------------------------------------------------------------------------------
             decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_store_c;
             decoded(8 downto 7)                                   <= "00";
-            decoded(9)                                            <= ci_instr16_i(9);
-            decoded(10)                                           <= ci_instr16_i(10);
-            decoded(11)                                           <= ci_instr16_i(11);
-            decoded(25)                                           <= ci_instr16_i(12);
-            decoded(26)                                           <= ci_instr16_i(7);
-            decoded(27)                                           <= ci_instr16_i(8);
+            decoded(9)                                            <= instr16_i(9);
+            decoded(10)                                           <= instr16_i(10);
+            decoded(11)                                           <= instr16_i(11);
+            decoded(25)                                           <= instr16_i(12);
+            decoded(26)                                           <= instr16_i(7);
+            decoded(27)                                           <= instr16_i(8);
             decoded(31 downto 28)                                 <= (others => '0');
             decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_sw_c;
             decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= "00010"; -- stack pointer
-            decoded(instr_rs2_msb_c downto instr_rs2_lsb_c)       <= ci_instr16_i(ci_rs2_5_msb_c downto ci_rs2_5_lsb_c);
-            if (ci_instr16_i(ci_funct3_lsb_c) = '1') then -- C.FSWSP -> illegal
+            decoded(instr_rs2_msb_c downto instr_rs2_lsb_c)       <= instr16_i(ci_rs2_5_msb_c downto ci_rs2_5_lsb_c);
+            if (instr16_i(ci_funct3_lsb_c) = '1') then -- C.FSWSP -> illegal
               illegal <= '1';
             end if;
 
           when "100" => -- "100": C.JR, C.JALR, C.MV, C.EBREAK, C.ADD
           -- ----------------------------------------------------------------------------------------------------------
-            if (ci_instr16_i(12) = '0') then -- C.JR, C.MV
-              if (ci_instr16_i(6 downto 2) = "00000") then -- C.JR
+            if (instr16_i(12) = '0') then -- C.JR, C.MV
+              if (instr16_i(6 downto 2) = "00000") then -- C.JR
                 decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_jalr_c;
-                decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= ci_instr16_i(ci_rs1_5_msb_c downto ci_rs1_5_lsb_c);
+                decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= instr16_i(ci_rs1_5_msb_c downto ci_rs1_5_lsb_c);
                 decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= "00000"; -- discard return address
-                if (ci_instr16_i(ci_rs1_5_msb_c downto ci_rs1_5_lsb_c) = "00000") or -- rs1 = 0 -> reserved
-                   (ci_instr16_i(ci_rs2_5_msb_c downto ci_rs2_5_lsb_c) /= "00000") then -- rs2 != 0 -> illegal
+                if (instr16_i(ci_rs1_5_msb_c downto ci_rs1_5_lsb_c) = "00000") or -- rs1 = 0 -> reserved
+                   (instr16_i(ci_rs2_5_msb_c downto ci_rs2_5_lsb_c) /= "00000") then -- rs2 != 0 -> illegal
                   illegal <= '1';
                 end if;
               else -- C.MV
                 decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_alu_c;
                 decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= "000";
-                decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= ci_instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
+                decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
                 decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= "00000"; -- x0
-                decoded(instr_rs2_msb_c downto instr_rs2_lsb_c)       <= ci_instr16_i(ci_rs2_5_msb_c downto ci_rs2_5_lsb_c);
-                if (ci_instr16_i(ci_rs2_5_msb_c downto ci_rs2_5_lsb_c) = "00000") then -- rs2 = 0 -> reserved
+                decoded(instr_rs2_msb_c downto instr_rs2_lsb_c)       <= instr16_i(ci_rs2_5_msb_c downto ci_rs2_5_lsb_c);
+                if (instr16_i(ci_rs2_5_msb_c downto ci_rs2_5_lsb_c) = "00000") then -- rs2 = 0 -> reserved
                   illegal <= '1';
                 end if;
               end if;
             else -- C.EBREAK, C.JALR, C.ADD
-              if (ci_instr16_i(6 downto 2) = "00000") then -- C.EBREAK, C.JALR
-                if (ci_instr16_i(11 downto 7) = "00000") then -- C.EBREAK
+              if (instr16_i(6 downto 2) = "00000") then -- C.EBREAK, C.JALR
+                if (instr16_i(11 downto 7) = "00000") then -- C.EBREAK
                   decoded(instr_opcode_msb_c downto instr_opcode_lsb_c)   <= opcode_system_c;
                   decoded(instr_funct12_msb_c downto instr_funct12_lsb_c) <= funct12_ebreak_c;
                 else -- C.JALR
                   decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_jalr_c;
-                  decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= ci_instr16_i(ci_rs1_5_msb_c downto ci_rs1_5_lsb_c);
+                  decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= instr16_i(ci_rs1_5_msb_c downto ci_rs1_5_lsb_c);
                   decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= "00001"; -- save return address to link register
                 end if;
               else -- C.ADD
                 decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_alu_c;
                 decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= "000";
-                decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= ci_instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
-                decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= ci_instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
-                decoded(instr_rs2_msb_c downto instr_rs2_lsb_c)       <= ci_instr16_i(ci_rs2_5_msb_c downto ci_rs2_5_lsb_c);
+                decoded(instr_rd_msb_c downto instr_rd_lsb_c)         <= instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
+                decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= instr16_i(ci_rd_5_msb_c downto ci_rd_5_lsb_c);
+                decoded(instr_rs2_msb_c downto instr_rs2_lsb_c)       <= instr16_i(ci_rs2_5_msb_c downto ci_rs2_5_lsb_c);
               end if;
             end if;
 
@@ -406,8 +403,10 @@ begin
     end case;
   end process decompressor;
 
-  -- output original 16-bit instruction word if illegal instruction --
-  ci_instr32_o <= (x"0000" & ci_instr16_i) when (illegal = '1') else decoded;
+  -- output illegal instruction in its pre-decoded 32-bit form --
+  instr32_o(31 downto 2) <= decoded(31 downto 2);
+  instr32_o(1) <= decoded(1) when (illegal = '0') else '0'; -- force OPCODE[1] to zero if illegal
+  instr32_o(0) <= decoded(0);
 
 
 end neorv32_cpu_decompressor_rtl;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100004"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100005"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -157,7 +157,7 @@ begin
     if ci_mode then
       -- No need to send the full expectation in one big chunk
       check_uart(net, uart1_rx_handle, nul & nul);
-      check_uart(net, uart1_rx_handle, "0/56" & cr & lf);
+      check_uart(net, uart1_rx_handle, "0/55" & cr & lf);
     end if;
 
     -- Wait until all expected data has been received


### PR DESCRIPTION
#### :warning: Rework CFU Interface

* remove "proxy/controller" logic from CFU module (reducing size); put a minimal proxy logic to the ALU
* allow implementers to skip registered CFU output to reduce latency (faster execution)

#### :sparkles: Simplify RVC Decompressor

Output illegal instruction word "as-is" in their pre-decoded 32-bit format.