### PR TITLE
Minor SDI edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 20.07.2024 | 1.10.1.6 | SDI: remove explicit "RX clear flag"; add new flag to check the current state of the chip-select input | [#955](https://github.com/stnolting/neorv32/pull/955) |
 | 19.07.2024 | 1.10.1.5 | :sparkles: add "programmable" chip-select enable/disable functionality to SPI module | [#954](https://github.com/stnolting/neorv32/pull/954) |
 | 19.07.2024 | 1.10.1.4 | :bug: fix SDI "TX FIFO full" flag | [#953](https://github.com/stnolting/neorv32/pull/953) |
 | 18.07.2024 | 1.10.1.3 | :test_tube: add new generic to disable the SYSINFO module (:warning: for advanced users only that wish to use a CPU-only setup): `IO_DISABLE_SYSINFO` | [#952](https://github.com/stnolting/neorv32/pull/952) |

--- a/docs/datasheet/soc_sdi.adoc
+++ b/docs/datasheet/soc_sdi.adoc
@@ -21,48 +21,51 @@
 **Overview**
 
 The serial data interface module provides a **device-class** SPI interface and allows to connect the processor
-to an external SPI _host_, which is responsible for triggering (clocking) the actual transmission - the SDI is entirely
-passive. An optional receive/transmit FIFO can be configured via the _IO_SDI_FIFO_ generic to support block-based
-transmissions without CPU interaction.
+to an **external SPI host**, which is responsible of performing the actual transmission - the SDI is entirely
+passive. An optional receive/transmit ring buffer (FIFOs) can be configured via the `IO_SDI_FIFO` generic to
+support block-based transmissions without CPU interaction.
 
 .Device-Mode Only
 [NOTE]
 The NEORV32 SDI module only supports _device mode_. Transmission are initiated by an external host and not by the
 the processor itself. If you are looking for a _host-mode_ serial peripheral interface (transactions
-initiated by the NEORV32) check out the <<_serial_peripheral_interface_controller_spi>>.
+performed by the NEORV32) check out the <<_serial_peripheral_interface_controller_spi>>.
 
 The SDI module provides a single control register `CTRL` to configure the module and to check it's status
-and a single data register `DATA` for receiving/transmitting data.
+and a single data register `DATA` for receiving/transmitting data. Any access to the `DATA` register
+actually accesses the internal ring buffer.
 
 
 **Theory of Operation**
 
 The SDI module is enabled by setting the `SDI_CTRL_EN` bit in the `CTRL` control register. Clearing this bit
-resets the entire module including the RX and TX FIFOs.
+resets the entire module and will also clear the entire RX/TX ring buffer.
 
 The SDI operates on byte-level only. Data written to the `DATA` register will be pushed to the TX FIFO. Received
 data can be retrieved by reading the RX FIFO via the `DATA` register. The current state of these FIFOs is available
-via the control register's `SDI_CTRL_RX_*` and `SDI_CTRL_TX_*` flags. The RX FIFO can be manually cleared at any time
-by setting the `SDI_CTRL_CLR_RX` bit.
+via the control register's `SDI_CTRL_RX_*` and `SDI_CTRL_TX_*` flags. If no data is available in the TX FIFO while
+an external device performs a transmission the external device will read all-zero from the SDI controller.
 
-If no data is available in the TX FIFO while an external device performs a transmission the external device will
-read all-zero from the SDI controller.
+Application software can check the current state of the SDI chip-select input via the control register's
+`SDI_CTRL_CS_ACTIVE` flag (the flag is set when the chip-select line is active (pulled low)).
 
 .MSB-first Only
 [NOTE]
 The NEORV32 SDI module only supports MSB-first mode.
 
-.Transmission Abort
+.In-Transmission Abort
 [NOTE]
-If the external SPI controller aborts an transmission (by setting the chip-select signal high again) _before_
+If the external SPI controller aborts the transmission by setting the chip-select signal high again _before_
 8 data bits have been transferred, no data is written to the RX FIFO.
 
 
 **SDI Clocking**
 
-The SDI module supports both SPI clock polarity modes ("CPOL") but regarding the clock phase only "CPHA=0" is supported
-yet. All SDI operations are clocked by the external `sdi_clk_i` signal. This signal is synchronized to the processor's
-clock domain to simplify timing behavior. However, the clock synchronization requires that the external SDI clock
+The SDI module supports both SPI clock polarity modes ("CPOL") but only "CPHA=0"-clock-phase is _officially_ supported
+yet. However, experiments have shown that the SDI module can also deal with both clock phase modes (for slow SDI clock speeds).
+
+All SDI operations are clocked by the external `sdi_clk_i` signal. This signal is synchronized to the processor's
+clock domain to simplify timing behavior. This clock synchronization requires the external SDI clock
 (`sdi_clk_i`) does **not exceed 1/4 of the processor's main clock**.
 
 
@@ -84,8 +87,7 @@ example if just the `SDI_CTRL_IRQ_RX_AVAIL` bit is set, the interrupt will keep 
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
 .18+<| `0xfffff700` .18+<| `CTRL` <|`0`     `SDI_CTRL_EN`                           ^| r/w <| SDI module enable
-                                  <|`1`     `SDI_CTRL_CLR_RX`                       ^| -/w <| clear RX FIFO when set, bit auto-clears
-                                  <|`3:2`   _reserved_                              ^| r/- <| reserved, read as zero
+                                  <|`3:1`   _reserved_                              ^| r/- <| reserved, read as zero
                                   <|`7:4`   `SDI_CTRL_FIFO_MSB : SDI_CTRL_FIFO_LSB` ^| r/- <| FIFO depth; log2(_IO_SDI_FIFO_)
                                   <|`14:8`  _reserved_                              ^| r/- <| reserved, read as zero
                                   <|`15`    `SDI_CTRL_IRQ_RX_AVAIL`                 ^| r/w <| fire interrupt if RX FIFO is not empty
@@ -100,6 +102,8 @@ example if just the `SDI_CTRL_IRQ_RX_AVAIL` bit is set, the interrupt will keep 
                                   <|`26`    `SDI_CTRL_TX_EMPTY`                     ^| r/- <| TX FIFO empty
                                   <|`27`    `SDI_CTRL_TX_NHALF`                     ^| r/- <| TX FIFO not at least half full
                                   <|`28`    `SDI_CTRL_TX_FULL`                      ^| r/- <| TX FIFO full
-                                  <|`31:29` _reserved_                              ^| r/- <| reserved, read as zero
-| `0xfffff704` | `DATA` |`7:0` | r/w | receive/transmit data (FIFO)
+                                  <|`30:29` _reserved_                              ^| r/- <| reserved, read as zero
+                                  <|`31`    `SDI_CTRL_CS_ACTIVE`                    ^| r/- <| Chip-select is active when set
+.2+<| `0xfffff704` .2+<| `DATA` <|`7:0`             ^| r/w <| receive/transmit data (FIFO)
+                                <|`31:8` _reserved_ ^| r/- <| reserved, read as zero
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100105"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100106"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -382,11 +382,11 @@ begin
   -- 1-Wire termination (pull-up) --
   onewire <= 'H';
 
-  -- SPI/SDI echo --
-  sdi_clk <= spi_clk;
-  sdi_csn <= spi_csn(7);
-  sdi_di  <= spi_do;
-  spi_di  <= sdi_do when (spi_csn(7) = '0') else spi_do;
+  -- SPI/SDI echo with propagation delay --
+  sdi_clk <= spi_clk after 40 ns;
+  sdi_csn <= spi_csn(7) after 40 ns;
+  sdi_di  <= spi_do after 40 ns;
+  spi_di  <= sdi_do when (spi_csn(7) = '0') else spi_do after 40 ns;
 
   uart0_checker: entity work.uart_rx
     generic map (uart0_rx_handle)

--- a/sim/simple/neorv32_tb.simple.vhd
+++ b/sim/simple/neorv32_tb.simple.vhd
@@ -358,11 +358,11 @@ begin
   -- 1-Wire termination (pull-up) --
   onewire <= 'H';
 
-  -- SPI/SDI echo --
-  sdi_clk <= spi_clk;
-  sdi_csn <= spi_csn(7);
-  sdi_di  <= spi_do;
-  spi_di  <= sdi_do when (spi_csn(7) = '0') else spi_do;
+  -- SPI/SDI echo with propagation delay --
+  sdi_clk <= spi_clk after 40 ns;
+  sdi_csn <= spi_csn(7) after 40 ns;
+  sdi_di  <= spi_do after 40 ns;
+  spi_di  <= sdi_do when (spi_csn(7) = '0') else spi_do after 40 ns;
 
 
   -- UART Simulation Receiver ---------------------------------------------------------------

--- a/sw/example/demo_sdi/main.c
+++ b/sw/example/demo_sdi/main.c
@@ -84,17 +84,13 @@ int main() {
       neorv32_uart0_printf("Available commands:\n"
                           " help - show this text\n"
                           " put  - write byte to TX buffer\n"
-                          " get  - read byte from RX buffer\n"
-                          " clr  - clear RX buffer\n");
+                          " get  - read byte from RX buffer\n");
     }
     else if (!strcmp(buffer, "put")) {
       sdi_put();
     }
     else if (!strcmp(buffer, "get")) {
       sdi_get();
-    }
-    else if (!strcmp(buffer, "clr")) {
-      neorv32_sdi_rx_clear();
     }
     else {
       neorv32_uart0_printf("Invalid command. Type 'help' to see all commands.\n");

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1452,7 +1452,6 @@ int main() {
     neorv32_cpu_csr_write(CSR_MIE, 1 << SDI_FIRQ_ENABLE);
 
     // write test data to SDI
-    neorv32_sdi_rx_clear();
     neorv32_sdi_put(0xab);
 
     // trigger SDI IRQ by sending data via SPI

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1226,7 +1226,7 @@ int main() {
     cnt_test++;
 
     // configure SPI
-    neorv32_spi_setup(CLK_PRSC_8, 0, 0, 0, 1<<SPI_CTRL_IRQ_IDLE); // IRQ when TX FIFO is empty and SPI bus engine is idle
+    neorv32_spi_setup(CLK_PRSC_8, 0, 1, 1, 1<<SPI_CTRL_IRQ_IDLE); // IRQ when TX FIFO is empty and SPI bus engine is idle
 
     // trigger SPI transmissions
     neorv32_spi_put_nonblocking(0xab); // non-blocking
@@ -1446,13 +1446,13 @@ int main() {
 
     // configure and enable SDI + SPI
     neorv32_sdi_setup(1 << SDI_CTRL_IRQ_RX_AVAIL);
-    neorv32_spi_setup(CLK_PRSC_4, 0, 0, 0, 0);
+    neorv32_spi_setup(CLK_PRSC_8, 0, 0, 0, 0);
 
     // enable fast interrupt
     neorv32_cpu_csr_write(CSR_MIE, 1 << SDI_FIRQ_ENABLE);
 
     // write test data to SDI
-    neorv32_sdi_put(0xab);
+    neorv32_sdi_put(0xeb);
 
     // trigger SDI IRQ by sending data via SPI
     neorv32_spi_cs_en(7); // select SDI
@@ -1469,7 +1469,7 @@ int main() {
     if ((neorv32_cpu_csr_read(CSR_MCAUSE) == SDI_TRAP_CODE) && // correct trap code
         (neorv32_sdi_get(&sdi_read_data) == 0) && // correct SDI read data status
         (sdi_read_data == 0x83) && // correct SDI read data
-        ((tmp_a & 0xff) == 0xab)) { // correct SPI read data
+        ((tmp_a & 0xff) == 0xeb)) { // correct SPI read data
       test_ok();
     }
     else {

--- a/sw/lib/include/neorv32_sdi.h
+++ b/sw/lib/include/neorv32_sdi.h
@@ -36,11 +36,10 @@ typedef volatile struct __attribute__((packed,aligned(4))) {
 
 /** SDI control register bits */
 enum NEORV32_SDI_CTRL_enum {
-  SDI_CTRL_EN           =  0, /**< SDI control register(00) (r/w): SID module enable */
-  SDI_CTRL_CLR_RX       =  1, /**< SDI control register(01) (-/w): Clear RX FIFO when set, auto-clear */
+  SDI_CTRL_EN           =  0, /**< SDI control register(0) (r/w): SID module enable */
 
-  SDI_CTRL_FIFO_LSB     =  4, /**< SDI control register(04) (r/-): log2 of SDI FIFO size, LSB */
-  SDI_CTRL_FIFO_MSB     =  7, /**< SDI control register(07) (r/-): log2 of SDI FIFO size, MSB */
+  SDI_CTRL_FIFO_LSB     =  4, /**< SDI control register(4) (r/-): log2 of SDI FIFO size, LSB */
+  SDI_CTRL_FIFO_MSB     =  7, /**< SDI control register(7) (r/-): log2 of SDI FIFO size, MSB */
 
   SDI_CTRL_IRQ_RX_AVAIL = 15, /**< SDI control register(15) (r/w): IRQ when RX FIFO not empty */
   SDI_CTRL_IRQ_RX_HALF  = 16, /**< SDI control register(16) (r/w): IRQ when RX FIFO at least half full */
@@ -53,7 +52,9 @@ enum NEORV32_SDI_CTRL_enum {
   SDI_CTRL_RX_FULL      = 25, /**< SDI control register(25) (r/-): RX FIFO full */
   SDI_CTRL_TX_EMPTY     = 26, /**< SDI control register(26) (r/-): TX FIFO empty */
   SDI_CTRL_TX_NHALF     = 27, /**< SDI control register(27) (r/-): TX FIFO not at least half full */
-  SDI_CTRL_TX_FULL      = 28  /**< SDI control register(28) (r/-): TX FIFO full */
+  SDI_CTRL_TX_FULL      = 28, /**< SDI control register(28) (r/-): TX FIFO full */
+
+  SDI_CTRL_CS_ACTIVE    = 31  /**< SDI control register(31) (r/-): Chip-select is active when set */
 };
 /**@}*/
 
@@ -64,12 +65,12 @@ enum NEORV32_SDI_CTRL_enum {
 /**@{*/
 int  neorv32_sdi_available(void);
 void neorv32_sdi_setup(uint32_t irq_mask);
-void neorv32_sdi_rx_clear(void);
 void neorv32_sdi_disable(void);
 void neorv32_sdi_enable(void);
 int  neorv32_sdi_get_fifo_depth(void);
 int  neorv32_sdi_put(uint8_t data);
 int  neorv32_sdi_get(uint8_t* data);
+int  neorv32_sdi_check_cs(void);
 /**@}*/
 
 

--- a/sw/lib/source/neorv32_sdi.c
+++ b/sw/lib/source/neorv32_sdi.c
@@ -54,15 +54,6 @@ void neorv32_sdi_setup(uint32_t irq_mask) {
 
 
 /**********************************************************************//**
- * Clear SDI receive FIFO.
- **************************************************************************/
-void neorv32_sdi_rx_clear(void) {
-
-  NEORV32_SDI->CTRL |= (uint32_t)(1 << SDI_CTRL_CLR_RX);
-}
-
-
-/**********************************************************************//**
  * Disable SDI controller.
  **************************************************************************/
 void neorv32_sdi_disable(void) {
@@ -124,5 +115,21 @@ int neorv32_sdi_get(uint8_t* data) {
   }
   else {
     return -1;
+  }
+}
+
+
+/**********************************************************************//**
+ * Get status of chip-select line.
+ *
+ * @return 1 if chip-select line is enabled/active (driven low), 0 otherwise.
+ **************************************************************************/
+int neorv32_sdi_check_cs(void) {
+
+  if (NEORV32_SDI->CTRL & (1 << SDI_CTRL_CS_ACTIVE)) {
+    return 1;
+  }
+  else {
+    return 0;
   }
 }

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -144,11 +144,6 @@
               <description>SDI enable flag</description>
             </field>
             <field>
-              <name>SDI_CTRL_CLR_RX</name>
-              <bitRange>[1:1]</bitRange>
-              <description>Clear RX FIFO, bit auto-clears</description>
-            </field>
-            <field>
               <name>SDI_CTRL_FIFO</name>
               <bitRange>[7:4]</bitRange>
               <description>Log2 of SDI FIFO size</description>
@@ -213,6 +208,12 @@
               <bitRange>[28:28]</bitRange>
               <access>read-only</access>
               <description>TX FIFO full</description>
+            </field>
+            <field>
+              <name>SDI_CTRL_CS_ACTIVE</name>
+              <bitRange>[31:31]</bitRange>
+              <access>read-only</access>
+              <description>Chip-select line is active when set</description>
             </field>
           </fields>
         </register>


### PR DESCRIPTION
* :warning: remove control register flag to clear the RX FIFO; can be done by toggling the modules enable bit
* :sparkles: add new control register flag to check the current state of the SDI's chip-select input