### PR TITLE
[vivado ip] hide entire AXI-Stream interface in block diagram if disabled

### DIFF
--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -66,8 +66,8 @@ set_property description "The NEORV32 RISC-V Processor" [ipx::current_core]
 # **************************************************************
 # Interfaces: Configuration Dependencies
 # **************************************************************
-set_property enablement_dependency {$axi4_stream_en = true} [ipx::get_ports s0_axis_*    -of_objects [ipx::current_core]]
-set_property enablement_dependency {$axi4_stream_en = true} [ipx::get_ports s1_axis_*    -of_objects [ipx::current_core]]
+set_property enablement_dependency {$axi4_stream_en = true} [ipx::get_bus_interfaces s0_axis -of_objects [ipx::current_core]]
+set_property enablement_dependency {$axi4_stream_en = true} [ipx::get_bus_interfaces s1_axis -of_objects [ipx::current_core]]
 set_property enablement_dependency {$ocd_en = true}         [ipx::get_ports jtag_*       -of_objects [ipx::current_core]]
 set_property enablement_dependency {$xip_en = true}         [ipx::get_ports xip_*        -of_objects [ipx::current_core]]
 set_property enablement_dependency {$io_gpio_en = true}     [ipx::get_ports gpio_*       -of_objects [ipx::current_core]]


### PR DESCRIPTION
Currently empty ports for AXI-Stream interfaces (`s1_axis` and `s0_axis`) are still shown even if they're not enabled (shown in the picture). Setting `enablement_dependency` property for the bus interfaces instead can hide them entirely.

Tested in Vivado 2022.2

<img width="524" alt="neorv-axis" src="https://github.com/user-attachments/assets/a85ce8a7-9c1c-4a67-8d9a-1606e72eaee8">
