### PR TITLE
Cleanup debug symbols

### DIFF
--- a/docs/datasheet/software.adoc
+++ b/docs/datasheet/software.adoc
@@ -290,11 +290,17 @@ The makefile's `CC_OPTS` is exported as **define** to be available within a C pr
 | `-lc`                 | Search for the standard C library when linking.
 | `-lgcc`               | Make sure we have no unresolved references to internal GCC library subroutines.
 | `-mno-fdiv`           | Use built-in software functions for floating-point divisions and square roots (since the according instructions are not supported yet).
-| `-g`                  | Include debugging information/symbols in ELF.
 | `-mstrict-align`      | Unaligned memory accesses cannot be resolved by the hardware and require emulation.
 | `-mbranch-cost=10`    | Branching costs a lot of cycles.
 | `-ffp-contract=off`   | Do not allow contraction of floating-point operations (no fused operations as they are not supported).
 |=======================
+
+.Debug Symbols
+[IMPORTANT]
+By default, no debug symbols are added to the ELF.
+You can add them manually (to your local project's makefile) via `USER_FLAGS+=-g`.
+Note that other debug flags may be required depending of the GCC/GDB version
+(e.g. `USER_FLAGS += -ggdb -gdwarf-3`).
 
 :sectnums:
 ==== Custom (Compiler) Flags

--- a/docs/userguide/eclipse_ide.adoc
+++ b/docs/userguide/eclipse_ide.adoc
@@ -190,6 +190,12 @@ the required `main.elf` file gets generated instead of _all_ executable files (l
 When you start debugging the first time you might need to select the provided debug configuration:
 **GDB OpenOCD Debugging > eclipse_example Default**
 
+.Debug Symbols
+[IMPORTANT]
+For debugging the ELF has to compiled to contain according debug symbols.
+Debug symbols are enabled by the project's local makefile: `USER_FLAGS += -ggdb -gdwarf-3`
+(this configuration seems to work best for Eclipse - at least for me).
+
 If you need to reconfigure OpenOCD binaries and/or paths:
 
 [start=1]

--- a/sw/common/common.mk
+++ b/sw/common/common.mk
@@ -106,7 +106,7 @@ IMAGE_GEN = $(NEORV32_EXG_PATH)/image_gen
 
 # Compiler & linker flags
 CC_OPTS  = -march=$(MARCH) -mabi=$(MABI) $(EFFORT) -Wall -ffunction-sections -fdata-sections -nostartfiles -mno-fdiv
-CC_OPTS += -mstrict-align -mbranch-cost=10 -g -Wl,--gc-sections -ffp-contract=off
+CC_OPTS += -mstrict-align -mbranch-cost=10 -Wl,--gc-sections -ffp-contract=off
 CC_OPTS += $(USER_FLAGS)
 LD_LIBS =  -lm -lc -lgcc
 LD_LIBS += $(USER_LIBS)

--- a/sw/example/eclipse/.settings/org.eclipse.cdt.core.prefs
+++ b/sw/example/eclipse/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+indexer/indexAllFiles=true
+indexer/indexAllHeaderVersions=true
+indexer/indexAllVersionsSpecificHeaders=
+indexer/indexOnOpen=true
+indexer/indexUnusedHeadersWithAlternateLang=true
+indexer/indexUnusedHeadersWithDefaultLang=true
+indexer/indexerId=org.eclipse.cdt.core.fastIndexer
+indexer/skipFilesLargerThanMB=8
+indexer/skipImplicitReferences=false
+indexer/skipIncludedFilesLargerThanMB=16
+indexer/skipMacroReferences=false
+indexer/skipReferences=false
+indexer/skipTypeReferences=false
+indexer/useHeuristicIncludeResolution=true

--- a/sw/example/eclipse/.settings/org.eclipse.embedcdt.debug.gdbjtag.openocd.core.prefs
+++ b/sw/example/eclipse/.settings/org.eclipse.embedcdt.debug.gdbjtag.openocd.core.prefs
@@ -1,3 +1,3 @@
 eclipse.preferences.version=1
 executable.name=openocd.exe
-install.folder=C\:\\xpack\\xpack-openocd-0.12.0-3\\bin
+install.folder=C\:\\xpack\\xpack-openocd-0.12.0-4\\bin

--- a/sw/example/eclipse/.settings/org.eclipse.embedcdt.managedbuild.cross.riscv.core.prefs
+++ b/sw/example/eclipse/.settings/org.eclipse.embedcdt.managedbuild.cross.riscv.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-toolchain.path.2273142913=C\:\\xpack\\xpack-riscv-none-elf-gcc-14.1.0-1\\bin
+toolchain.path.2273142913=C\:\\xpack\\xpack-riscv-none-elf-gcc-14.2.0-2\\bin

--- a/sw/example/eclipse/makefile
+++ b/sw/example/eclipse/makefile
@@ -7,6 +7,9 @@
 # Override the default RISC-V GCC prefix
 RISCV_PREFIX = riscv-none-elf-
 
+# Add debug symbols
+USER_FLAGS += -ggdb -gdwarf-3
+
 # Modify this variable to fit your NEORV32 setup (neorv32 home folder)
 NEORV32_HOME ?= ../../..
 


### PR DESCRIPTION
By default, **no** debug symbols are added to the final ELF. You can add debug symbols manually (in your project's local makefile), e.g. `USER_FLAGS += -g`.

#### Eclipse IDE

This PR also fixes a problem in the default Eclipse project: sometimes the sources (during debugging) cannot be found. This is fixed by adding an explicit indexer configuration and explicit debug symbols: `USER_FLAGS += -ggdb -gdwarf-3`