### PR TITLE
[cpu] rework ALU instruction decoding and CPU co-processor interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
-| 20.09-2024 | 1.10.4.2 | :bug: fix minor bug in FPU's multiplication instruction (invalid-check logic if any operand is sNAN) | [#1028](https://github.com/stnolting/neorv32/pull/1028) |
+| 23.09.2024 | 1.10.4.3 | rework/optimize ALU instruction decoding and CPU co-processor interface | [#1032](https://github.com/stnolting/neorv32/pull/1032) |
+| 20.09.2024 | 1.10.4.2 | :bug: fix minor bug in FPU's multiplication instruction (invalid-check logic if any operand is sNAN) | [#1028](https://github.com/stnolting/neorv32/pull/1028) |
 | 20.09.2024 | 1.10.4.1 | rtl signal renamings to make the code more readable | [#1026](https://github.com/stnolting/neorv32/pull/1026) |
 | 16.09.2024 | [**:rocket:1.10.4**](https://github.com/stnolting/neorv32/releases/tag/v1.10.4) | **New release** | |
 | 15.09.2024 | 1.10.3.10 | :bug: SW: fix stack-alignment (has to be 128-bit-aligned) before entering the very first procedure (`main`) | [#1021](https://github.com/stnolting/neorv32/pull/1021) |

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -135,15 +135,6 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
   end record;
   signal issue_engine : issue_engine_t;
 
-  -- instruction decoding helper logic --
-  type decode_aux_t is record
-    opcode             : std_ulogic_vector(6 downto 0);
-    is_m_mul, is_m_div : std_ulogic;
-    is_b_imm, is_b_reg : std_ulogic;
-    is_zicond          : std_ulogic;
-  end record;
-  signal decode_aux : decode_aux_t;
-
   -- instruction execution engine --
   type execute_engine_state_t is (DISPATCH, TRAP_ENTER, TRAP_EXIT, RESTART, SLEEP, EXECUTE,
                                   ALU_WAIT, BRANCH, BRANCHED, SYSTEM, MEM_REQ, MEM_WAIT);
@@ -160,6 +151,9 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
     next_pc      : std_ulogic_vector(XLEN-1 downto 0); -- next PC, corresponding to next instruction to be executed
   end record;
   signal execute_engine : execute_engine_t;
+
+  -- simplified opcode --
+  signal opcode : std_ulogic_vector(6 downto 0);
 
   -- execution monitor --
   type monitor_t is record
@@ -507,7 +501,7 @@ begin
         end if;
       else
         alu_imm_o <= replicate_f(execute_engine.ir(31), 21) & execute_engine.ir(30 downto 21) & execute_engine.ir(20); -- default: I-immediate
-        case decode_aux.opcode is
+        case opcode is
           when opcode_store_c => -- S-immediate
             alu_imm_o <= replicate_f(execute_engine.ir(31), 21) & execute_engine.ir(30 downto 25) & execute_engine.ir(11 downto 7);
           when opcode_branch_c => -- B-immediate
@@ -621,76 +615,19 @@ begin
   -- current PC output --
   pc_curr_o <= execute_engine.pc(XLEN-1 downto 1) & '0';
 
-
-  -- Decoding Helper Logic ------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  decode_helper: process(execute_engine)
-    variable f7_v : std_ulogic_vector(6 downto 0);
-    variable f5_v : std_ulogic_vector(4 downto 0);
-    variable f3_v : std_ulogic_vector(2 downto 0);
-  begin
-    -- shortcuts --
-    f7_v := execute_engine.ir(instr_funct7_msb_c downto instr_funct7_lsb_c); -- funct7
-    f5_v := execute_engine.ir(instr_funct12_lsb_c+4 downto instr_funct12_lsb_c); -- funct5
-    f3_v := execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c); -- funct3
-
-    -- defaults --
-    decode_aux.is_b_imm  <= '0';
-    decode_aux.is_b_reg  <= '0';
-    decode_aux.is_m_mul  <= '0';
-    decode_aux.is_m_div  <= '0';
-    decode_aux.is_zicond <= '0';
-
-    -- BITMANIP instruction --
-    if CPU_EXTENSION_RISCV_B then -- implemented at all?
-      -- register-immediate operation --
-      if ((f7_v = "0110000") and (f3_v = "001") and ((f5_v = "00000") or (f5_v = "00001") or (f5_v = "00010") or (f5_v = "00100") or (f5_v = "00101"))) or -- CLZ, CTZ, CPOP, SEXT.[B/H]
-         ((f7_v = "0110000") and (f3_v = "101")) or -- RORI
-         ((f7_v = "0010100") and (f3_v = "101") and (f5_v = "00111")) or -- ORCB
-         ((f7_v = "0100100") and (f3_v(1 downto 0) = "01")) or -- BCLRI / BEXTI
-         ((f7_v = "0110100") and (f3_v(1 downto 0) = "01")) or -- REV8 / BINVI
-         ((f7_v = "0010100") and (f3_v = "001")) then -- BSETI
-        decode_aux.is_b_imm <= '1';
-      end if;
-      -- register-register operation --
-      if ((f7_v = "0110000") and (f3_v(1 downto 0) = "01")) or -- ROR / ROL
-         ((f7_v = "0000101") and (f3_v(2) = '1')) or -- MIN[U] / MAX[U]
-         ((f7_v = "0000100") and (f3_v = "100")) or -- ZEXTH
-         ((f7_v = "0100100") and (f3_v(1 downto 0) = "01")) or -- BCLR / BEXT
-         (((f7_v = "0110100") or (f7_v = "0010100")) and (f3_v = "001")) or  -- BINV / BSET
-         ((f7_v = "0100000") and ((f3_v = "111") or (f3_v = "110") or (f3_v = "100"))) or -- ANDN, ORN, XORN
-         ((f7_v = "0010000") and ((f3_v = "010") or (f3_v = "100") or (f3_v = "110"))) then -- SH1ADD, SH2ADD, SH3ADD
-        decode_aux.is_b_reg <= '1';
-      end if;
-    end if;
-
-    -- integer MUL (M/Zmmul) / DIV (M) instruction --
-    if (f7_v = "0000001") then
-      if (CPU_EXTENSION_RISCV_M or CPU_EXTENSION_RISCV_Zmmul) and (f3_v(2) = '0') then
-        decode_aux.is_m_mul <= '1';
-      end if;
-      if CPU_EXTENSION_RISCV_M and (f3_v(2) = '1') then
-        decode_aux.is_m_div <= '1';
-      end if;
-    end if;
-
-    -- CONDITIONAL instruction (Zicond) --
-    if CPU_EXTENSION_RISCV_Zicond and (f7_v = "0000111") and (f3_v(2) = '1') and (f3_v(0) = '1') then
-      decode_aux.is_zicond <= '1';
-    end if;
-
-    -- simplified rv32 opcode --
-    decode_aux.opcode <= execute_engine.ir(instr_opcode_msb_c downto instr_opcode_lsb_c+2) & "11";
-  end process decode_helper;
+  -- simplified rv32 opcode --
+  opcode <= execute_engine.ir(instr_opcode_msb_c downto instr_opcode_lsb_c+2) & "11";
 
 
   -- Execute Engine FSM Comb ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  execute_engine_fsm_comb: process(execute_engine, debug_ctrl, trap_ctrl, hw_trigger_match, decode_aux, issue_engine, csr, alu_cp_done_i, lsu_wait_i)
+  execute_engine_fsm_comb: process(execute_engine, debug_ctrl, trap_ctrl, hw_trigger_match, opcode, issue_engine, csr, alu_cp_done_i, lsu_wait_i)
     variable funct3_v : std_ulogic_vector(2 downto 0);
+    variable funct7_v : std_ulogic_vector(6 downto 0);
   begin
     -- shortcuts --
     funct3_v := execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c);
+    funct7_v := execute_engine.ir(instr_funct7_msb_c downto instr_funct7_lsb_c);
 
     -- arbiter defaults --
     execute_engine.state_nxt <= execute_engine.state;
@@ -710,14 +647,14 @@ begin
     ctrl_nxt                 <= ctrl_bus_zero_c; -- all zero/off by default (default ALU operation = ZERO, ALU.adder_out = ADD)
 
     -- ALU sign control --
-    if (decode_aux.opcode(4) = '1') then -- ALU ops
+    if (opcode(4) = '1') then -- ALU ops
       ctrl_nxt.alu_unsigned <= funct3_v(0); -- unsigned ALU operation? (SLTIU, SLTU)
     else -- branches
       ctrl_nxt.alu_unsigned <= funct3_v(1); -- unsigned branches? (BLTU, BGEU)
     end if;
 
     -- ALU operand A: is PC? --
-    case decode_aux.opcode is
+    case opcode is
       when opcode_auipc_c | opcode_jal_c | opcode_branch_c =>
         ctrl_nxt.alu_opa_mux <= '1';
       when others =>
@@ -725,7 +662,7 @@ begin
     end case;
 
     -- ALU operand B: is immediate? --
-    case decode_aux.opcode is
+    case opcode is
       when opcode_alui_c | opcode_lui_c | opcode_auipc_c | opcode_load_c | opcode_store_c | opcode_amo_c | opcode_branch_c | opcode_jal_c | opcode_jalr_c =>
         ctrl_nxt.alu_opb_mux <= '1';
       when others =>
@@ -733,7 +670,7 @@ begin
     end case;
 
     -- memory read/write access --
-    if CPU_EXTENSION_RISCV_A and (decode_aux.opcode(2) = opcode_amo_c(2)) then -- atomic lr/sc
+    if CPU_EXTENSION_RISCV_A and (opcode(2) = opcode_amo_c(2)) then -- atomic lr/sc
       ctrl_nxt.lsu_rw <= execute_engine.ir(instr_funct7_lsb_c+2);
     else -- normal load/store
       ctrl_nxt.lsu_rw <= execute_engine.ir(5);
@@ -783,7 +720,7 @@ begin
       when EXECUTE => -- decode and execute instruction (control will be here for exactly 1 cycle in any case)
       -- [NOTE] register file is read in this stage; due to the sync read, data will be available in the _next_ state
       -- ------------------------------------------------------------
-        case decode_aux.opcode is
+        case opcode is
 
           -- register/immediate ALU operation --
           when opcode_alu_c | opcode_alui_c =>
@@ -800,33 +737,25 @@ begin
 
             -- addition/subtraction control --
             if (funct3_v(2 downto 1) = funct3_slt_c(2 downto 1)) or -- SLT(I), SLTU(I)
-               ((funct3_v = funct3_subadd_c) and (decode_aux.opcode(5) = '1') and (execute_engine.ir(instr_funct7_msb_c-1) = '1')) then -- SUB
+               ((funct3_v = funct3_subadd_c) and (opcode(5) = '1') and (execute_engine.ir(instr_funct7_msb_c-1) = '1')) then -- SUB
               ctrl_nxt.alu_sub <= '1';
             end if;
 
-            -- EXT: co-processor MULDIV operation (multi-cycle) --
-            if (CPU_EXTENSION_RISCV_M and (decode_aux.opcode(5) = opcode_alu_c(5)) and ((decode_aux.is_m_mul = '1') or (decode_aux.is_m_div = '1'))) or -- MUL/DIV
-               (CPU_EXTENSION_RISCV_Zmmul and (decode_aux.opcode(5) = opcode_alu_c(5)) and (decode_aux.is_m_mul = '1')) then -- MUL
-              ctrl_nxt.alu_cp_trig(cp_sel_muldiv_c) <= '1'; -- trigger MULDIV co-processor
-              execute_engine.state_nxt              <= ALU_WAIT;
-            -- EXT: co-processor BIT-MANIPULATION operation (multi-cycle) --
-            elsif CPU_EXTENSION_RISCV_B and
-                  (((decode_aux.opcode(5) = opcode_alu_c(5))  and (decode_aux.is_b_reg = '1')) or -- register operation
-                   ((decode_aux.opcode(5) = opcode_alui_c(5)) and (decode_aux.is_b_imm = '1'))) then -- immediate operation
-              ctrl_nxt.alu_cp_trig(cp_sel_bitmanip_c) <= '1'; -- trigger BITMANIP co-processor
-              execute_engine.state_nxt                <= ALU_WAIT;
-            -- EXT: co-processor CONDITIONAL operation (multi-cycle) --
-            elsif CPU_EXTENSION_RISCV_Zicond and (decode_aux.is_zicond = '1') and (decode_aux.opcode(5) = opcode_alu_c(5)) then
-              ctrl_nxt.alu_cp_trig(cp_sel_cond_c) <= '1'; -- trigger COND co-processor
-              execute_engine.state_nxt            <= ALU_WAIT;
-            -- BASE: co-processor SHIFT operation (multi-cycle) --
-            elsif (funct3_v(1 downto 0) = "01") then -- sll/sr
-              ctrl_nxt.alu_cp_trig(cp_sel_shifter_c) <= '1'; -- trigger SHIFTER co-processor
-              execute_engine.state_nxt               <= ALU_WAIT;
-            -- BASE: ALU CORE operation (single-cycle) --
-            else
+            -- is base rv32i/e ALU[I] instruction (excluding shifts)? --
+            if ((opcode(5) = '0') and (funct3_v /= funct3_sll_c) and (funct3_v /= funct3_sr_c)) or -- base ALUI instruction (excluding SLLI, SRLI, SRAI)
+               ((opcode(5) = '1') and (((funct3_v = funct3_subadd_c) and (funct7_v = "0000000")) or
+                                       ((funct3_v = funct3_subadd_c) and (funct7_v = "0100000")) or
+                                       ((funct3_v = funct3_slt_c)    and (funct7_v = "0000000")) or
+                                       ((funct3_v = funct3_sltu_c)   and (funct7_v = "0000000")) or
+                                       ((funct3_v = funct3_xor_c)    and (funct7_v = "0000000")) or
+                                       ((funct3_v = funct3_or_c)     and (funct7_v = "0000000")) or
+                                       ((funct3_v = funct3_and_c)    and (funct7_v = "0000000")) -- base ALU instruction (excluding SLL, SRL, SRA)?
+                                      )) then
               ctrl_nxt.rf_wb_en        <= '1'; -- valid RF write-back (won't happen if exception)
               execute_engine.state_nxt <= DISPATCH;
+            else -- [NOTE] potential illegal ALU[I] instruction are handled as multi-cycle operations that will time-out if no co-processor responds
+              ctrl_nxt.alu_cp_alu      <= '1'; -- trigger ALU[I] opcode-space co-processor
+              execute_engine.state_nxt <= ALU_WAIT;
             end if;
 
           -- load upper immediate --
@@ -856,13 +785,13 @@ begin
 
           -- FPU: floating-point operations --
           when opcode_fop_c =>
-            ctrl_nxt.alu_cp_trig(cp_sel_fpu_c) <= '1'; -- trigger FPU co-processor
-            execute_engine.state_nxt           <= ALU_WAIT; -- will be aborted via monitor timeout if FPU is not implemented
+            ctrl_nxt.alu_cp_fpu      <= '1'; -- trigger FPU co-processor
+            execute_engine.state_nxt <= ALU_WAIT; -- will be aborted via monitor timeout if FPU is not implemented
 
           -- CFU: custom RISC-V instructions --
           when opcode_cust0_c | opcode_cust1_c =>
-            ctrl_nxt.alu_cp_trig(cp_sel_cfu_c) <= '1'; -- trigger CFU co-processor
-            execute_engine.state_nxt           <= ALU_WAIT; -- will be aborted via monitor timeout if CFU is not implemented
+            ctrl_nxt.alu_cp_cfu      <= '1'; -- trigger CFU co-processor
+            execute_engine.state_nxt <= ALU_WAIT; -- will be aborted via monitor timeout if CFU is not implemented
 
           -- environment/CSR operation or ILLEGAL opcode --
           when others =>
@@ -881,7 +810,7 @@ begin
 
       when BRANCH => -- update next_pc on taken branches and jumps
       -- ------------------------------------------------------------
-        ctrl_nxt.rf_wb_en <= decode_aux.opcode(2); -- save return address if link operation (won't happen if exception)
+        ctrl_nxt.rf_wb_en <= opcode(2); -- save return address if link operation (won't happen if exception)
         if (trap_ctrl.exc_buf(exc_illegal_c) = '0') and (execute_engine.branch_taken = '1') then -- valid taken branch
           fetch_engine.reset       <= '1'; -- reset instruction fetch to restart at modified PC
           execute_engine.state_nxt <= BRANCHED; -- shortcut (faster than going to RESTART)
@@ -906,7 +835,7 @@ begin
            (trap_ctrl.exc_buf(exc_saccess_c) = '1') or (trap_ctrl.exc_buf(exc_laccess_c) = '1') or -- access exception
            (trap_ctrl.exc_buf(exc_salign_c)  = '1') or (trap_ctrl.exc_buf(exc_lalign_c)  = '1') or -- alignment exception
            (trap_ctrl.exc_buf(exc_illegal_c) = '1') then -- illegal instruction exception
-          if (CPU_EXTENSION_RISCV_A and (decode_aux.opcode(2) = opcode_amo_c(2))) or (decode_aux.opcode(5) = '0') then -- atomic operation / normal load
+          if (CPU_EXTENSION_RISCV_A and (opcode(2) = opcode_amo_c(2))) or (opcode(5) = '0') then -- atomic operation / normal load
             ctrl_nxt.rf_wb_en <= '1'; -- allow write-back to register file (won't happen in case of exception)
           end if;
           execute_engine.state_nxt <= DISPATCH;
@@ -956,7 +885,9 @@ begin
   ctrl_o.alu_opa_mux  <= ctrl.alu_opa_mux;
   ctrl_o.alu_opb_mux  <= ctrl.alu_opb_mux;
   ctrl_o.alu_unsigned <= ctrl.alu_unsigned;
-  ctrl_o.alu_cp_trig  <= ctrl.alu_cp_trig;
+  ctrl_o.alu_cp_alu   <= ctrl.alu_cp_alu;
+  ctrl_o.alu_cp_cfu   <= ctrl.alu_cp_cfu;
+  ctrl_o.alu_cp_fpu   <= ctrl.alu_cp_fpu;
   -- load/store unit --
   ctrl_o.lsu_req      <= ctrl.lsu_req;
   ctrl_o.lsu_rw       <= ctrl.lsu_rw;
@@ -966,7 +897,7 @@ begin
   -- instruction word bit fields --
   ctrl_o.ir_funct3    <= execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c);
   ctrl_o.ir_funct12   <= execute_engine.ir(instr_funct12_msb_c downto instr_funct12_lsb_c);
-  ctrl_o.ir_opcode    <= decode_aux.opcode;
+  ctrl_o.ir_opcode    <= opcode;
   -- cpu status --
   ctrl_o.cpu_priv     <= csr.privilege_eff;
   ctrl_o.cpu_sleep    <= sleep_mode;
@@ -1099,105 +1030,79 @@ begin
 
   -- Illegal Instruction Check --------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  illegal_check: process(execute_engine, decode_aux, csr, csr_valid, debug_ctrl)
-    variable f7_v : std_ulogic_vector(6 downto 0);
-    variable f3_v : std_ulogic_vector(2 downto 0);
+  illegal_check: process(opcode, execute_engine, csr, csr_valid, debug_ctrl)
   begin
-    -- shortcuts --
-    f7_v := execute_engine.ir(instr_funct7_msb_c downto instr_funct7_lsb_c); -- funct7
-    f3_v := execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c); -- funct3
-
-    -- check opcode-groups --
     illegal_cmd <= '0'; -- default
-    case decode_aux.opcode is
+    case opcode is
 
       when opcode_lui_c | opcode_auipc_c | opcode_jal_c => -- U-instruction type
         illegal_cmd <= '0'; -- all encodings are valid
 
       when opcode_jalr_c => -- unconditional jump-and-link
-        case f3_v is
+        case execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) is
           when "000"  => illegal_cmd <= '0';
           when others => illegal_cmd <= '1';
         end case;
 
       when opcode_branch_c => -- conditional branch
-        case f3_v is
+        case execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) is
           when funct3_beq_c | funct3_bne_c | funct3_blt_c | funct3_bge_c | funct3_bltu_c | funct3_bgeu_c => illegal_cmd <= '0';
           when others => illegal_cmd <= '1';
         end case;
 
       when opcode_load_c => -- memory load
-        case f3_v is
+        case execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) is
           when funct3_lb_c | funct3_lh_c | funct3_lw_c | funct3_lbu_c | funct3_lhu_c => illegal_cmd <= '0';
           when others => illegal_cmd <= '1';
         end case;
 
       when opcode_store_c => -- memory store
-        case f3_v is
+        case execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) is
           when funct3_sb_c | funct3_sh_c | funct3_sw_c => illegal_cmd <= '0';
           when others => illegal_cmd <= '1';
         end case;
 
       when opcode_amo_c => -- atomic memory operation (LR/SC)
