### PR TITLE
minor software updates and fixes

### DIFF
--- a/sw/example/demo_cfu/main.c
+++ b/sw/example/demo_cfu/main.c
@@ -31,7 +31,7 @@
 
 
 /**********************************************************************//**
- * @name Define macros for easy custom instruction wrapping
+ * @name Define macros for easy CFU instruction wrapping
  **************************************************************************/
 /**@{*/
 #define xtea_hw_init(sum)           neorv32_cfu_r3_instr(0b0000000, 0b100, sum, 0)
@@ -39,13 +39,14 @@
 #define xtea_hw_enc_v1_step(v0, v1) neorv32_cfu_r3_instr(0b0000000, 0b001, v0, v1)
 #define xtea_hw_dec_v0_step(v0, v1) neorv32_cfu_r3_instr(0b0000000, 0b010, v0, v1)
 #define xtea_hw_dec_v1_step(v0, v1) neorv32_cfu_r3_instr(0b0000000, 0b011, v0, v1)
+#define xtea_hw_illegal_inst()      neorv32_cfu_r3_instr(0b0000000, 0b111, 0, 0)
 /**@}*/
 
 // The CFU custom instructions can be used as plain C functions as they are simple "intrinsics".
 // There are 4 "prototype primitives" for the CFU instructions (define in sw/lib/include/neorv32_cfu.h):
 //
-// > neorv32_cfu_r3_instr(funct7, funct3, rs1, rs2) - for r3-type instructions (custom-0 opcode)
-// > neorv32_cfu_r4_instr(funct3, rs1, rs2, rs3)    - for r4-type instructions (custom-1 opcode)
+// > neorv32_cfu_r3_instr(funct7, funct3, rs1, rs2) - for r3-type instructions  (custom-0 opcode)
+// > neorv32_cfu_r4_instr(funct3, rs1, rs2, rs3)    - for r4-type instructions  (custom-1 opcode)
 // > neorv32_cfu_r5_instr_a(rs1, rs2, rs3, rs4)     - for r5-type instruction A (custom-2 opcode)
 // > neorv32_cfu_r5_instr_b(rs1, rs2, rs3, rs4)     - for r5-type instruction B (custom-3 opcode)
 //
