### PR TITLE
Add option to disable SYSINFO module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 18.07.2024 | 1.10.1.3 | :test_tube: add new generic to disable the SYSINFO module (:warning: for advanced users only that wish to use a CPU-only setup): `IO_DISABLE_SYSINFO` | [#952](https://github.com/stnolting/neorv32/pull/952) |
 | 10.07.2024 | 1.10.1.2 | minor rtl edits and cleanups | [#948](https://github.com/stnolting/neorv32/pull/948) |
 | 05.07.2024 | 1.10.1.1 | minor rtl cleanups and optimizations | [#941](https://github.com/stnolting/neorv32/pull/941) |
 | 04.07.2024 | [**:rocket:1.10.1**](https://github.com/stnolting/neorv32/releases/tag/v1.10.1) | **New release** | |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -258,6 +258,7 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 4+^| **<<_external_interrupt_controller_xirq>>**
 | `XIRQ_NUM_CH`           | natural   | 0          | Number of channels of the external interrupt controller. Valid values are 0..32.
 4+^| **Peripheral/IO Modules**
+| `IO_DISABLE_SYSINFO`    | boolean   | false      | Disable <<_system_configuration_information_memory_sysinfo>> module; ⚠️ not recommended - for advanced users only!
 | `IO_GPIO_NUM`           | natural   | 0          | Number of general purpose input/output pairs of the <<_general_purpose_input_and_output_port_gpio>>.
 | `IO_MTIME_EN`           | boolean   | false      | Implement the <<_machine_system_timer_mtime>>.
 | `IO_UART0_EN`           | boolean   | false      | Implement the <<_primary_universal_asynchronous_receiver_and_transmitter_uart0>>.

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100102"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100103"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -772,6 +772,7 @@ package neorv32_package is
       -- External Interrupts Controller (XIRQ) --
       XIRQ_NUM_CH                : natural range 0 to 32          := 0;
       -- Processor peripherals --
+      IO_DISABLE_SYSINFO         : boolean                        := false;
       IO_GPIO_NUM                : natural range 0 to 64          := 0;
       IO_MTIME_EN                : boolean                        := false;
       IO_UART0_EN                : boolean                        := false;


### PR DESCRIPTION
This PR adds a new top generic (`IO_DISABLE_SYSINFO`, default `false`) that allows to disable the SYSINFO module. This option is intended for advanced users that wish to use a **"CPU-only"** processor setup with a custom software framework.

> [!WARNING]
> Deactivating the module means that large parts of the default NEORV32 software framework will no longer work (bootloader, HAL/drivers, etc.)!