-        if CPU_EXTENSION_RISCV_A and (f3_v = "010") and (f7_v(6 downto 3) = "0001") then -- LR.W/SC.W
+        if CPU_EXTENSION_RISCV_A and
+           (execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = "010") and
+           (execute_engine.ir(instr_funct7_lsb_c+6 downto instr_funct7_lsb_c+3) = "0001") then -- LR.W/SC.W
           illegal_cmd <= '0';
         else
           illegal_cmd <= '1';
         end if;
 
-      when opcode_alu_c => -- register-register ALU operation
-        if ((((f3_v = funct3_subadd_c) or (f3_v = funct3_sr_c)) and (f7_v(4 downto 0) = "00000") and (f7_v(6) = '0')) or
-            (((f3_v = funct3_sll_c) or (f3_v = funct3_slt_c) or (f3_v = funct3_sltu_c) or (f3_v = funct3_xor_c) or (f3_v = funct3_or_c) or (f3_v = funct3_and_c)) and (f7_v = "0000000"))
-           ) or -- valid base ALU instruction?
-           ((CPU_EXTENSION_RISCV_M or CPU_EXTENSION_RISCV_Zmmul) and (decode_aux.is_m_mul = '1')) or -- valid MUL instruction?
-           (CPU_EXTENSION_RISCV_M and (decode_aux.is_m_div = '1')) or -- valid DIV instruction?
-           (CPU_EXTENSION_RISCV_B and (decode_aux.is_b_reg = '1')) or -- valid BITMANIP register instruction?
-           (CPU_EXTENSION_RISCV_Zicond and (decode_aux.is_zicond = '1')) then -- valid CONDITIONAL instruction?
-          illegal_cmd <= '0';
-        else
-          illegal_cmd <= '1';
-        end if;
-
-      when opcode_alui_c => -- register-immediate ALU operation
-        if ((f3_v = funct3_subadd_c) or (f3_v = funct3_slt_c) or (f3_v = funct3_sltu_c) or (f3_v = funct3_xor_c) or (f3_v = funct3_or_c) or (f3_v = funct3_and_c) or
-            ((f3_v = funct3_sll_c) and (f7_v = "0000000")) or
-            ((f3_v = funct3_sr_c) and ((f7_v(4 downto 0) = "00000") and (f7_v(6) = '0')))
-           ) or -- valid base ALUI instruction?
-           (CPU_EXTENSION_RISCV_B and (decode_aux.is_b_imm = '1')) then -- valid BITMANIP immediate instruction?
-          illegal_cmd <= '0';
-        else
-          illegal_cmd <= '1';
-        end if;
+      when opcode_alu_c | opcode_alui_c => -- ALU[I] operation
+        illegal_cmd <= '0'; -- [NOTE] valid if not terminated by the "instruction execution monitor"
 
       when opcode_fence_c => -- memory ordering
