### PR TITLE
Minor rtl/CSR optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
-| 08.09.2024 | 1.10.3.4 | optimize CSR address logic (to reduce switching activity) | [#1008](https://github.com/stnolting/neorv32/pull/1008) |
+| 08.09.2024 | 1.10.3.4 | minor rtl/CSR optimizations | [#1010](https://github.com/stnolting/neorv32/pull/1010) |
+| 08.09.2024 | 1.10.3.3 | optimize CSR address logic (to reduce switching activity) | [#1008](https://github.com/stnolting/neorv32/pull/1008) |
 | 05.09.2024 | 1.10.3.2 | :test_tube: Remove "for loop" construct from memory initialization function as the max. number of loop/unrolling iterations might be constrained | [#1005](https://github.com/stnolting/neorv32/pull/1005) |
 | 05.09.2024 | 1.10.3.1 | minor CPU RTL cleanups and optimizations | [#1004](https://github.com/stnolting/neorv32/pull/1004) |
 | 03.09.2024 | [**:rocket:1.10.3**](https://github.com/stnolting/neorv32/releases/tag/v1.10.3) | **New release** | |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -271,7 +271,7 @@ Machine-mode software can discover available `Z*` _sub-extensions_ (like `Zicsr`
 |=======================
 | Name        | Machine trap-handler base address
 | Address     | `0x305`
-| Reset value | `CPU_BOOT_ADDR`, CPU boot address, 4-byte aligned (see <<_cpu_top_entity_generics>> and <<_address_space>>)
+| Reset value | `0x00000000`
 | ISA         | `Zicsr`
 | Description | The `mtvec` CSR holds the trap vector configuration.
 |=======================
@@ -281,13 +281,16 @@ Machine-mode software can discover available `Z*` _sub-extensions_ (like `Zicsr`
 [options="header",grid="rows"]
 |=======================
 | Bit  | R/W | Function
-| 1:0  | r/w | **MODE**: mode configuration, `00` = DIRECT, `01` = VECTORED. (Others will fall back to DIRECT mode.)
-| 31:2 | r/w | **BASE**: in DIRECT mode = 4-byte aligned base address of trap base handler, _all_ traps set `pc` = `BASE`; in VECTORED mode = 128-byte aligned base address of trap vector table, interrupts cause a jump to `pc` = `BASE` + 4 * `mcause` and exceptions to `pc` = `BASE`.
+| 1:0  | r/w | **MODE**: mode configuration, `00` = DIRECT, `01` = VECTORED; other encodings are _reserved_.
+| 31:2 | r/w | **BASE**: in DIRECT mode = 4-byte-aligned base address of trap base handler, _all_ traps jump to `pc = BASE`;
+in VECTORED mode = 128-byte-aligned base address of trap vector table, interrupts cause a jump to `pc = BASE + 4 * mcause`
+and exceptions a jump to `pc = BASE`.
 |=======================
 
 .Interrupt Latency
 [TIP]
-The vectored `mtvec` mode is useful for reducing the time between interrupt request (IRQ) and servicing it (ISR). As software does not need to determine the interrupt cause the reduction in latency can be 5 to 10 times and as low as _26_ cycles.
+The vectored `mtvec` mode is useful for reducing the time between interrupt request (IRQ) and servicing it (ISR).
+As software does not need to determine the interrupt cause the reduction in latency can be 5 to 10 times and as low as _26_ cycles.
 
 {empty} +
 [discrete]
@@ -358,10 +361,10 @@ The vectored `mtvec` mode is useful for reducing the time between interrupt requ
 |=======================
 | Name        | Machine exception program counter
 | Address     | `0x341`
-| Reset value | `CPU_BOOT_ADDR`, CPU boot address, 4-byte aligned (see <<_cpu_top_entity_generics>> and <<_address_space>>)
+| Reset value | `0x00000000`
 | ISA         | `Zicsr`
 | Description | The `mepc` CSR provides the instruction address where execution has stopped/failed when
-an instruction is triggered / an exception is raised. See section <<_traps_exceptions_and_interrupts>> for a list of all legal values.
+an interrupt is triggered / an exception is raised. See section <<_traps_exceptions_and_interrupts>> for a list of all legal values.
 The `mret` instruction will return to the address stored in `mepc` by automatically moving `mepc` to the program counter.
 |=======================
 

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -585,7 +585,7 @@ an illegal instruction exception is raised.
 |=======================
 | Name        | Debug control and status register
 | Address     | `0x7b0`
-| Reset value | `0x40000413`
+| Reset value | `0x40000410`
 | ISA         | `Zicsr` & `Sdext`
 | Description | This register is used to configure the debug mode environment and provides additional status information.
 |=======================
@@ -628,7 +628,7 @@ Cause codes in `dcsr.cause` (highest priority first):
 |=======================
 | Name        | Debug program counter
 | Address     | `0x7b1`
-| Reset value | `CPU_BOOT_ADDR`, CPU boot address, 4-byte aligned (see <<_cpu_top_entity_generics>> and <<_address_space>>)
+| Reset value | `0x00000000`
 | ISA         | `Zicsr` & `Sdext`
 | Description | The register is used to store the current program counter when debug mode is entered. The `dret` instruction will
 return to the address stored in `dpc` by automatically moving `dpc` to the program counter.

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -594,7 +594,7 @@ begin
           elsif (debug_ctrl.running = '1') and CPU_EXTENSION_RISCV_Sdext then -- any other trap INSIDE debug mode
             execute_engine.next_pc <= CPU_DEBUG_EXC_ADDR(XLEN-1 downto 2) & "00"; -- debug mode enter: start at "parking loop" <exception_entry>
           else -- normal start of trap
-            if (csr.mtvec(1 downto 0) = "01") and (trap_ctrl.cause(6) = '1') then -- vectored mode + interrupt
+            if (csr.mtvec(0) = '1') and (trap_ctrl.cause(6) = '1') then -- vectored mode + interrupt
               execute_engine.next_pc <= csr.mtvec(XLEN-1 downto 7) & trap_ctrl.cause(4 downto 0) & "00"; -- pc = mtvec + 4 * mcause
             else
               execute_engine.next_pc <= csr.mtvec(XLEN-1 downto 2) & "00"; -- pc = mtvec
@@ -995,7 +995,7 @@ begin
   -- instruction word bit fields --
   ctrl_o.ir_funct3    <= execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c);
   ctrl_o.ir_funct12   <= execute_engine.ir(instr_funct12_msb_c downto instr_funct12_lsb_c);
-  ctrl_o.ir_opcode    <= execute_engine.ir(instr_opcode_msb_c downto instr_opcode_lsb_c);
+  ctrl_o.ir_opcode    <= decode_aux.opcode;
   -- cpu status --
   ctrl_o.cpu_priv     <= csr.privilege_eff;
   ctrl_o.cpu_sleep    <= sleep_mode;
@@ -1587,11 +1587,7 @@ begin
             csr.mie_firq <= csr.wdata(31 downto 16);
 
           when csr_mtvec_c => -- machine trap-handler base address
-            if (csr.wdata(1 downto 0) = "01") then
-              csr.mtvec <= csr.wdata(XLEN-1 downto 7) & "00000" & "01"; -- mtvec.MODE=1 (vectored)
-            else
-              csr.mtvec <= csr.wdata(XLEN-1 downto 2) & "00"; -- mtvec.MODE=0 (direct)
-            end if;
+            csr.mtvec <= csr.wdata(XLEN-1 downto 2) & '0' & csr.wdata(0); -- base + mode (vectored/direct)
 
           when csr_mcounteren_c => -- machine counter access enable
             if CPU_EXTENSION_RISCV_U and CPU_EXTENSION_RISCV_Zicntr then

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1537,9 +1537,9 @@ begin
       csr.mie_mei        <= '0';
       csr.mie_mti        <= '0';
       csr.mie_firq       <= (others => '0');
-      csr.mtvec          <= CPU_BOOT_ADDR(XLEN-1 downto 2) & "00"; -- 32-bit aligned boot address
+      csr.mtvec          <= (others => '0');
       csr.mscratch       <= x"19880704";
-      csr.mepc           <= CPU_BOOT_ADDR(XLEN-1 downto 2) & "00"; -- 32-bit aligned boot address
+      csr.mepc           <= (others => '0');
       csr.mcause         <= (others => '0');
       csr.mtval          <= (others => '0');
       csr.mtinst         <= (others => '0');
@@ -1549,9 +1549,9 @@ begin
       csr.dcsr_ebreakm   <= '0';
       csr.dcsr_ebreaku   <= '0';
       csr.dcsr_step      <= '0';
-      csr.dcsr_prv       <= priv_mode_m_c;
+      csr.dcsr_prv       <= '0';
       csr.dcsr_cause     <= (others => '0');
-      csr.dpc            <= CPU_BOOT_ADDR(XLEN-1 downto 2) & "00"; -- 32-bit aligned boot address
+      csr.dpc            <= (others => '0');
       csr.dscratch0      <= (others => '0');
       csr.tdata1_execute <= '0';
       csr.tdata1_action  <= '0';

--- a/rtl/core/neorv32_intercon.vhd
+++ b/rtl/core/neorv32_intercon.vhd
@@ -384,38 +384,38 @@ entity neorv32_bus_io_switch is
   generic (
     DEV_SIZE  : natural; -- size of a single IO device, has to be a power of two
     -- device port enable and base address; enabled ports do not have to be contiguous --
-    DEV_00_EN : boolean := false; DEV_00_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_01_EN : boolean := false; DEV_01_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_02_EN : boolean := false; DEV_02_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_03_EN : boolean := false; DEV_03_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_04_EN : boolean := false; DEV_04_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_05_EN : boolean := false; DEV_05_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_06_EN : boolean := false; DEV_06_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_07_EN : boolean := false; DEV_07_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_08_EN : boolean := false; DEV_08_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_09_EN : boolean := false; DEV_09_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_10_EN : boolean := false; DEV_10_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_11_EN : boolean := false; DEV_11_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_12_EN : boolean := false; DEV_12_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_13_EN : boolean := false; DEV_13_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_14_EN : boolean := false; DEV_14_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_15_EN : boolean := false; DEV_15_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_16_EN : boolean := false; DEV_16_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_17_EN : boolean := false; DEV_17_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_18_EN : boolean := false; DEV_18_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_19_EN : boolean := false; DEV_19_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_20_EN : boolean := false; DEV_20_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_21_EN : boolean := false; DEV_21_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_22_EN : boolean := false; DEV_22_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_23_EN : boolean := false; DEV_23_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_24_EN : boolean := false; DEV_24_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_25_EN : boolean := false; DEV_25_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_26_EN : boolean := false; DEV_26_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_27_EN : boolean := false; DEV_27_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_28_EN : boolean := false; DEV_28_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_29_EN : boolean := false; DEV_29_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_30_EN : boolean := false; DEV_30_BASE : std_ulogic_vector(31 downto 0) := (others => '-');
-    DEV_31_EN : boolean := false; DEV_31_BASE : std_ulogic_vector(31 downto 0) := (others => '-')
+    DEV_00_EN : boolean := false; DEV_00_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_01_EN : boolean := false; DEV_01_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_02_EN : boolean := false; DEV_02_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_03_EN : boolean := false; DEV_03_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_04_EN : boolean := false; DEV_04_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_05_EN : boolean := false; DEV_05_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_06_EN : boolean := false; DEV_06_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_07_EN : boolean := false; DEV_07_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_08_EN : boolean := false; DEV_08_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_09_EN : boolean := false; DEV_09_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_10_EN : boolean := false; DEV_10_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_11_EN : boolean := false; DEV_11_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_12_EN : boolean := false; DEV_12_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_13_EN : boolean := false; DEV_13_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_14_EN : boolean := false; DEV_14_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_15_EN : boolean := false; DEV_15_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_16_EN : boolean := false; DEV_16_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_17_EN : boolean := false; DEV_17_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_18_EN : boolean := false; DEV_18_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_19_EN : boolean := false; DEV_19_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_20_EN : boolean := false; DEV_20_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_21_EN : boolean := false; DEV_21_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_22_EN : boolean := false; DEV_22_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_23_EN : boolean := false; DEV_23_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_24_EN : boolean := false; DEV_24_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_25_EN : boolean := false; DEV_25_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_26_EN : boolean := false; DEV_26_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_27_EN : boolean := false; DEV_27_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_28_EN : boolean := false; DEV_28_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_29_EN : boolean := false; DEV_29_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_30_EN : boolean := false; DEV_30_BASE : std_ulogic_vector(31 downto 0) := (others => '0');
+    DEV_31_EN : boolean := false; DEV_31_BASE : std_ulogic_vector(31 downto 0) := (others => '0')
   );
   port (
     -- global control --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100303"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100304"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -882,7 +882,7 @@ begin
         generic map (
           NUM_BLOCKS => XIP_CACHE_NUM_BLOCKS,
           BLOCK_SIZE => XIP_CACHE_BLOCK_SIZE,
-          UC_BEGIN   => (others => '-'),
+          UC_BEGIN   => (others => '0'),
           UC_ENABLE  => false,
           READ_ONLY  => true
         )
@@ -1020,17 +1020,17 @@ begin
       DEV_18_EN => IO_DMA_EN,           DEV_18_BASE => base_io_dma_c,
       DEV_19_EN => IO_SLINK_EN,         DEV_19_BASE => base_io_slink_c,
       DEV_20_EN => IO_CFS_EN,           DEV_20_BASE => base_io_cfs_c,
-      DEV_21_EN => false,               DEV_31_BASE => (others => '-'), -- reserved
-      DEV_22_EN => false,               DEV_30_BASE => (others => '-'), -- reserved
-      DEV_23_EN => false,               DEV_29_BASE => (others => '-'), -- reserved
-      DEV_24_EN => false,               DEV_28_BASE => (others => '-'), -- reserved
-      DEV_25_EN => false,               DEV_27_BASE => (others => '-'), -- reserved
-      DEV_26_EN => false,               DEV_26_BASE => (others => '-'), -- reserved
-      DEV_27_EN => false,               DEV_25_BASE => (others => '-'), -- reserved
-      DEV_28_EN => false,               DEV_24_BASE => (others => '-'), -- reserved
-      DEV_29_EN => false,               DEV_23_BASE => (others => '-'), -- reserved
-      DEV_30_EN => false,               DEV_22_BASE => (others => '-'), -- reserved
-      DEV_31_EN => false,               DEV_21_BASE => (others => '-')  -- reserved
+      DEV_21_EN => false,               DEV_31_BASE => (others => '0'), -- reserved
+      DEV_22_EN => false,               DEV_30_BASE => (others => '0'), -- reserved
+      DEV_23_EN => false,               DEV_29_BASE => (others => '0'), -- reserved
+      DEV_24_EN => false,               DEV_28_BASE => (others => '0'), -- reserved
+      DEV_25_EN => false,               DEV_27_BASE => (others => '0'), -- reserved
+      DEV_26_EN => false,               DEV_26_BASE => (others => '0'), -- reserved
+      DEV_27_EN => false,               DEV_25_BASE => (others => '0'), -- reserved
+      DEV_28_EN => false,               DEV_24_BASE => (others => '0'), -- reserved
+      DEV_29_EN => false,               DEV_23_BASE => (others => '0'), -- reserved
+      DEV_30_EN => false,               DEV_22_BASE => (others => '0'), -- reserved
+      DEV_31_EN => false,               DEV_21_BASE => (others => '0')  -- reserved
     )
     port map (
       clk_i        => clk_i,


### PR DESCRIPTION
* reset `mtvec`, `mepc` and `dpc` CSRs to all-zero
* reset `dcsr.priv` CSR bit to zero
* replace all `'-'` (don't care) by `'0'` (Yosys seems to have problems with this sometimes)
* simplify `mtvec` logic for _vectored_ interrupt mode