### PR TITLE
[rtl] remove redundant `prog_buf`

### DIFF
--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -133,10 +133,6 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   end record;
   signal dm_ctrl : dm_ctrl_t;
 
-  -- program buffer access --
-  type prog_buf_t is array (0 to 3) of std_ulogic_vector(31 downto 0);
-  signal prog_buf : prog_buf_t;
-
   -- **********************************************************
   -- CPU Bus and Debug Interfaces
   -- **********************************************************


### PR DESCRIPTION
Just found this signal that is completely redundant. I kinda remember us having found that and removing it a few months ago... did it creep back it? 🤔

Unrelated: I'm playing around with implementing system bus access for the DM. Is that something you would accept a PR for?