-        case f3_v is
+        case execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) is
           when funct3_fence_c | funct3_fencei_c => illegal_cmd <= '0';
           when others                           => illegal_cmd <= '1';
         end case;
 
-      when opcode_system_c => -- CSR and system instructions
-        if (f3_v = funct3_env_c) then -- system environment
+      when opcode_system_c => -- CSR / system instruction
+        if (execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_env_c) then -- system environment
           if (execute_engine.ir(instr_rs1_msb_c downto instr_rs1_lsb_c) = "00000") and (execute_engine.ir(instr_rd_msb_c downto instr_rd_lsb_c) = "00000") then
             case execute_engine.ir(instr_funct12_msb_c downto instr_funct12_lsb_c) is
               when funct12_ecall_c | funct12_ebreak_c => illegal_cmd <= '0'; -- ecall and ebreak are always allowed
               when funct12_mret_c                     => illegal_cmd <= (not csr.privilege) or debug_ctrl.running; -- mret allowed in (real/non-debug) M-mode only
               when funct12_dret_c                     => illegal_cmd <= not debug_ctrl.running; -- dret allowed in debug mode only
               when funct12_wfi_c                      => illegal_cmd <= (not csr.privilege) and csr.mstatus_tw; -- wfi allowed in M-mode or if TW is zero
