### PR TITLE
minor rtl edits and cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 30.06.2024 | 1.10.0.6 | minor rtl edits and cleanups | [#935](https://github.com/stnolting/neorv32/pull/935) |
 | 29.06.2024 | 1.10.0.5 | :warning: rework and optimize custom functions unit (CFU) interface; simplified illegal RVC decoding | [#932](https://github.com/stnolting/neorv32/pull/932) |
 | 23.06.2024 | 1.10.0.4 | minor rtl edits/cleanups | [#931](https://github.com/stnolting/neorv32/pull/931) |
 | 22.06.2024 | 1.10.0.3 | UARTs: add flags to clear RX/TX FIFOs; DMA: add FIRQ trigger type configuration flag | [#930](https://github.com/stnolting/neorv32/pull/930) |

--- a/rtl/core/neorv32_cfs.vhd
+++ b/rtl/core/neorv32_cfs.vhd
@@ -147,14 +147,11 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      cfs_reg_wr(0)  <= (others => '0');
-      cfs_reg_wr(1)  <= (others => '0');
-      cfs_reg_wr(2)  <= (others => '0');
-      cfs_reg_wr(3)  <= (others => '0');
-      --
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
+      cfs_reg_wr(0) <= (others => '0');
+      cfs_reg_wr(1) <= (others => '0');
+      cfs_reg_wr(2) <= (others => '0');
+      cfs_reg_wr(3) <= (others => '0');
+      bus_rsp_o     <= rsp_terminate_c;
     elsif rising_edge(clk_i) then -- synchronous interface for read and write accesses
       -- transfer/access acknowledge --
       bus_rsp_o.ack <= bus_req_i.stb;

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -129,6 +129,7 @@ begin
     cond_sel_string_f(CPU_EXTENSION_RISCV_C,      "c",         "" ) &
     cond_sel_string_f(CPU_EXTENSION_RISCV_B,      "b",         "" ) &
     cond_sel_string_f(CPU_EXTENSION_RISCV_U,      "u",         "" ) &
+    cond_sel_string_f(true,                       "x",         "" ) & -- always enabled
     cond_sel_string_f(true,                       "_zicsr",    "" ) & -- always enabled
     cond_sel_string_f(CPU_EXTENSION_RISCV_Zicntr, "_zicntr",   "" ) &
     cond_sel_string_f(CPU_EXTENSION_RISCV_Zicond, "_zicond",   "" ) &

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -389,7 +389,7 @@ begin
   bus_req_o.rw    <= '0'; -- read-only
   bus_req_o.src   <= '1'; -- source = instruction fetch
   bus_req_o.rvso  <= '0'; -- cannot be a reservation set operation
-  bus_req_o.fence <= ctrl.lsu_fence; -- fence(.i) operation, valid without STB being set
+  bus_req_o.fence <= ctrl.lsu_fence; -- fence operation, valid without STB being set
 
 
   -- Instruction Prefetch Buffer (FIFO) -----------------------------------------------------
@@ -766,21 +766,16 @@ begin
     execute_engine.ir_nxt    <= execute_engine.ir;
     execute_engine.is_ci_nxt <= execute_engine.is_ci;
     execute_engine.pc_we     <= '0';
-    --
     issue_engine.ack         <= '0';
-    --
     fetch_engine.reset       <= '0';
-    --
     trap_ctrl.env_enter      <= '0';
     trap_ctrl.env_exit       <= '0';
     trap_ctrl.instr_be       <= '0';
     trap_ctrl.ecall          <= '0';
     trap_ctrl.ebreak         <= '0';
     trap_ctrl.hwtrig         <= '0';
-    --
     csr.we_nxt               <= '0';
     csr.re_nxt               <= '0';
-    --
     ctrl_nxt                 <= ctrl_bus_zero_c; -- all zero/off by default (default ALU operation = ZERO, adder.out = ADD)
 
     -- ALU sign control --
@@ -1306,7 +1301,7 @@ begin
         illegal_cmd <= not bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zxcfu); -- all encodings valid if CFU enable
 
       when others =>
-        illegal_cmd <= '1'; -- undefined/illegal opcode
+        illegal_cmd <= '1'; -- undefined/unimplemented/illegal opcode
 
     end case;
   end process illegal_check;
@@ -2094,7 +2089,6 @@ begin
     end case;
   end process csr_read_access;
 
-
   -- CSR read-data gate --
   csr_read_reg: process(rstn_i, clk_i)
   begin
@@ -2136,7 +2130,6 @@ begin
     end if;
   end process cnt_we;
 
-
   -- hardware counters --
   cnt_gen:
   for i in 0 to 2+hpm_num_c generate
@@ -2169,7 +2162,6 @@ begin
     cnt.nxt(i) <= std_ulogic_vector(unsigned('0' & cnt.lo(i)) + unsigned(cnt.inc(i)));
 
   end generate; -- /cnt_gen
-
 
   -- read-back --
   cnt_connect: process(cnt)
@@ -2239,7 +2231,6 @@ begin
     end generate;
 
   end generate;
-
 
   -- no HPMs implemented --
   hpmevent_gen_disable:

--- a/rtl/core/neorv32_cpu_lsu.vhd
+++ b/rtl/core/neorv32_cpu_lsu.vhd
@@ -36,8 +36,8 @@ entity neorv32_cpu_lsu is
     be_store_o  : out std_ulogic; -- bus error on store data access
     pmp_fault_i : in  std_ulogic; -- PMP read/write access fault
     -- data bus --
-    bus_req_o   : out bus_req_t;  -- request
-    bus_rsp_i   : in  bus_rsp_t   -- response
+    bus_req_o   : out bus_req_t; -- request
+    bus_rsp_i   : in  bus_rsp_t  -- response
   );
 end neorv32_cpu_lsu;
 
@@ -101,8 +101,8 @@ begin
   -- source identifier --
   bus_req_o.src <= '0'; -- 0 = data access
 
-  -- data/instruction fence(.i)
-  bus_req_o.fence <= ctrl_i.lsu_fence; -- this is valid even without STB being set
+  -- data fence --
+  bus_req_o.fence <= ctrl_i.lsu_fence; -- this is valid without STB being set
 
 
   -- Data Output - Alignment and Byte Enable ------------------------------------------------

--- a/rtl/core/neorv32_crc.vhd
+++ b/rtl/core/neorv32_crc.vhd
@@ -54,13 +54,11 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      crc.mode <= (others => '0');
-      crc.poly <= (others => '0');
-      crc.data <= (others => '0');
-      we_ack   <= (others => '0');
+      bus_rsp_o <= rsp_terminate_c;
+      crc.mode  <= (others => '0');
+      crc.poly  <= (others => '0');
+      crc.data  <= (others => '0');
+      we_ack    <= (others => '0');
     elsif rising_edge(clk_i) then
       -- bus handshake --
       bus_rsp_o.data <= (others => '0');

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -641,9 +641,7 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack     <= '0';
-      bus_rsp_o.err     <= '0';
-      bus_rsp_o.data    <= (others => '0');
+      bus_rsp_o         <= rsp_terminate_c;
       dci.data_reg      <= (others => '0');
       dci.halt_ack      <= '0';
       dci.resume_ack    <= '0';

--- a/rtl/core/neorv32_dma.vhd
+++ b/rtl/core/neorv32_dma.vhd
@@ -112,9 +112,7 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack    <= '0';
-      bus_rsp_o.err    <= '0';
-      bus_rsp_o.data   <= (others => '0');
+      bus_rsp_o        <= rsp_terminate_c;
       config.enable    <= '0';
       config.auto      <= '0';
       config.fence     <= '0';

--- a/rtl/core/neorv32_gpio.vhd
+++ b/rtl/core/neorv32_gpio.vhd
@@ -40,10 +40,8 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      dout           <= (others => '0');
+      bus_rsp_o <= rsp_terminate_c;
+      dout      <= (others => '0');
     elsif rising_edge(clk_i) then
       -- bus handshake --
       bus_rsp_o.ack  <= bus_req_i.stb;

--- a/rtl/core/neorv32_gptmr.vhd
+++ b/rtl/core/neorv32_gptmr.vhd
@@ -82,14 +82,12 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      ctrl           <= (others => '0');
-      trig_match     <= '0';
-      trig_capture   <= '0';
-      timer.cnt_we   <= '0';
-      timer.thres    <= (others => '0');
+      bus_rsp_o    <= rsp_terminate_c;
+      ctrl         <= (others => '0');
+      trig_match   <= '0';
+      trig_capture <= '0';
+      timer.cnt_we <= '0';
+      timer.thres  <= (others => '0');
     elsif rising_edge(clk_i) then
       -- defaults --
       bus_rsp_o.ack  <= bus_req_i.stb;

--- a/rtl/core/neorv32_intercon.vhd
+++ b/rtl/core/neorv32_intercon.vhd
@@ -480,16 +480,16 @@ begin
 
   -- Combine Device Ports -------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  dev_00_req_o <= dev_req(00); dev_rsp(00) <= dev_00_rsp_i;
-  dev_01_req_o <= dev_req(01); dev_rsp(01) <= dev_01_rsp_i;
-  dev_02_req_o <= dev_req(02); dev_rsp(02) <= dev_02_rsp_i;
-  dev_03_req_o <= dev_req(03); dev_rsp(03) <= dev_03_rsp_i;
-  dev_04_req_o <= dev_req(04); dev_rsp(04) <= dev_04_rsp_i;
-  dev_05_req_o <= dev_req(05); dev_rsp(05) <= dev_05_rsp_i;
-  dev_06_req_o <= dev_req(06); dev_rsp(06) <= dev_06_rsp_i;
-  dev_07_req_o <= dev_req(07); dev_rsp(07) <= dev_07_rsp_i;
-  dev_08_req_o <= dev_req(08); dev_rsp(08) <= dev_08_rsp_i;
-  dev_09_req_o <= dev_req(09); dev_rsp(09) <= dev_09_rsp_i;
+  dev_00_req_o <= dev_req(0);  dev_rsp(0)  <= dev_00_rsp_i;
+  dev_01_req_o <= dev_req(1);  dev_rsp(1)  <= dev_01_rsp_i;
+  dev_02_req_o <= dev_req(2);  dev_rsp(2)  <= dev_02_rsp_i;
+  dev_03_req_o <= dev_req(3);  dev_rsp(3)  <= dev_03_rsp_i;
+  dev_04_req_o <= dev_req(4);  dev_rsp(4)  <= dev_04_rsp_i;
+  dev_05_req_o <= dev_req(5);  dev_rsp(5)  <= dev_05_rsp_i;
+  dev_06_req_o <= dev_req(6);  dev_rsp(6)  <= dev_06_rsp_i;
+  dev_07_req_o <= dev_req(7);  dev_rsp(7)  <= dev_07_rsp_i;
+  dev_08_req_o <= dev_req(8);  dev_rsp(8)  <= dev_08_rsp_i;
+  dev_09_req_o <= dev_req(9);  dev_rsp(9)  <= dev_09_rsp_i;
   dev_10_req_o <= dev_req(10); dev_rsp(10) <= dev_10_rsp_i;
   dev_11_req_o <= dev_req(11); dev_rsp(11) <= dev_11_rsp_i;
   dev_12_req_o <= dev_req(12); dev_rsp(12) <= dev_12_rsp_i;
@@ -554,7 +554,7 @@ end neorv32_bus_io_switch_rtl;
 
 
 -- ================================================================================ --
--- NEORV32 SoC - PProcessor Bus Infrastructure: Reservation Set Control             --
+-- NEORV32 SoC - Processor Bus Infrastructure: Reservation Set Control              --
 -- -------------------------------------------------------------------------------- --
 -- Reservation set controller for the A (atomic) ISA extension's LR.W               --
 -- (load-reservate) and SC.W (store-conditional) instructions. Only a single        --

--- a/rtl/core/neorv32_mtime.vhd
+++ b/rtl/core/neorv32_mtime.vhd
@@ -49,16 +49,13 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      mtimecmp_lo    <= (others => '0');
-      mtimecmp_hi    <= (others => '0');
-      mtime_we       <= (others => '0');
-      mtime_lo       <= (others => '0');
-      mtime_lo_cry   <= (others => '0');
-      mtime_hi       <= (others => '0');
-      --
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
+      mtimecmp_lo  <= (others => '0');
+      mtimecmp_hi  <= (others => '0');
+      mtime_we     <= (others => '0');
+      mtime_lo     <= (others => '0');
+      mtime_lo_cry <= (others => '0');
+      mtime_hi     <= (others => '0');
+      bus_rsp_o    <= rsp_terminate_c;
     elsif rising_edge(clk_i) then
       -- mtimecmp --
       if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(3) = '1') then

--- a/rtl/core/neorv32_neoled.vhd
+++ b/rtl/core/neorv32_neoled.vhd
@@ -123,18 +123,15 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      ctrl.enable    <= '0';
-      ctrl.mode      <= '0';
-      ctrl.strobe    <= '0';
-      ctrl.clk_prsc  <= (others => '0');
-      ctrl.irq_conf  <= '0';
-      ctrl.t_total   <= (others => '0');
-      ctrl.t0_high   <= (others => '0');
-      ctrl.t1_high   <= (others => '0');
-      --
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
+      ctrl.enable   <= '0';
+      ctrl.mode     <= '0';
+      ctrl.strobe   <= '0';
+      ctrl.clk_prsc <= (others => '0');
+      ctrl.irq_conf <= '0';
+      ctrl.t_total  <= (others => '0');
+      ctrl.t0_high  <= (others => '0');
+      ctrl.t1_high  <= (others => '0');
+      bus_rsp_o     <= rsp_terminate_c;
     elsif rising_edge(clk_i) then
       -- bus handshake --
       bus_rsp_o.ack  <= bus_req_i.stb;

--- a/rtl/core/neorv32_onewire.vhd
+++ b/rtl/core/neorv32_onewire.vhd
@@ -104,9 +104,7 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
+      bus_rsp_o      <= rsp_terminate_c;
       ctrl.enable    <= '0';
       ctrl.clk_prsc  <= (others => '0');
       ctrl.clk_div   <= (others => '0');

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100005"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100006"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -735,14 +735,14 @@ package neorv32_package is
       REGFILE_HW_RST             : boolean                        := false;
       -- Physical Memory Protection (PMP) --
       PMP_NUM_REGIONS            : natural range 0 to 16          := 0;
-      PMP_MIN_GRANULARITY        : natural                        := 4;
+      PMP_MIN_GRANULARITY        : natural range 4 to 2**30       := 4;
       PMP_TOR_MODE_EN            : boolean                        := true;
       PMP_NAP_MODE_EN            : boolean                        := true;
       -- Hardware Performance Monitors (HPM) --
       HPM_NUM_CNTS               : natural range 0 to 13          := 0;
       HPM_CNT_WIDTH              : natural range 0 to 64          := 40;
       -- Atomic Memory Access - Reservation Set Granularity --
-      AMO_RVS_GRANULARITY        : natural                        := 4;
+      AMO_RVS_GRANULARITY        : natural range 4 to 2**30       := 4;
       -- Internal Instruction memory (IMEM) --
       MEM_INT_IMEM_EN            : boolean                        := false;
       MEM_INT_IMEM_SIZE          : natural                        := 16*1024;
@@ -762,8 +762,8 @@ package neorv32_package is
       XBUS_TIMEOUT               : natural                        := 255;
       XBUS_REGSTAGE_EN           : boolean                        := false;
       XBUS_CACHE_EN              : boolean                        := false;
-      XBUS_CACHE_NUM_BLOCKS      : natural                        := 64;
-      XBUS_CACHE_BLOCK_SIZE      : natural                        := 32;
+      XBUS_CACHE_NUM_BLOCKS      : natural range 1 to 256         := 64;
+      XBUS_CACHE_BLOCK_SIZE      : natural range 1 to 2**16       := 32;
       -- Execute in-place module (XIP) --
       XIP_EN                     : boolean                        := false;
       XIP_CACHE_EN               : boolean                        := false;

--- a/rtl/core/neorv32_pwm.vhd
+++ b/rtl/core/neorv32_pwm.vhd
@@ -60,12 +60,10 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      enable         <= '0';
-      prsc           <= (others => '0');
-      pwm_ch         <= (others => (others => '0'));
+      bus_rsp_o <= rsp_terminate_c;
+      enable    <= '0';
+      prsc      <= (others => '0');
+      pwm_ch    <= (others => (others => '0'));
     elsif rising_edge(clk_i) then
       -- bus handshake --
       bus_rsp_o.ack  <= bus_req_i.stb;

--- a/rtl/core/neorv32_sdi.vhd
+++ b/rtl/core/neorv32_sdi.vhd
@@ -111,9 +111,7 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack     <= '0';
-      bus_rsp_o.err     <= '0';
-      bus_rsp_o.data    <= (others => '0');
+      bus_rsp_o         <= rsp_terminate_c;
       ctrl.enable       <= '0';
       ctrl.clr_rx       <= '0';
       ctrl.irq_rx_avail <= '0';

--- a/rtl/core/neorv32_slink.vhd
+++ b/rtl/core/neorv32_slink.vhd
@@ -115,9 +115,7 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack      <= '0';
-      bus_rsp_o.err      <= '0';
-      bus_rsp_o.data     <= (others => '0');
+      bus_rsp_o          <= rsp_terminate_c;
       ctrl.enable        <= '0';
       ctrl.rx_clr        <= '0';
       ctrl.tx_clr        <= '0';

--- a/rtl/core/neorv32_spi.vhd
+++ b/rtl/core/neorv32_spi.vhd
@@ -121,9 +121,7 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack     <= '0';
-      bus_rsp_o.err     <= '0';
-      bus_rsp_o.data    <= (others => '0');
+      bus_rsp_o         <= rsp_terminate_c;
       ctrl.enable       <= '0';
       ctrl.cpha         <= '0';
       ctrl.cpol         <= '0';

--- a/rtl/core/neorv32_sysinfo.vhd
+++ b/rtl/core/neorv32_sysinfo.vhd
@@ -145,13 +145,9 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
+      bus_rsp_o <= rsp_terminate_c;
     elsif rising_edge(clk_i) then
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
+      bus_rsp_o <= rsp_terminate_c; -- default
       if (bus_req_i.stb = '1') and (bus_req_i.rw = '0') then -- read-only
         bus_rsp_o.ack  <= '1';
         bus_rsp_o.data <= sysinfo(to_integer(unsigned(bus_req_i.addr(3 downto 2))));

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -2,9 +2,10 @@
 -- NEORV32 SoC - Processor Top Entity                                               --
 -- -------------------------------------------------------------------------------- --
 -- Check out the processor's online documentation for more information:             --
---  HQ:         https://github.com/stnolting/neorv32                                --
---  Data Sheet: https://stnolting.github.io/neorv32                                 --
---  User Guide: https://stnolting.github.io/neorv32/ug                              --
+-- > HQ:           https://github.com/stnolting/neorv32                             --
+-- > Data Sheet:   https://stnolting.github.io/neorv32                              --
+-- > User Guide:   https://stnolting.github.io/neorv32/ug                           --
+-- > Software Ref: https://stnolting.github.io/neorv32/sw/files.html                --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
@@ -54,7 +55,7 @@ entity neorv32_top is
 
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS            : natural range 0 to 16          := 0;           -- number of regions (0..16)
-    PMP_MIN_GRANULARITY        : natural                        := 4;           -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
+    PMP_MIN_GRANULARITY        : natural range 4 to 2**30       := 4;           -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
     PMP_TOR_MODE_EN            : boolean                        := true;        -- implement TOR mode
     PMP_NAP_MODE_EN            : boolean                        := true;        -- implement NAPOT/NA4 modes
 
@@ -63,7 +64,7 @@ entity neorv32_top is
     HPM_CNT_WIDTH              : natural range 0 to 64          := 40;          -- total size of HPM counters (0..64)
 
     -- Atomic Memory Access - Reservation Set Granularity --
-    AMO_RVS_GRANULARITY        : natural                        := 4;           -- size in bytes, has to be a power of 2, min 4
+    AMO_RVS_GRANULARITY        : natural range 4 to 2**30       := 4;           -- size in bytes, has to be a power of 2, min 4
 
     -- Internal Instruction memory (IMEM) --
     MEM_INT_IMEM_EN            : boolean                        := false;       -- implement processor-internal instruction memory
@@ -88,8 +89,8 @@ entity neorv32_top is
     XBUS_TIMEOUT               : natural                        := 255;         -- cycles after a pending bus access auto-terminates (0 = disabled)
     XBUS_REGSTAGE_EN           : boolean                        := false;       -- add XBUS register stage
     XBUS_CACHE_EN              : boolean                        := false;       -- enable external bus cache (x-cache)
-    XBUS_CACHE_NUM_BLOCKS      : natural                        := 64;          -- x-cache: number of blocks (min 1), has to be a power of 2
-    XBUS_CACHE_BLOCK_SIZE      : natural                        := 32;          -- x-cache: block size in bytes (min 4), has to be a power of 2
+    XBUS_CACHE_NUM_BLOCKS      : natural range 1 to 256         := 64;          -- x-cache: number of blocks (min 1), has to be a power of 2
+    XBUS_CACHE_BLOCK_SIZE      : natural range 1 to 2**16       := 32;          -- x-cache: block size in bytes (min 4), has to be a power of 2
 
     -- Execute in-place module (XIP) --
     XIP_EN                     : boolean                        := false;       -- implement execute in place module (XIP)?

--- a/rtl/core/neorv32_trng.vhd
+++ b/rtl/core/neorv32_trng.vhd
@@ -92,12 +92,10 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack   <= '0';
-      bus_rsp_o.err   <= '0';
-      bus_rsp_o.data  <= (others => '0');
-      fifo_clr        <= '0';
-      irq_sel         <= '0';
-      enable          <= '0';
+      bus_rsp_o <= rsp_terminate_c;
+      fifo_clr  <= '0';
+      irq_sel   <= '0';
+      enable    <= '0';
     elsif rising_edge(clk_i) then
       -- defaults --
       bus_rsp_o.ack  <= bus_req_i.stb;

--- a/rtl/core/neorv32_twi.vhd
+++ b/rtl/core/neorv32_twi.vhd
@@ -120,12 +120,10 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      ctrl.enable    <= '0';
-      ctrl.prsc      <= (others => '0');
-      ctrl.cdiv      <= (others => '0');
+      bus_rsp_o   <= rsp_terminate_c;
+      ctrl.enable <= '0';
+      ctrl.prsc   <= (others => '0');
+      ctrl.cdiv   <= (others => '0');
     elsif rising_edge(clk_i) then
       -- bus handshake defaults --
       bus_rsp_o.ack  <= bus_req_i.stb;

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -148,9 +148,7 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack      <= '0';
-      bus_rsp_o.err      <= '0';
-      bus_rsp_o.data     <= (others => '0');
+      bus_rsp_o          <= rsp_terminate_c;
       ctrl.enable        <= '0';
       ctrl.sim_mode      <= '0';
       ctrl.hwfc_en       <= '0';

--- a/rtl/core/neorv32_wdt.vhd
+++ b/rtl/core/neorv32_wdt.vhd
@@ -79,17 +79,15 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      ctrl.enable    <= '0'; -- disable WDT after reset
-      ctrl.lock      <= '0'; -- unlock after reset
-      ctrl.dben      <= '0';
-      ctrl.sen       <= '0';
-      ctrl.strict    <= '0';
-      ctrl.timeout   <= (others => '0');
-      reset_wdt      <= '0';
-      reset_force    <= '0';
+      bus_rsp_o    <= rsp_terminate_c;
+      ctrl.enable  <= '0'; -- disable WDT after reset
+      ctrl.lock    <= '0'; -- unlock after reset
+      ctrl.dben    <= '0';
+      ctrl.sen     <= '0';
+      ctrl.strict  <= '0';
+      ctrl.timeout <= (others => '0');
+      reset_wdt    <= '0';
+      reset_force  <= '0';
     elsif rising_edge(clk_i) then
       -- bus handshake --
       bus_rsp_o.ack  <= bus_req_i.stb;

--- a/rtl/core/neorv32_xip.vhd
+++ b/rtl/core/neorv32_xip.vhd
@@ -135,13 +135,11 @@ begin
   ctrl_bus_access : process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      ctrl           <= (others => '0');
-      spi_data_lo    <= (others => '0');
-      spi_data_hi    <= (others => '0');
-      spi_trigger    <= '0';
+      bus_rsp_o   <= rsp_terminate_c;
+      ctrl        <= (others => '0');
+      spi_data_lo <= (others => '0');
+      spi_data_hi <= (others => '0');
+      spi_trigger <= '0';
     elsif rising_edge(clk_i) then
       -- bus handshake --
       bus_rsp_o.ack  <= bus_req_i.stb;

--- a/rtl/core/neorv32_xirq.vhd
+++ b/rtl/core/neorv32_xirq.vhd
@@ -64,13 +64,11 @@ begin
   bus_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o.ack  <= '0';
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      nclr_pending   <= (others => '0');
-      irq_type       <= (others => '0');
-      irq_polarity   <= (others => '0');
-      irq_enable     <= (others => '0');
+      bus_rsp_o    <= rsp_terminate_c;
+      nclr_pending <= (others => '0');
+      irq_type     <= (others => '0');
+      irq_polarity <= (others => '0');
+      irq_enable   <= (others => '0');
     elsif rising_edge(clk_i) then
       -- defaults --
       bus_rsp_o.ack  <= bus_req_i.stb;


### PR DESCRIPTION
* IO devices: use termination record for response bus reset
* rtl tops: constrain all relevant (`natural`) generics
* minor code edits and cleanups