### PR TITLE
RTL reworks, cleanups and optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 25.08.2024 | 1.10.2.8 | :warning: remove user-mode HPM counters; add individual `mocuntern` bits (`CY` and `IR`) rework Vivado IP module; minor RTL cleanups and optimization | [#996](https://github.com/stnolting/neorv32/pull/996) |
 | 16.08.2024 | 1.10.2.7 | minor CPU area and critical path optimizations; minor code cleanups | [#990](https://github.com/stnolting/neorv32/pull/990) |
 | 09.08.2024 | 1.10.2.6 | :warning: re-organize RTL files; all core files are now located in `rtl/core`; remove `mem` sub-folder | [#985](https://github.com/stnolting/neorv32/pull/985) |
 | 09.08.2024 | 1.10.2.5 | minor HDL edits | [#984](https://github.com/stnolting/neorv32/pull/984) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -783,9 +783,9 @@ See section <<_hardware_performance_monitors_hpm_csrs>> for a list of all HPM-re
 Note that only the machine-mode hardware performance counter CSR are available (`mhpmcounter*[h]`).
 Accessing any user-mode HPM CSR (`hpmcounter*[h]`) will raise an illegal instruction exception.
 
-.Auto-Increment
+.Increment Inhibit
 [TIP]
-The vent-driven increment of the HPMs can be deactivated individually via the <<_mcountinhibit>> CSR.
+The event-driven increment of the HPMs can be deactivated individually via the <<_mcountinhibit>> CSR.
 
 
 ==== `Zmmul` - ISA Extension

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -150,6 +150,7 @@ these two bus interfaces are merged into a single processor-internal bus via a p
 have higher priority). Hence, _all_ memory addresses including peripheral devices are mapped to a single unified 32-bit
 <<_address_space>>.
 
+.Linear/In-Order Execution Only
 [NOTE]
 The CPU does not perform any speculative/out-of-order operations at all. Hence, it is not vulnerable to security issues
 caused by speculative execution (like Spectre or Meltdown).
@@ -270,6 +271,7 @@ includes the <<_control_and_status_registers_csrs>> as well as the trap controll
 The NEORV32 CPU provides a single sleep mode that can be entered to power-down the core reducing
 dynamic power consumption. Sleep mode is entered by executing the `wfi` ("wait for interrupt") instruction.
 
+.Execution Details
 [NOTE]
 The `wfi` instruction will raise an illegal instruction exception when executed in user-mode
 if `TW` in <<_mstatus>> is set. When executed in debug-mode or during single-stepping `wfi` will behave as
@@ -409,7 +411,7 @@ operation is indicated by a **1** being returned via `rsp.data` together with `a
 .Three Exemplary LR/SC Bus Transactions
 image::bus_interface_atomic.png[700]
 
-.SC Status
+.Store-Conditional Status
 [NOTE]
 The "normal" load data mechanism is used to return success/failure of the `sc.w` instruction to the CPU (via the LSB of `rsp.data`).
 
@@ -569,6 +571,7 @@ The "compressed" ISA extension provides 16-bit encodings of commonly used instru
 The "embedded" ISA extensions reduces the size of the general purpose register file from 32 entries to 16 entries to
 shrink hardware size. It provides the same instructions as the the base `I` ISA extensions.
 
+.Alternative MABI
 [NOTE]
 Due to the reduced register file size an alternate toolchain ABI (`ilp32e*`) is required.
 
@@ -714,13 +717,19 @@ If a computational instruction generates a subnormal result it is also flushed t
 The `Zicntr` ISA extension adds the basic <<_cycleh>>, <<_mcycleh>>, <<_instreth>> and <<_minstreth>>
 counter CSRs. Section <<_machine_counter_and_timer_csrs>> shows a list of all `Zicntr`-related CSRs.
 
+.Time CSRs
 [NOTE]
 The user-mode `time[h]` CSRs are **not implemented**. Any access will trap allowing the trap handler to
 retrieve system time from the <<_machine_system_timer_mtime>>.
 
+.Mandatory Extension
 [NOTE]
 This extensions is stated as _mandatory_ by the RISC-V spec. However, area-constrained setups may remove
 support for these counters.
+
+.Constrained Access
+[TIP]
+User-level access to the counter CSRs can be constrained by the <<_mcounteren>> CSR.
 
 
 ==== `Zicond` ISA Extension
@@ -744,6 +753,7 @@ This ISA extensions provides instructions for accessing the <<_control_and_statu
 privileged-architecture extensions. This extension is mandatory and cannot be disabled. Hence, there is no generic
 for enabling/disabling this ISA extension.
 
+.Side-Effects if Destination is Zero-Register
 [NOTE]
 If `rd=x0` for the `csrrw[i]` instructions there will be no actual read access to the according CSR.
 However, access privileges are still enforced so these instruction variants _do_ cause side-effects
@@ -762,13 +772,20 @@ However, access privileges are still enforced so these instruction variants _do_
 
 In additions to the base counters the NEORV32 CPU provides up to 13 hardware performance monitors (HPM 3..15),
 which can be used to benchmark applications. Each HPM consists of an N-bit wide counter (split in a high-word 32-bit
-CSR and a low-word 32-bit CSR), where N is defined via the top's
-`HPM_CNT_WIDTH` generic and a corresponding event configuration CSR. The event configuration
-CSR defines the architectural events that lead to an increment of the associated HPM counter. See section
-<<_hardware_performance_monitors_hpm_csrs>> for a list of all HPM-related CSRs and event configurations.
+CSR and a low-word 32-bit CSR), where N is defined via the top's `HPM_CNT_WIDTH` generic and a corresponding event
+configuration CSR.
 
+The event configuration CSR defines the architectural events that lead to an increment of the associated HPM counter.
+See section <<_hardware_performance_monitors_hpm_csrs>> for a list of all HPM-related CSRs and event configurations.
+
+.Machine-Mode HPMs Only
+[NOTE]
+Note that only the machine-mode hardware performance counter CSR are available (`mhpmcounter*[h]`).
+Accessing any user-mode HPM CSR (`hpmcounter*[h]`) will raise an illegal instruction exception.
+
+.Auto-Increment
 [TIP]
-Auto-increment of the HPMs can be deactivated individually via the <<_mcountinhibit>> CSR.
+The vent-driven increment of the HPMs can be deactivated individually via the <<_mcountinhibit>> CSR.
 
 
 ==== `Zmmul` - ISA Extension

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -299,7 +299,7 @@ The vectored `mtvec` mode is useful for reducing the time between interrupt requ
 | Name        | Machine counter enable
 | Address     | `0x306`
 | Reset value | `0x00000000`
-| ISA         | `Zicsr` & `U`
+| ISA         | `Zicsr` & `Zicntr` & `U`
 | Description | The `mcounteren` CSR is used to constrain user-mode access to the CPU's counter CSRs.
 |=======================
 
@@ -311,7 +311,7 @@ The vectored `mtvec` mode is useful for reducing the time between interrupt requ
 | 0    | `CSR_MCOUNTEREN_CY` | r/w | **CY**: User-mode is allowed to read <<_cycleh>> CSRs when set
 | 1    | -                   | r/- | **TM**: not implemented, hardwired to zero
 | 2    | `CSR_MCOUNTEREN_IR` | r/w | **IR**: User-mode is allowed to read <<_instreth>> CSRs when set
-| 31:3 | -                   | r/- | **HPM**: not implemented, hardwired to zero
+| 31:3 | -                   | r/- | not implemented, hardwired to zero
 |=======================
 
 
@@ -532,7 +532,7 @@ See section <<_smpmp_isa_extension>> for more information.
 |             | `0x3a2` (`pmpcfg2`)
 |             | `0x3a3` (`pmpcfg3`)
 | Reset value | `0x00000000`
-| ISA         | `Zicsr` & `PMP`
+| ISA         | `Zicsr` & `Smpmp`
 | Description | Configuration of physical memory protection regions. Each region provides an individual 8-bit array in these CSRs.
 |=======================
 
@@ -581,7 +581,7 @@ The `pmpaddr*` CSRs are used to configure the region's address boundaries.
 |             | `0x3be` (`pmpaddr14`)
 |             | `0x3bf` (`pmpaddr15`)
 | Reset value | `0x00000000`
-| ISA         | `Zicsr` & `PMP`
+| ISA         | `Zicsr` & `Smpmp`
 | Description | Region address configuration. The two MSBs of each CSR are hardwired to zero (= bits 33:32 of the physical address).
 |=======================
 

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -72,8 +72,6 @@ to check if the targeted bits can actually be modified.
 | 0x323 .. 0x32f | <<_mhpmevent, `mhpmevent3`>> .. <<_mhpmevent, `mhpmevent15`>>             | `CSR_MHPMEVENT3` .. `CSR_MHPMEVENT15`       | MRW | Machine performance-monitoring event select for counter 3..15
 | 0xb03 .. 0xb0f | <<_mhpmcounterh, `mhpmcounter3`>> .. <<_mhpmcounterh, `mhpmcounter15`>>   | `CSR_MHPMCOUNTER3` .. `CSR_MHPMCOUNTER15`   | MRW | Machine performance-monitoring counter 3..15 low word
 | 0xb83 .. 0xb8f | <<_mhpmcounterh, `mhpmcounter3h`>> .. <<_mhpmcounterh, `mhpmcounter15h`>> | `CSR_MHPMCOUNTER3H` .. `CSR_MHPMCOUNTER15H` | MRW | Machine performance-monitoring counter 3..15 high word
-| 0xc03 .. 0xc0f | <<_hpmcounterh, `hpmcounter3`>> .. <<_hpmcounterh, `hpmcounter15`>>       | `CSR_HPMCOUNTER3`  .. `CSR_HPMCOUNTER15H`   | URO | User performance-monitoring counter 3..15 low word
-| 0xc83 .. 0xc8f | <<_hpmcounterh, `hpmcounter3h`>> .. <<_hpmcounterh, `hpmcounter15h`>>     | `CSR_HPMCOUNTER3H` .. `CSR_HPMCOUNTER15H`   | URO | User performance-monitoring counter 3..15 high word
 5+^| **<<_machine_information_csrs>>**
 | 0xf11 | <<_mvendorid>>  | `CSR_MVENDORID`  | MRO | Machine vendor ID
 | 0xf12 | <<_marchid>>    | `CSR_MARCHID`    | MRO | Machine architecture ID
@@ -309,17 +307,12 @@ The vectored `mtvec` mode is useful for reducing the time between interrupt requ
 [cols="^1,^1,<8"]
 [options="header",grid="rows"]
 |=======================
-| Bit   | R/W     | Function
-| 0     | r/w (!) | **CY**: User-mode is allowed to read <<_cycleh>> CSRs when set
-| 1     | r/-     | **TM**: not implemented, hardwired to zero
-| 2     | r/w (!) | **IR**: User-mode is allowed to read <<_instreth>> CSRs when set
-| 15:3  | r/w (!) | **HPM**: user-mode is allowed to read <<_hpmcounterh>> CSRs when set
+| Bit | Name [C] | R/W | Function
+| 0    | `CSR_MCOUNTEREN_CY` | r/w | **CY**: User-mode is allowed to read <<_cycleh>> CSRs when set
+| 1    | -                   | r/- | **TM**: not implemented, hardwired to zero
+| 2    | `CSR_MCOUNTEREN_IR` | r/w | **IR**: User-mode is allowed to read <<_instreth>> CSRs when set
+| 31:3 | -                   | r/- | **HPM**: not implemented, hardwired to zero
 |=======================
-
-[IMPORTANT]
-Physically, the NEORV32's `mcounteren` CSR is implemented as a **single 1-bit register**. Setting _any_ bit of
-the CSR will result in all bits being set. Hence, user-mode access can either be granted for **all** counter CSRs
-or entirely denied allowing access to **none** counter CSRs.
 
 
 {empty} +
@@ -708,12 +701,16 @@ Note that **all** executed instruction do increment the `[m]instret`[h] counters
 :sectnums:
 ==== Hardware Performance Monitors (HPM) CSRs
 
-The actual number of implemented hardware performance monitors is configured via the `HPM_NUM_CNTS` top entity generic,
-Note that always all 13 HPM counter and configuration registers (`mhpmcounter*[h]` and `mhpmevent*`) are implemented, but
-only the actually configured ones are implemented as "real" physical registers - the remaining ones will be hardwired to zero.
+.Machine-Mode HPMs Only
+[NOTE]
+Note that only the machine-mode hardware performance counter CSR are available (`mhpmcounter*[h]`).
+Accessing any user-mode HPM CSR (`hpmcounter*[h]`) will raise an illegal instruction exception.
 
+The actual number of implemented hardware performance monitors is configured via the `HPM_NUM_CNTS` top entity generic,
+Note that always all 13 HPM counter and configuration registers (`mhpmcounter*[h]`) are implemented, but
+only the actually configured ones are implemented as "real" physical registers - the remaining ones will be hardwired to zero.
 If trying to access an HPM-related CSR beyond `HPM_NUM_CNTS` **no illegal instruction exception is
-triggered**. These CSRs are read-only (writes are ignored) and always return zero.
+triggered**. These CSRs are read-only, writes are ignored and reads always return zero.
 
 The total counter width of the HPMs can be configured before synthesis via the `HPM_CNT_WIDTH` generic (0..64-bit).
 If `HPM_NUM_CNTS` is less than 64, all remaining MSB-aligned bits are hardwired to zero.
@@ -772,7 +769,7 @@ caused by a fence instruction, a control flow transfer or a instruction fetch bu
 .Instruction Retiring ("Retired == Executed")
 [IMPORTANT]
 The CPU HPM/counter logic treats all executed instruction as "retired" even if they raise an exception,
-cause an interrupt, trigger a privilege mode change or were not meant to retire (by the RISC-V spec.).
+cause an interrupt, trigger a privilege mode change or were not meant to retire (i.e. claimed by the RISC-V spec.).
 
 
 {empty} +
@@ -798,37 +795,9 @@ cause an interrupt, trigger a privilege mode change or were not meant to retire 
 |             | `0xb0f`, `0xb8f` (`mhpmcounter15`, `mhpmcounter15h`)
 | Reset value | `0x00000000`
 | ISA         | `Zicsr` & `Zihpm`
-| Description | If not halted via the <<_mcountinhibit>> CSR the HPM counter CSR(s) increment whenever a
+| Description | If not halted via the <<_mcountinhibit>> CSR the HPM counter CSR(s) increment whenever the
 configured event from the according <<_mhpmevent>> CSR occurs. The counter registers are read/write for machine mode
 and are not accessible for lower-privileged software.
-|=======================
-
-
-{empty} +
-[discrete]
-===== **`hpmcounter[h]`**
-
-[cols="<1,<8"]
-[frame="topbot",grid="none"]
-|=======================
-| Name        | User hardware performance monitor (HPM) counter
-| Address     | `0xc03`, `0xc83` (`hpmcounter3`, `hpmcounter3h`)
-|             | `0xc04`, `0xc84` (`hpmcounter4`, `hpmcounter4h`)
-|             | `0xc05`, `0xc85` (`hpmcounter5`, `hpmcounter5h`)
-|             | `0xc06`, `0xc86` (`hpmcounter6`, `hpmcounter6h`)
-|             | `0xc07`, `0xc87` (`hpmcounter7`, `hpmcounter7h`)
-|             | `0xc08`, `0xc88` (`hpmcounter8`, `hpmcounter8h`)
-|             | `0xc09`, `0xc89` (`hpmcounter9`, `hpmcounter9h`)
-|             | `0xc0a`, `0xc8a` (`hpmcounter10`, `hpmcounter10h`)
-|             | `0xc0b`, `0xc8b` (`hpmcounter11`, `hpmcounter11h`)
-|             | `0xc0c`, `0xc8c` (`hpmcounter12`, `hpmcounter12h`)
-|             | `0xc0d`, `0xc8d` (`hpmcounter13`, `hpmcounter13h`)
-|             | `0xc0e`, `0xc8e` (`hpmcounter14`, `hpmcounter14h`)
-|             | `0xc0f`, `0xc8f` (`hpmcounter15`, `hpmcounter15h`)
-| Reset value | `0x00000000`
-| ISA         | `Zicsr` & `Zihpm`
-| Description | The `hpmcounter*[h]` are user-mode shadow copies of the according <<_mhpmcounterh>> CSRs. The user mode
-counter CSRs are read-only. Any write access will raise an illegal instruction exception.
 |=======================
 
 

--- a/rtl/core/neorv32_cpu_cp_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_cp_muldiv.vhd
@@ -151,24 +151,30 @@ begin
   multiplier_core_parallel:
   if FAST_MUL_EN generate
 
-    -- direct approach --
-    multiplier_core: process(rstn_i, clk_i)
+    -- input registers --
+    multiplier_core_in_reg: process(rstn_i, clk_i)
     begin
       if (rstn_i = '0') then
         mul.dsp_x <= (others => '0');
         mul.dsp_y <= (others => '0');
-        mul.prod  <= (others => '0');
       elsif rising_edge(clk_i) then
         if (mul.start = '1') then
           mul.dsp_x <= signed((rs1_i(rs1_i'left) and ctrl.rs1_is_signed) & rs1_i);
           mul.dsp_y <= signed((rs2_i(rs2_i'left) and ctrl.rs2_is_signed) & rs2_i);
         end if;
-        mul.prod <= std_ulogic_vector(mul.dsp_z(63 downto 0));
       end if;
-    end process multiplier_core;
+    end process multiplier_core_in_reg;
 
     -- actual multiplication --
     mul.dsp_z <= mul.dsp_x * mul.dsp_y;
+
+    -- output register --
+    multiplier_core_out_reg: process(clk_i)
+    begin
+      if rising_edge(clk_i) then -- no reset to improve DSP mapping
+        mul.prod <= std_ulogic_vector(mul.dsp_z(63 downto 0));
+      end if;
+    end process multiplier_core_out_reg;
 
   end generate; --/multiplier_core_parallel
 

--- a/rtl/core/neorv32_crc.vhd
+++ b/rtl/core/neorv32_crc.vhd
@@ -122,10 +122,10 @@ begin
   end process crc_core;
 
   -- operation mode --
-	with crc.mode select crc.msb <=
-		crc.sreg(07) when "00",   -- crc8
-		crc.sreg(15) when "01",   -- crc16
-		crc.sreg(31) when others; -- crc32
+  with crc.mode select crc.msb <=
+    crc.sreg(07) when "00",   -- crc8
+    crc.sreg(15) when "01",   -- crc16
+    crc.sreg(31) when others; -- crc32
 
 
 end neorv32_crc_rtl;

--- a/rtl/core/neorv32_imem.vhd
+++ b/rtl/core/neorv32_imem.vhd
@@ -56,7 +56,7 @@ begin
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   assert false report
-    "[NEORV32] Implementing DEFAULT processor-internal IMEM as " &
+    "[NEORV32] Implementing processor-internal IMEM as " &
     cond_sel_string_f(IMEM_AS_IROM, "pre-initialized ROM.", "blank RAM.") severity note;
 
   assert not ((IMEM_AS_IROM = true) and (imem_app_size_c > IMEM_SIZE)) report

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100207"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100208"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -433,36 +433,10 @@ package neorv32_package is
   constant csr_cycle_c          : std_ulogic_vector(11 downto 0) := x"c00";
 --constant csr_time_c           : std_ulogic_vector(11 downto 0) := x"c01";
   constant csr_instret_c        : std_ulogic_vector(11 downto 0) := x"c02";
-  constant csr_hpmcounter3_c    : std_ulogic_vector(11 downto 0) := x"c03";
-  constant csr_hpmcounter4_c    : std_ulogic_vector(11 downto 0) := x"c04";
-  constant csr_hpmcounter5_c    : std_ulogic_vector(11 downto 0) := x"c05";
-  constant csr_hpmcounter6_c    : std_ulogic_vector(11 downto 0) := x"c06";
-  constant csr_hpmcounter7_c    : std_ulogic_vector(11 downto 0) := x"c07";
-  constant csr_hpmcounter8_c    : std_ulogic_vector(11 downto 0) := x"c08";
-  constant csr_hpmcounter9_c    : std_ulogic_vector(11 downto 0) := x"c09";
-  constant csr_hpmcounter10_c   : std_ulogic_vector(11 downto 0) := x"c0a";
-  constant csr_hpmcounter11_c   : std_ulogic_vector(11 downto 0) := x"c0b";
-  constant csr_hpmcounter12_c   : std_ulogic_vector(11 downto 0) := x"c0c";
-  constant csr_hpmcounter13_c   : std_ulogic_vector(11 downto 0) := x"c0d";
-  constant csr_hpmcounter14_c   : std_ulogic_vector(11 downto 0) := x"c0e";
-  constant csr_hpmcounter15_c   : std_ulogic_vector(11 downto 0) := x"c0f";
   --
   constant csr_cycleh_c         : std_ulogic_vector(11 downto 0) := x"c80";
 --constant csr_timeh_c          : std_ulogic_vector(11 downto 0) := x"c81";
   constant csr_instreth_c       : std_ulogic_vector(11 downto 0) := x"c82";
-  constant csr_hpmcounter3h_c   : std_ulogic_vector(11 downto 0) := x"c83";
-  constant csr_hpmcounter4h_c   : std_ulogic_vector(11 downto 0) := x"c84";
-  constant csr_hpmcounter5h_c   : std_ulogic_vector(11 downto 0) := x"c85";
-  constant csr_hpmcounter6h_c   : std_ulogic_vector(11 downto 0) := x"c86";
-  constant csr_hpmcounter7h_c   : std_ulogic_vector(11 downto 0) := x"c87";
-  constant csr_hpmcounter8h_c   : std_ulogic_vector(11 downto 0) := x"c88";
-  constant csr_hpmcounter9h_c   : std_ulogic_vector(11 downto 0) := x"c89";
-  constant csr_hpmcounter10h_c  : std_ulogic_vector(11 downto 0) := x"c8a";
-  constant csr_hpmcounter11h_c  : std_ulogic_vector(11 downto 0) := x"c8b";
-  constant csr_hpmcounter12h_c  : std_ulogic_vector(11 downto 0) := x"c8c";
-  constant csr_hpmcounter13h_c  : std_ulogic_vector(11 downto 0) := x"c8d";
-  constant csr_hpmcounter14h_c  : std_ulogic_vector(11 downto 0) := x"c8e";
-  constant csr_hpmcounter15h_c  : std_ulogic_vector(11 downto 0) := x"c8f";
   -- machine information registers --
   constant csr_mvendorid_c      : std_ulogic_vector(11 downto 0) := x"f11";
   constant csr_marchid_c        : std_ulogic_vector(11 downto 0) := x"f12";

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -30,8 +30,6 @@ set files [glob -nocomplain "$outputdir/*"]
 if {[llength $files] != 0} {
     puts "DELETING ALL FILES in $outputdir"
     file delete -force {*}[glob -directory $outputdir *];
-} else {
-    puts "$outputdir is empty"
 }
 
 
@@ -55,14 +53,11 @@ puts $file_list
 add_files $file_list
 set_property library neorv32 [get_files $file_list]
 
-# add IP top module
+# IP top module
 add_file $neorv32_home/rtl/system_integration/$rtl_top
 set_property library neorv32 [get_files [glob $neorv32_home/rtl/system_integration/$rtl_top]]
-
-# Compile top module with VHDL2008 standard to allow connecting std_logic_vector and std_ulogic_vector without casting (#974)
-set_property file_type {VHDL 2008} [get_files [glob $neorv32_home/rtl/system_integration/$rtl_top]]
-
 ##set_property top $rtl_top [current_fileset]
+
 update_compile_order -fileset sources_1
 
 
@@ -249,48 +244,48 @@ ipgui::move_param -component [ipx::current_core] -order 14 [ipgui::get_guiparams
 # **************************************************************
 # Configuration GUI: Peripherals
 # **************************************************************
-set_property display_name {Enable external interrupt controller (XIRQ)}           [ipgui::get_guiparamspec -name "XIRQ_EN"               -component [ipx::current_core]]
-set_property display_name {External interrupt controller (XIRQ) channels}         [ipgui::get_guiparamspec -name "XIRQ_NUM_CH"           -component [ipx::current_core]]
-set_property display_name {Enable general-purpose input/output controller (GPIO)} [ipgui::get_guiparamspec -name "IO_GPIO_EN"            -component [ipx::current_core]]
-set_property display_name {General-purpose inputs}                                [ipgui::get_guiparamspec -name "IO_GPIO_IN_NUM"        -component [ipx::current_core]]
-set_property display_name {General-purpose outputs}                               [ipgui::get_guiparamspec -name "IO_GPIO_OUT_NUM"       -component [ipx::current_core]]
-set_property display_name {Machine timer}                                         [ipgui::get_guiparamspec -name "IO_MTIME_EN"           -component [ipx::current_core]]
-set_property display_name {Primary UART (UART0)}                                  [ipgui::get_guiparamspec -name "IO_UART0_EN"           -component [ipx::current_core]]
-set_property display_name {Primary UART (UART0) RX FIFO depth}                    [ipgui::get_guiparamspec -name "IO_UART0_RX_FIFO"      -component [ipx::current_core]]
-set_property tooltip      {Number of entries (use a power of two)}                [ipgui::get_guiparamspec -name "IO_UART0_RX_FIFO"      -component [ipx::current_core]]
-set_property display_name {Primary UART (UART0) TX FIFO depth}                    [ipgui::get_guiparamspec -name "IO_UART0_TX_FIFO"      -component [ipx::current_core]]
-set_property tooltip      {Number of entries (use a power of two)}                [ipgui::get_guiparamspec -name "IO_UART0_TX_FIFO"      -component [ipx::current_core]]
-set_property display_name {Secondary UART (UART1)}                                [ipgui::get_guiparamspec -name "IO_UART1_EN"           -component [ipx::current_core]]
-set_property display_name {Secondary UART (UART1) RX FIFO depth}                  [ipgui::get_guiparamspec -name "IO_UART1_RX_FIFO"      -component [ipx::current_core]]
-set_property tooltip      {Number of entries (use a power of two)}                [ipgui::get_guiparamspec -name "IO_UART1_RX_FIFO"      -component [ipx::current_core]]
-set_property display_name {Secondary UART (UART1) TX FIFO depth}                  [ipgui::get_guiparamspec -name "IO_UART1_TX_FIFO"      -component [ipx::current_core]]
-set_property tooltip      {Number of entries (use a power of two)}                [ipgui::get_guiparamspec -name "IO_UART1_TX_FIFO"      -component [ipx::current_core]]
-set_property display_name {SPI}                                                   [ipgui::get_guiparamspec -name "IO_SPI_EN"             -component [ipx::current_core]]
-set_property display_name {SPI FIFO depth}                                        [ipgui::get_guiparamspec -name "IO_SPI_FIFO"           -component [ipx::current_core]]
-set_property tooltip      {Number of entries (use a power of two)}                [ipgui::get_guiparamspec -name "IO_SPI_FIFO"           -component [ipx::current_core]]
-set_property display_name {SDI}                                                   [ipgui::get_guiparamspec -name "IO_SDI_EN"             -component [ipx::current_core]]
-set_property display_name {SDI FIFO depth}                                        [ipgui::get_guiparamspec -name "IO_SDI_FIFO"           -component [ipx::current_core]]
-set_property tooltip      {Number of entries (use a power of two)}                [ipgui::get_guiparamspec -name "IO_SDI_FIFO"           -component [ipx::current_core]]
-set_property display_name {TWI}                                                   [ipgui::get_guiparamspec -name "IO_TWI_EN"             -component [ipx::current_core]]
-set_property display_name {TWI FIFO depth}                                        [ipgui::get_guiparamspec -name "IO_TWI_FIFO"           -component [ipx::current_core]]
-set_property tooltip      {Number of entries (use a power of two)}                [ipgui::get_guiparamspec -name "IO_TWI_FIFO"           -component [ipx::current_core]]
-set_property display_name {Enable PWM controller}                                 [ipgui::get_guiparamspec -name "IO_PWM_EN"             -component [ipx::current_core]]
-set_property display_name {PWM channels}                                          [ipgui::get_guiparamspec -name "IO_PWM_NUM_CH"         -component [ipx::current_core]]
-set_property display_name {Watchdog}                                              [ipgui::get_guiparamspec -name "IO_WDT_EN"             -component [ipx::current_core]]
-set_property display_name {TRNG}                                                  [ipgui::get_guiparamspec -name "IO_TRNG_EN"            -component [ipx::current_core]]
-set_property display_name {TRNG FIFO depth}                                       [ipgui::get_guiparamspec -name "IO_TRNG_FIFO"          -component [ipx::current_core]]
-set_property tooltip      {Number of entries (use a power of two)}                [ipgui::get_guiparamspec -name "IO_TRNG_FIFO"          -component [ipx::current_core]]
-set_property display_name {Custom Functions Subsystem (CFU)}                      [ipgui::get_guiparamspec -name "IO_CFS_EN"             -component [ipx::current_core]]
-set_property display_name {Custom Functions Subsystem (CFU) configuration string} [ipgui::get_guiparamspec -name "IO_CFS_CONFIG"         -component [ipx::current_core]]
-set_property display_name {Custom Functions Subsystem (CFU) input port width}     [ipgui::get_guiparamspec -name "IO_CFS_IN_SIZE"        -component [ipx::current_core]]
-set_property display_name {Custom Functions Subsystem (CFU) output port width}    [ipgui::get_guiparamspec -name "IO_CFS_OUT_SIZE"       -component [ipx::current_core]]
-set_property display_name {NEOLED}                                                [ipgui::get_guiparamspec -name "IO_NEOLED_EN"          -component [ipx::current_core]]
-set_property display_name {NEOLED FIFO depth}                                     [ipgui::get_guiparamspec -name "IO_NEOLED_TX_FIFO"     -component [ipx::current_core]]
-set_property tooltip      {Number of entries (use a power of two)}                [ipgui::get_guiparamspec -name "IO_NEOLED_TX_FIFO"     -component [ipx::current_core]]
-set_property display_name {General Purpose Timer (GPTM)}                          [ipgui::get_guiparamspec -name "IO_GPTMR_EN"           -component [ipx::current_core]]
-set_property display_name {ONEWIRE}                                               [ipgui::get_guiparamspec -name "IO_ONEWIRE_EN"         -component [ipx::current_core]]
-set_property display_name {DMA controller}                                        [ipgui::get_guiparamspec -name "IO_DMA_EN"             -component [ipx::current_core]]
-set_property display_name {CRC Unit}                                              [ipgui::get_guiparamspec -name "IO_CRC_EN"             -component [ipx::current_core]]
+set_property display_name {External interrupt controller (XIRQ)}                [ipgui::get_guiparamspec -name "XIRQ_EN"               -component [ipx::current_core]]
+set_property display_name {External interrupt controller (XIRQ) channels}       [ipgui::get_guiparamspec -name "XIRQ_NUM_CH"           -component [ipx::current_core]]
+set_property display_name {General-Purpose Input/Output (GPIO) controller}      [ipgui::get_guiparamspec -name "IO_GPIO_EN"            -component [ipx::current_core]]
+set_property display_name {General-purpose (GPIO) inputs}                       [ipgui::get_guiparamspec -name "IO_GPIO_IN_NUM"        -component [ipx::current_core]]
+set_property display_name {General-purpose (GPIO) outputs}                      [ipgui::get_guiparamspec -name "IO_GPIO_OUT_NUM"       -component [ipx::current_core]]
+set_property display_name {Machine timer (MTIME)}                               [ipgui::get_guiparamspec -name "IO_MTIME_EN"           -component [ipx::current_core]]
+set_property display_name {Primary UART (UART0)}                                [ipgui::get_guiparamspec -name "IO_UART0_EN"           -component [ipx::current_core]]
+set_property display_name {Primary UART (UART0) RX FIFO depth}                  [ipgui::get_guiparamspec -name "IO_UART0_RX_FIFO"      -component [ipx::current_core]]
+set_property tooltip      {Number of entries (use a power of two)}              [ipgui::get_guiparamspec -name "IO_UART0_RX_FIFO"      -component [ipx::current_core]]
+set_property display_name {Primary UART (UART0) TX FIFO depth}                  [ipgui::get_guiparamspec -name "IO_UART0_TX_FIFO"      -component [ipx::current_core]]
+set_property tooltip      {Number of entries (use a power of two)}              [ipgui::get_guiparamspec -name "IO_UART0_TX_FIFO"      -component [ipx::current_core]]
+set_property display_name {Secondary UART (UART1)}                              [ipgui::get_guiparamspec -name "IO_UART1_EN"           -component [ipx::current_core]]
+set_property display_name {Secondary UART (UART1) RX FIFO depth}                [ipgui::get_guiparamspec -name "IO_UART1_RX_FIFO"      -component [ipx::current_core]]
+set_property tooltip      {Number of entries (use a power of two)}              [ipgui::get_guiparamspec -name "IO_UART1_RX_FIFO"      -component [ipx::current_core]]
+set_property display_name {Secondary UART (UART1) TX FIFO depth}                [ipgui::get_guiparamspec -name "IO_UART1_TX_FIFO"      -component [ipx::current_core]]
+set_property tooltip      {Number of entries (use a power of two)}              [ipgui::get_guiparamspec -name "IO_UART1_TX_FIFO"      -component [ipx::current_core]]
+set_property display_name {SPI host controller (SPI)}                           [ipgui::get_guiparamspec -name "IO_SPI_EN"             -component [ipx::current_core]]
+set_property display_name {SPI host controller (SPI) FIFO depth}                [ipgui::get_guiparamspec -name "IO_SPI_FIFO"           -component [ipx::current_core]]
+set_property tooltip      {Number of entries (use a power of two)}              [ipgui::get_guiparamspec -name "IO_SPI_FIFO"           -component [ipx::current_core]]
+set_property display_name {SPI device controller (SDI)}                         [ipgui::get_guiparamspec -name "IO_SDI_EN"             -component [ipx::current_core]]
+set_property display_name {SPI device controller (SDI) FIFO depth}              [ipgui::get_guiparamspec -name "IO_SDI_FIFO"           -component [ipx::current_core]]
+set_property tooltip      {Number of entries (use a power of two)}              [ipgui::get_guiparamspec -name "IO_SDI_FIFO"           -component [ipx::current_core]]
+set_property display_name {Two-Wire/I2C Interface (TWI)}                        [ipgui::get_guiparamspec -name "IO_TWI_EN"             -component [ipx::current_core]]
+set_property display_name {Two-Wire/I2C Interface (TWI) FIFO depth}             [ipgui::get_guiparamspec -name "IO_TWI_FIFO"           -component [ipx::current_core]]
+set_property tooltip      {Number of entries (use a power of two)}              [ipgui::get_guiparamspec -name "IO_TWI_FIFO"           -component [ipx::current_core]]
+set_property display_name {Pulse-Width Moduleation (PWM) controller}            [ipgui::get_guiparamspec -name "IO_PWM_EN"             -component [ipx::current_core]]
+set_property display_name {Pulse-Width Moduleation (PWM) channels}              [ipgui::get_guiparamspec -name "IO_PWM_NUM_CH"         -component [ipx::current_core]]
+set_property display_name {Watchdog timer (WDT)}                                [ipgui::get_guiparamspec -name "IO_WDT_EN"             -component [ipx::current_core]]
+set_property display_name {True-Random-Number Generator (TRNG)}                 [ipgui::get_guiparamspec -name "IO_TRNG_EN"            -component [ipx::current_core]]
+set_property display_name {True-Random-Number Generator (TRNG) FIFO depth}      [ipgui::get_guiparamspec -name "IO_TRNG_FIFO"          -component [ipx::current_core]]
+set_property tooltip      {Number of entries (use a power of two)}              [ipgui::get_guiparamspec -name "IO_TRNG_FIFO"          -component [ipx::current_core]]
+set_property display_name {Custom Functions Subsystem (CFS)}                    [ipgui::get_guiparamspec -name "IO_CFS_EN"             -component [ipx::current_core]]
+set_property display_name {Custom Functions Subsystem (CFS) configuration word} [ipgui::get_guiparamspec -name "IO_CFS_CONFIG"         -component [ipx::current_core]]
+set_property display_name {Custom Functions Subsystem (CFS) input port width}   [ipgui::get_guiparamspec -name "IO_CFS_IN_SIZE"        -component [ipx::current_core]]
+set_property display_name {Custom Functions Subsystem (CFS) output port width}  [ipgui::get_guiparamspec -name "IO_CFS_OUT_SIZE"       -component [ipx::current_core]]
+set_property display_name {Smart LED Interface (NEOLED)}                        [ipgui::get_guiparamspec -name "IO_NEOLED_EN"          -component [ipx::current_core]]
+set_property display_name {Smart LED Interface (NEOLED) FIFO depth}             [ipgui::get_guiparamspec -name "IO_NEOLED_TX_FIFO"     -component [ipx::current_core]]
+set_property tooltip      {Number of entries (use a power of two)}              [ipgui::get_guiparamspec -name "IO_NEOLED_TX_FIFO"     -component [ipx::current_core]]
+set_property display_name {General Purpose Timer (GPTMR)}                       [ipgui::get_guiparamspec -name "IO_GPTMR_EN"           -component [ipx::current_core]]
+set_property display_name {1-Wire (ONEWIRE) controller}                         [ipgui::get_guiparamspec -name "IO_ONEWIRE_EN"         -component [ipx::current_core]]
+set_property display_name {Direct Memory Access (DMA) controller}               [ipgui::get_guiparamspec -name "IO_DMA_EN"             -component [ipx::current_core]]
+set_property display_name {Cyclic Redundancy Check (CRC) Unit}                  [ipgui::get_guiparamspec -name "IO_CRC_EN"             -component [ipx::current_core]]
 
 ipgui::add_group -name {Peripherals} -component [ipx::current_core] -parent [ipgui::get_pagespec -name "Page 0" -component [ipx::current_core]] -display_name {Peripherals}
 ipgui::move_group -component [ipx::current_core] -order  3 [ipgui::get_groupspec    -name "Peripherals"           -component [ipx::current_core]] -parent [ipgui::get_pagespec  -name "Page 0"      -component [ipx::current_core]]
@@ -355,6 +350,6 @@ update_ip_catalog
 
 
 # **************************************************************
-# Close temporary IP-building project
+# Close IP-packaging project
 # **************************************************************
 close_project

--- a/sw/lib/include/neorv32_cpu_csr.h
+++ b/sw/lib/include/neorv32_cpu_csr.h
@@ -24,51 +24,51 @@
  **************************************************************************/
 enum NEORV32_CSR_enum {
   /* floating-point unit control and status */
-  CSR_FFLAGS         = 0x001, /**< 0x001 - fflags: Floating-point accrued exception flags */
+  CSR_FFLAGS         = 0x001, /**< 0x001 - fflags: Floating-point accrued exception flags (#NEORV32_CSR_FFLAGS_enum) */
   CSR_FRM            = 0x002, /**< 0x002 - frm:    Floating-point dynamic rounding mode */
   CSR_FCSR           = 0x003, /**< 0x003 - fcsr:   Floating-point control/status register (frm + fflags) */
 
   /* machine control and status */
-  CSR_MSTATUS        = 0x300, /**< 0x300 - mstatus:       Machine status register */
-  CSR_MISA           = 0x301, /**< 0x301 - misa:          Machine ISA and extensions */
-  CSR_MIE            = 0x304, /**< 0x304 - mie:           Machine interrupt-enable register */
+  CSR_MSTATUS        = 0x300, /**< 0x300 - mstatus:       Machine status register (#NEORV32_CSR_MSTATUS_enum) */
+  CSR_MISA           = 0x301, /**< 0x301 - misa:          Machine ISA and extensions (#NEORV32_CSR_MISA_enum) */
+  CSR_MIE            = 0x304, /**< 0x304 - mie:           Machine interrupt-enable register (#NEORV32_CSR_MIE_enum) */
   CSR_MTVEC          = 0x305, /**< 0x305 - mtvec:         Machine trap-handler base address */
-  CSR_MCOUNTEREN     = 0x306, /**< 0x305 - mcounteren:    Machine counter enable register */
+  CSR_MCOUNTEREN     = 0x306, /**< 0x305 - mcounteren:    Machine counter enable register (#NEORV32_CSR_MCOUNTEREN_enum) */
   CSR_MSTATUSH       = 0x310, /**< 0x310 - mstatush:      Machine status register - high word */
-  CSR_MCOUNTINHIBIT  = 0x320, /**< 0x320 - mcountinhibit: Machine counter-inhibit register */
+  CSR_MCOUNTINHIBIT  = 0x320, /**< 0x320 - mcountinhibit: Machine counter-inhibit register (#NEORV32_CSR_MCOUNTINHIBIT_enum) */
 
   /* machine configuration */
   CSR_MENVCFG        = 0x30a, /**< 0x30a - menvcfg:  Machine environment configuration register - low word */
   CSR_MENVCFGH       = 0x31a, /**< 0x31a - menvcfgh: Machine environment configuration register - high word */
 
   /* hardware performance monitors - event configuration */
-  CSR_MHPMEVENT3     = 0x323, /**< 0x323 - mhpmevent3:  Machine hardware performance monitor event selector 3  */
-  CSR_MHPMEVENT4     = 0x324, /**< 0x324 - mhpmevent4:  Machine hardware performance monitor event selector 4  */
-  CSR_MHPMEVENT5     = 0x325, /**< 0x325 - mhpmevent5:  Machine hardware performance monitor event selector 5  */
-  CSR_MHPMEVENT6     = 0x326, /**< 0x326 - mhpmevent6:  Machine hardware performance monitor event selector 6  */
-  CSR_MHPMEVENT7     = 0x327, /**< 0x327 - mhpmevent7:  Machine hardware performance monitor event selector 7  */
-  CSR_MHPMEVENT8     = 0x328, /**< 0x328 - mhpmevent8:  Machine hardware performance monitor event selector 8  */
-  CSR_MHPMEVENT9     = 0x329, /**< 0x329 - mhpmevent9:  Machine hardware performance monitor event selector 9  */
-  CSR_MHPMEVENT10    = 0x32a, /**< 0x32a - mhpmevent10: Machine hardware performance monitor event selector 10 */
-  CSR_MHPMEVENT11    = 0x32b, /**< 0x32b - mhpmevent11: Machine hardware performance monitor event selector 11 */
-  CSR_MHPMEVENT12    = 0x32c, /**< 0x32c - mhpmevent12: Machine hardware performance monitor event selector 12 */
-  CSR_MHPMEVENT13    = 0x32d, /**< 0x32d - mhpmevent13: Machine hardware performance monitor event selector 13 */
-  CSR_MHPMEVENT14    = 0x32e, /**< 0x32e - mhpmevent14: Machine hardware performance monitor event selector 14 */
-  CSR_MHPMEVENT15    = 0x32f, /**< 0x32f - mhpmevent15: Machine hardware performance monitor event selector 15 */
+  CSR_MHPMEVENT3     = 0x323, /**< 0x323 - mhpmevent3:  Machine hardware performance monitor event selector 3  (#NEORV32_HPMCNT_EVENT_enum) */
+  CSR_MHPMEVENT4     = 0x324, /**< 0x324 - mhpmevent4:  Machine hardware performance monitor event selector 4  (#NEORV32_HPMCNT_EVENT_enum) */
+  CSR_MHPMEVENT5     = 0x325, /**< 0x325 - mhpmevent5:  Machine hardware performance monitor event selector 5  (#NEORV32_HPMCNT_EVENT_enum) */
+  CSR_MHPMEVENT6     = 0x326, /**< 0x326 - mhpmevent6:  Machine hardware performance monitor event selector 6  (#NEORV32_HPMCNT_EVENT_enum) */
+  CSR_MHPMEVENT7     = 0x327, /**< 0x327 - mhpmevent7:  Machine hardware performance monitor event selector 7  (#NEORV32_HPMCNT_EVENT_enum) */
+  CSR_MHPMEVENT8     = 0x328, /**< 0x328 - mhpmevent8:  Machine hardware performance monitor event selector 8  (#NEORV32_HPMCNT_EVENT_enum) */
+  CSR_MHPMEVENT9     = 0x329, /**< 0x329 - mhpmevent9:  Machine hardware performance monitor event selector 9  (#NEORV32_HPMCNT_EVENT_enum) */
+  CSR_MHPMEVENT10    = 0x32a, /**< 0x32a - mhpmevent10: Machine hardware performance monitor event selector 10 (#NEORV32_HPMCNT_EVENT_enum) */
+  CSR_MHPMEVENT11    = 0x32b, /**< 0x32b - mhpmevent11: Machine hardware performance monitor event selector 11 (#NEORV32_HPMCNT_EVENT_enum) */
+  CSR_MHPMEVENT12    = 0x32c, /**< 0x32c - mhpmevent12: Machine hardware performance monitor event selector 12 (#NEORV32_HPMCNT_EVENT_enum) */
+  CSR_MHPMEVENT13    = 0x32d, /**< 0x32d - mhpmevent13: Machine hardware performance monitor event selector 13 (#NEORV32_HPMCNT_EVENT_enum) */
+  CSR_MHPMEVENT14    = 0x32e, /**< 0x32e - mhpmevent14: Machine hardware performance monitor event selector 14 (#NEORV32_HPMCNT_EVENT_enum) */
+  CSR_MHPMEVENT15    = 0x32f, /**< 0x32f - mhpmevent15: Machine hardware performance monitor event selector 15 (#NEORV32_HPMCNT_EVENT_enum) */
 
   /* machine trap control */
   CSR_MSCRATCH       = 0x340, /**< 0x340 - mscratch: Machine scratch register */
   CSR_MEPC           = 0x341, /**< 0x341 - mepc:     Machine exception program counter */
-  CSR_MCAUSE         = 0x342, /**< 0x342 - mcause:   Machine trap cause */
+  CSR_MCAUSE         = 0x342, /**< 0x342 - mcause:   Machine trap cause (#NEORV32_EXCEPTION_CODES_enum) */
   CSR_MTVAL          = 0x343, /**< 0x343 - mtval:    Machine trap value */
-  CSR_MIP            = 0x344, /**< 0x344 - mip:      Machine interrupt pending register */
+  CSR_MIP            = 0x344, /**< 0x344 - mip:      Machine interrupt pending register (#NEORV32_CSR_MIP_enum) */
   CSR_MTINST         = 0x34a, /**< 0x34a - mtinst:   Machine trap instruction */
 
   /* physical memory protection */
-  CSR_PMPCFG0        = 0x3a0, /**< 0x3a0 - pmpcfg0: Physical memory protection configuration register 0 (regions 0..3) */
-  CSR_PMPCFG1        = 0x3a1, /**< 0x3a1 - pmpcfg1: Physical memory protection configuration register 1 (regions 4..7) */
-  CSR_PMPCFG2        = 0x3a2, /**< 0x3a2 - pmpcfg2: Physical memory protection configuration register 2 (regions 8..11) */
-  CSR_PMPCFG3        = 0x3a3, /**< 0x3a3 - pmpcfg3: Physical memory protection configuration register 3 (regions 12..15) */
+  CSR_PMPCFG0        = 0x3a0, /**< 0x3a0 - pmpcfg0: Physical memory protection configuration register 0: regions 0..3 (#NEORV32_PMPCFG_ATTRIBUTES_enum, #NEORV32_PMP_MODES_enum) */
+  CSR_PMPCFG1        = 0x3a1, /**< 0x3a1 - pmpcfg1: Physical memory protection configuration register 1: regions 4..7 (#NEORV32_PMPCFG_ATTRIBUTES_enum, #NEORV32_PMP_MODES_enum) */
+  CSR_PMPCFG2        = 0x3a2, /**< 0x3a2 - pmpcfg2: Physical memory protection configuration register 2: regions 8..11 (#NEORV32_PMPCFG_ATTRIBUTES_enum, #NEORV32_PMP_MODES_enum) */
+  CSR_PMPCFG3        = 0x3a3, /**< 0x3a3 - pmpcfg3: Physical memory protection configuration register 3: regions 12..15 (#NEORV32_PMPCFG_ATTRIBUTES_enum, #NEORV32_PMP_MODES_enum) */
 
   CSR_PMPADDR0       = 0x3b0, /**< 0x3b0 - pmpaddr0: Physical memory protection address register 0 */
   CSR_PMPADDR1       = 0x3b1, /**< 0x3b1 - pmpaddr1: Physical memory protection address register 1 */
@@ -140,35 +140,9 @@ enum NEORV32_CSR_enum {
   /* user counters and timers */
   CSR_CYCLE          = 0xc00, /**< 0xc00 - cycle:        User cycle counter low word */
   CSR_INSTRET        = 0xc02, /**< 0xc02 - instret:      User instructions-retired counter low word */
-  CSR_HPMCOUNTER3    = 0xc03, /**< 0xc03 - hpmcounter3:  User hardware performance monitor 3  counter low word */
-  CSR_HPMCOUNTER4    = 0xc04, /**< 0xc04 - hpmcounter4:  User hardware performance monitor 4  counter low word */
-  CSR_HPMCOUNTER5    = 0xc05, /**< 0xc05 - hpmcounter5:  User hardware performance monitor 5  counter low word */
-  CSR_HPMCOUNTER6    = 0xc06, /**< 0xc06 - hpmcounter6:  User hardware performance monitor 6  counter low word */
-  CSR_HPMCOUNTER7    = 0xc07, /**< 0xc07 - hpmcounter7:  User hardware performance monitor 7  counter low word */
-  CSR_HPMCOUNTER8    = 0xc08, /**< 0xc08 - hpmcounter8:  User hardware performance monitor 8  counter low word */
-  CSR_HPMCOUNTER9    = 0xc09, /**< 0xc09 - hpmcounter9:  User hardware performance monitor 9  counter low word */
-  CSR_HPMCOUNTER10   = 0xc0a, /**< 0xc0a - hpmcounter10: User hardware performance monitor 10 counter low word */
-  CSR_HPMCOUNTER11   = 0xc0b, /**< 0xc0b - hpmcounter11: User hardware performance monitor 11 counter low word */
-  CSR_HPMCOUNTER12   = 0xc0c, /**< 0xc0c - hpmcounter12: User hardware performance monitor 12 counter low word */
-  CSR_HPMCOUNTER13   = 0xc0d, /**< 0xc0d - hpmcounter13: User hardware performance monitor 13 counter low word */
-  CSR_HPMCOUNTER14   = 0xc0e, /**< 0xc0e - hpmcounter14: User hardware performance monitor 14 counter low word */
-  CSR_HPMCOUNTER15   = 0xc0f, /**< 0xc0f - hpmcounter15: User hardware performance monitor 15 counter low word */
 
   CSR_CYCLEH         = 0xc80, /**< 0xc80 - cycleh:        User cycle counter high word */
   CSR_INSTRETH       = 0xc82, /**< 0xc82 - instreth:      User instructions-retired counter high word */
-  CSR_HPMCOUNTER3H   = 0xc83, /**< 0xc83 - hpmcounter3h:  User hardware performance monitor 3  counter high word */
-  CSR_HPMCOUNTER4H   = 0xc84, /**< 0xc84 - hpmcounter4h:  User hardware performance monitor 4  counter high word */
-  CSR_HPMCOUNTER5H   = 0xc85, /**< 0xc85 - hpmcounter5h:  User hardware performance monitor 5  counter high word */
-  CSR_HPMCOUNTER6H   = 0xc86, /**< 0xc86 - hpmcounter6h:  User hardware performance monitor 6  counter high word */
-  CSR_HPMCOUNTER7H   = 0xc87, /**< 0xc87 - hpmcounter7h:  User hardware performance monitor 7  counter high word */
-  CSR_HPMCOUNTER8H   = 0xc88, /**< 0xc88 - hpmcounter8h:  User hardware performance monitor 8  counter high word */
-  CSR_HPMCOUNTER9H   = 0xc89, /**< 0xc89 - hpmcounter9h:  User hardware performance monitor 9  counter high word */
-  CSR_HPMCOUNTER10H  = 0xc8a, /**< 0xc8a - hpmcounter10h: User hardware performance monitor 10 counter high word */
-  CSR_HPMCOUNTER11H  = 0xc8b, /**< 0xc8b - hpmcounter11h: User hardware performance monitor 11 counter high word */
-  CSR_HPMCOUNTER12H  = 0xc8c, /**< 0xc8c - hpmcounter12h: User hardware performance monitor 12 counter high word */
-  CSR_HPMCOUNTER13H  = 0xc8d, /**< 0xc8d - hpmcounter13h: User hardware performance monitor 13 counter high word */
-  CSR_HPMCOUNTER14H  = 0xc8e, /**< 0xc8e - hpmcounter14h: User hardware performance monitor 14 counter high word */
-  CSR_HPMCOUNTER15H  = 0xc8f, /**< 0xc8f - hpmcounter15h: User hardware performance monitor 15 counter high word */
 
   /* machine information registers */
   CSR_MVENDORID      = 0xf11, /**< 0xf11 - mvendorid:  Machine vendor ID */
@@ -176,12 +150,12 @@ enum NEORV32_CSR_enum {
   CSR_MIMPID         = 0xf13, /**< 0xf13 - mimpid:     Machine implementation ID */
   CSR_MHARTID        = 0xf14, /**< 0xf14 - mhartid:    Machine hardware thread ID */
   CSR_MCONFIGPTR     = 0xf15, /**< 0xf15 - mconfigptr: Machine configuration pointer register */
-  CSR_MXISA          = 0xfc0  /**< 0xfc0 - mxisa:      Machine extended ISA and extensions (NEORV32-specific) */
+  CSR_MXISA          = 0xfc0  /**< 0xfc0 - mxisa:      Machine extended ISA and extensions (#NEORV32_CSR_XISA_enum) */
 };
 
 
 /**********************************************************************//**
- * CPU <b>fflags (fcsr)</b> CSR (r/w): FPU accrued exception flags
+ * CPU fflags (fcsr)</b> CSR (r/w): FPU accrued exception flags
  **************************************************************************/
 enum NEORV32_CSR_FFLAGS_enum {
   CSR_FFLAGS_NX = 0, /**< CPU fflags CSR (0): NX - inexact (r/w) */
@@ -193,7 +167,16 @@ enum NEORV32_CSR_FFLAGS_enum {
 
 
 /**********************************************************************//**
- * CPU <b>mstatus</b> CSR (r/w): Machine status
+ * CPU mcountern CSR (r/w): Machine counter-enable register
+ **************************************************************************/
+enum NEORV32_CSR_MCOUNTEREN_enum {
+  CSR_MCOUNTEREN_CY = 0, /**< CPU mcountern CSR (0): CY - cycle counter (r/w) */
+  CSR_MCOUNTEREN_IR = 2  /**< CPU mcountern CSR (2): IR instruction-retired counter (r/w) */
+};
+
+
+/**********************************************************************//**
+ * CPU mstatus CSR (r/w): Machine status
  **************************************************************************/
 enum NEORV32_CSR_MSTATUS_enum {
   CSR_MSTATUS_MIE   =  3, /**< CPU mstatus CSR  (3): MIE - Machine interrupt enable bit (r/w) */
@@ -206,7 +189,7 @@ enum NEORV32_CSR_MSTATUS_enum {
 
 
 /**********************************************************************//**
- * CPU <b>mcountinhibit</b> CSR (r/w): Machine counter-inhibit
+ * CPU mcountinhibitCSR (r/w): Machine counter-inhibit
  **************************************************************************/
 enum NEORV32_CSR_MCOUNTINHIBIT_enum {
   CSR_MCOUNTINHIBIT_CY    = 0,  /**< CPU mcountinhibit CSR (0): CY - Enable auto-increment of [m]cycle[h]   CSR when set (r/w) */
@@ -245,7 +228,7 @@ enum NEORV32_CSR_MCOUNTINHIBIT_enum {
 
 
 /**********************************************************************//**
- * CPU <b>mie</b> CSR (r/w): Machine interrupt enable
+ * CPU mie CSR (r/w): Machine interrupt enable
  **************************************************************************/
 enum NEORV32_CSR_MIE_enum {
   CSR_MIE_MSIE    =  3, /**< CPU mie CSR  (3): MSIE - Machine software interrupt enable (r/w) */
@@ -273,7 +256,7 @@ enum NEORV32_CSR_MIE_enum {
 
 
 /**********************************************************************//**
- * CPU <b>mip</b> CSR (r/-): Machine interrupt pending
+ * CPU mip CSR (r/-): Machine interrupt pending
  **************************************************************************/
 enum NEORV32_CSR_MIP_enum {
   CSR_MIP_MSIP    =  3, /**< CPU mip CSR  (3): MSIP - Machine software interrupt pending (r/-) */
@@ -301,7 +284,7 @@ enum NEORV32_CSR_MIP_enum {
 
 
 /**********************************************************************//**
- * CPU <b>misa</b> CSR (r/-): Machine instruction set extensions
+ * CPU misa CSR (r/-): Machine instruction set extensions
  **************************************************************************/
 enum NEORV32_CSR_MISA_enum {
   CSR_MISA_A      =  0, /**< CPU misa CSR  (0): A: Atomic instructions CPU extension available (r/-)*/
@@ -320,7 +303,7 @@ enum NEORV32_CSR_MISA_enum {
 
 
 /**********************************************************************//**
- * CPU <b>mxisa</b> CSR (r/-): Machine _extended_ instruction set extensions (NEORV32-specific)
+ * CPU mxisa CSR (r/-): Machine _extended_ instruction set extensions (NEORV32-specific)
  **************************************************************************/
 enum NEORV32_CSR_XISA_enum {
   // ISA (sub-)extensions
@@ -348,7 +331,7 @@ enum NEORV32_CSR_XISA_enum {
 
 
 /**********************************************************************//**
- * CPU <b>mhpmevent</b> hardware performance monitor events
+ * CPU mhpmevent hardware performance monitor events
  **************************************************************************/
 enum NEORV32_HPMCNT_EVENT_enum {
   HPMCNT_EVENT_CY       = 0,  /**< CPU mhpmevent CSR (0):  Active cycle */
@@ -367,7 +350,7 @@ enum NEORV32_HPMCNT_EVENT_enum {
 
 
 /**********************************************************************//**
- * CPU <b>pmpcfg</b> PMP configuration attributes
+ * CPU pmpcfg PMP configuration attributes
  **************************************************************************/
 enum NEORV32_PMPCFG_ATTRIBUTES_enum {
   PMPCFG_R     = 0, /**< CPU pmpcfg attribute (0): Read */


### PR DESCRIPTION
* Vivado IP module: major rework; use explicit `std_logic[_vector] <-> std_ulogic[_vector]` conversion; remove VHDL2008 requirement (not supported by the IP packager?)
* CPU: remove output register of multiplier unit to improve mapping to DSP block (`FAST_MUL_EN` option only)
* CPU: :warning: remove user-level HPMs
* CPU: rework `mcountern` CSR; add explicit `CY` and `IR` bits
* CPU: rework "next PC" logic - use ALU adder to compute the next instruction address (removes one carry chain and shortens the critical path of the base CPU core)
* DOCs: updates, cleanups and fixes