-              when others                             => illegal_cmd <= '1';
+              when others                             => illegal_cmd <= '1'; -- undefined
             end case;
           else
             illegal_cmd <= '1';
           end if;
-        elsif (csr_valid /= "111") or (f3_v = funct3_csril_c) then -- invalid CSR access?
+        elsif (csr_valid /= "111") or (execute_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_csril_c) then -- invalid CSR access?
           illegal_cmd <= '1';
         else
           illegal_cmd <= '0';
         end if;
 
-      when opcode_fop_c => -- floating-point operations
+      when opcode_fop_c => -- floating-point operation
         illegal_cmd <= not bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zfinx); -- valid encodings checked by FPU
 
-      when opcode_cust0_c | opcode_cust1_c => -- custom instructions
+      when opcode_cust0_c | opcode_cust1_c => -- custom instruction
         illegal_cmd <= not bool_to_ulogic_f(CPU_EXTENSION_RISCV_Zxcfu); -- all encodings valid if CFU enable
 
       when others => -- undefined/unimplemented/illegal opcode
@@ -1451,7 +1356,7 @@ begin
       csr.addr <= (others => '0');
     elsif rising_edge(clk_i) then
       -- update only for actual CSR operations to reduce switching activity on the CSR address net --
-      if (execute_engine.state = EXECUTE) and (decode_aux.opcode = opcode_system_c) then
+      if (execute_engine.state = EXECUTE) and (opcode = opcode_system_c) then
         csr.addr(11 downto 10) <= execute_engine.ir(instr_imm12_lsb_c+11 downto instr_imm12_lsb_c+10);
         csr.addr(9 downto 8)   <= replicate_f(execute_engine.ir(instr_imm12_lsb_c+8), 2); -- M-mode (11) and U-mode (00) CSRs only
         csr.addr(7 downto 0)   <= execute_engine.ir(instr_imm12_lsb_c+7 downto instr_imm12_lsb_c);

