### PR TITLE
Make SYSINFO CLK writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 28.07.2024 | 1.10.1.9 | make SYSINFO.CLK read/**write** | [#966](https://github.com/stnolting/neorv32/pull/966) |
 | 21.07.2024 | 1.10.1.8 | :lock: restrict IO access to privileged (machine-mode) software | [#958](https://github.com/stnolting/neorv32/pull/958) |
 | 20.07.2024 | 1.10.1.7 | :bug: fix bug in `sbrk` newlib system call (causing `malloc` to provide infinite memory until heap and stack collide) | [#957](https://github.com/stnolting/neorv32/pull/957) |
 | 20.07.2024 | 1.10.1.6 | SDI: remove explicit "RX clear flag"; add new flag to check the current state of the chip-select input | [#955](https://github.com/stnolting/neorv32/pull/955) |

--- a/docs/datasheet/soc_sysinfo.adoc
+++ b/docs/datasheet/soc_sysinfo.adoc
@@ -16,37 +16,49 @@
 
 **Overview**
 
-The SYSINFO allows the application software to determine the setting of most of the <<_processor_top_entity_generics>>
-that are related to processor/SoC configuration. All registers of this unit are read-only.
-This device is always implemented - regardless of the actual hardware configuration. The bootloader as well
-as the NEORV32 software runtime environment require information from this device (like memory layout
-and default clock frequency) for correct operation.
+The SYSINFO module allows the application software to determine the setting of most of the <<_processor_top_entity_generics>>
+that are related to CPU and processor/SoC configuration. This device is always implemented - regardless of the actual hardware
+configuration since the NEORV32 software framework requires information from this device for correct operation.
+However, advanced users that do not want to use the default NEORV32 software framework can choose to disable the
+entire SYSINFO module. This might also be suitable for setups that use the processor just as wrapper for a CPU-only
+configuration.
+
+.Disabling the SYSINFO Module
+[WARNING]
+Setting the `IO_DISABLE_SYSINFO` top entity generic to `true` will remove the SYSINFO module from the design.
+This option is suitable for advanced uses that wish to use a CPU-only setup that still contains the bus infrastructure.
+As a result, large parts of the NEORV32 software framework no longer work (e.g. most IO drivers, the RTE and the bootloader).
+**Hence, this option is not recommended.**
 
 
 **Register Map**
 
+All registers of this module are read-only except for the `CLK` register. Upon reset, the `CLK` registers is initialized
+from the `CLOCK_FREQUENCY` top entity generic. Application software can override this default value in order, for example,
+to take into account a dynamic frequency scaling of the processor.
+
 .SYSINFO register map (`struct NEORV32_SYSINFO`)
-[cols="<2,<1,<7"]
+[cols="<2,<1,^1,<7"]
 [options="header",grid="all"]
 |=======================
-| Address | Name [C] | Function
-| `0xfffffe00` | `CLK`    | clock frequency in Hz (via top's `CLOCK_FREQUENCY` generic)
-| `0xfffffe04` | `MEM[4]` | internal memory configuration (see <<_sysinfo_memory_configuration>>)
-| `0xfffffe08` | `SOC`    | specific SoC configuration (see <<_sysinfo_soc_configuration>>)
-| `0xfffffe0c` | `CACHE`  | cache configuration information (see <<_sysinfo_cache_configuration>>)
+| Address | Name [C] | R/W | Description
+| `0xfffffe00` | `CLK`    | r/w | clock frequency in Hz (initialized from top's `CLOCK_FREQUENCY` generic)
+| `0xfffffe04` | `MEM[4]` | r/- | internal memory configuration (see <<_sysinfo_memory_configuration>>)
+| `0xfffffe08` | `SOC`    | r/- | specific SoC configuration (see <<_sysinfo_soc_configuration>>)
+| `0xfffffe0c` | `CACHE`  | r/- | cache configuration information (see <<_sysinfo_cache_configuration>>)
 |=======================
 
 
 ===== SYSINFO - Memory Configuration
 
 [NOTE]
-Bit fields in this register are set to all-zero if the according cache is not implemented.
+Bit fields in this register are set to all-zero if the according memory system is not implemented.
 
 .SYSINFO `MEM` Bytes
 [cols="^1,<2,<7"]
 [options="header",grid="all"]
 |=======================
-| Byte | Name [C] | Function
+| Byte | Name [C] | Description
 | `0`  | `SYSINFO_MEM_IMEM` | _log2_(internal IMEM size in bytes), via top's `MEM_INT_IMEM_SIZE` generic
 | `1`  | `SYSINFO_MEM_DMEM` | _log2_(internal DMEM size in bytes), via top's `MEM_INT_DMEM_SIZE` generic
 | `2`  | -                  | _reserved_, read as zero
@@ -60,7 +72,7 @@ Bit fields in this register are set to all-zero if the according cache is not im
 [cols="^2,<6,<10"]
 [options="header",grid="all"]
 |=======================
-| Bit | Name [C] | Function
+| Bit | Name [C] | Description
 | `0`     | `SYSINFO_SOC_BOOTLOADER`     | set if processor-internal bootloader is implemented (via top's `INT_BOOTLOADER_EN` generic)
 | `1`     | `SYSINFO_SOC_XBUS`           | set if external Wishbone bus interface is implemented (via top's `XBUS_EN` generic)
 | `2`     | `SYSINFO_SOC_MEM_INT_IMEM`   | set if processor-internal DMEM implemented (via top's `MEM_INT_DMEM_EN` generic)
@@ -103,7 +115,7 @@ Bit fields in this register are set to all-zero if the according cache is not im
 [cols="^1,<10,<10"]
 [options="header",grid="all"]
 |=======================
-| Bit     | Name [C] | Function
+| Bit     | Name [C] | Description
 | `3:0`   | `SYSINFO_CACHE_INST_BLOCK_SIZE_3 : SYSINFO_CACHE_INST_BLOCK_SIZE_0` | _log2_(i-cache block size in bytes), via top's `ICACHE_BLOCK_SIZE` generic
 | `7:4`   | `SYSINFO_CACHE_INST_NUM_BLOCKS_3 : SYSINFO_CACHE_INST_NUM_BLOCKS_0` | _log2_(i-cache number of cache blocks), via top's `ICACHE_NUM_BLOCKS` generic
 | `11:8`  | `SYSINFO_CACHE_DATA_BLOCK_SIZE_3 : SYSINFO_CACHE_DATA_BLOCK_SIZE_0` | _log2_(d-cache block size in bytes), via top's `DCACHE_BLOCK_SIZE` generic

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100108"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100109"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -1061,12 +1061,12 @@ package body neorv32_package is
     variable hex_v : string(1 to 16);
   begin
     hex_v := "0123456789abcdef";
-    if su_undefined_f(input(3)) or su_undefined_f(input(2)) or
-       su_undefined_f(input(1)) or su_undefined_f(input(0)) then
-      return '?';
-    else
-      return hex_v(to_integer(unsigned(input)) + 1);
-    end if;
+    for i in 0 to 3 loop
+      if su_undefined_f(input(i)) then
+        return '?';
+      end if;
+    end loop;
+    return hex_v(to_integer(unsigned(input)) + 1);
   end function to_hexchar_f;
 
   -- Convert 32-bit std_ulogic_vector to hex string -----------------------------------------

--- a/sw/example/coremark/core_portme.c
+++ b/sw/example/coremark/core_portme.c
@@ -115,7 +115,7 @@ CORE_TICKS get_time(void) {
 */
 secs_ret time_in_secs(CORE_TICKS ticks) {
     /* NEORV32-specific */
-    secs_ret retval = (secs_ret)(((CORE_TICKS)ticks) / ((CORE_TICKS)NEORV32_SYSINFO->CLK));
+    secs_ret retval = (secs_ret)(((CORE_TICKS)ticks) / ((CORE_TICKS)neorv32_sysinfo_get_clk()));
     return retval;
 }
 
