### PR TITLE
:bug: fix minor regression bug; minor RTL optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 30.08.2024 | 1.10.2.9 | minor RTL optimizations (size and critical path) | [#998](https://github.com/stnolting/neorv32/pull/998) |
 | 25.08.2024 | 1.10.2.8 | :warning: remove user-mode HPM counters; add individual `mocuntern` bits (`CY` and `IR`) rework Vivado IP module; minor RTL cleanups and optimization | [#996](https://github.com/stnolting/neorv32/pull/996) |
 | 16.08.2024 | 1.10.2.7 | minor CPU area and critical path optimizations; minor code cleanups | [#990](https://github.com/stnolting/neorv32/pull/990) |
 | 09.08.2024 | 1.10.2.6 | :warning: re-organize RTL files; all core files are now located in `rtl/core`; remove `mem` sub-folder | [#985](https://github.com/stnolting/neorv32/pull/985) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
-| 30.08.2024 | 1.10.2.9 | minor RTL optimizations (size and critical path) | [#998](https://github.com/stnolting/neorv32/pull/998) |
+| 30.08.2024 | 1.10.2.9 | :bug: fix PC reset bug (introduced in v1.10.2.8); minor RTL optimizations (size and critical path) | [#998](https://github.com/stnolting/neorv32/pull/998) |
 | 25.08.2024 | 1.10.2.8 | :warning: remove user-mode HPM counters; add individual `mocuntern` bits (`CY` and `IR`) rework Vivado IP module; minor RTL cleanups and optimization | [#996](https://github.com/stnolting/neorv32/pull/996) |
 | 16.08.2024 | 1.10.2.7 | minor CPU area and critical path optimizations; minor code cleanups | [#990](https://github.com/stnolting/neorv32/pull/990) |
 | 09.08.2024 | 1.10.2.6 | :warning: re-organize RTL files; all core files are now located in `rtl/core`; remove `mem` sub-folder | [#985](https://github.com/stnolting/neorv32/pull/985) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -298,11 +298,11 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 :sectnums:
 === Processor Clocking
 
-The processor is implemented as fully-synchronous logic design using a single clock domain that is driven entirely by the
-top's `clk_i` signal. This clock signal is used by all internal registers and memories, which trigger on the rising edge of
-this clock signal - except for the <<_processor_reset>> and the clock switching gate that trigger on a falling edge.
-External "clocks" like the OCD's JTAG clock or the SDI's serial clock are synchronized into the processor's clock domain
-before being further processed.
+The processor is implemented as fully-synchronous logic design using a single clock domain that is driven entirely
+by the top's `clk_i` signal. This clock signal is used by all internal registers and memories. All of them trigger
+on the **rising edge** of this clock signal - the only exception it the default <<_clock_gating>> module. External
+"clocks" like the OCD's JTAG clock or the SDI's serial clock are synchronized into the processor's clock domain
+before being used as "general logic signal" (and not as a dedicated clock).
 
 ==== Clock Gating
 
@@ -371,8 +371,8 @@ The actual reset cause can be determined via the <<_watchdog_timer_wdt>>.
 
 If any of these sources trigger a reset, the internal reset will be triggered for at least 4 clock cycles ensuring
 a valid reset of the entire processor. The internal global reset is asserted _aysynchronoulsy_ if triggered by the external
-`rstn_i` signal. For internal reset sources, the global reset is asserted _synchronously_. If the reset cause gets inactive
-the internal reset is de-asserted _synchronously_ at a falling clock edge.
+`rstn_i` signal. For internal reset sources, the global reset is asserted _synchronously_. If the reset cause is de-asserted
+the internal reset is de-asserted _synchronously_ at the next rising clock edge.
 
 Internally, **all registers** that are not meant for mapping to blockRAM (like the register file) do provide a dedicated and
 low-active **asynchronous hardware reset**. This asynchronous reset ensures that the entire processor logic is reset to a

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -646,6 +646,12 @@ package file (`rtl/core/neorv323_package.vhd`).
   constant base_io_dma_c   : std_ulogic_vector(31 downto 0) := x"ffffed00";
 ----
 
+.IO Access Latency
+[IMPORTANT]
+In order to shorten the critical path of the IO system, the IO switch contain a partial register stage that
+buffers the address bus. Hence, accesses to the processor-internal IO region requires an additional clock cycle
+to complete.
+
 
 :sectnums:
 ==== Boot Configuration

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -115,7 +115,7 @@ begin
   addsub_res <= std_ulogic_vector(unsigned(opa_x) - unsigned(opb_x)) when (ctrl_i.alu_sub = '1') else
                 std_ulogic_vector(unsigned(opa_x) + unsigned(opb_x));
 
-  add_o <= addsub_res(XLEN-1 downto 0); -- direct output of adder result
+  add_o <= addsub_res(XLEN-1 downto 0); -- direct output
 
 
   -- ALU Operation Select -------------------------------------------------------------------

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -317,9 +317,9 @@ begin
   begin
     if (rstn_i = '0') then
       fetch_engine.state   <= IF_RESTART;
-      fetch_engine.restart <= '1'; -- set to reset IPB
-      fetch_engine.pc      <= CPU_BOOT_ADDR(XLEN-1 downto 2) & "00"; -- 32-bit aligned boot address
-      fetch_engine.priv    <= priv_mode_m_c; -- start in machine mode
+      fetch_engine.restart <= '1'; -- reset IPB and issue engine
+      fetch_engine.pc      <= (others => '0');
+      fetch_engine.priv    <= '0';
     elsif rising_edge(clk_i) then
       -- restart request --
       if (fetch_engine.state = IF_RESTART) then -- restart done

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -566,7 +566,7 @@ begin
       execute_engine.ir      <= (others => '0');
       execute_engine.is_ci   <= '0';
       execute_engine.pc      <= CPU_BOOT_ADDR(XLEN-1 downto 2) & "00"; -- 32-bit-aligned boot address
-      execute_engine.next_pc <= (others => '0');
+      execute_engine.next_pc <= CPU_BOOT_ADDR(XLEN-1 downto 2) & "00"; -- 32-bit-aligned boot address
       execute_engine.link_pc <= (others => '0');
     elsif rising_edge(clk_i) then
       -- control bus --
@@ -617,7 +617,7 @@ begin
             execute_engine.next_pc <= alu_add_i(XLEN-1 downto 1) & '0';
           end if;
 
-        when EXECUTE => -- linear increment (ise ALU's adder to compute next_p = pm + imm)
+        when EXECUTE => -- linear increment (use ALU's adder to compute next_pc = current_pc + imm)
           execute_engine.next_pc <= alu_add_i(XLEN-1 downto 1) & '0';
 
         when others => -- no update

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100208"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100209"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -285,11 +285,6 @@ package neorv32_package is
 
   -- RISC-V Floating-Point Stuff ------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant float_single_c : std_ulogic_vector(1 downto 0) := "00"; -- single-precision (32-bit)
---constant float_double_c : std_ulogic_vector(1 downto 0) := "01"; -- double-precision (64-bit)
---constant float_half_c   : std_ulogic_vector(1 downto 0) := "10"; -- half-precision (16-bit)
---constant float_quad_c   : std_ulogic_vector(1 downto 0) := "11"; -- quad-precision (128-bit)
-
   -- number class flags --
   constant fp_class_neg_inf_c    : natural := 0; -- negative infinity
   constant fp_class_neg_norm_c   : natural := 1; -- negative normal number

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -387,7 +387,7 @@ begin
         rstn_ext      <= '0';
         rstn_sys_sreg <= (others => '0');
         rstn_sys      <= '0';
-      elsif falling_edge(clk_i) then -- inverted clock to release reset _before_ all FFs trigger (rising edge)
+      elsif rising_edge(clk_i) then -- inverted clock to release reset _before_ all FFs trigger (rising edge)
         -- external reset --
         rstn_ext_sreg <= rstn_ext_sreg(rstn_ext_sreg'left-1 downto 0) & '1'; -- active for at least <rstn_ext_sreg'size> clock cycles
         rstn_ext      <= and_reduce_f(rstn_ext_sreg);
@@ -408,7 +408,7 @@ begin
     begin
       if (rstn_ext = '0') then
         rst_cause <= "00"; -- reset from external pin
-      elsif falling_edge(clk_i) then
+      elsif rising_edge(clk_i) then
         if (dci_ndmrstn = '0') then
           rst_cause <= "01"; -- reset from on-chip debugger
         elsif (rstn_wdt = '0') then

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -1033,6 +1033,8 @@ begin
       DEV_31_EN => false,               DEV_21_BASE => (others => '-')  -- reserved
     )
     port map (
+      clk_i        => clk_i,
+      rstn_i       => rstn_sys,
       main_req_i   => io_req,
       main_rsp_o   => io_rsp,
       dev_00_req_o => iodev_req(IODEV_OCD),     dev_00_rsp_i => iodev_rsp(IODEV_OCD),


### PR DESCRIPTION
* :bug: CPU: fix PC reset bug (introduced in v1.10.2.8)
* CPU: clean-up illegal instruction decoding logic (FPU and atomic instructions)
* CPU: simplify `fence[.i]` decoding
* SoC: add register stage to IO switch to relax the critical path of the interconnect; IO accesses now require an additional clock cycle to complete
* SoC: rework reset system; all registers of the entire processor now trigger exclusively on the rising clock edge (no more `falling_edge()`)
* minor edits and clean-ups