--- a/rtl/core/neorv32_cpu_cp_fpu.vhd
+++ b/rtl/core/neorv32_cpu_cp_fpu.vhd
@@ -40,7 +40,6 @@ entity neorv32_cpu_cp_fpu is
     clk_i       : in  std_ulogic; -- global clock, rising edge
     rstn_i      : in  std_ulogic; -- global reset, low-active, async
     ctrl_i      : in  ctrl_bus_t; -- main control bus
-    start_i     : in  std_ulogic; -- trigger operation
     -- CSR interface --
     csr_we_i    : in  std_ulogic; -- write enable
     csr_addr_i  : in  std_ulogic_vector(1 downto 0); -- address
@@ -224,7 +223,7 @@ architecture neorv32_cpu_cp_fpu_rtl of neorv32_cpu_cp_fpu is
     small_man : std_ulogic_vector(23 downto 0); -- mantissa + hidden one
     large_exp : std_ulogic_vector(7 downto 0);
     large_man : std_ulogic_vector(23 downto 0); -- mantissa + hidden one
-    -- smaller mantissa alginment --
+    -- smaller mantissa alignment --
     man_sreg  : std_ulogic_vector(23 downto 0); -- mantissa + hidden one
     man_g_ext : std_ulogic;
     man_r_ext : std_ulogic;
