### PR TITLE
Minor RTL edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 09.08.2024 | 1.10.2.5 | minor HDL edits | [#984](https://github.com/stnolting/neorv32/pull/984) |
 | 06.08.2024 | 1.10.2.4 | :warning: **Vivado IP module**: constrain minimal ALL input/output size to 1; add explicit PWM controller enable option | [#980](https://github.com/stnolting/neorv32/pull/980) |
 | 05.08.2024 | 1.10.2.3 | :bug: fix bug in **Vivado IP module** (error zero-sized input port is unconnected) | [#978](https://github.com/stnolting/neorv32/pull/978) |
 | 04.08.2024 | 1.10.2.2 | :bug: fix bug in **Vivado IP module** (error if AXI port is unconnected) | [#976](https://github.com/stnolting/neorv32/pull/976) |

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -491,6 +491,7 @@ begin
   -- issue engine disabled --
   issue_engine_disabled:
   if not CPU_EXTENSION_RISCV_C generate
+    issue_engine.align     <= '0';
     issue_engine.align_set <= '0';
     issue_engine.align_clr <= '0';
     issue_engine.ci_i16    <= (others => '0');

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -402,7 +402,7 @@ begin
       FIFO_WIDTH => ipb.wdata(i)'length, -- size of data elements in fifo
       FIFO_RSYNC => false,               -- we NEED to read data asynchronously
       FIFO_SAFE  => false,               -- no safe access required (ensured by FIFO-external logic)
-      FULL_RESET => false                -- no HW reset, try to infer RAM primitives
+      FULL_RESET => REGFILE_HW_RST       -- default: no HW reset, try to infer RAM primitives
     )
     port map (
       -- control --
@@ -2193,6 +2193,7 @@ begin
   -- no HPMs implemented --
   hpmevent_gen_disable:
   if (not CPU_EXTENSION_RISCV_Zihpm) or (hpm_num_c = 0) generate
+    hpmevent_we  <= (others => '0');
     hpmevent_cfg <= (others => (others => '0'));
     hpmevent_rd  <= (others => (others => '0'));
   end generate;

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -47,8 +47,7 @@ end neorv32_cpu_pmp;
 architecture neorv32_cpu_pmp_rtl of neorv32_cpu_pmp is
 
   -- auto-configuration --
-  constant granularity_valid_c : boolean := is_power_of_two_f(GRANULARITY);
-  constant granularity_c       : natural := cond_sel_natural_f(granularity_valid_c, GRANULARITY, 2**index_size_f(GRANULARITY));
+  constant granularity_c : natural := cond_sel_natural_f(boolean(GRANULARITY < 4), 4, 2**index_size_f(GRANULARITY));
 
   -- PMP configuration register bits --
   constant cfg_r_c  : natural := 0; -- read permit
@@ -109,7 +108,7 @@ begin
 
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  assert granularity_valid_c report
+  assert (GRANULARITY = granularity_c) report
     "[NEORV32] Auto-adjusting invalid PMP granularity configuration." severity warning;
 
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100204"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100205"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 


### PR DESCRIPTION
* CPU control: terminate all unused signals (if the according extension disabled)
* fix PMP granularity configuration: auto-adjust configuration if PMP granularity is less than 4 bytes
* also build instruction prefetch buffer flip flops with hardware reset if `REGFILE_HW_RST` is enabled