### PR TITLE
Cleanup and extend watch dog's reset-cause logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 13.09.2024 | 1.10.3.6 | cleanup and extend watchdog's reset-cause identification logic | [#1015](https://github.com/stnolting/neorv32/pull/1015) |
 | 13.09.2024 | 1.10.3.5 | rtl code cleanups; minor CPU control optimizations | [#1014](https://github.com/stnolting/neorv32/pull/1014) |
 | 08.09.2024 | 1.10.3.4 | minor rtl/CSR optimizations | [#1010](https://github.com/stnolting/neorv32/pull/1010) |
 | 08.09.2024 | 1.10.3.3 | optimize CSR address logic (to reduce switching activity) | [#1008](https://github.com/stnolting/neorv32/pull/1008) |

--- a/docs/datasheet/soc_wdt.adoc
+++ b/docs/datasheet/soc_wdt.adoc
@@ -71,9 +71,10 @@ control register bit an **immediate hardware** reset if enforced if
 
 The cause of the last system hardware reset can be determined via the `WDT_CTRL_RCAUSE_*` bits:
 
-* `0b00`: Reset caused by external reset signal/pin
-* `0b01`: Reset caused by on-chip debugger
-* `0b10`: Reset caused by watchdog
+* `WDT_RCAUSE_EXT` (0b00): Reset caused by external reset signal/pin
+* `WDT_RCAUSE_OCD` (0b01): Reset caused by on-chip debugger
+* `WDT_RCAUSE_TMO` (0b10): Reset caused by watchdog timeout
+* `WDT_RCAUSE_ACC` (0b11): Reset caused by illegal watchdog access (strict mode)
 
 
 **Register Map**

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100305"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100306"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_wdt.vhd
+++ b/rtl/core/neorv32_wdt.vhd
@@ -18,8 +18,9 @@ use neorv32.neorv32_package.all;
 entity neorv32_wdt is
   port (
     clk_i       : in  std_ulogic; -- global clock line
-    rstn_i      : in  std_ulogic; -- system reset, low-active, async
-    rst_cause_i : in  std_ulogic_vector(1 downto 0); -- reset cause
+    rstn_ext_i  : in  std_ulogic; -- external reset, low-active
+    rstn_db_i   : in  std_ulogic; -- debugger reset, low-active
+    rstn_sys_i  : in  std_ulogic; -- system reset, low-active
     bus_req_i   : in  bus_req_t;  -- bus request
     bus_rsp_o   : out bus_rsp_t;  -- bus response
     cpu_debug_i : in  std_ulogic; -- CPU is in debug mode
@@ -40,10 +41,10 @@ architecture neorv32_wdt_rtl of neorv32_wdt is
   constant ctrl_lock_c        : natural :=  1; -- r/w: lock write access to control register when set
   constant ctrl_dben_c        : natural :=  2; -- r/w: allow WDT to continue operation even when CPU is in debug mode
   constant ctrl_sen_c         : natural :=  3; -- r/w: allow WDT to continue operation even when CPU is in sleep mode
-  constant ctrl_strict_c      : natural :=  4; -- r/w: force hardware reset if reset password is incorrect
+  constant ctrl_strict_c      : natural :=  4; -- r/w: force hardware reset if reset password is incorrect or if access to locked config
   constant ctrl_rcause_lo_c   : natural :=  5; -- r/-: cause of last system reset - low
   constant ctrl_rcause_hi_c   : natural :=  6; -- r/-: cause of last system reset - high
-  --
+--constant ctrl_reserved_c    : natural :=  7; -- r/-: reserved
   constant ctrl_timeout_lsb_c : natural :=  8; -- r/w: timeout value LSB
   constant ctrl_timeout_msb_c : natural := 31; -- r/w: timeout value MSB
 
@@ -58,27 +59,25 @@ architecture neorv32_wdt_rtl of neorv32_wdt is
   end record;
   signal ctrl : ctrl_t;
 
-  -- prescaler clock generator --
-  signal prsc_tick : std_ulogic;
-
-  -- timeout counter --
-  signal cnt                 : std_ulogic_vector(23 downto 0); -- timeout counter
-  signal cnt_started         : std_ulogic;
-  signal cnt_inc, cnt_inc_ff : std_ulogic; -- increment counter when set
-  signal timeout_rst         : std_ulogic;
-
-  -- misc --
-  signal hw_rst      : std_ulogic;
-  signal reset_wdt   : std_ulogic;
-  signal reset_force : std_ulogic;
+  signal prsc_tick      : std_ulogic; -- prescaler clock generator
+  signal cnt            : std_ulogic_vector(23 downto 0); -- timeout counter
+  signal cnt_started    : std_ulogic; -- set when timeout counter has started
+  signal cnt_inc        : std_ulogic; -- increment counter when set
+  signal cnt_inc_ff     : std_ulogic;
+  signal cnt_timeout    : std_ulogic; -- counter matches programmed timeout value
+  signal reset_cause    : std_ulogic_vector(1 downto 0); -- cause of last reset
+  signal hw_rst_timeout : std_ulogic; -- trigger reset because of timeout
+  signal hw_rst_access  : std_ulogic; -- trigger reset because of illegal access in strict mode
+  signal reset_wdt      : std_ulogic; -- reset timeout counter ("feed the watch dog")
+  signal reset_force    : std_ulogic; -- trigger reset because of illegal access in strict mode (raw)
 
 begin
 
   -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_access: process(rstn_sys_i, clk_i)
   begin
-    if (rstn_i = '0') then
+    if (rstn_sys_i = '0') then
       bus_rsp_o    <= rsp_terminate_c;
       ctrl.enable  <= '0'; -- disable WDT after reset
       ctrl.lock    <= '0'; -- unlock after reset
@@ -93,15 +92,12 @@ begin
       bus_rsp_o.ack  <= bus_req_i.stb;
       bus_rsp_o.err  <= '0';
       bus_rsp_o.data <= (others => '0');
-
       -- defaults --
       reset_wdt   <= '0';
       reset_force <= '0';
-
+      -- bus access --
       if (bus_req_i.stb = '1') then
-
-        -- write access --
-        if (bus_req_i.rw = '1') then
+        if (bus_req_i.rw = '1') then -- write access
           if (bus_req_i.addr(2) = '0') then -- control register
             if (ctrl.lock = '0') then -- update configuration only if not locked
               ctrl.enable  <= bus_req_i.data(ctrl_enable_c);
@@ -120,18 +116,15 @@ begin
               reset_force <= '1'; -- password incorrect
             end if;
           end if;
-
-        -- read access --
-        else
+        else -- read access
           bus_rsp_o.data(ctrl_enable_c)                                <= ctrl.enable;
           bus_rsp_o.data(ctrl_lock_c)                                  <= ctrl.lock;
           bus_rsp_o.data(ctrl_dben_c)                                  <= ctrl.dben;
           bus_rsp_o.data(ctrl_sen_c)                                   <= ctrl.sen;
-          bus_rsp_o.data(ctrl_rcause_hi_c downto ctrl_rcause_lo_c)     <= rst_cause_i;
+          bus_rsp_o.data(ctrl_rcause_hi_c downto ctrl_rcause_lo_c)     <= reset_cause;
           bus_rsp_o.data(ctrl_strict_c)                                <= ctrl.strict;
           bus_rsp_o.data(ctrl_timeout_msb_c downto ctrl_timeout_lsb_c) <= ctrl.timeout;
         end if;
-
       end if;
     end if;
   end process bus_access;
@@ -139,9 +132,9 @@ begin
 
   -- Timeout Counter ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  wdt_counter: process(rstn_i, clk_i)
+  wdt_counter: process(rstn_sys_i, clk_i)
   begin
-    if (rstn_i = '0') then
+    if (rstn_sys_i = '0') then
       cnt_inc_ff  <= '0';
       cnt_started <= '0';
       cnt         <= (others => '0');
@@ -162,31 +155,46 @@ begin
 
   -- valid counter increment? --
   cnt_inc <= '1' when ((prsc_tick = '1') and (cnt_started = '1')) and -- clock tick and started
-                      ((cpu_debug_i = '0') or (ctrl.dben = '1'))  and -- not in debug mode or allowed to run in debug mode
+                      ((cpu_debug_i = '0') or (ctrl.dben = '1')) and -- not in debug mode or allowed to run in debug mode
                       ((cpu_sleep_i = '0') or (ctrl.sen = '1')) else '0'; -- not in sleep mode or allowed to run in sleep mode
 
   -- timeout detector --
-  timeout_rst <= '1' when (cnt_started = '1') and (cnt = ctrl.timeout) else '0';
+  cnt_timeout <= '1' when (cnt_started = '1') and (cnt = ctrl.timeout) else '0';
 
 
   -- Reset Generator ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  reset_generator: process(rstn_i, clk_i)
+  reset_generator: process(rstn_sys_i, clk_i)
   begin
-    if (rstn_i = '0') then
-      hw_rst <= '0';
+    if (rstn_sys_i = '0') then
+      hw_rst_timeout <= '0';
+      hw_rst_access  <= '0';
     elsif rising_edge(clk_i) then
-      hw_rst <= '0';
-      if (ctrl.enable = '1') and -- enabled
-         (((timeout_rst = '1') and (prsc_tick = '1')) or -- timeout
-          ((ctrl.strict = '1') and (reset_force = '1'))) then -- strict mode and incorrect password
-        hw_rst <= '1';
-      end if;
+      hw_rst_timeout <= ctrl.enable and cnt_timeout and prsc_tick; -- timeout
+      hw_rst_access  <= ctrl.enable and ctrl.strict and reset_force; -- strict mode and incorrect password
     end if;
   end process reset_generator;
 
   -- system-wide reset --
-  rstn_o <= not hw_rst;
+  rstn_o <= not (hw_rst_timeout or hw_rst_access);
+
+
+  -- Reset-Cause Indicator ------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  reset_identifier: process(rstn_ext_i, clk_i)
+  begin
+    if (rstn_ext_i = '0') then
+      reset_cause <= "00"; -- reset from external hardware signal
+    elsif rising_edge(clk_i) then
+      if (rstn_db_i = '0') then
+        reset_cause <= "01"; -- reset from on-chip debugger
+      elsif (hw_rst_timeout = '1') then
+        reset_cause <= "10"; -- reset from watchdog timer
+      elsif (hw_rst_access = '1') then
+        reset_cause <= "11"; -- reset from invalid watchdog access (incorrect password)
+      end if;
+    end if;
+  end process reset_identifier;
 
 
 end neorv32_wdt_rtl;

--- a/sw/lib/include/neorv32_wdt.h
+++ b/sw/lib/include/neorv32_wdt.h
@@ -62,7 +62,8 @@ enum NEORV32_WDT_CTRL_enum {
 enum NEORV32_WDT_RCAUSE_enum {
   WDT_RCAUSE_EXT = 0b00, /**< Reset caused by external signal/pin */
   WDT_RCAUSE_OCD = 0b01, /**< Reset caused by on-chip debugger */
-  WDT_RCAUSE_WDT = 0b10  /**< Reset caused by watchdog timer */
+  WDT_RCAUSE_TMO = 0b10, /**< Reset caused by watchdog timer timeout */
+  WDT_RCAUSE_ACC = 0b11  /**< Reset caused by watchdog timer invalid access */
 };
 
 
@@ -73,7 +74,7 @@ enum NEORV32_WDT_RCAUSE_enum {
 int  neorv32_wdt_available(void);
 void neorv32_wdt_setup(uint32_t timeout, int lock, int debug_en, int sleep_en, int strict);
 int  neorv32_wdt_disable(void);
-void neorv32_wdt_feed(void);
+void neorv32_wdt_feed(uint32_t password);
 int  neorv32_wdt_get_cause(void);
 /**@}*/
 


### PR DESCRIPTION
The watchdog is now able to distinguish 4 reset causes:
* `WDT_RCAUSE_EXT` (0b00): Reset caused by external reset signal/pin
* `WDT_RCAUSE_OCD` (0b01): Reset caused by on-chip debugger
* `WDT_RCAUSE_TMO` (0b10): Reset caused by watchdog timeout
* `WDT_RCAUSE_ACC` (0b11): Reset caused by illegal watchdog access (strict mode) - invalid reset password or a write attempt to the _locked_ configuration register