@@ -317,7 +316,7 @@ begin
   cmd.instr_class  <= '1' when (ctrl_i.ir_funct12(11 downto 7) = "11100") and (ctrl_i.ir_funct3 = "001")               else '0'; -- FCLASS
   cmd.instr_comp   <= '1' when (ctrl_i.ir_funct12(11 downto 7) = "10100") and (ctrl_i.ir_funct3(2) = '0')              else '0'; -- FEQ/FLT/FLE
   cmd.instr_i2f    <= '1' when (ctrl_i.ir_funct12(11 downto 7) = "11010") and (ctrl_i.ir_funct12(4 downto 1) = "0000") else '0'; -- FCVT
-  cmd.instr_f2i    <= '1' when (ctrl_i.ir_funct12(11 downto 7) = "11000") and (ctrl_i.ir_funct12(4 downto 1) = "0000") else '0' ;-- FCVT
+  cmd.instr_f2i    <= '1' when (ctrl_i.ir_funct12(11 downto 7) = "11000") and (ctrl_i.ir_funct12(4 downto 1) = "0000") else '0'; -- FCVT
   cmd.instr_sgnj   <= '1' when (ctrl_i.ir_funct12(11 downto 7) = "00100") and (ctrl_i.ir_funct3(2) = '0')              else '0'; -- FSGNJ
   cmd.instr_minmax <= '1' when (ctrl_i.ir_funct12(11 downto 7) = "00101") and (ctrl_i.ir_funct3(2 downto 1) = "00")    else '0'; -- FMIN/FMAX
   cmd.instr_addsub <= '1' when (ctrl_i.ir_funct12(11 downto 8) = "0000")                                               else '0'; -- FADD/FSUB
