### PR TITLE
[vivado ip] make m_axi (XBUS) interface optional

### DIFF
--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -151,7 +151,7 @@ proc setup_ip_gui {} {
     { OCD_AUTHENTICATION    {OCD Authentication}    {Implement Debug Authentication module}                   {$OCD_EN} {$OCD_EN ? $OCD_AUTHENTICATION : false}}
   }
 
-  set group [add_group $page {External Bus Interface (XBUS)}]
+  set group [add_group $page {External Bus Interface (XBUS / AXI4-Lite-MM Host)}]
   add_params $group {
     { XBUS_EN               {Enable XBUS}           {} }
     { XBUS_TIMEOUT          {Timeout}               {Max number of clock cycles before AXI access times out}  {$XBUS_EN} }
@@ -164,7 +164,7 @@ proc setup_ip_gui {} {
     { XBUS_CACHE_BLOCK_SIZE {Block Size}            {In bytes (use a power of two)}                           {$XBUS_CACHE_EN} }
   }
 
-  set group [add_group $page {Stream Link Interface (SLINK)}]
+  set group [add_group $page {Stream Link Interface (SLINK / AXI4-Stream Source & Sink)}]
   add_params $group {
     { AXI4_STREAM_EN        {Enable SLINK}          {} }
     { IO_SLINK_RX_FIFO      {RX FIFO Depth}         {Number of entries (use a power of two)}                  {$AXI4_STREAM_EN} }

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -110,6 +110,7 @@ proc setup_ip_gui {} {
   # **************************************************************
   set_property enablement_dependency {$AXI4_STREAM_EN} [ipx::get_bus_interfaces s0_axis -of_objects [ipx::current_core]]
   set_property enablement_dependency {$AXI4_STREAM_EN} [ipx::get_bus_interfaces s1_axis -of_objects [ipx::current_core]]
+  set_property enablement_dependency {$XBUS_EN}        [ipx::get_bus_interfaces m_axi   -of_objects [ipx::current_core]]
   set_property enablement_dependency {$OCD_EN}         [ipx::get_ports jtag_*           -of_objects [ipx::current_core]]
   set_property enablement_dependency {$XIP_EN}         [ipx::get_ports xip_*            -of_objects [ipx::current_core]]
   set_property enablement_dependency {$IO_GPIO_EN}     [ipx::get_ports gpio_*           -of_objects [ipx::current_core]]
@@ -152,12 +153,13 @@ proc setup_ip_gui {} {
 
   set group [add_group $page {External Bus Interface (XBUS)}]
   add_params $group {
-    { XBUS_TIMEOUT          {Timeout}               {Max number of clock cycles before AXI access times out} }
+    { XBUS_EN               {Enable XBUS}           {} }
+    { XBUS_TIMEOUT          {Timeout}               {Max number of clock cycles before AXI access times out}  {$XBUS_EN} }
   }
 
   set sub_group [add_group $group {XBUS Cache}]
   add_params $sub_group {
-    { XBUS_CACHE_EN         {Enable XBUS Cache}     {} }
+    { XBUS_CACHE_EN         {Enable XBUS Cache}     {}                                                        {$XBUS_EN} {$XBUS_EN ? $XBUS_CACHE_EN : false}}
     { XBUS_CACHE_NUM_BLOCKS {Number of Blocks}      {}                                                        {$XBUS_CACHE_EN} }
     { XBUS_CACHE_BLOCK_SIZE {Block Size}            {In bytes (use a power of two)}                           {$XBUS_CACHE_EN} }
   }

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -85,6 +85,7 @@ entity neorv32_vivado_ip is
     DCACHE_NUM_BLOCKS     : natural range 1 to 256        := 4;
     DCACHE_BLOCK_SIZE     : natural range 4 to 2**16      := 64;
     -- External Bus Interface --
+    XBUS_EN               : boolean                       := true;
     XBUS_TIMEOUT          : natural range 8 to 65536      := 64;
     XBUS_CACHE_EN         : boolean                       := false;
     XBUS_CACHE_NUM_BLOCKS : natural range 1 to 256        := 8;
@@ -139,7 +140,7 @@ entity neorv32_vivado_ip is
     clk            : in  std_logic;
     resetn         : in  std_logic; -- low-active
     -- ------------------------------------------------------------
-    -- AXI4-Lite-Compatible Host Interface (always available)
+    -- AXI4-Lite Host Interface (available if XBUS_EN = true)
     -- ------------------------------------------------------------
     -- Clock and Reset --
 --  m_axi_aclk     : in  std_logic := '0'; -- just to satisfy Vivado, but not actually used
@@ -169,7 +170,7 @@ entity neorv32_vivado_ip is
     m_axi_bvalid   : in  std_logic := '0';
     m_axi_bready   : out std_logic;
     -- ------------------------------------------------------------
-    -- AXI4-Stream-Compatible Interfaces (available if AXI4_STREAM_EN = true)
+    -- AXI4-Stream Interfaces (available if AXI4_STREAM_EN = true)
     -- ------------------------------------------------------------
     -- Source --
 --  s0_axis_aclk   : in  std_logic := '0'; -- just to satisfy Vivado, but not actually used
@@ -409,7 +410,7 @@ begin
     DCACHE_NUM_BLOCKS     => DCACHE_NUM_BLOCKS,
     DCACHE_BLOCK_SIZE     => DCACHE_BLOCK_SIZE,
     -- External bus interface --
-    XBUS_EN               => true,
+    XBUS_EN               => XBUS_EN,
     XBUS_TIMEOUT          => XBUS_TIMEOUT,
     XBUS_REGSTAGE_EN      => false,
     XBUS_CACHE_EN         => XBUS_CACHE_EN,
@@ -613,53 +614,56 @@ begin
 
   -- Wishbone-to-AXI4-Lite Bridge -----------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  axi4_bridge_inst: xbus2axi4lite_bridge
-  port map (
-    -- ------------------------------------------------------------
-    -- Global Control
-    -- ------------------------------------------------------------
-    clk           => clk,
-    resetn        => resetn,
-    -- ------------------------------------------------------------
-    -- XBUS Device Interface
-    -- ------------------------------------------------------------
-    xbus_adr_i    => xbus_adr,
-    xbus_dat_i    => xbus_do,
-    xbus_tag_i    => xbus_tag,
-    xbus_we_i     => xbus_we,
-    xbus_sel_i    => xbus_sel,
-    xbus_stb_i    => xbus_stb,
-    xbus_cyc_i    => xbus_cyc,
-    xbus_ack_o    => xbus_ack,
-    xbus_err_o    => xbus_err,
-    xbus_dat_o    => xbus_di,
-    -- ------------------------------------------------------------
-    -- AXI4-Lite Host Interface
-    -- ------------------------------------------------------------
-    -- Write Address Channel --
-    m_axi_awaddr  => m_axi_awaddr,
-    m_axi_awprot  => m_axi_awprot,
-    m_axi_awvalid => m_axi_awvalid,
-    m_axi_awready => m_axi_awready,
-    -- Write Data Channel --
-    m_axi_wdata   => m_axi_wdata,
-    m_axi_wstrb   => m_axi_wstrb,
-    m_axi_wvalid  => m_axi_wvalid,
-    m_axi_wready  => m_axi_wready,
-    -- Read Address Channel --
-    m_axi_araddr  => m_axi_araddr,
-    m_axi_arprot  => m_axi_arprot,
-    m_axi_arvalid => m_axi_arvalid,
-    m_axi_arready => m_axi_arready,
-    -- Read Data Channel --
-    m_axi_rdata   => m_axi_rdata,
-    m_axi_rresp   => m_axi_rresp,
-    m_axi_rvalid  => m_axi_rvalid,
-    m_axi_rready  => m_axi_rready,
-    -- Write Response Channel --
-    m_axi_bresp   => m_axi_bresp,
-    m_axi_bvalid  => m_axi_bvalid,
-    m_axi_bready  => m_axi_bready
-  );
+  axi4_bridge:
+  if XBUS_EN generate
+    axi4_bridge_inst: xbus2axi4lite_bridge
+    port map (
+      -- ------------------------------------------------------------
+      -- Global Control
+      -- ------------------------------------------------------------
+      clk           => clk,
+      resetn        => resetn,
+      -- ------------------------------------------------------------
+      -- XBUS Device Interface
+      -- ------------------------------------------------------------
+      xbus_adr_i    => xbus_adr,
+      xbus_dat_i    => xbus_do,
+      xbus_tag_i    => xbus_tag,
+      xbus_we_i     => xbus_we,
+      xbus_sel_i    => xbus_sel,
+      xbus_stb_i    => xbus_stb,
+      xbus_cyc_i    => xbus_cyc,
+      xbus_ack_o    => xbus_ack,
+      xbus_err_o    => xbus_err,
+      xbus_dat_o    => xbus_di,
+      -- ------------------------------------------------------------
+      -- AXI4-Lite Host Interface
+      -- ------------------------------------------------------------
+      -- Write Address Channel --
+      m_axi_awaddr  => m_axi_awaddr,
+      m_axi_awprot  => m_axi_awprot,
+      m_axi_awvalid => m_axi_awvalid,
+      m_axi_awready => m_axi_awready,
+      -- Write Data Channel --
+      m_axi_wdata   => m_axi_wdata,
+      m_axi_wstrb   => m_axi_wstrb,
+      m_axi_wvalid  => m_axi_wvalid,
+      m_axi_wready  => m_axi_wready,
+      -- Read Address Channel --
+      m_axi_araddr  => m_axi_araddr,
+      m_axi_arprot  => m_axi_arprot,
+      m_axi_arvalid => m_axi_arvalid,
+      m_axi_arready => m_axi_arready,
+      -- Read Data Channel --
+      m_axi_rdata   => m_axi_rdata,
+      m_axi_rresp   => m_axi_rresp,
+      m_axi_rvalid  => m_axi_rvalid,
+      m_axi_rready  => m_axi_rready,
+      -- Write Response Channel --
+      m_axi_bresp   => m_axi_bresp,
+      m_axi_bvalid  => m_axi_bvalid,
+      m_axi_bready  => m_axi_bready
+    );
+  end generate;
 
 end architecture neorv32_vivado_ip_rtl;

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -162,11 +162,11 @@ entity neorv32_vivado_ip is
     m_axi_arready  : in  std_logic := '0';
     -- Read Data Channel --
     m_axi_rdata    : in  std_logic_vector(31 downto 0) := x"00000000";
-    m_axi_rresp    : in  std_logic_vector(1 downto 0) := "11"; -- error by default
+    m_axi_rresp    : in  std_logic_vector(1 downto 0); -- no default here (#1067)
     m_axi_rvalid   : in  std_logic := '0';
     m_axi_rready   : out std_logic;
     -- Write Response Channel --
-    m_axi_bresp    : in  std_logic_vector(1 downto 0) := "11"; -- error by default
+    m_axi_bresp    : in  std_logic_vector(1 downto 0); -- no default here (#1067)
     m_axi_bvalid   : in  std_logic := '0';
     m_axi_bready   : out std_logic;
     -- ------------------------------------------------------------
@@ -282,31 +282,31 @@ architecture neorv32_vivado_ip_rtl of neorv32_vivado_ip is
       -- AXI4-Lite Host Interface
       -- ------------------------------------------------------------
       -- Clock and Reset --
-  --  m_axi_aclk     : in  std_logic := '0'; -- just to satisfy Vivado, but not actually used
-  --  m_axi_aresetn  : in  std_logic := '0'; -- just to satisfy Vivado, but not actually used
+  --  m_axi_aclk     : in  std_logic; -- just to satisfy Vivado, but not actually used
+  --  m_axi_aresetn  : in  std_logic; -- just to satisfy Vivado, but not actually used
       -- Write Address Channel --
       m_axi_awaddr   : out std_logic_vector(31 downto 0);
       m_axi_awprot   : out std_logic_vector(2 downto 0);
       m_axi_awvalid  : out std_logic;
-      m_axi_awready  : in  std_logic := '0';
+      m_axi_awready  : in  std_logic;
       -- Write Data Channel --
       m_axi_wdata    : out std_logic_vector(31 downto 0);
       m_axi_wstrb    : out std_logic_vector(3 downto 0);
       m_axi_wvalid   : out std_logic;
-      m_axi_wready   : in  std_logic := '0';
+      m_axi_wready   : in  std_logic;
       -- Read Address Channel --
       m_axi_araddr   : out std_logic_vector(31 downto 0);
       m_axi_arprot   : out std_logic_vector(2 downto 0);
       m_axi_arvalid  : out std_logic;
-      m_axi_arready  : in  std_logic := '0';
+      m_axi_arready  : in  std_logic;
       -- Read Data Channel --
-      m_axi_rdata    : in  std_logic_vector(31 downto 0) := x"00000000";
-      m_axi_rresp    : in  std_logic_vector(1 downto 0) := "11"; -- error by default
-      m_axi_rvalid   : in  std_logic := '0';
+      m_axi_rdata    : in  std_logic_vector(31 downto 0);
+      m_axi_rresp    : in  std_logic_vector(1 downto 0);
+      m_axi_rvalid   : in  std_logic;
       m_axi_rready   : out std_logic;
       -- Write Response Channel --
-      m_axi_bresp    : in  std_logic_vector(1 downto 0) := "11"; -- error by default
-      m_axi_bvalid   : in  std_logic := '0';
+      m_axi_bresp    : in  std_logic_vector(1 downto 0);
+      m_axi_bvalid   : in  std_logic;
       m_axi_bready   : out std_logic
     );
   end component;

--- a/rtl/system_integration/xbus2axi4lite_bridge.vhd
+++ b/rtl/system_integration/xbus2axi4lite_bridge.vhd
@@ -36,31 +36,31 @@ entity xbus2axi4lite_bridge is
     -- AXI4-Lite Host Interface
     -- ------------------------------------------------------------
     -- Clock and Reset --
---  m_axi_aclk     : in  std_logic := '0'; -- just to satisfy Vivado, but not actually used
---  m_axi_aresetn  : in  std_logic := '0'; -- just to satisfy Vivado, but not actually used
+--  m_axi_aclk     : in  std_logic; -- just to satisfy Vivado, but not actually used
+--  m_axi_aresetn  : in  std_logic; -- just to satisfy Vivado, but not actually used
     -- Write Address Channel --
     m_axi_awaddr   : out std_logic_vector(31 downto 0);
     m_axi_awprot   : out std_logic_vector(2 downto 0);
     m_axi_awvalid  : out std_logic;
-    m_axi_awready  : in  std_logic := '0';
+    m_axi_awready  : in  std_logic;
     -- Write Data Channel --
     m_axi_wdata    : out std_logic_vector(31 downto 0);
     m_axi_wstrb    : out std_logic_vector(3 downto 0);
     m_axi_wvalid   : out std_logic;
-    m_axi_wready   : in  std_logic := '0';
+    m_axi_wready   : in  std_logic;
     -- Read Address Channel --
     m_axi_araddr   : out std_logic_vector(31 downto 0);
     m_axi_arprot   : out std_logic_vector(2 downto 0);
     m_axi_arvalid  : out std_logic;
-    m_axi_arready  : in  std_logic := '0';
+    m_axi_arready  : in  std_logic;
     -- Read Data Channel --
-    m_axi_rdata    : in  std_logic_vector(31 downto 0) := x"00000000";
-    m_axi_rresp    : in  std_logic_vector(1 downto 0) := "11"; -- error by default
-    m_axi_rvalid   : in  std_logic := '0';
+    m_axi_rdata    : in  std_logic_vector(31 downto 0);
+    m_axi_rresp    : in  std_logic_vector(1 downto 0);
+    m_axi_rvalid   : in  std_logic;
     m_axi_rready   : out std_logic;
     -- Write Response Channel --
-    m_axi_bresp    : in  std_logic_vector(1 downto 0) := "11"; -- error by default
-    m_axi_bvalid   : in  std_logic := '0';
+    m_axi_bresp    : in  std_logic_vector(1 downto 0);
+    m_axi_bvalid   : in  std_logic;
     m_axi_bready   : out std_logic
   );
 end entity;


### PR DESCRIPTION
Hey thank you for merging my recent pulls! And here's the last split of #1060.

As mentioned in https://github.com/stnolting/neorv32/pull/1060#issuecomment-2420540728 did you encounter any error from the tool? It works fine for me on my computer with Vivado 2022.2.