@@ -162,7 +162,7 @@ void portable_init(core_portable *p, int *argc, char *argv[]) {
   if (num_hpm_cnts_global > 7)  {neorv32_cpu_csr_write(CSR_MHPMCOUNTER10, 0); neorv32_cpu_csr_write(CSR_MHPMEVENT10, 1 << HPMCNT_EVENT_WAIT_LSU); }
   if (num_hpm_cnts_global > 8)  {neorv32_cpu_csr_write(CSR_MHPMCOUNTER11, 0); neorv32_cpu_csr_write(CSR_MHPMEVENT11, 1 << HPMCNT_EVENT_TRAP);     }
 
-  neorv32_uart0_printf("NEORV32: Processor running at %u Hz\n", (uint32_t)NEORV32_SYSINFO->CLK);
+  neorv32_uart0_printf("NEORV32: Processor running at %u Hz\n", (uint32_t)neorv32_sysinfo_get_clk());
   neorv32_uart0_printf("NEORV32: Executing coremark (%u iterations). This may take some time...\n\n", (uint32_t)ITERATIONS);
 
 /*

--- a/sw/example/demo_gptmr/main.c
+++ b/sw/example/demo_gptmr/main.c
@@ -64,7 +64,7 @@ int main() {
   neorv32_rte_handler_install(GPTMR_RTE_ID, gptmr_firq_handler);
 
   // configure timer for 0.5Hz ticks with clock divisor = 8 and set to run in continuous mode
-  neorv32_gptmr_setup(CLK_PRSC_8, NEORV32_SYSINFO->CLK / (8 * 2), 1);
+  neorv32_gptmr_setup(CLK_PRSC_8, neorv32_sysinfo_get_clk() / (8 * 2), 1);
 
   // enable interrupt
   neorv32_cpu_csr_set(CSR_MIE, 1 << GPTMR_FIRQ_ENABLE);   // enable GPTMR FIRQ channel

--- a/sw/example/demo_mtime/main.c
+++ b/sw/example/demo_mtime/main.c
@@ -72,7 +72,7 @@ int main() {
   neorv32_rte_handler_install(RTE_TRAP_MTI, mtime_irq_handler);
 
   // configure MTIME timer's first interrupt to trigger after 1 second starting from now
-  neorv32_mtime_set_timecmp(neorv32_mtime_get_time() + NEORV32_SYSINFO->CLK);
+  neorv32_mtime_set_timecmp(neorv32_mtime_get_time() + neorv32_sysinfo_get_clk());
 
   // enable interrupt
   neorv32_cpu_csr_set(CSR_MIE, 1 << CSR_MIE_MTIE); // enable MTIME interrupt
@@ -96,7 +96,7 @@ int main() {
 void mtime_irq_handler(void) {
 
   // configure MTIME timer's next interrupt to trigger after 1 second starting from now
-  neorv32_mtime_set_timecmp(neorv32_mtime_get_timecmp() + NEORV32_SYSINFO->CLK);
+  neorv32_mtime_set_timecmp(neorv32_mtime_get_timecmp() + neorv32_sysinfo_get_clk());
 
   // toggle output port bit 0
   neorv32_gpio_pin_toggle(0);

--- a/sw/example/demo_spi/main.c
+++ b/sw/example/demo_spi/main.c
@@ -216,7 +216,7 @@ void spi_setup(void) {
   neorv32_uart0_scan(terminal_buffer, 2, 1);
   clk_div = (uint8_t)neorv32_aux_hexstr2uint64(terminal_buffer, strlen(terminal_buffer));
 
-  uint32_t clock = NEORV32_SYSINFO->CLK / (2 * PRSC_LUT[spi_prsc] * (1 + clk_div));
+  uint32_t clock = neorv32_sysinfo_get_clk() / (2 * PRSC_LUT[spi_prsc] * (1 + clk_div));
   neorv32_uart0_printf("\n+ New SPI clock speed = %u Hz\n", clock);
 
   // ---- SPI clock mode ----

--- a/sw/example/demo_trng/main.c
+++ b/sw/example/demo_trng/main.c
@@ -360,7 +360,7 @@ void compute_rate(void) {
 
   uint32_t delta = neorv32_cpu_csr_read(CSR_CYCLE) - cycles;
   uint32_t cycles_per_rnd = delta / n_samples;
-  uint32_t rnd_per_sec = NEORV32_SYSINFO->CLK / cycles_per_rnd;
+  uint32_t rnd_per_sec = neorv32_sysinfo_get_clk() / cycles_per_rnd;
 
   neorv32_uart0_printf("\nAverage random generation rate\n");
   neorv32_uart0_printf("Cycles per random byte: ~%u\n", cycles_per_rnd);

--- a/sw/example/demo_twi/main.c
+++ b/sw/example/demo_twi/main.c
@@ -166,7 +166,7 @@ void set_clock(void) {
   neorv32_twi_setup(prsc, cdiv, clkstr);
 
   // print new clock frequency
-  uint32_t clock = NEORV32_SYSINFO->CLK / (4 * PRSC_LUT[prsc] * (1 + cdiv));
+  uint32_t clock = neorv32_sysinfo_get_clk() / (4 * PRSC_LUT[prsc] * (1 + cdiv));
   neorv32_uart0_printf("\nNew I2C clock: %u Hz\n", clock);
 }
 

--- a/sw/example/demo_wdt/main.c
+++ b/sw/example/demo_wdt/main.c
@@ -74,7 +74,7 @@ int main() {
 
   // compute WDT timeout value
   // - the WDT counter increments at f_wdt = f_main / 4096
-  uint32_t timeout = WDT_TIMEOUT_S * (NEORV32_SYSINFO->CLK / 4096);
+  uint32_t timeout = WDT_TIMEOUT_S * (neorv32_sysinfo_get_clk() / 4096);
   if (timeout & 0xFF000000U) { // check if timeout value fits into 24-bit
     neorv32_uart0_puts("Timeout value does not fit into 24-bit!\n");
     return -1;

--- a/sw/example/dhrystone/dhry_1.c
+++ b/sw/example/dhrystone/dhry_1.c
@@ -106,7 +106,7 @@ int main (void)
     neorv32_cpu_csr_write(CSR_MIE, 0); // no interrupts
     neorv32_uart0_setup(19200, 0);
 
-    neorv32_uart0_printf("NEORV32: Processor running at %u Hz\n", (uint32_t)NEORV32_SYSINFO->CLK);
+    neorv32_uart0_printf("NEORV32: Processor running at %u Hz\n", (uint32_t)neorv32_sysinfo_get_clk());
     neorv32_uart0_printf("NEORV32: Executing Dhrystone (%u iterations). This may take some time...\n\n", (uint32_t)DHRY_ITERS);
 
     // clear cycle counter
@@ -340,24 +340,24 @@ int main (void)
 #endif
 */
     { /* *****  NEORV32-SPECIFIC ***** */
-      neorv32_uart0_printf ("Microseconds for one run through Dhrystone: %u \n", (uint32_t)((User_Time * (Mic_secs_Per_Second / Number_Of_Runs)) / NEORV32_SYSINFO->CLK));
+      neorv32_uart0_printf ("Microseconds for one run through Dhrystone: %u \n", (uint32_t)((User_Time * (Mic_secs_Per_Second / Number_Of_Runs)) / neorv32_sysinfo_get_clk()));
 
-      uint32_t dhry_per_sec = (uint32_t)(NEORV32_SYSINFO->CLK / (User_Time / Number_Of_Runs));
+      uint32_t dhry_per_sec = (uint32_t)(neorv32_sysinfo_get_clk() / (User_Time / Number_Of_Runs));
 
       neorv32_uart0_printf ("Dhrystones per Second:                      %u \n\n", (uint32_t)dhry_per_sec);
 
       neorv32_uart0_printf("NEORV32: << DETAILED RESULTS (integer parts only) >>\n");
       neorv32_uart0_printf("NEORV32: Total cycles:      %u\n", (uint32_t)User_Time);
-      neorv32_uart0_printf("NEORV32: Cycles per second: %u\n", (uint32_t)NEORV32_SYSINFO->CLK);
+      neorv32_uart0_printf("NEORV32: Cycles per second: %u\n", (uint32_t)neorv32_sysinfo_get_clk());
       neorv32_uart0_printf("NEORV32: Total runs:        %u\n", (uint32_t)Number_Of_Runs);
 
       neorv32_uart0_printf("\n");
       neorv32_uart0_printf("NEORV32: DMIPS/s:           %u\n", (uint32_t)dhry_per_sec);
-      neorv32_uart0_printf("NEORV32: DMIPS/s/MHz:       %u\n", (uint32_t)(dhry_per_sec / (NEORV32_SYSINFO->CLK / 1000000)));
+      neorv32_uart0_printf("NEORV32: DMIPS/s/MHz:       %u\n", (uint32_t)(dhry_per_sec / (neorv32_sysinfo_get_clk() / 1000000)));
 
       neorv32_uart0_printf("\n");
       neorv32_uart0_printf("NEORV32: VAX DMIPS/s:       %u\n", (uint32_t)dhry_per_sec/1757);
-      neorv32_uart0_printf("NEORV32: VAX DMIPS/s/MHz:   %u/1757\n", (uint32_t)(dhry_per_sec / (NEORV32_SYSINFO->CLK / 1000000)));
+      neorv32_uart0_printf("NEORV32: VAX DMIPS/s/MHz:   %u/1757\n", (uint32_t)(dhry_per_sec / (neorv32_sysinfo_get_clk() / 1000000)));
     } /* ***** /NEORV32-SPECIFIC ***** */
     /*
       neorv32_uart0_printf ("Microseconds for one run through Dhrystone: ");

--- a/sw/lib/include/neorv32_sysinfo.h
+++ b/sw/lib/include/neorv32_sysinfo.h
@@ -8,7 +8,7 @@
 
 /**
  * @file neorv32_cfs.h
- * @brief System Configuration Information Memory (SYSINFO) HW driver header file.
+ * @brief System Information Memory (SYSINFO) HW driver header file.
  *
  * @see https://stnolting.github.io/neorv32/sw/files.html
  */
@@ -23,58 +23,58 @@
  * @name IO Device: System Configuration Information Memory (SYSINFO)
  **************************************************************************/
 /**@{*/
-/** SYSINFO module prototype - whole module is read-only */
+/** SYSINFO module prototype */
 typedef volatile struct __attribute__((packed,aligned(4))) {
-  const uint32_t CLK;    /**< offset 0:  clock speed in Hz */
-  const uint8_t  MEM[4]; /**< offset 4:  Memory configuration (sizes) (#NEORV32_SYSINFO_MEM_enum) */
+        uint32_t CLK;    /**< offset 0:  Clock speed in Hz */
+  const uint8_t  MEM[4]; /**< offset 4:  Internal memory sizes (#NEORV32_SYSINFO_MEM_enum) */
   const uint32_t SOC;    /**< offset 8:  SoC features (#NEORV32_SYSINFO_SOC_enum) */
-  const uint32_t CACHE;  /**< offset 12: cache configuration (#NEORV32_SYSINFO_CACHE_enum) */
+  const uint32_t CACHE;  /**< offset 12: Cache configuration (#NEORV32_SYSINFO_CACHE_enum) */
 } neorv32_sysinfo_t;
 
 /** SYSINFO module hardware access (#neorv32_sysinfo_t) */
 #define NEORV32_SYSINFO ((neorv32_sysinfo_t*) (NEORV32_SYSINFO_BASE))
 
-/** NEORV32_SYSINFO->MEM (r/-): Memory configuration (sizes) */
+/** NEORV32_SYSINFO.MEM (r/-): Memory configuration (sizes) */
 enum NEORV32_SYSINFO_MEM_enum {
   SYSINFO_MEM_IMEM = 0, /**< SYSINFO_MEM byte 0 (r/-): log2(internal IMEM size in bytes) (via MEM_INT_IMEM_SIZE generic) */
   SYSINFO_MEM_DMEM = 1  /**< SYSINFO_MEM byte 1 (r/-): log2(internal DMEM size in bytes) (via MEM_INT_DMEM_SIZE generic) */
 };
 
-/** NEORV32_SYSINFO->SOC (r/-): Implemented processor devices/features */
+/** NEORV32_SYSINFO.SOC (r/-): Implemented processor devices/features */
 enum NEORV32_SYSINFO_SOC_enum {
-  SYSINFO_SOC_BOOTLOADER     =  0, /**< SYSINFO_SOC  (0) (r/-): Bootloader implemented when 1 (via INT_BOOTLOADER_EN generic) */
-  SYSINFO_SOC_XBUS           =  1, /**< SYSINFO_SOC  (1) (r/-): External bus interface implemented when 1 (via XBUS_EN generic) */
-  SYSINFO_SOC_MEM_INT_IMEM   =  2, /**< SYSINFO_SOC  (2) (r/-): Processor-internal instruction memory implemented when 1 (via MEM_INT_IMEM_EN generic) */
-  SYSINFO_SOC_MEM_INT_DMEM   =  3, /**< SYSINFO_SOC  (3) (r/-): Processor-internal data memory implemented when 1 (via MEM_INT_DMEM_EN generic) */
-  SYSINFO_SOC_OCD            =  4, /**< SYSINFO_SOC  (4) (r/-): On-chip debugger implemented when 1 (via ON_CHIP_DEBUGGER_EN generic) */
-  SYSINFO_SOC_ICACHE         =  5, /**< SYSINFO_SOC  (5) (r/-): Processor-internal instruction cache implemented when 1 (via ICACHE_EN generic) */
-  SYSINFO_SOC_DCACHE         =  6, /**< SYSINFO_SOC  (6) (r/-): Processor-internal instruction cache implemented when 1 (via DCACHE_EN generic) */
-  SYSINFO_SOC_CLOCK_GATING   =  7, /**< SYSINFO_SOC  (7) (r/-): Clock gating implemented when 1 (via CLOCK_GATING_EN generic) */
-  SYSINFO_SOC_XBUS_CACHE     =  8, /**< SYSINFO_SOC  (8) (r/-): External bus cache implemented when 1 (via XBUS_CACHE_EN generic) */
-  SYSINFO_SOC_XIP            =  9, /**< SYSINFO_SOC  (9) (r/-): Execute in-place module implemented when 1 (via XIP_EN generic) */
-  SYSINFO_SOC_XIP_CACHE      = 10, /**< SYSINFO_S C (10) (r/-): Execute in-place cache implemented when 1 (via XIP_CACHE_EN generic) */
+  SYSINFO_SOC_BOOTLOADER   =  0, /**< SYSINFO_SOC  (0) (r/-): Bootloader implemented when 1 (via INT_BOOTLOADER_EN generic) */
+  SYSINFO_SOC_XBUS         =  1, /**< SYSINFO_SOC  (1) (r/-): External bus interface implemented when 1 (via XBUS_EN generic) */
+  SYSINFO_SOC_MEM_INT_IMEM =  2, /**< SYSINFO_SOC  (2) (r/-): Processor-internal instruction memory implemented when 1 (via MEM_INT_IMEM_EN generic) */
+  SYSINFO_SOC_MEM_INT_DMEM =  3, /**< SYSINFO_SOC  (3) (r/-): Processor-internal data memory implemented when 1 (via MEM_INT_DMEM_EN generic) */
+  SYSINFO_SOC_OCD          =  4, /**< SYSINFO_SOC  (4) (r/-): On-chip debugger implemented when 1 (via ON_CHIP_DEBUGGER_EN generic) */
+  SYSINFO_SOC_ICACHE       =  5, /**< SYSINFO_SOC  (5) (r/-): Processor-internal instruction cache implemented when 1 (via ICACHE_EN generic) */
+  SYSINFO_SOC_DCACHE       =  6, /**< SYSINFO_SOC  (6) (r/-): Processor-internal instruction cache implemented when 1 (via DCACHE_EN generic) */
+  SYSINFO_SOC_CLOCK_GATING =  7, /**< SYSINFO_SOC  (7) (r/-): Clock gating implemented when 1 (via CLOCK_GATING_EN generic) */
+  SYSINFO_SOC_XBUS_CACHE   =  8, /**< SYSINFO_SOC  (8) (r/-): External bus cache implemented when 1 (via XBUS_CACHE_EN generic) */
+  SYSINFO_SOC_XIP          =  9, /**< SYSINFO_SOC  (9) (r/-): Execute in-place module implemented when 1 (via XIP_EN generic) */
+  SYSINFO_SOC_XIP_CACHE    = 10, /**< SYSINFO_S C (10) (r/-): Execute in-place cache implemented when 1 (via XIP_CACHE_EN generic) */
 
-  SYSINFO_SOC_IO_DMA         = 14, /**< SYSINFO_SOC (14) (r/-): Direct memory access controller implemented when 1 (via IO_DMA_EN generic) */
-  SYSINFO_SOC_IO_GPIO        = 15, /**< SYSINFO_SOC (15) (r/-): General purpose input/output port unit implemented when 1 (via IO_GPIO_EN generic) */
-  SYSINFO_SOC_IO_MTIME       = 16, /**< SYSINFO_SOC (16) (r/-): Machine system timer implemented when 1 (via IO_MTIME_EN generic) */
-  SYSINFO_SOC_IO_UART0       = 17, /**< SYSINFO_SOC (17) (r/-): Primary universal asynchronous receiver/transmitter 0 implemented when 1 (via IO_UART0_EN generic) */
-  SYSINFO_SOC_IO_SPI         = 18, /**< SYSINFO_SOC (18) (r/-): Serial peripheral interface implemented when 1 (via IO_SPI_EN generic) */
-  SYSINFO_SOC_IO_TWI         = 19, /**< SYSINFO_SOC (19) (r/-): Two-wire interface implemented when 1 (via IO_TWI_EN generic) */
-  SYSINFO_SOC_IO_PWM         = 20, /**< SYSINFO_SOC (20) (r/-): Pulse-width modulation unit implemented when 1 (via IO_PWM_EN generic) */
-  SYSINFO_SOC_IO_WDT         = 21, /**< SYSINFO_SOC (21) (r/-): Watchdog timer implemented when 1 (via IO_WDT_EN generic) */
-  SYSINFO_SOC_IO_CFS         = 22, /**< SYSINFO_SOC (22) (r/-): Custom functions subsystem implemented when 1 (via IO_CFS_EN generic) */
-  SYSINFO_SOC_IO_TRNG        = 23, /**< SYSINFO_SOC (23) (r/-): True random number generator implemented when 1 (via IO_TRNG_EN generic) */
-  SYSINFO_SOC_IO_SDI         = 24, /**< SYSINFO_SOC (24) (r/-): Serial data interface implemented when 1 (via IO_SDI_EN generic) */
-  SYSINFO_SOC_IO_UART1       = 25, /**< SYSINFO_SOC (25) (r/-): Secondary universal asynchronous receiver/transmitter 1 implemented when 1 (via IO_UART1_EN generic) */
-  SYSINFO_SOC_IO_NEOLED      = 26, /**< SYSINFO_SOC (26) (r/-): NeoPixel-compatible smart LED interface implemented when 1 (via IO_NEOLED_EN generic) */
-  SYSINFO_SOC_IO_XIRQ        = 27, /**< SYSINFO_SOC (27) (r/-): External interrupt controller implemented when 1 (via XIRQ_NUM_IO generic) */
-  SYSINFO_SOC_IO_GPTMR       = 28, /**< SYSINFO_SOC (28) (r/-): General purpose timer implemented when 1 (via IO_GPTMR_EN generic) */
-  SYSINFO_SOC_IO_SLINK       = 29, /**< SYSINFO_SOC (29) (r/-): Stream link interface implemented when 1 (via IO_SLINK_EN generic) */
-  SYSINFO_SOC_IO_ONEWIRE     = 30, /**< SYSINFO_SOC (30) (r/-): 1-wire interface controller implemented when 1 (via IO_ONEWIRE_EN generic) */
-  SYSINFO_SOC_IO_CRC         = 31  /**< SYSINFO_SOC (31) (r/-): Cyclic redundancy check unit implemented when 1 (via IO_CRC_EN generic) */
+  SYSINFO_SOC_IO_DMA       = 14, /**< SYSINFO_SOC (14) (r/-): Direct memory access controller implemented when 1 (via IO_DMA_EN generic) */
+  SYSINFO_SOC_IO_GPIO      = 15, /**< SYSINFO_SOC (15) (r/-): General purpose input/output port unit implemented when 1 (via IO_GPIO_EN generic) */
+  SYSINFO_SOC_IO_MTIME     = 16, /**< SYSINFO_SOC (16) (r/-): Machine system timer implemented when 1 (via IO_MTIME_EN generic) */
+  SYSINFO_SOC_IO_UART0     = 17, /**< SYSINFO_SOC (17) (r/-): Primary universal asynchronous receiver/transmitter 0 implemented when 1 (via IO_UART0_EN generic) */
+  SYSINFO_SOC_IO_SPI       = 18, /**< SYSINFO_SOC (18) (r/-): Serial peripheral interface implemented when 1 (via IO_SPI_EN generic) */
+  SYSINFO_SOC_IO_TWI       = 19, /**< SYSINFO_SOC (19) (r/-): Two-wire interface implemented when 1 (via IO_TWI_EN generic) */
+  SYSINFO_SOC_IO_PWM       = 20, /**< SYSINFO_SOC (20) (r/-): Pulse-width modulation unit implemented when 1 (via IO_PWM_EN generic) */
+  SYSINFO_SOC_IO_WDT       = 21, /**< SYSINFO_SOC (21) (r/-): Watchdog timer implemented when 1 (via IO_WDT_EN generic) */
+  SYSINFO_SOC_IO_CFS       = 22, /**< SYSINFO_SOC (22) (r/-): Custom functions subsystem implemented when 1 (via IO_CFS_EN generic) */
+  SYSINFO_SOC_IO_TRNG      = 23, /**< SYSINFO_SOC (23) (r/-): True random number generator implemented when 1 (via IO_TRNG_EN generic) */
+  SYSINFO_SOC_IO_SDI       = 24, /**< SYSINFO_SOC (24) (r/-): Serial data interface implemented when 1 (via IO_SDI_EN generic) */
+  SYSINFO_SOC_IO_UART1     = 25, /**< SYSINFO_SOC (25) (r/-): Secondary universal asynchronous receiver/transmitter 1 implemented when 1 (via IO_UART1_EN generic) */
+  SYSINFO_SOC_IO_NEOLED    = 26, /**< SYSINFO_SOC (26) (r/-): NeoPixel-compatible smart LED interface implemented when 1 (via IO_NEOLED_EN generic) */
+  SYSINFO_SOC_IO_XIRQ      = 27, /**< SYSINFO_SOC (27) (r/-): External interrupt controller implemented when 1 (via XIRQ_NUM_IO generic) */
+  SYSINFO_SOC_IO_GPTMR     = 28, /**< SYSINFO_SOC (28) (r/-): General purpose timer implemented when 1 (via IO_GPTMR_EN generic) */
+  SYSINFO_SOC_IO_SLINK     = 29, /**< SYSINFO_SOC (29) (r/-): Stream link interface implemented when 1 (via IO_SLINK_EN generic) */
+  SYSINFO_SOC_IO_ONEWIRE   = 30, /**< SYSINFO_SOC (30) (r/-): 1-wire interface controller implemented when 1 (via IO_ONEWIRE_EN generic) */
+  SYSINFO_SOC_IO_CRC       = 31  /**< SYSINFO_SOC (31) (r/-): Cyclic redundancy check unit implemented when 1 (via IO_CRC_EN generic) */
 };
 
-/** NEORV32_SYSINFO->CACHE (r/-): Cache configuration */
+/** NEORV32_SYSINFO.CACHE (r/-): Cache configuration */
  enum NEORV32_SYSINFO_CACHE_enum {
   SYSINFO_CACHE_INST_BLOCK_SIZE_0 =  0, /**< SYSINFO_CACHE  (0) (r/-): i-cache: log2(Block size in bytes), bit 0 (via ICACHE_BLOCK_SIZE generic) */
   SYSINFO_CACHE_INST_BLOCK_SIZE_3 =  3, /**< SYSINFO_CACHE  (3) (r/-): i-cache: log2(Block size in bytes), bit 3 (via ICACHE_BLOCK_SIZE generic) */
@@ -96,6 +96,15 @@ enum NEORV32_SYSINFO_SOC_enum {
   SYSINFO_CACHE_XBUS_NUM_BLOCKS_0 = 28, /**< SYSINFO_CACHE (28) (r/-): xbus-cache: log2(Number of cache blocks), bit 0 (via XBUS_CACHE_NUM_BLOCKS generic) */
   SYSINFO_CACHE_XBUS_NUM_BLOCKS_3 = 31  /**< SYSINFO_CACHE (31) (r/-): xbus-cache: log2(Number of cache blocks), bit 3 (via XBUS_CACHE_NUM_BLOCKS generic) */
 };
+/**@}*/
+
+
+/**********************************************************************//**
+ * @name Prototypes
+ **************************************************************************/
+/**@{*/
+uint32_t neorv32_sysinfo_get_clk(void);
+void     neorv32_sysinfo_set_clk(uint32_t clock);
 /**@}*/
 
 

--- a/sw/lib/source/neorv32_cpu.c
+++ b/sw/lib/source/neorv32_cpu.c
@@ -137,7 +137,7 @@ void neorv32_cpu_set_minstret(uint64_t value) {
  **************************************************************************/
 void neorv32_cpu_delay_ms(uint32_t time_ms) {
 
-  uint32_t clock = NEORV32_SYSINFO->CLK; // clock ticks per second
+  uint32_t clock = neorv32_sysinfo_get_clk(); // clock ticks per second
   clock = clock / 1000; // clock ticks per ms
   uint64_t wait_cycles = ((uint64_t)clock) * ((uint64_t)time_ms);
   uint64_t tmp = 0;
@@ -192,7 +192,7 @@ uint32_t neorv32_cpu_get_clk_from_prsc(int prsc) {
   }
 
   uint32_t res = 0;
-  uint32_t clock = NEORV32_SYSINFO->CLK; // SoC main clock in Hz
+  uint32_t clock = neorv32_sysinfo_get_clk(); // SoC main clock in Hz
 
   switch(prsc & 7) {
     case CLK_PRSC_2    : res = clock/2    ; break;

--- a/sw/lib/source/neorv32_mtime.c
+++ b/sw/lib/source/neorv32_mtime.c
@@ -122,20 +122,20 @@ uint64_t neorv32_mtime_get_timecmp(void) {
 /**********************************************************************//**
  * Set TIME to Unix time.
  *
- * @param[in] unixtime Unix time since 00:00:00 UTC, January 1, 1970 in seconds.
+ * @param[in] unixtime Unix time since 00:00:00 UTC, January 1st, 1970 in seconds.
  **************************************************************************/
 void neorv32_mtime_set_unixtime(uint64_t unixtime) {
 
-  neorv32_mtime_set_time(((uint64_t)NEORV32_SYSINFO->CLK) * unixtime);
+  neorv32_mtime_set_time(((uint64_t)neorv32_sysinfo_get_clk()) * unixtime);
 }
 
 
 /**********************************************************************//**
  * Get Unix time from TIME.
  *
- * @return Unix time since 00:00:00 UTC, January 1, 1970 in seconds.
+ * @return Unix time since 00:00:00 UTC, January 1st, 1970 in seconds.
  **************************************************************************/
 uint64_t neorv32_mtime_get_unixtime(void) {
 
-  return neorv32_mtime_get_time() / ((uint64_t)NEORV32_SYSINFO->CLK);
+  return neorv32_mtime_get_time() / ((uint64_t)neorv32_sysinfo_get_clk());
 }

--- a/sw/lib/source/neorv32_neoled.c
+++ b/sw/lib/source/neorv32_neoled.c
@@ -79,7 +79,7 @@ void neorv32_neoled_setup_ws2812(int irq_mode) {
   const uint16_t CLK_PRSC_FACTOR_LUT[8] = {2, 4, 8, 64, 128, 1024, 2048, 4096};
 
   // get base clock period in multiples of 0.5ns
-  uint32_t t_clock_x500ps = (2 * 1000 * 1000 * 1000) / NEORV32_SYSINFO->CLK;
+  uint32_t t_clock_x500ps = (2 * 1000 * 1000 * 1000) / neorv32_sysinfo_get_clk();
 
   // compute LED interface timing parameters
   uint32_t t_base         = 0;

--- a/sw/lib/source/neorv32_onewire.c
+++ b/sw/lib/source/neorv32_onewire.c
@@ -51,7 +51,7 @@ int neorv32_onewire_setup(uint32_t t_base) {
   uint32_t t_tick;
   uint32_t clkdiv;
   uint32_t clk_prsc_sel   = 0; // initial prsc = CLK/2
-  uint32_t t_clock_x250ps = (4 * 1000 * 1000 * 1000U) / NEORV32_SYSINFO->CLK; // t_clock in multiples of 0.25 ns
+  uint32_t t_clock_x250ps = (4 * 1000 * 1000 * 1000U) / neorv32_sysinfo_get_clk(); // t_clock in multiples of 0.25 ns
 
   // find best base tick configuration
   while (1) {

--- a/sw/lib/source/neorv32_rte.c
+++ b/sw/lib/source/neorv32_rte.c
@@ -400,7 +400,7 @@ void neorv32_rte_print_hw_config(void) {
   if (neorv32_cpu_csr_read(CSR_MXISA) & (1 << CSR_MXISA_IS_SIM)) { neorv32_uart0_printf("yes\n"); }
   else { neorv32_uart0_printf("no\n"); }
 
-  neorv32_uart0_printf("Clock speed:         %u Hz\n", NEORV32_SYSINFO->CLK);
+  neorv32_uart0_printf("Clock speed:         %u Hz\n", neorv32_sysinfo_get_clk());
 
   neorv32_uart0_printf("Clock gating:        ");
   if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_CLOCK_GATING)) { neorv32_uart0_printf("enabled\n"); }

--- a/sw/lib/source/neorv32_spi.c
+++ b/sw/lib/source/neorv32_spi.c
@@ -99,7 +99,7 @@ uint32_t neorv32_spi_get_clock_speed(void) {
     tmp = 2 * PRSC_LUT[prsc_sel] * (1 + clock_div);
   }
 
-  return NEORV32_SYSINFO->CLK / tmp;
+  return neorv32_sysinfo_get_clk() / tmp;
 }
 
 

--- a/sw/lib/source/neorv32_sysinfo.c
+++ b/sw/lib/source/neorv32_sysinfo.c
@@ -1,0 +1,38 @@
+// ================================================================================ //
+// The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
+// Copyright (c) NEORV32 contributors.                                              //
+// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Licensed under the BSD-3-Clause license, see LICENSE for details.                //
+// SPDX-License-Identifier: BSD-3-Clause                                            //
+// ================================================================================ //
+
+/**
+ * @file neorv32_sysinfo.c
+ * @brief System Information Memory (SYSINFO) HW driver source file.
+ *
+ * @see https://stnolting.github.io/neorv32/sw/files.html
+ */
+
+#include "neorv32.h"
+
+
+/**********************************************************************//**
+ * Get current processor clock frequency.
+ *
+ * @return Clock frequency in Hz.
+ **************************************************************************/
+uint32_t neorv32_sysinfo_get_clk(void) {
+
+  return NEORV32_SYSINFO->CLK;
+}
+
+
+/**********************************************************************//**
+ * Set processor clock frequency.
+ *
+ * @param[in] clock Clock frequency in Hz.
+ **************************************************************************/
+void neorv32_sysinfo_set_clk(uint32_t clock) {
+
+  NEORV32_SYSINFO->CLK = clock;
+}

--- a/sw/lib/source/neorv32_uart.c
+++ b/sw/lib/source/neorv32_uart.c
@@ -61,7 +61,7 @@ void neorv32_uart_setup(neorv32_uart_t *UARTx, uint32_t baudrate, uint32_t irq_m
   UARTx->CTRL = 0;
 
   // raw clock prescaler
-  uint32_t clock = NEORV32_SYSINFO->CLK; // system clock in Hz
+  uint32_t clock = neorv32_sysinfo_get_clk(); // system clock in Hz
 #ifndef MAKE_BOOTLOADER // use div instructions
   baud_div = clock / (2*baudrate);
 #else // division via repeated subtraction (minimal size, only for bootloader)
@@ -355,16 +355,6 @@ void neorv32_uart_vprintf(neorv32_uart_t *UARTx, const char *format, va_list arg
           }
           neorv32_uart_puts(UARTx, string_buf);
           break;
-
-//      case 'f': // floating point: print binary representation in hex
-//        union { double fp64; uint32_t u32[2]; } fp2hex;
-//        neorv32_uart_puts(UARTx, "FP64:0x");
-//        fp2hex.fp64 = va_arg(args, double); // C promotes float to double!
-//        __neorv32_uart_tohex(fp2hex.u32[0], string_buf);
-//        neorv32_uart_puts(UARTx, string_buf);
-//        __neorv32_uart_tohex(fp2hex.u32[1], string_buf);
-//        neorv32_uart_puts(UARTx, string_buf);
-//        break;
 
         case '%': // escaped percent sign
           neorv32_uart_putc(UARTx, c);

--- a/sw/lib/source/neorv32_xip.c
+++ b/sw/lib/source/neorv32_xip.c
@@ -150,7 +150,7 @@ uint32_t neorv32_xip_get_clock_speed(void) {
     tmp = 2 * PRSC_LUT[prsc_sel] * (1 + clock_div);
   }
 
-  return NEORV32_SYSINFO->CLK / tmp;
+  return neorv32_sysinfo_get_clk() / tmp;
 }
 
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -1589,7 +1589,6 @@
           <name>CLK</name>
           <description>Processor clock speed in Hz</description>
           <addressOffset>0x00</addressOffset>
-          <access>read-only</access>
         </register>
         <register>
           <name>MEM</name>


### PR DESCRIPTION
Implementing #951 (option 3).

`NEORV32_SYSINFO.CLK` is now a real register that can be overridden by application software (e.g. to take into account any _dynamic_ frequency scaling of the processor clock). Upon reset, `CLK` is initialized from the `CLOCK_FREQUENCY` generic.