@@ -354,7 +353,7 @@ begin
   op_data(1)(22 downto 0)  <= (others => '0') when (rs2_i(30 downto 23) = "00000000") else rs2_i(22 downto 0); -- flush mantissa to zero if subnormal
 
 
-  -- O Classifier ----------------------------------------------------------------------
+  -- Number Classifier ----------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   number_classifier: process(op_data, rs1_i, rs2_i)
     variable op_m_all_zero_v, op_e_all_zero_v, op_e_all_one_v       : std_ulogic;
@@ -433,7 +432,7 @@ begin
             fpu_operands.frm <= ctrl_i.ir_funct3(2 downto 0);
           end if;
           --
-          if (start_i = '1') and (cmd.valid = '1') then
+          if (ctrl_i.alu_cp_fpu = '1') and (cmd.valid = '1') then
             -- operand data --
             fpu_operands.rs1       <= op_data(0);
             fpu_operands.rs1_class <= op_class(0);

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100402"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100403"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -460,7 +460,9 @@ package neorv32_package is
     alu_opa_mux  : std_ulogic;                     -- operand A select (0=rs1, 1=PC)
     alu_opb_mux  : std_ulogic;                     -- operand B select (0=rs2, 1=IMM)
     alu_unsigned : std_ulogic;                     -- is unsigned ALU operation
