### PR TITLE
🐛 [newlib] fix broken `sbrk` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 20.07.2024 | 1.10.1.7 | :bug: fix bug in `sbrk` newlib system call (causing `malloc` to provide infinite memory until heap and stack collide) | [#957](https://github.com/stnolting/neorv32/pull/957) |
 | 20.07.2024 | 1.10.1.6 | SDI: remove explicit "RX clear flag"; add new flag to check the current state of the chip-select input | [#955](https://github.com/stnolting/neorv32/pull/955) |
 | 19.07.2024 | 1.10.1.5 | :sparkles: add "programmable" chip-select enable/disable functionality to SPI module | [#954](https://github.com/stnolting/neorv32/pull/954) |
 | 19.07.2024 | 1.10.1.4 | :bug: fix SDI "TX FIFO full" flag | [#953](https://github.com/stnolting/neorv32/pull/953) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100106"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100107"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/sw/common/neorv32.ld
+++ b/sw/common/neorv32.ld
@@ -199,6 +199,8 @@ SECTIONS
   .heap : ALIGN(4)
   {
     PROVIDE(__heap_start = .);
+    /* start section on WORD boundary */
+    . = ALIGN(4);
     . = __neorv32_heap_size;
     /* finish section on WORD boundary */
     . = ALIGN(4);

--- a/sw/example/demo_newlib/makefile
+++ b/sw/example/demo_newlib/makefile
@@ -1,5 +1,5 @@
 # Configure max HEAP size
-override USER_FLAGS += "-Wl,--defsym,__neorv32_heap_size=1024"
+override USER_FLAGS += "-Wl,--defsym,__neorv32_heap_size=3072"
 
 NEORV32_HOME ?= ../../..
 include $(NEORV32_HOME)/sw/common/common.mk

--- a/sw/lib/source/syscalls.c
+++ b/sw/lib/source/syscalls.c
@@ -6,25 +6,6 @@
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
 
-/* An extremely minimalist syscalls.c for newlib
- * Based on riscv newlib libgloss/riscv/sys_*.c
- *
- * Copyright 2019 Clifford Wolf
- * Copyright 2019 ETH Zürich and University of Bologna
- *
- * Permission to use, copy, modify, and/or distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
- * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
- * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
- * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
- * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- */
-
 /**
  * @file syscalls.c
  * @brief Newlib system calls
@@ -32,17 +13,16 @@
  * @warning UART0 (if available) is used to read/write console data (STDIN, STDOUT, STDERR, ...).
  *
  * @note Original source file: https://github.com/openhwgroup/cv32e40p/blob/master/example_tb/core/custom/syscalls.c
- * @note Original license: SOLDERPAD HARDWARE LICENSE version 0.51
  * @note More information was derived from: https://interrupt.memfault.com/blog/boostrapping-libc-with-newlib#implementing-newlib
  *
  * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
+#include <newlib.h>
 #include <sys/stat.h>
 #include <sys/timeb.h>
 #include <sys/times.h>
 #include <utime.h>
-#include <newlib.h>
 #include <unistd.h>
 #include <errno.h>
 #include <neorv32.h>
@@ -53,254 +33,136 @@ extern int errno;
 // defined in sw/common/crt0.S
 extern const volatile unsigned int __crt0_main_exit;
 
-/* It turns out that older newlib versions use different symbol names which goes
- * against newlib recommendations. Anyway this is fixed in later version.
- */
-#if __NEWLIB__ <= 2 && __NEWLIB_MINOR__ <= 5
-#    define _sbrk sbrk
-#    define _write write
-#    define _close close
-#    define _lseek lseek
-#    define _read read
-#    define _fstat fstat
-#    define _isatty isatty
-#endif
+// linker script symbols
+extern char __heap_start[];
+extern char __heap_end[];
+extern char __crt0_max_heap[];
 
-void unimplemented_syscall()
-{
+
+void *_sbrk(int incr) {
+
+  static unsigned char *curr_heap_ptr = NULL; // current heap pointer
+  unsigned char *prev_heap_ptr; // previous heap pointer
+
+  const uint32_t heap_begin = (uint32_t)&__heap_start[0];
+  const uint32_t heap_end   = (uint32_t)&__heap_end[0];
+  const uint32_t heap_size  = (uint32_t)&__crt0_max_heap[0];
+
+  // initialize
+  if (curr_heap_ptr == NULL) {
+    curr_heap_ptr = (unsigned char *)heap_begin;
+  }
+
+  // do we have a heap at all?
+  if ((heap_begin == heap_end) || (heap_size == 0)) {
+    errno = ENOMEM;
+    return (void*)-1; // error - no more memory
+  }
+
+  // sufficient space left?
+  if ((((uint32_t)curr_heap_ptr) + ((uint32_t)incr)) >= heap_end) {
+    errno = ENOMEM;
+    return (void*)-1; // error - no more memory
+  }
+
+  prev_heap_ptr = curr_heap_ptr;
+  curr_heap_ptr += incr;
+
+  return (void*)prev_heap_ptr;
+}
+
+
+int _close(int file) {
+
+  return -1;
+}
+
+
+int _fstat(int file, struct stat *st) {
+
+  st->st_mode = S_IFCHR; // all files are "character special files"
+  return 0;
+}
+
+
+int _isatty(int file) {
+
+  return 1;
+}
+
+
+int _lseek(int file, int ptr, int dir) {
+
+  return 0;
+}
+
+
+void _exit(int status) {
+
+  // jump to crt0's shutdown code
+  asm volatile ("la t0, __crt0_main_exit \n"
+                "jr t0                   \n");
+  while(1); // will never be reached
+}
+
+
+void _kill(int pid, int sig) {
+
+  errno = EINVAL;
+  return;
+}
+
+
+int _getpid() {
+
+  return 1;
+}
+
+
+int _write(int file, char *ptr, int len) {
+
+  // write everything (STDOUT, STDERR, ...) to NEORV32.UART0 (if available)
+  const void *eptr = ptr + len;
   if (neorv32_uart0_available()) {
-    neorv32_uart0_puts("<syscalls.c> Unimplemented system call called!\n");
+    while (ptr != eptr) {
+      neorv32_uart0_putc(*(char *)(ptr++));
+    }
+    return len;
+  }
+  else {
+    return 0; // nothing sent
   }
 }
 
-int nanosleep(const struct timespec *rqtp, struct timespec *rmtp)
-{
-    errno = ENOSYS;
-    return -1;
+
+int _read(int file, char *ptr, int len) {
+  int read_cnt = 0;
+
+  // read everything (STDIN, ...) from NEORV32.UART0 (if available)
+  if (neorv32_uart0_available()) {
+    char *char_ptr;
+    char_ptr = (char *)ptr;
+    while (len > 0) {
+      *char_ptr++ = (char)neorv32_uart0_getc();
+      read_cnt++;
+      len--;
+    }
+  }
+
+  return read_cnt;
 }
 
-int _access(const char *file, int mode)
-{
-    errno = ENOSYS;
-    return -1;
-}
 
-int _chdir(const char *path)
-{
-    errno = ENOSYS;
-    return -1;
-}
+int _gettimeofday(struct timeval *tp, void *tzp) {
 
-int _chmod(const char *path, mode_t mode)
-{
-    errno = ENOSYS;
-    return -1;
-}
-
-int _chown(const char *path, uid_t owner, gid_t group)
-{
-    errno = ENOSYS;
-    return -1;
-}
-
-int _close(int file)
-{
-    return -1;
-}
-
-int _execve(const char *name, char *const argv[], char *const env[])
-{
-    errno = ENOMEM;
-    return -1;
-}
-
-void _exit(int exit_status)
-{
-    // jump to crt0's shutdown code
-    asm volatile ("la t0, __crt0_main_exit \n"
-                  "jr t0                   \n");
-
-    while(1); // will never be reached
-}
-
-int _faccessat(int dirfd, const char *file, int mode, int flags)
-{
-    errno = ENOSYS;
-    return -1;
-}
-
-int _fork(void)
-{
-    errno = EAGAIN;
-    return -1;
-}
-
-int _fstat(int file, struct stat *st)
-{
-    st->st_mode = S_IFCHR; // all files are "character special files"
+  // use MTIME as system time (if available)
+  if (neorv32_mtime_available()) {
+    tp->tv_sec = (long int)neorv32_mtime_get_unixtime();
+    tp->tv_usec = 0;
     return 0;
-}
-
-int _fstatat(int dirfd, const char *file, struct stat *st, int flags)
-{
+  }
+  else {
     errno = ENOSYS;
     return -1;
-}
-
-int _ftime(struct timeb *tp)
-{
-    errno = ENOSYS;
-    return -1;
-}
-
-char *_getcwd(char *buf, size_t size)
-{
-    errno = -ENOSYS;
-    return NULL;
-}
-
-int _getpid()
-{
-    return 1;
-}
-
-int _gettimeofday(struct timeval *tp, void *tzp)
-{
-    errno = -ENOSYS;
-    return -1;
-}
-
-int _isatty(int file)
-{
-    return (file == STDOUT_FILENO);
-}
-
-int _kill(int pid, int sig)
-{
-    errno = EINVAL;
-    return -1;
-}
-
-int _link(const char *old_name, const char *new_name)
-{
-    errno = EMLINK;
-    return -1;
-}
-
-off_t _lseek(int file, off_t ptr, int dir)
-{
-    return 0;
-}
-
-int _lstat(const char *file, struct stat *st)
-{
-    errno = ENOSYS;
-    return -1;
-}
-
-int _open(const char *name, int flags, int mode)
-{
-    return -1;
-}
-
-int _openat(int dirfd, const char *name, int flags, int mode)
-{
-    errno = ENOSYS;
-    return -1;
-}
-
-ssize_t _read(int file, void *ptr, size_t len)
-{
-    ssize_t read_cnt = 0;
-
-    // read everything (STDIN, ...) from NEORV32.UART0 (if available)
-    if (neorv32_uart0_available()) {
-      char *char_ptr;
-      char_ptr = (char *)ptr;
-      while (len > 0) {
-        *char_ptr++ = (char)neorv32_uart0_getc();
-        read_cnt++;
-        len--;
-      }
-    }
-
-    return read_cnt;
-}
-
-int _stat(const char *file, struct stat *st)
-{
-    st->st_mode = S_IFCHR;
-    return 0;
-    // errno = ENOSYS;
-    // return -1;
-}
-
-long _sysconf(int name)
-{
-
-    return -1;
-}
-
-clock_t _times(struct tms *buf)
-{
-    return -1;
-}
-
-int _unlink(const char *name)
-{
-    errno = ENOENT;
-    return -1;
-}
-
-int _utime(const char *path, const struct utimbuf *times)
-{
-    errno = ENOSYS;
-    return -1;
-}
-
-int _wait(int *status)
-{
-    errno = ECHILD;
-    return -1;
-}
-
-ssize_t _write(int file, const void *ptr, size_t len)
-{
-    // write everything (STDOUT, STDERR, ...) to NEORV32.UART0 (if available)
-    const void *eptr = ptr + len;
-    if (neorv32_uart0_available()) {
-      while (ptr != eptr) {
-        neorv32_uart0_putc(*(char *)(ptr++));
-      }
-      return len;
-    }
-    else {
-      return (ssize_t)0; // nothing sent
-    }
-}
-
-extern char __heap_start[];
-extern char __heap_end[];
-static char *brk = &__heap_start[0];
-
-int _brk(void *addr)
-{
-    brk = addr;
-    return 0;
-}
-
-void *_sbrk(ptrdiff_t incr)
-{
-    char *old_brk = brk;
-
-    if (&__heap_start[0] == &__heap_end[0]) {
-        return NULL;
-    }
-
-    if ((brk += incr) < &__heap_end[0]) {
-        brk += incr;
-    } else {
-        brk = &__heap_end[0];
-    }
-    return old_brk;
+  }
 }


### PR DESCRIPTION
A bug in the implementation of newlib's `sbrk` function caused `malloc` to always make memory available, even though the heap was already full. This caused a collision of heap and stack and finally a CPU crash.

* :bug: fixed bug in newlib's `sbrk` function; `malloc` works now as expected
* :sparkles: add support for `time()` function