### PR TITLE
:warning: rework CFU handshake interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 02.10.2024 | 1.10.5.1 | :warning: rework CFU interface; reduce minimal latency of CFU instructions from 4 cycles to 3 cycles | [#1046](https://github.com/stnolting/neorv32/pull/1046) |
 | 01.10.2024 | [**:rocket:1.10.5**](https://github.com/stnolting/neorv32/releases/tag/v1.10.5) | **New release** | |
 | 30.09.2024 | 1.10.4.11 | :warning: split `B` ISA extensions into individual sub-extensions: `Zba`, `Zbb`, `Zbs` | [#1044](https://github.com/stnolting/neorv32/pull/1044) |
 | 29.09.2024 | 1.10.4.10 | :warning: rename CPU ISA configuration generics: `CPU_EXTENSION_* -> RISCV_ISA_*` | [#1041](https://github.com/stnolting/neorv32/pull/1041) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -1051,6 +1051,20 @@ see section <<_custom_functions_unit_cfu>>.
 Software can utilize the custom instructions by using _intrinsics_, which are basically inline assembly functions that
 behave like regular C functions but that evaluate to a single custom instruction word (no calling overhead at all).
 
+.CFU Execution Time
+[NOTE]
+The actual CFU execution time depends on the logic being implemented. The CPU architecture requires a minimal execution
+time of 3 cycle and automatically terminates execution after 512 cycles if the CFU does not complete operation within
+this time window.
+
+.Instructions and Timing
+[cols="<2,<5,<2"]
+[options="header", grid="rows"]
+|=======================
+| Class | Instructions | Execution cycles
+| Custom instructions | Instruction words with `custom-0` or `custom-1` opcode | 3 ... 3+512
+|=======================
+
 
 ==== `Smpmp` ISA Extension
 

--- a/docs/datasheet/cpu_cfu.adoc
+++ b/docs/datasheet/cpu_cfu.adoc
@@ -45,8 +45,8 @@ The NEORV32 CFU utilizes these two opcodes to support user-defined **R3-type** i
 1 destination register) and **R4-type** instructions (3 source registers, 1 destination register). Both instruction
 formats are compliant to the RISC-V specification.
 
-* `custom-0`: `0001011` RISC-V standard, used for NEORV32 <<_cfu_r3_type_instructions>> (3 register addresses)
-* `custom-1`: `0101011` RISC-V standard, used for NEORV32 <<_cfu_r4_type_instructions>> (4 register addresses)
+* `custom-0`: `0001011` RISC-V standard, used for NEORV32 <<_cfu_r3_type_instructions>> (3x register addresses)
+* `custom-1`: `0101011` RISC-V standard, used for NEORV32 <<_cfu_r4_type_instructions>> (4x register addresses)
 
 [TIP]
 The provided instructions formats are _predefined_ to allow an easy integration framework.
@@ -68,11 +68,11 @@ Example operation: `rd <= rs1 xnor rs2` (bit-wise logical XNOR)
 image::cfu_r3type_instruction.png[align=left]
 
 * `funct7`: 7-bit immediate (immediate data or function select)
-* `rs2`: address of second source register (32-bit source data)
-* `rs1`: address of first source register (32-bit source data)
+* `rs2`: address of second source register (providing 32-bit source data)
+* `rs1`: address of first source register (providing 32-bit source data)
 * `funct3`: 3-bit immediate (immediate data or function select)
 * `rd`: address of destination register (32-bit processing result)
-* `opcode`: `0001011` (RISC-V "custom-0" opcode)
+* `opcode`: `0001011` (RISC-V `custom-0` opcode)
 
 .Instruction encoding space
 [NOTE]
@@ -94,14 +94,14 @@ Example operation: `rd <= (rs1 * rs2 + rs3)[31:0]` (multiply-and-accumulate; "MA
 .CFU R4-type instruction format
 image::cfu_r4type_instruction.png[align=left]
 
-* `rs3`: address of third source register (32-bit source data)
-* `rs2`: address of second source register (32-bit source data)
-* `rs1`: address of first source register (32-bit source data)
+* `rs3`: address of third source register (providing 32-bit source data)
+* `rs2`: address of second source register (providing 32-bit source data)
+* `rs1`: address of first source register (providing 32-bit source data)
 * `funct3`: 3-bit immediate (immediate data or function select)
 * `rd`: address of destination register (32-bit processing result)
-* `opcode`: `0101011` (RISC-V "custom-1" opcode)
-* ⚠️ bits [26:25] of the R4-type instruction word are unused and should always be set to zero. However, these bits
-are ignored by the CPU's illegal instruction check logic.
+* `opcode`: `0101011` (RISC-V `custom-1` opcode)
+* ⚠️ bits [26:25] of the R4-type instruction word are unused. However, these bits are ignored
+by CPU's instruction decoder and can be retrieved via the CFU's `funct7_i(6 downto 5)` signal.
 
 .Instruction encoding space
 [NOTE]
@@ -195,7 +195,7 @@ CSRs.
 ==== Custom Instructions Hardware
 
 The actual functionality of the CFU's custom instructions is defined by the user-defined logic inside the CFU
-hardware module `rtl/core/neorv32_cpu_cp_cfu.vhd`. This file is highly commented to explain the interface and
+hardware module (`rtl/core/neorv32_cpu_cp_cfu.vhd`). This file is highly commented to explain the interface and
 to illustrate hardware design considerations.
 
 CFU operations can be entirely combinatorial (like bit-reversal) so the result is available at the end of the

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -90,10 +90,8 @@ architecture neorv32_cpu_cpu_rtl of neorv32_cpu_alu is
   signal fpu_csr_rd, cfu_csr_rd : std_ulogic_vector(XLEN-1 downto 0);
 
   -- CFU proxy --
-  signal cfu_run  : std_ulogic;
-  signal cfu_done : std_ulogic;
-  signal cfu_wait : std_ulogic_vector(1 downto 0);
-  signal cfu_res  : std_ulogic_vector(XLEN-1 downto 0);
+  signal cfu_active, cfu_done, cfu_busy : std_ulogic;
+  signal cfu_res : std_ulogic_vector(XLEN-1 downto 0);
 
   -- CSR read-backs --
   signal csr_rdata_fpu, csr_rdata_cfu : std_ulogic_vector(XLEN-1 downto 0);
@@ -285,6 +283,8 @@ begin
 
   neorv32_cpu_cp_fpu_inst_false:
   if not RISCV_ISA_Zfinx generate
+    fpu_csr_en    <= '0';
+    fpu_csr_we    <= '0';
     csr_rdata_fpu <= (others => '0');
     cp_result(3)  <= (others => '0');
     cp_valid(3)   <= '0';
@@ -302,7 +302,7 @@ begin
       rstn_i      => rstn_i,                         -- global reset, low-active, async
       -- operation control --
       start_i     => ctrl_i.alu_cp_cfu,              -- operation trigger/strobe
-      active_i    => cfu_run,                        -- operation in progress, CPU is waiting for CFU
+      active_i    => cfu_active,                     -- operation in progress, CPU is waiting for CFU
       -- CSR interface --
       csr_we_i    => cfu_csr_we,                     -- write enable
       csr_addr_i  => csr_addr_i(1 downto 0),         -- address
@@ -325,35 +325,43 @@ begin
     cfu_csr_we    <= cfu_csr_en and csr_we_i;
     csr_rdata_cfu <= cfu_csr_rd when (cfu_csr_en = '1') else (others => '0');
 
-    -- operation proxy --
+    -- response proxy --
     cfu_arbiter: process(rstn_i, clk_i)
     begin
       if (rstn_i = '0') then
-        cfu_wait <= (others => '0');
+        cfu_busy     <= '0';
+        cp_result(4) <= (others => '0');
       elsif rising_edge(clk_i) then
-        cfu_wait(1) <= cfu_wait(0);
-        if (cfu_wait(0) = '0') then -- CFU is idle
-          cfu_wait(0) <= ctrl_i.alu_cp_cfu; -- trigger new CFU operation
-        elsif (cfu_done = '1') or (ctrl_i.cpu_trap = '1') then -- operation done or abort if trap (exception)
-          cfu_wait(0) <= '0';
+        if (cfu_done = '1') or (ctrl_i.cpu_trap = '1') then -- terminate also on trap
+          cfu_busy <= '0';
+        elsif (ctrl_i.alu_cp_cfu = '1') then
+          cfu_busy <= '1';
+        end if;
+        if (cfu_done = '1') and ((ctrl_i.alu_cp_cfu = '1') or (cfu_busy = '1')) then
+          cp_result(4) <= cfu_res;
+        else -- output zero if there is no CFU operation
+          cp_result(4) <= (others => '0');
         end if;
       end if;
     end process cfu_arbiter;
 
-    cfu_run      <= ctrl_i.alu_cp_cfu or cfu_wait(0); -- CFU operation in progress
-    cp_result(4) <= cfu_res when (cfu_wait(1) = '1') else (others => '0'); -- output gate
-    cp_valid(4)  <= cfu_wait(0) and cfu_done;
+    cfu_active  <= ctrl_i.alu_cp_cfu or cfu_busy; -- CFU operation in progress
+    cp_valid(4) <= cfu_done and (ctrl_i.alu_cp_cfu or cfu_busy);
   end generate;
 
   neorv32_cpu_cp_cfu_inst_false:
   if not RISCV_ISA_Zxcfu generate
+    cfu_csr_en    <= '0';
+    cfu_csr_we    <= '0';
     csr_rdata_cfu <= (others => '0');
+    cfu_busy      <= '0';
+    cfu_active    <= '0';
     cp_result(4)  <= (others => '0');
     cp_valid(4)   <= '0';
   end generate;
 
 
-  -- ALU-Opcode Co-Processor: Integer Conditional Operations Unit ('Zicond' ISA Extension) ---
+  -- ALU-Opcode Co-Processor: Conditional Operations Unit ('Zicond' ISA Extension) ----------
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_cp_cond_inst_true:
   if RISCV_ISA_Zicond generate

--- a/rtl/core/neorv32_cpu_cp_cfu.vhd
+++ b/rtl/core/neorv32_cpu_cp_cfu.vhd
@@ -1,9 +1,9 @@
 -- ================================================================================ --
 -- NEORV32 CPU - Co-Processor: Custom (RISC-V Instructions) Functions Unit (CFU)    --
 -- -------------------------------------------------------------------------------- --
--- For custom/user-defined RISC-V instructions See the  CPU's documentation for     --
--- more information. Also take a look at the "software-counterpart" this default    --
--- CFU hardware in 'sw/example/demo_cfu'.                                           --
+-- For custom/user-defined RISC-V instructions. See the CPU's documentation for     --
+-- more information. Also take a look at the "software-counterpart" of this default --
+-- CFU hardware example in 'sw/example/demo_cfu'.                                   --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
@@ -26,22 +26,21 @@ entity neorv32_cpu_cp_cfu is
     active_i    : in std_ulogic; -- operation in progress, CPU is waiting for CFU
     -- CSR interface --
     csr_we_i    : in  std_ulogic; -- write enable
-    csr_addr_i  : in  std_ulogic_vector(1 downto 0); -- address
+    csr_addr_i  : in  std_ulogic_vector(1 downto 0); -- address (CSR address 0x800 to 0x803)
     csr_wdata_i : in  std_ulogic_vector(31 downto 0); -- write data
-    csr_rdata_o : out std_ulogic_vector(31 downto 0) := (others => '0'); -- read data
-    -- operands --
-    rtype_i     : in std_ulogic; -- instruction type (R3-type or R4-type)
+    csr_rdata_o : out std_ulogic_vector(31 downto 0); -- read data
+    -- operands (form/via custom instruction word) --
+    rtype_i     : in std_ulogic; -- instruction type (R3-type or R4-type); from instruction word's "opcode[5]" bit
     funct3_i    : in std_ulogic_vector(2 downto 0); -- "funct3" bit-field from custom instruction word
     funct7_i    : in std_ulogic_vector(6 downto 0); -- "funct7" bit-field from custom instruction word
-    rs1_i       : in  std_ulogic_vector(31 downto 0); -- rf source 1
-    rs2_i       : in  std_ulogic_vector(31 downto 0); -- rf source 2
-    rs3_i       : in  std_ulogic_vector(31 downto 0); -- rf source 3
+    rs1_i       : in  std_ulogic_vector(31 downto 0); -- rf source 1 via "rs1" bit-field from custom instruction word
+    rs2_i       : in  std_ulogic_vector(31 downto 0); -- rf source 2 via "rs2" bit-field from custom instruction word
+    rs3_i       : in  std_ulogic_vector(31 downto 0); -- rf source 3 via "rs3" bit-field from custom instruction word
     -- result and status --
-    result_o    : out std_ulogic_vector(31 downto 0) := (others => '0'); -- operation result
-    valid_o     : out std_ulogic := '0' -- result valid, operation done; set one cycle before result_o is valid
+    result_o    : out std_ulogic_vector(31 downto 0); -- operation result
+    valid_o     : out std_ulogic -- result valid, operation done; set one cycle before result_o is valid
   );
 end neorv32_cpu_cp_cfu;
-
 
   -- **************************************************************************************************************************
   -- CFU Interface Documentation
@@ -81,30 +80,28 @@ end neorv32_cpu_cp_cfu;
   -- > active_i (input,   1-bit): operation in progress while (optional signal)
   --
   -- > result_o (output, 32-bit): processing result
-  -- > valid_o  (output,  1-bit): set high when processing is done
+  -- > valid_o  (output,  1-bit): set high (for one cycle) when processing is done
   --
   -- The start of a new CFU operation is indicated by <start_i> being high for exactly one cycle. The CFU may operate while
   -- <active_i> is high and should terminate (and reset) all internal operations when it clears again. However, using
   -- <active_i> is optional. When the CFU has completed processing, the data returned via <result_o> will be written to the
   -- CPU's register file (indexed by the 'rd' bit-field).
   --
-  -- [TIP] For complex CFU designs it is highly recommended to register <result_o> in order to keep the CPU's critical
-  --       path as short as possible.
-  --
   -- The <valid_o> signal is used to signal the completion of the CFU operation. For pure-combinatorial instructions
   -- (completing within 1 clock cycle) <valid_o> can be hardwired to 1. If the CFU requires several clock cycles for
-  -- completion the <valid_o> signal has to be set exactly ONE CYCLE BEFORE <result_o> is valid.
+  -- completion the <valid_o> signal has to be set when <result_o> is valid. Otherwise, <valid_o> should be cleared.
+  -- However, the CPU execution logic will evaluate <valid_o> only while <active_i> is high.
   --
-  -- Example interface timing for a multi-cycle CFU operation:
-  -- clk_i    ____/----\____/----\____/----\____/----\____/----\____
-  -- start_i  ____/---------\_______________________________________ trigger is high for one cycle
-  -- active_i ____/-----------------------------\___________________ cease processing when low
-  -- valid_o  ....\___________________/---------\................... set one cycle before output phase, zero during processing
-  -- result_o ..................................|DDDDDDDDD|......... don't care ('.') except for output phase ('D')
+  -- Example interface timing for a multi-cycle CFU operation (with 2 cycles processing latency):
+  -- clk_i    ____/----\____/----\____/----\____/----\____
+  -- start_i  ____/---------\_____________________________ trigger is high for one cycle
+  -- active_i ____/-----------------------------\_________ cease processing when low
+  -- valid_o  ________________________/---------\_________ set for one cycle when operation is done / result is valid
+  -- result_o ........................|DDDDDDDDD|......... don't care ('.') except for valid-output phase ('D')
   --
-  -- [NOTE] If the <valid_o> signal is not set within a bound time window (default = 512 cycles; see "monitor_mc_tmo_c"
-  --        constant in the main NEORV32 package file) the CFU operation is automatically terminated by the hardware
-  --        (clearing <active_i>) and an illegal instruction exception is raised.
+  -- [NOTE] If the <valid_o> signal is not set within a bound time window after the CFU has been triggered via <start_i>
+  --        (default = 512 cycles; see "monitor_mc_tmo_c" constant in the main NEORV32 package file) the CFU operation
+  --        is automatically terminated by the hardware (clearing <active_i>) and an illegal instruction exception is raised.
 
   -- ----------------------------------------------------------------------------------------
   -- CFU-Internal Control and Status Registers (CFU-CSRs)
@@ -115,12 +112,12 @@ end neorv32_cpu_cp_cfu;
   -- > csr_rdata_i (output, 32-bit): CSR read data
   --
   -- The CFU provides four directly accessible CSR addresses for implementing custom control and status register inside the CFU.
-  --  These registers can be used to pass further operands, to check the unit's status or to configure operation modes.
+  -- These are accessed via the global CSR addresses 0x800 to 0x803. The CFU-exclusive CSRs can be used to pass further operands,
+  -- to check the unit's status or to configure additional operation modes.
   --
   -- [TIP] If more than four CFU-internal CSRs are required the designer can implement an "indirect access mechanism" based
   --       on just two of the default CSRs: one CSR is used to configure the index while the other is used as an alias to
   --       exchange data with the indexed CFU-internal CSR.
-
 
   -- **************************************************************************************************************************
   -- Actual CFU User Logic Example: XTEA - Extended Tiny Encryption Algorithm (replace this with your custom logic)
@@ -156,7 +153,7 @@ architecture neorv32_cpu_cp_cfu_rtl of neorv32_cpu_cp_cfu is
 
   -- processing logic --
   type xtea_t is record
-    done : std_ulogic; -- multi-cycle done shift register
+    done : std_ulogic_vector(1 downto 0); -- multi-cycle done shift register; 2 stages = 2 cyles latency
     opa  : std_ulogic_vector(31 downto 0); -- input operand a
     opb  : std_ulogic_vector(31 downto 0); -- input operand b
     sum  : std_ulogic_vector(31 downto 0); -- round key buffer
@@ -192,23 +189,25 @@ begin
   xtea_core: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      xtea.done <= '0';
+      xtea.done <= (others => '0');
       xtea.opa  <= (others => '0');
       xtea.opb  <= (others => '0');
       xtea.sum  <= (others => '0');
       xtea.res  <= (others => '0');
     elsif rising_edge(clk_i) then
+      -- "operation-done" shift register: module has 2 cycles latency --
+      xtea.done(0) <= '0'; -- default: no operation trigger
+      xtea.done(1) <= xtea.done(0);
 
       -- trigger new operation --
-      xtea.done <= '0'; -- default
       if (start_i = '1') and (rtype_i = r3type_c) then -- execution trigger and correct instruction type
-        xtea.opa  <= rs1_i; -- buffer input operand rs1 (for improved physical timing)
-        xtea.opb  <= rs2_i; -- buffer input operand rs2 (for improved physical timing)
-        xtea.done <= '1'; -- result is available in the 2nd cycle
+        xtea.opa     <= rs1_i; -- buffer input operand rs1 (for improved physical timing)
+        xtea.opb     <= rs2_i; -- buffer input operand rs2 (for improved physical timing)
+        xtea.done(0) <= '1'; -- trigger operation
       end if;
 
       -- data processing --
-      if (xtea.done = '1') then -- second-stage execution trigger
+      if (xtea.done(0) = '1') then -- second-stage execution trigger
         -- update "sum" round key --
         if (funct3_i(2) = '1') then -- initialize
           xtea.sum <= xtea.opa; -- set initial round key
@@ -247,7 +246,7 @@ begin
       case funct3_i is -- just check "funct3" here; "funct7" bit-field is ignored in this example
         when xtea_enc_v0_c | xtea_enc_v1_c | xtea_dec_v0_c | xtea_dec_v1_c => -- xtea encryption/decryption
           result_o <= xtea.res; -- processing result
-          valid_o  <= xtea.done; -- multi-cycle processing done when set
+          valid_o  <= xtea.done(1); -- multi-cycle processing done when set
         when xtea_init_c => -- xtea initialization
           result_o <= (others => '0'); -- just output zero
           valid_o  <= '1'; -- pure-combinatorial, so we are done "immediately"

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100500"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100501"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -423,7 +423,7 @@ package neorv32_package is
   constant csr_mhpmcounter14h_c : std_ulogic_vector(11 downto 0) := x"b8e";
   constant csr_mhpmcounter15h_c : std_ulogic_vector(11 downto 0) := x"b8f";
   -- NEORV32-specific read-write machine registers --
---constant csr_mxstatus_c       : std_ulogic_vector(11 downto 0) := x"bc0";
+--constant csr_mxstatus_c       : std_ulogic_vector(11 downto 0) := x"bc0"; -- to-be-implemented
   -- user counters/timers --
   constant csr_cycle_c          : std_ulogic_vector(11 downto 0) := x"c00";
 --constant csr_time_c           : std_ulogic_vector(11 downto 0) := x"c01";
@@ -440,6 +440,7 @@ package neorv32_package is
   constant csr_mconfigptr_c     : std_ulogic_vector(11 downto 0) := x"f15";
   -- NEORV32-specific read-only machine registers --
   constant csr_mxisa_c          : std_ulogic_vector(11 downto 0) := x"fc0";
+--constant csr_mxisah_c         : std_ulogic_vector(11 downto 0) := x"fc1"; -- to-be-implemented
 
 -- **********************************************************************************************************
 -- CPU Control


### PR DESCRIPTION
⚠️ This PR is a rework of the _custom functions unit's_ (CFU) handshake protocol.

With the changes from this PR, the "processing done" / "result valid" signal `valid_o` has to be set (for one cycle) at the same time the processing result / output data `result_o` is valid.

Thus, the handshake is easier to understand and easier to implement.

✨ Furthermore, this PR provides a rework of the "CFU proxy logic" allowing an (all-combinatorial) CFU operation to commit much faster: the minimum CPU execution time of a single CFU operation is reduced from 4 clock cycles down to 3 clock cycles.