### PR TITLE
🧪 Remove "loop" from memory initialization function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 05.09.2024 | 1.10.3.2 | :test_tube: Remove "for loop" construct from memory initialization function as the max. number of loop/unrolling iterations might be constrained | [#1005](https://github.com/stnolting/neorv32/pull/1005) |
 | 05.09.2024 | 1.10.3.1 | minor CPU RTL cleanups and optimizations | [#1004](https://github.com/stnolting/neorv32/pull/1004) |
 | 03.09.2024 | [**:rocket:1.10.3**](https://github.com/stnolting/neorv32/releases/tag/v1.10.3) | **New release** | |
 | 30.08.2024 | 1.10.2.9 | :bug: fix PC reset bug (introduced in v1.10.2.8); minor RTL optimizations (size and critical path) | [#998](https://github.com/stnolting/neorv32/pull/998) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100301"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100302"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -1070,11 +1070,10 @@ package body neorv32_package is
     variable mem_v : mem32_t(0 to depth-1) := (others => (others => '0'));
   begin
     if (init'length > depth) then
-      return mem_v;
+      report "[NEORV32] mem32_init_f: initialization image is overflowing memory range!" severity warning;
+    else
+      mem_v(0 to init'length-1) := init(0 to init'length-1);
     end if;
-    for i in 0 to init'length-1 loop -- initialize only in range of source data array
-      mem_v(i) := init(i);
-    end loop;
     return mem_v;
   end function mem32_init_f;
 


### PR DESCRIPTION
As discussed in #1002 the maximum number of `loop` iterations (for unrolling by the synthesizer) might be constrained (e.g. by AMD Vivado). This PR removes the `for .. loop` construct.