-    alu_cp_trig  : std_ulogic_vector(5 downto 0);  -- co-processor trigger (one-hot)
+    alu_cp_alu   : std_ulogic;                     -- ALU.base co-processor trigger (one-shot)
+    alu_cp_cfu   : std_ulogic;                     -- CFU co-processor trigger (one-shot)
+    alu_cp_fpu   : std_ulogic;                     -- FPU co-processor trigger (one-shot)
     -- load/store unit --
     lsu_req      : std_ulogic;                     -- trigger memory access request
     lsu_rw       : std_ulogic;                     -- 0: read access, 1: write access
@@ -490,7 +492,9 @@ package neorv32_package is
     alu_opa_mux  => '0',
     alu_opb_mux  => '0',
     alu_unsigned => '0',
-    alu_cp_trig  => (others => '0'),
+    alu_cp_alu   => '0',
+    alu_cp_cfu   => '0',
+    alu_cp_fpu   => '0',
     lsu_req      => '0',
     lsu_rw       => '0',
     lsu_mo_we    => '0',
@@ -509,15 +513,6 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   constant cmp_equal_c : natural := 0;
   constant cmp_less_c  : natural := 1; -- for signed and unsigned comparisons
-
-  -- CPU Co-Processor IDs -------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  constant cp_sel_shifter_c  : natural := 0; -- CP0: shift operations (base ISA)
-  constant cp_sel_muldiv_c   : natural := 1; -- CP1: multiplication/division operations ('M' extensions)
-  constant cp_sel_bitmanip_c : natural := 2; -- CP2: bit manipulation ('B' extensions)
-  constant cp_sel_fpu_c      : natural := 3; -- CP3: floating-point unit ('Zfinx' extension)
-  constant cp_sel_cfu_c      : natural := 4; -- CP4: custom instructions CFU ('Zxcfu' extension)
-  constant cp_sel_cond_c     : natural := 5; -- CP5: conditional operations ('Zicond' extension)
 
   -- ALU Function Codes ---------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -571,6 +571,8 @@ int main() {
   asm volatile (".word 0x00008073"); // ecall with rd != 0
   asm volatile (".word 0x7b300073"); // illegal system funct12
   asm volatile (".word 0xfe000033"); // illegal add funct7
+  asm volatile (".word 0xf0a01013"); // illegal slli funct7
+  asm volatile (".word 0xde000033"); // illegal mul funct7
   asm volatile (".word 0x80002163"); // illegal branch funct3 (misaligned DST if C not available)
   asm volatile (".word 0x0000200f"); // illegal fence funct3
   asm volatile (".word 0xfe002fe3"); // illegal store funct3
@@ -585,11 +587,11 @@ int main() {
   // number of traps we are expecting + expected instruction word of last illegal instruction
   uint32_t invalid_instr;
   if (neorv32_cpu_csr_read(CSR_MISA) & (1<<CSR_MISA_C)) { // C extension enabled
-    tmp_a += 15;
+    tmp_a += 17;
     invalid_instr = 0x08812681; // mtinst: pre-decompressed; clear bit 1 if compressed instruction
   }
   else { // C extension disabled
-    tmp_a += 13;
+    tmp_a += 15;
     invalid_instr = 0xfe002fe3;
   }
 


### PR DESCRIPTION
This is a massive rework of the CPU instruction decoding logic that replaces the centralized instruction decoding (inside the control unit) by a "split" decoding.

Only the basic rv32 register-register / register-immediate ALU instruction (`alu/alui` opcode space) are decoded inside the control unit. All further instructions (including shift operation) are forwarded to the CPU co-processors. If no co-processor generates a response within a bound amount of time the instruction is considered "illegal" (raising an exception). Therefore, each co-processor has to decode all relevant instructions locally.

This change aims to reduce hardware complexity and to make the code base easier to understand and maintain.

**🚧 work-in-progress 🚧**