@@ -325,6 +326,12 @@ int main() {
   neorv32_uart0_printf("DEC SW = %u cycles\n", time_dec_sw);
   neorv32_uart0_printf("DEC HW = %u cycles\n", time_dec_hw);
 
+
+  // ----------------------------------------------------------
+  // Execute an unimplemented CFU instruction word
+  // ----------------------------------------------------------
+  neorv32_uart0_printf("\nExecuting non-implemented CFU instruction (raise ILLEGAL INSTRUCTION exception)...\n");
+  xtea_hw_illegal_inst();
 
 
   neorv32_uart0_printf("\nCFU demo program completed.\n");

--- a/sw/example/demo_onewire/main.c
+++ b/sw/example/demo_onewire/main.c
@@ -36,7 +36,7 @@ void show_1wire_commands(void);
 void read_byte(void);
 void write_byte(void);
 void scan_bus(void);
-uint32_t hexstr_to_uint(char *buffer, uint8_t length);
+uint32_t hexstr_to_uint32(char *buffer, uint8_t length);
 
 
 /**********************************************************************//**
@@ -211,7 +211,7 @@ void write_byte(void) {
   // enter address
   neorv32_uart0_printf("Enter write data (2 hex chars): 0x");
   neorv32_uart0_scan(terminal_buffer, 2+1, 1); // 2 hex chars for address plus '\0'
-  uint8_t wdata = (uint8_t)hexstr_to_uint(terminal_buffer, strlen(terminal_buffer));
+  uint8_t wdata = (uint8_t)hexstr_to_uint32(terminal_buffer, strlen(terminal_buffer));
 
   // write to bus
   neorv32_uart0_printf("\nWriting 0x");
@@ -265,13 +265,13 @@ void scan_bus(void) {
 
 
 /**********************************************************************//**
- * Helper function to convert N hex char string into uint32_t.
+ * Helper function to convert N hex chars string into uint32_t
  *
- * @param[in] buffer Pointer to array of chars to convert into number.
- * @param[in] length Length of the conversion string.
- * @return Converted 32-bit number.
+ * @param[in,out] buffer Pointer to array of chars to convert into number.
+ * @param[in,out] length Length of the conversion string.
+ * @return Converted number.
  **************************************************************************/
-uint32_t hexstr_to_uint(char *buffer, uint8_t length) {
+uint32_t hexstr_to_uint32(char *buffer, uint8_t length) {
 
   uint32_t res = 0, d = 0;
   char c = 0;
@@ -279,16 +279,25 @@ uint32_t hexstr_to_uint(char *buffer, uint8_t length) {
   while (length--) {
     c = *buffer++;
 
-    if ((c >= '0') && (c <= '9'))
-      d = (uint32_t)(c - '0');
-    else if ((c >= 'a') && (c <= 'f'))
-      d = (uint32_t)((c - 'a') + 10);
-    else if ((c >= 'A') && (c <= 'F'))
-      d = (uint32_t)((c - 'A') + 10);
-    else
-      d = 0;
+    if (c == '\0') {
+      break;
+    }
 
-    res = res + (d << (length*4));
+    if ((c >= '0') && (c <= '9')) {
+      d = (uint32_t)(c - '0');
+    }
+    else if ((c >= 'a') && (c <= 'f')) {
+      d = (uint32_t)((c - 'a') + 10);
+    }
+    else if ((c >= 'A') && (c <= 'F')) {
+      d = (uint32_t)((c - 'A') + 10);
+    }
+    else {
+      d = 0;
+    }
+
+    res <<= 4;
+    res |= d & 0xf;
   }
 
   return res;

--- a/sw/example/demo_sdi/main.c
+++ b/sw/example/demo_sdi/main.c
@@ -28,7 +28,7 @@
 // Prototypes
 void sdi_put(void);
 void sdi_get(void);
-uint32_t hexstr_to_uint(char *buffer, uint8_t length);
+uint32_t hexstr_to_uint32(char *buffer, uint8_t length);
 
 
 /**********************************************************************//**
@@ -115,7 +115,7 @@ void sdi_put(void) {
 
   neorv32_uart0_printf("Enter TX data (2 hex chars): 0x");
   neorv32_uart0_scan(terminal_buffer, sizeof(terminal_buffer), 1);
-  uint32_t tx_data = (uint32_t)hexstr_to_uint(terminal_buffer, strlen(terminal_buffer));
+  uint32_t tx_data = (uint32_t)hexstr_to_uint32(terminal_buffer, strlen(terminal_buffer));
 
   neorv32_uart0_printf("\nWriting 0x%x to SDI TX buffer... ", tx_data);
 
@@ -145,13 +145,13 @@ void sdi_get(void) {
 
 
 /**********************************************************************//**
- * Helper function to convert N hex chars string into uint32_T
+ * Helper function to convert N hex chars string into uint32_t
  *
  * @param[in,out] buffer Pointer to array of chars to convert into number.
  * @param[in,out] length Length of the conversion string.
  * @return Converted number.
  **************************************************************************/
-uint32_t hexstr_to_uint(char *buffer, uint8_t length) {
+uint32_t hexstr_to_uint32(char *buffer, uint8_t length) {
 
   uint32_t res = 0, d = 0;
   char c = 0;
@@ -159,16 +159,25 @@ uint32_t hexstr_to_uint(char *buffer, uint8_t length) {
   while (length--) {
     c = *buffer++;
 
-    if ((c >= '0') && (c <= '9'))
-      d = (uint32_t)(c - '0');
-    else if ((c >= 'a') && (c <= 'f'))
-      d = (uint32_t)((c - 'a') + 10);
-    else if ((c >= 'A') && (c <= 'F'))
-      d = (uint32_t)((c - 'A') + 10);
-    else
-      d = 0;
+    if (c == '\0') {
+      break;
+    }
 
-    res = res + (d << (length*4));
+    if ((c >= '0') && (c <= '9')) {
+      d = (uint32_t)(c - '0');
+    }
+    else if ((c >= 'a') && (c <= 'f')) {
+      d = (uint32_t)((c - 'a') + 10);
+    }
+    else if ((c >= 'A') && (c <= 'F')) {
+      d = (uint32_t)((c - 'A') + 10);
+    }
+    else {
+      d = 0;
+    }
+
+    res <<= 4;
+    res |= d & 0xf;
   }
 
   return res;

--- a/sw/example/demo_twi/main.c
+++ b/sw/example/demo_twi/main.c
@@ -30,7 +30,7 @@
 void scan_twi(void);
 void set_clock(void);
 void send_twi(void);
-uint32_t hexstr_to_uint(char *buffer, uint8_t length);
+uint32_t hexstr_to_uint32(char *buffer, uint8_t length);
 void print_hex_byte(uint8_t data);
 
 
@@ -131,7 +131,7 @@ void set_clock(void) {
   // clock prescaler
   neorv32_uart0_printf("Select new clock prescaler (0..7; one hex char): ");
   neorv32_uart0_scan(terminal_buffer, 2, 1); // 1 hex char plus '\0'
-  int prsc = (int)hexstr_to_uint(terminal_buffer, strlen(terminal_buffer));
+  int prsc = (int)hexstr_to_uint32(terminal_buffer, strlen(terminal_buffer));
 
   if ((prsc < 0) || (prsc > 7)) { // invalid?
     neorv32_uart0_printf("\nInvalid selection!\n");
@@ -141,7 +141,7 @@ void set_clock(void) {
   // clock divider
   neorv32_uart0_printf("\nSelect new clock divider (0..15; one hex char): ");
   neorv32_uart0_scan(terminal_buffer, 2, 1); // 1 hex char plus '\0'
-  int cdiv = (int)hexstr_to_uint(terminal_buffer, strlen(terminal_buffer));
+  int cdiv = (int)hexstr_to_uint32(terminal_buffer, strlen(terminal_buffer));
 
   if ((cdiv < 0) || (cdiv > 15)) { // invalid?
     neorv32_uart0_printf("\nInvalid selection!\n");
@@ -217,7 +217,7 @@ void send_twi(void) {
   // TX data
   neorv32_uart0_printf("Enter TX data (2 hex chars): ");
   neorv32_uart0_scan(terminal_buffer, 3, 1); // 2 hex chars for address plus '\0'
-  data = (uint8_t)hexstr_to_uint(terminal_buffer, strlen(terminal_buffer));
+  data = (uint8_t)hexstr_to_uint32(terminal_buffer, strlen(terminal_buffer));
 
   // host ACK
   neorv32_uart0_printf("\nIssue ACK by host (y/n)? ");
@@ -257,7 +257,7 @@ void send_twi(void) {
  * @param[in,out] length Length of the conversion string.
  * @return Converted number.
  **************************************************************************/
-uint32_t hexstr_to_uint(char *buffer, uint8_t length) {
+uint32_t hexstr_to_uint32(char *buffer, uint8_t length) {
 
   uint32_t res = 0, d = 0;
   char c = 0;
@@ -265,16 +265,25 @@ uint32_t hexstr_to_uint(char *buffer, uint8_t length) {
   while (length--) {
     c = *buffer++;
 
-    if ((c >= '0') && (c <= '9'))
-      d = (uint32_t)(c - '0');
-    else if ((c >= 'a') && (c <= 'f'))
-      d = (uint32_t)((c - 'a') + 10);
-    else if ((c >= 'A') && (c <= 'F'))
-      d = (uint32_t)((c - 'A') + 10);
-    else
-      d = 0;
+    if (c == '\0') {
+      break;
+    }
 
-    res = res + (d << (length*4));
+    if ((c >= '0') && (c <= '9')) {
+      d = (uint32_t)(c - '0');
+    }
+    else if ((c >= 'a') && (c <= 'f')) {
+      d = (uint32_t)((c - 'a') + 10);
+    }
+    else if ((c >= 'A') && (c <= 'F')) {
+      d = (uint32_t)((c - 'A') + 10);
+    }
+    else {
+      d = 0;
+    }
+
+    res <<= 4;
+    res |= d & 0xf;
   }
 
   return res;

--- a/sw/example/demo_xirq/main.c
+++ b/sw/example/demo_xirq/main.c
@@ -121,6 +121,13 @@ int main() {
     return 1;
   }
 
+  // enable XIRQ channels
+  neorv32_xirq_channel_enable(0);
+  neorv32_xirq_channel_enable(1);
+  neorv32_xirq_channel_enable(2);
+  neorv32_xirq_channel_enable(3);
+
+
   // allow XIRQ to trigger CPU interrupt
   neorv32_xirq_global_enable();
 

--- a/sw/lib/include/neorv32_mtime.h
+++ b/sw/lib/include/neorv32_mtime.h
@@ -36,6 +36,22 @@ typedef volatile struct __attribute__((packed,aligned(4))) {
 
 
 /**********************************************************************//**
+ * @name Date and time struct
+ **************************************************************************/
+/**@{*/
+typedef struct {
+  uint16_t year;    /**< current year (absolute) */
+  uint8_t  month;   /**< 1..12 */
+  uint8_t  day;     /**< 1..31 */
+  uint8_t  weekday; /**< 1..7 starting with Monday */
+  uint8_t  hours;   /**< 0..23 */
+  uint8_t  minutes; /**< 0..59 */
+  uint8_t  seconds; /**< 0..59 */
+} date_t;
+/**@}*/
+
+
+/**********************************************************************//**
  * @name Prototypes
  **************************************************************************/
 /**@{*/
@@ -44,7 +60,12 @@ void     neorv32_mtime_set_time(uint64_t time);
 uint64_t neorv32_mtime_get_time(void);
 void     neorv32_mtime_set_timecmp(uint64_t timecmp);
 uint64_t neorv32_mtime_get_timecmp(void);
+void     neorv32_mtime_set_unixtime(uint64_t unixtime);
+uint64_t neorv32_mtime_get_unixtime(void);
+uint64_t neorv32_mtime_date2unixtime(date_t* date);
+void     neorv32_mtime_unixtime2date(uint64_t unixtime, date_t* date);
 /**@}*/
+
 
 
 #endif // neorv32_mtime_h

--- a/sw/lib/source/neorv32_mtime.c
+++ b/sw/lib/source/neorv32_mtime.c
@@ -94,7 +94,7 @@ uint64_t neorv32_mtime_get_time(void) {
  * Set compare time register (MTIMECMP) for generating interrupts.
  *
  * @note The interrupt is triggered when MTIME >= MTIMECMP.
- * @note Global interrupts and the timer interrupt source have to be enabled .
+ * @note Global interrupts and the timer interrupt source have to be enabled.
  *
  * @param[in] timecmp System time for interrupt (uint64_t)
  **************************************************************************/
@@ -129,4 +129,152 @@ uint64_t neorv32_mtime_get_timecmp(void) {
   cycles.uint32[1] = NEORV32_MTIME->TIMECMP_HI;
 
   return cycles.uint64;
+}
+
+
+/**********************************************************************//**
+ * Set TIME to Unix time.
+ *
+ * @param[in] unixtime Unix time since 00:00:00 UTC, January 1, 1970 in seconds.
+ **************************************************************************/
+void neorv32_mtime_set_unixtime(uint64_t unixtime) {
+
+  neorv32_mtime_set_time(((uint64_t)NEORV32_SYSINFO->CLK) * unixtime);
+}
+
+
+/**********************************************************************//**
+ * Get Unix time from TIME.
+ *
+ * @return Unix time since 00:00:00 UTC, January 1, 1970 in seconds.
+ **************************************************************************/
+uint64_t neorv32_mtime_get_unixtime(void) {
+
+  return neorv32_mtime_get_time() / ((uint64_t)NEORV32_SYSINFO->CLK);
+}
+
+
+/**********************************************************************//**
+ * Convert date to Unix time stamp.
+ *
+ * @copyright Copyright (C) 2010-2024 Oryx Embedded SARL. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ * https://github.com/Oryx-Embedded/Common/blob/master/date_time.c
+ *
+ * @param[in] date Pointer to date and time struct (#date_t).
+ * @return Unix time since 00:00:00 UTC, January 1, 1970 in seconds.
+ **************************************************************************/
+uint64_t neorv32_mtime_date2unixtime(date_t* date) {
+
+  uint32_t y, m, d, t;
+
+  // range checks
+  if (date->year < 1970) {
+    y = 1970;
+  }
+  else {
+    y = date->year;
+  }
+
+  if ((date->month < 1) || (date->month > 12)) {
+    m = 1;
+  }
+  else {
+    m = date->month;
+  }
+
+  if ((date->day < 1) || (date->day > 31)) {
+    d = 1;
+  }
+  else {
+    d = date->day;
+  }
+
+  // Jan and Feb are counted as months 13 and 14 of the previous year
+  if (m <= 2) {
+    m += 12;
+    y -= 1;
+  }
+
+  // years to days
+  t = (365 * y) + (y / 4) - (y / 100) + (y / 400);
+  // month to days
+  t += (30 * m) + (3 * (m + 1) / 5) + d;
+  // Unix time base: January 1st, 1970
+  t -= 719561;
+  // days to seconds
+  t *= 86400;
+  // sum up
+  t += (3600 * (date->hours % 24)) + (60 * (date->minutes % 60)) + (date->seconds % 60);
+
+  return t;
+}
+
+
+/**********************************************************************//**
+ * Convert Unix time stamp to date.
+ *
+ * @copyright Copyright (C) 2010-2024 Oryx Embedded SARL. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ * https://github.com/Oryx-Embedded/Common/blob/master/date_time.c
+ *
+ * @param[in] unixtime Unix time since 00:00:00 UTC, January 1, 1970 in seconds.
+ * @param[in,out] date Pointer to date and time struct (#date_t).
+ **************************************************************************/
+void neorv32_mtime_unixtime2date(uint64_t unixtime, date_t* date) {
+
+  uint32_t a, b, c, d, e, f;
+
+  // invalid
+  if (unixtime < 1) {
+    unixtime = 0;
+  }
+
+  date->seconds = unixtime % 60;
+  unixtime /= 60;
+  date->minutes = unixtime % 60;
+  unixtime /= 60;
+  date->hours = unixtime % 24;
+  unixtime /= 24;
+
+  // convert
+  a = (uint32_t) ((4 * unixtime + 102032) / 146097 + 15);
+  b = (uint32_t) (unixtime + 2442113 + a - (a / 4));
+  c = (20 * b - 2442) / 7305;
+  d = b - 365 * c - (c / 4);
+  e = d * 1000 / 30601;
+  f = d - e * 30 - e * 601 / 1000;
+
+  // Jan and Feb are counted as months 13 and 14 of the previous year
+  if (e <= 13) {
+    c -= 4716;
+    e -= 1;
+  }
+  else {
+    c -= 4715;
+    e -= 13;
+  }
+
+  date->year = c;
+  date->month = e;
+  date->day = f;
+
+  // day of the week
+  uint32_t h, j, k;
+
+  // Jan and Feb are counted as months 13 and 14 of the previous year
+  if (e <= 2) {
+    e += 12;
+    c -= 1;
+  }
+
+  // century
+  j = c / 100;
+  // year of the century
+  k = c % 100;
+
+  // Zeller's congruence
+  h = f + (26 * (e + 1) / 10) + k + (k / 4) + (5 * j) + (j / 4);
+
+  date->weekday = ((h + 5) % 7) + 1;
 }

--- a/sw/lib/source/neorv32_xirq.c
+++ b/sw/lib/source/neorv32_xirq.c
@@ -214,8 +214,6 @@ void neorv32_xirq_channel_disable(int channel) {
 /**********************************************************************//**
  * Install interrupt handler function for XIRQ channel.
  *
- * @note This will also activate the according XIRQ channel and clear a pending IRQ at this channel.
- *
  * @param[in] channel XIRQ interrupt channel (0..31).
  * @param[in] handler The actual handler function for the specified interrupt (function MUST be of type "void function(void);").
  * @return 0 if success, 1 if error.
@@ -225,9 +223,6 @@ int neorv32_xirq_install(int channel, void (*handler)(void)) {
   // channel valid?
   if (channel < 32) {
     __neorv32_xirq_vector_lut[channel] = (uint32_t)handler; // install handler
-    uint32_t mask = 1 << channel;
-    NEORV32_XIRQ->EIP = ~mask; // clear if pending
-    NEORV32_XIRQ->EIE |= mask; // enable channel
     return 0;
   }
   return 1;

--- a/sw/lib/source/syscalls.c
+++ b/sw/lib/source/syscalls.c
@@ -211,7 +211,7 @@ int _openat(int dirfd, const char *name, int flags, int mode)
 
 ssize_t _read(int file, void *ptr, size_t len)
 {
-    int read_cnt = 0;
+    ssize_t read_cnt = 0;
 
     // read everything (STDIN, ...) from NEORV32.UART0 (if available)
     if (neorv32_uart0_available()) {
@@ -275,7 +275,7 @@ ssize_t _write(int file, const void *ptr, size_t len)
       return len;
     }
     else {
-      return (size_t)0; // nothing sent
+      return (ssize_t)0; // nothing sent
     }
 }
 


### PR DESCRIPTION
* newlib system calls: fix minor type issue
* improve `hexstr_to_uint` function (and rename to `hexstr_to_uint32`)
* improve [bus_explorer](https://github.com/stnolting/neorv32/tree/main/sw/example/bus_explorer) user console
* add Unix timestamping functions to MTIME library; MTIME machine timer can now easily be used as real-time clock
* fix XIRQ's `neorv32_xirq_install` function: XIRQ channels have to be enabled by hand (using `neorv32_xirq_channel_enable()`)
* minor cleanups and edits