### PR TITLE
🐛 Fix SDI "TX FIFO full" flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 19.07.2024 | 1.10.1.4 | :bug: fix SDI "TX FIFO full" flag | [#953](https://github.com/stnolting/neorv32/pull/953) |
 | 18.07.2024 | 1.10.1.3 | :test_tube: add new generic to disable the SYSINFO module (:warning: for advanced users only that wish to use a CPU-only setup): `IO_DISABLE_SYSINFO` | [#952](https://github.com/stnolting/neorv32/pull/952) |
 | 10.07.2024 | 1.10.1.2 | minor rtl edits and cleanups | [#948](https://github.com/stnolting/neorv32/pull/948) |
 | 05.07.2024 | 1.10.1.1 | minor rtl cleanups and optimizations | [#941](https://github.com/stnolting/neorv32/pull/941) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100103"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100104"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_sdi.vhd
+++ b/rtl/core/neorv32_sdi.vhd
@@ -55,7 +55,7 @@ architecture neorv32_sdi_rtl of neorv32_sdi is
   constant ctrl_rx_full_c      : natural := 25; -- r/-: RX FIFO full
   constant ctrl_tx_empty_c     : natural := 26; -- r/-: TX FIFO empty
   constant ctrl_tx_nhalf_c     : natural := 27; -- r/-: TX FIFO not at least half-full
-  constant ctrl_tx_full_c      : natural := 27; -- r/-: TX FIFO full
+  constant ctrl_tx_full_c      : natural := 28; -- r/-: TX FIFO full
 
   -- control register (see bit definitions above) --
   type ctrl_t is record

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1466,8 +1466,10 @@ int main() {
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
+    uint8_t sdi_read_data;
     if ((neorv32_cpu_csr_read(CSR_MCAUSE) == SDI_TRAP_CODE) && // correct trap code
-        (neorv32_sdi_get_nonblocking() == 0x83) && // correct SDI read data
+        (neorv32_sdi_get(&sdi_read_data) == 0) && // correct SDI read data status
+        (sdi_read_data == 0x83) && // correct SDI read data
         ((tmp_a & 0xff) == 0xab)) { // correct SPI read data
       test_ok();
     }

--- a/sw/lib/include/neorv32_sdi.h
+++ b/sw/lib/include/neorv32_sdi.h
@@ -62,16 +62,14 @@ enum NEORV32_SDI_CTRL_enum {
  * @name Prototypes
  **************************************************************************/
 /**@{*/
-int     neorv32_sdi_available(void);
-void    neorv32_sdi_setup(uint32_t irq_mask);
-void    neorv32_sdi_rx_clear(void);
-void    neorv32_sdi_disable(void);
-void    neorv32_sdi_enable(void);
-int     neorv32_sdi_get_fifo_depth(void);
-int     neorv32_sdi_put(uint8_t data);
-void    neorv32_sdi_put_nonblocking(uint8_t data);
-int     neorv32_sdi_get(uint8_t* data);
-uint8_t neorv32_sdi_get_nonblocking(void);
+int  neorv32_sdi_available(void);
+void neorv32_sdi_setup(uint32_t irq_mask);
+void neorv32_sdi_rx_clear(void);
+void neorv32_sdi_disable(void);
+void neorv32_sdi_enable(void);
+int  neorv32_sdi_get_fifo_depth(void);
+int  neorv32_sdi_put(uint8_t data);
+int  neorv32_sdi_get(uint8_t* data);
 /**@}*/
 
 

--- a/sw/lib/source/neorv32_sdi.c
+++ b/sw/lib/source/neorv32_sdi.c
@@ -83,7 +83,7 @@ void neorv32_sdi_enable(void) {
 /**********************************************************************//**
  * Get SDI FIFO depth.
  *
- * @return FIFO depth (number of entries), zero if no FIFO implemented
+ * @return FIFO depth (number of entries), 1 if no FIFO implemented
  **************************************************************************/
 int neorv32_sdi_get_fifo_depth(void) {
 
@@ -96,7 +96,7 @@ int neorv32_sdi_get_fifo_depth(void) {
  * Push data to SDI output FIFO.
  *
  * @param[in] data Byte to push into TX FIFO.
- * @return -1 if TX FIFO is full.
+ * @return -1 if TX FIFO is full, 0 if success.
  **************************************************************************/
 int neorv32_sdi_put(uint8_t data) {
 
@@ -111,21 +111,10 @@ int neorv32_sdi_put(uint8_t data) {
 
 
 /**********************************************************************//**
- * Push data to SDI output FIFO (ignoring TX FIFO status).
- *
- * @param[in] data Byte to push into TX FIFO.
- **************************************************************************/
-void neorv32_sdi_put_nonblocking(uint8_t data) {
-
-  NEORV32_SDI->DATA = (uint32_t)data;
-}
-
-
-/**********************************************************************//**
  * Get data from SDI input FIFO.
  *
  * @param[in,out] Pointer fro data byte read from RX FIFO.
- * @return -1 if RX FIFO is empty.
+ * @return -1 if RX FIFO is empty, 0 if success.
  **************************************************************************/
 int neorv32_sdi_get(uint8_t* data) {
 
@@ -136,15 +125,4 @@ int neorv32_sdi_get(uint8_t* data) {
   else {
     return -1;
   }
-}
-
-
-/**********************************************************************//**
- * Get data from SDI input FIFO (ignoring RX FIFO status).
- *
- * @param[in] data Byte read from RX FIFO.
- **************************************************************************/
-uint8_t neorv32_sdi_get_nonblocking(void) {
-
-  return (uint8_t)NEORV32_SDI->DATA;
 }


### PR DESCRIPTION
The SDI `SDI_CTRL_TX_FULL` flag was broken (not indicating when the TX FIFO is actually full).