### PR TITLE
Minor rtl edits and cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 06.11.2024 | 1.10.6.3 | minor rtl edits and cleanups | [#1090](https://github.com/stnolting/neorv32/pull/1090) |
 | 02.11.2024 | 1.10.6.2 | :warning: rework processor boot configuration; add new boot-configuration generics | [#1086](https://github.com/stnolting/neorv32/pull/1086) |
 | 01.11.2024 | 1.10.6.1 | :test_tube: convert VHDL memory images into full-scale VHDL packages | [#1084](https://github.com/stnolting/neorv32/pull/1084) |
 | 26.10.2024 | [**:rocket:1.10.6**](https://github.com/stnolting/neorv32/releases/tag/v1.10.6) | **New release** | |

--- a/rtl/core/neorv32_cfs.vhd
+++ b/rtl/core/neorv32_cfs.vhd
@@ -30,12 +30,12 @@ entity neorv32_cfs is
     clk_i       : in  std_ulogic; -- global clock line
     rstn_i      : in  std_ulogic; -- global reset line, low-active, use as async
     bus_req_i   : in  bus_req_t; -- bus request
-    bus_rsp_o   : out bus_rsp_t := rsp_terminate_c; -- bus response
-    clkgen_en_o : out std_ulogic := '0'; -- enable clock generator
+    bus_rsp_o   : out bus_rsp_t; -- bus response
+    clkgen_en_o : out std_ulogic; -- enable clock generator
     clkgen_i    : in  std_ulogic_vector(7 downto 0); -- "clock" inputs
-    irq_o       : out std_ulogic := '0'; -- interrupt request
+    irq_o       : out std_ulogic; -- interrupt request
     cfs_in_i    : in  std_ulogic_vector(CFS_IN_SIZE-1 downto 0); -- custom inputs
-    cfs_out_o   : out std_ulogic_vector(CFS_OUT_SIZE-1 downto 0) := (others => '0') -- custom outputs
+    cfs_out_o   : out std_ulogic_vector(CFS_OUT_SIZE-1 downto 0) -- custom outputs
   );
 end neorv32_cfs;
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100602"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100603"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -667,7 +667,7 @@ package neorv32_package is
 
   component neorv32_top
     generic (
-      -- Clocking --
+      -- Processor Clocking --
       CLOCK_FREQUENCY       : natural                        := 0;
       CLOCK_GATING_EN       : boolean                        := false;
       -- Identification --

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -347,7 +347,7 @@ begin
     -- show SoC configuration --
     assert false report
       "[NEORV32] Processor Configuration: CPU " & -- cpu core is always enabled
-      cond_sel_string_f(MEM_INT_IMEM_EN,           cond_sel_string_f(imem_as_rom_c, "IMEM_ROM ", "IMEM "), "") &
+      cond_sel_string_f(MEM_INT_IMEM_EN,           cond_sel_string_f(imem_as_rom_c, "IMEM-ROM ", "IMEM "), "") &
       cond_sel_string_f(MEM_INT_DMEM_EN,           "DMEM ",       "") &
       cond_sel_string_f(bootrom_en_c,              "BOOTROM ",    "") &
       cond_sel_string_f(ICACHE_EN,                 "I-CACHE ",    "") &
@@ -1217,6 +1217,7 @@ begin
     if IO_UART0_EN generate
       neorv32_uart0_inst: entity neorv32.neorv32_uart
       generic map (
+        SIM_MODE_EN  => true,
         SIM_LOG_FILE => "neorv32.uart0.sim_mode.text.out",
         UART_RX_FIFO => IO_UART0_RX_FIFO,
         UART_TX_FIFO => IO_UART0_TX_FIFO
@@ -1254,6 +1255,7 @@ begin
     if IO_UART1_EN generate
       neorv32_uart1_inst: entity neorv32.neorv32_uart
       generic map (
+        SIM_MODE_EN  => true,
         SIM_LOG_FILE => "neorv32.uart1.sim_mode.text.out",
         UART_RX_FIFO => IO_UART1_RX_FIFO,
         UART_TX_FIFO => IO_UART1_TX_FIFO

--- a/rtl/core/neorv32_trng.vhd
+++ b/rtl/core/neorv32_trng.vhd
@@ -448,16 +448,21 @@ begin
     -- latch with global reset and individual enable --
     latch(i) <= '0' when (en_i = '0') else latch(i) when (sreg(i) = '0') else inv_out(i);
 
-    -- inverter with "propagation delay" --
-    inverter_sim:
-    if SIM_MODE generate
-      inv_out(i) <= not inv_in(i) when rising_edge(clk_i); -- for SIMULATION ONLY
-    end generate;
-
     -- inverter for actual synthesis --
     inverter_phy:
     if not SIM_MODE generate
-      inv_out(i) <= not inv_in(i);
+      inv_out(i) <= not inv_in(i); -- this is one part of the ring oscillator's physical propagation delay
+    end generate;
+
+    -- inverter with "propagation delay (as a simple FF)" --
+    inverter_sim:
+    if SIM_MODE generate -- for SIMULATION ONLY
+      inverter_sim_ff: process(clk_i) -- this will NOT generate true random numbers
+      begin
+        if rising_edge(clk_i) then
+          inv_out(i) <= not inv_in(i);
+        end if;
+      end process inverter_sim_ff;
     end generate;
 
   end generate;

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -263,54 +263,44 @@ architecture neorv32_vivado_ip_rtl of neorv32_vivado_ip is
   -- AXI4-Lite bridge --
   component xbus2axi4lite_bridge
     port (
-      -- ------------------------------------------------------------
-      -- Global Control
-      -- ------------------------------------------------------------
-      clk            : in  std_logic;
-      resetn         : in  std_logic; -- low-active
-      -- ------------------------------------------------------------
-      -- XBUS Device Interface
-      -- ------------------------------------------------------------
-      xbus_adr_i     : in  std_ulogic_vector(31 downto 0); -- address
-      xbus_dat_i     : in  std_ulogic_vector(31 downto 0); -- write data
-      xbus_tag_i     : in  std_ulogic_vector(2 downto 0);  -- access tag
-      xbus_we_i      : in  std_ulogic;                     -- read/write
-      xbus_sel_i     : in  std_ulogic_vector(3 downto 0);  -- byte enable
-      xbus_stb_i     : in  std_ulogic;                     -- strobe
-      xbus_cyc_i     : in  std_ulogic;                     -- valid cycle
-      xbus_ack_o     : out std_ulogic;                     -- transfer acknowledge
-      xbus_err_o     : out std_ulogic;                     -- transfer error
-      xbus_dat_o     : out std_ulogic_vector(31 downto 0); -- read data
-      -- ------------------------------------------------------------
-      -- AXI4-Lite Host Interface
-      -- ------------------------------------------------------------
-      -- Clock and Reset --
-  --  m_axi_aclk     : in  std_logic; -- just to satisfy Vivado, but not actually used
-  --  m_axi_aresetn  : in  std_logic; -- just to satisfy Vivado, but not actually used
-      -- Write Address Channel --
-      m_axi_awaddr   : out std_logic_vector(31 downto 0);
-      m_axi_awprot   : out std_logic_vector(2 downto 0);
-      m_axi_awvalid  : out std_logic;
-      m_axi_awready  : in  std_logic;
-      -- Write Data Channel --
-      m_axi_wdata    : out std_logic_vector(31 downto 0);
-      m_axi_wstrb    : out std_logic_vector(3 downto 0);
-      m_axi_wvalid   : out std_logic;
-      m_axi_wready   : in  std_logic;
-      -- Read Address Channel --
-      m_axi_araddr   : out std_logic_vector(31 downto 0);
-      m_axi_arprot   : out std_logic_vector(2 downto 0);
-      m_axi_arvalid  : out std_logic;
-      m_axi_arready  : in  std_logic;
-      -- Read Data Channel --
-      m_axi_rdata    : in  std_logic_vector(31 downto 0);
-      m_axi_rresp    : in  std_logic_vector(1 downto 0);
-      m_axi_rvalid   : in  std_logic;
-      m_axi_rready   : out std_logic;
-      -- Write Response Channel --
-      m_axi_bresp    : in  std_logic_vector(1 downto 0);
-      m_axi_bvalid   : in  std_logic;
-      m_axi_bready   : out std_logic
+      -- Global control 
+      clk           : in  std_logic;
+      resetn        : in  std_logic;
+      -- XBUS device interface --
+      xbus_adr_i    : in  std_ulogic_vector(31 downto 0);
+      xbus_dat_i    : in  std_ulogic_vector(31 downto 0);
+      xbus_tag_i    : in  std_ulogic_vector(2 downto 0);
+      xbus_we_i     : in  std_ulogic;
+      xbus_sel_i    : in  std_ulogic_vector(3 downto 0);
+      xbus_stb_i    : in  std_ulogic;
+      xbus_cyc_i    : in  std_ulogic;
+      xbus_ack_o    : out std_ulogic;
+      xbus_err_o    : out std_ulogic;
+      xbus_dat_o    : out std_ulogic_vector(31 downto 0);
+      -- AXI4-Lite host write address channel --
+      m_axi_awaddr  : out std_logic_vector(31 downto 0);
+      m_axi_awprot  : out std_logic_vector(2 downto 0);
+      m_axi_awvalid : out std_logic;
+      m_axi_awready : in  std_logic;
+      -- AXI4-Lite host write data channel --
+      m_axi_wdata   : out std_logic_vector(31 downto 0);
+      m_axi_wstrb   : out std_logic_vector(3 downto 0);
+      m_axi_wvalid  : out std_logic;
+      m_axi_wready  : in  std_logic;
+      -- AXI4-Lite host read address channel --
+      m_axi_araddr  : out std_logic_vector(31 downto 0);
+      m_axi_arprot  : out std_logic_vector(2 downto 0);
+      m_axi_arvalid : out std_logic;
+      m_axi_arready : in  std_logic;
+      -- AXI4-Lite host read data channel --
+      m_axi_rdata   : in  std_logic_vector(31 downto 0);
+      m_axi_rresp   : in  std_logic_vector(1 downto 0);
+      m_axi_rvalid  : in  std_logic;
+      m_axi_rready  : out std_logic;
+      -- AXI4-Lite host write response channel --
+      m_axi_bresp   : in  std_logic_vector(1 downto 0);
+      m_axi_bvalid  : in  std_logic;
+      m_axi_bready  : out std_logic
     );
   end component;
 
@@ -625,14 +615,10 @@ begin
   if XBUS_EN generate
     axi4_bridge_inst: xbus2axi4lite_bridge
     port map (
-      -- ------------------------------------------------------------
-      -- Global Control
-      -- ------------------------------------------------------------
+      -- Global control --
       clk           => clk,
       resetn        => resetn,
-      -- ------------------------------------------------------------
-      -- XBUS Device Interface
-      -- ------------------------------------------------------------
+      -- XBUS device interface --
       xbus_adr_i    => xbus_adr,
       xbus_dat_i    => xbus_do,
       xbus_tag_i    => xbus_tag,
@@ -643,30 +629,27 @@ begin
       xbus_ack_o    => xbus_ack,
       xbus_err_o    => xbus_err,
       xbus_dat_o    => xbus_di,
-      -- ------------------------------------------------------------
-      -- AXI4-Lite Host Interface
-      -- ------------------------------------------------------------
-      -- Write Address Channel --
+      -- AXI4-Lite host write address channel --
       m_axi_awaddr  => m_axi_awaddr,
       m_axi_awprot  => m_axi_awprot,
       m_axi_awvalid => m_axi_awvalid,
       m_axi_awready => m_axi_awready,
-      -- Write Data Channel --
+      -- AXI4-Lite host write data channel --
       m_axi_wdata   => m_axi_wdata,
       m_axi_wstrb   => m_axi_wstrb,
       m_axi_wvalid  => m_axi_wvalid,
       m_axi_wready  => m_axi_wready,
-      -- Read Address Channel --
+      -- AXI4-Lite host read address channel --
       m_axi_araddr  => m_axi_araddr,
       m_axi_arprot  => m_axi_arprot,
       m_axi_arvalid => m_axi_arvalid,
       m_axi_arready => m_axi_arready,
-      -- Read Data Channel --
+      -- AXI4-Lite host read data channel --
       m_axi_rdata   => m_axi_rdata,
       m_axi_rresp   => m_axi_rresp,
       m_axi_rvalid  => m_axi_rvalid,
       m_axi_rready  => m_axi_rready,
-      -- Write Response Channel --
+      -- AXI4-Lite host write response channel --
       m_axi_bresp   => m_axi_bresp,
       m_axi_bvalid  => m_axi_bvalid,
       m_axi_bready  => m_axi_bready

--- a/rtl/system_integration/xbus2axi4lite_bridge.vhd
+++ b/rtl/system_integration/xbus2axi4lite_bridge.vhd
@@ -1,5 +1,5 @@
 -- ================================================================================ --
--- NEORV32 SoC - XBUS to AXI4-Lite Bridge (non-overlapping single transfers only)   --
+-- NEORV32 SoC - XBUS to AXI4-Lite Bridge (single non-overlapping transfers only)   --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
@@ -14,139 +14,94 @@ use ieee.numeric_std.all;
 
 entity xbus2axi4lite_bridge is
   port (
-    -- ------------------------------------------------------------
-    -- Global Control
-    -- ------------------------------------------------------------
-    clk            : in  std_logic;
-    resetn         : in  std_logic; -- low-active
-    -- ------------------------------------------------------------
-    -- XBUS Device Interface
-    -- ------------------------------------------------------------
-    xbus_adr_i     : in  std_ulogic_vector(31 downto 0); -- address
-    xbus_dat_i     : in  std_ulogic_vector(31 downto 0); -- write data
-    xbus_tag_i     : in  std_ulogic_vector(2 downto 0);  -- access tag
-    xbus_we_i      : in  std_ulogic;                     -- read/write
-    xbus_sel_i     : in  std_ulogic_vector(3 downto 0);  -- byte enable
-    xbus_stb_i     : in  std_ulogic;                     -- strobe
-    xbus_cyc_i     : in  std_ulogic;                     -- valid cycle
-    xbus_ack_o     : out std_ulogic;                     -- transfer acknowledge
-    xbus_err_o     : out std_ulogic;                     -- transfer error
-    xbus_dat_o     : out std_ulogic_vector(31 downto 0); -- read data
-    -- ------------------------------------------------------------
-    -- AXI4-Lite Host Interface
-    -- ------------------------------------------------------------
-    -- Clock and Reset --
---  m_axi_aclk     : in  std_logic; -- just to satisfy Vivado, but not actually used
---  m_axi_aresetn  : in  std_logic; -- just to satisfy Vivado, but not actually used
-    -- Write Address Channel --
-    m_axi_awaddr   : out std_logic_vector(31 downto 0);
-    m_axi_awprot   : out std_logic_vector(2 downto 0);
-    m_axi_awvalid  : out std_logic;
-    m_axi_awready  : in  std_logic;
-    -- Write Data Channel --
-    m_axi_wdata    : out std_logic_vector(31 downto 0);
-    m_axi_wstrb    : out std_logic_vector(3 downto 0);
-    m_axi_wvalid   : out std_logic;
-    m_axi_wready   : in  std_logic;
-    -- Read Address Channel --
-    m_axi_araddr   : out std_logic_vector(31 downto 0);
-    m_axi_arprot   : out std_logic_vector(2 downto 0);
-    m_axi_arvalid  : out std_logic;
-    m_axi_arready  : in  std_logic;
-    -- Read Data Channel --
-    m_axi_rdata    : in  std_logic_vector(31 downto 0);
-    m_axi_rresp    : in  std_logic_vector(1 downto 0);
-    m_axi_rvalid   : in  std_logic;
-    m_axi_rready   : out std_logic;
-    -- Write Response Channel --
-    m_axi_bresp    : in  std_logic_vector(1 downto 0);
-    m_axi_bvalid   : in  std_logic;
-    m_axi_bready   : out std_logic
+    -- Global control --
+    clk           : in  std_logic;
+    resetn        : in  std_logic;
+    -- XBUS device interface --
+    xbus_adr_i    : in  std_ulogic_vector(31 downto 0);
+    xbus_dat_i    : in  std_ulogic_vector(31 downto 0);
+    xbus_tag_i    : in  std_ulogic_vector(2 downto 0);
+    xbus_we_i     : in  std_ulogic;
+    xbus_sel_i    : in  std_ulogic_vector(3 downto 0);
+    xbus_stb_i    : in  std_ulogic;
+    xbus_cyc_i    : in  std_ulogic;
+    xbus_ack_o    : out std_ulogic;
+    xbus_err_o    : out std_ulogic;
+    xbus_dat_o    : out std_ulogic_vector(31 downto 0);
+    -- AXI4-Lite host write address channel --
+    m_axi_awaddr  : out std_logic_vector(31 downto 0);
+    m_axi_awprot  : out std_logic_vector(2 downto 0);
+    m_axi_awvalid : out std_logic;
+    m_axi_awready : in  std_logic;
+    -- AXI4-Lite host write data channel --
+    m_axi_wdata   : out std_logic_vector(31 downto 0);
+    m_axi_wstrb   : out std_logic_vector(3 downto 0);
+    m_axi_wvalid  : out std_logic;
+    m_axi_wready  : in  std_logic;
+    -- AXI4-Lite host read address channel --
+    m_axi_araddr  : out std_logic_vector(31 downto 0);
+    m_axi_arprot  : out std_logic_vector(2 downto 0);
+    m_axi_arvalid : out std_logic;
+    m_axi_arready : in  std_logic;
+    -- AXI4-Lite host read data channel --
+    m_axi_rdata   : in  std_logic_vector(31 downto 0);
+    m_axi_rresp   : in  std_logic_vector(1 downto 0);
+    m_axi_rvalid  : in  std_logic;
+    m_axi_rready  : out std_logic;
+    -- AXI4-Lite host write response channel --
+    m_axi_bresp   : in  std_logic_vector(1 downto 0);
+    m_axi_bvalid  : in  std_logic;
+    m_axi_bready  : out std_logic
   );
 end entity;
 
 architecture xbus2axi4lite_bridge_rtl of xbus2axi4lite_bridge is
 
-  -- AXI bridge control --
-  signal axi_radr_received, axi_wadr_received, axi_wdat_received : std_ulogic;
+  signal ready : std_ulogic_vector(2 downto 0);
+  signal xbus_rd_ack, xbus_rd_err, xbus_wr_ack, xbus_wr_err : std_ulogic;
 
 begin
 
-  -- channel arbiter --
-  axi_arbiter: process(resetn, clk)
+  -- channel handshake arbiter --
+  axi_handshake: process(resetn, clk)
   begin
     if (resetn = '0') then
-      axi_radr_received <= '0';
-      axi_wadr_received <= '0';
-      axi_wdat_received <= '0';
+      ready <= (others => '0');
     elsif rising_edge(clk) then
-      if (xbus_cyc_i = '0') then
-        axi_radr_received <= '0';
-        axi_wadr_received <= '0';
-        axi_wdat_received <= '0';
-      else -- pending access
-        if (xbus_we_i = '0') then -- read
-          if (m_axi_arready = '1') then -- read address received by interconnect?
-            axi_radr_received <= '1';
-          end if;
-        else -- write
-          if (m_axi_awready = '1') then -- write address received by interconnect?
-            axi_wadr_received <= '1';
-          end if;
-          if (m_axi_wready = '1') then -- write data received by interconnect?
-            axi_wdat_received <= '1';
-          end if;
-        end if;
-      end if;
+      ready(0) <= xbus_cyc_i and (ready(0) or std_ulogic(m_axi_arready));
+      ready(1) <= xbus_cyc_i and (ready(1) or std_ulogic(m_axi_awready));
+      ready(2) <= xbus_cyc_i and (ready(2) or std_ulogic(m_axi_wready));
     end if;
-  end process axi_arbiter;
+  end process axi_handshake;
 
-
-  -- read address channel --
+  -- AXI read address channel --
   m_axi_araddr  <= std_logic_vector(xbus_adr_i);
   m_axi_arprot  <= std_logic_vector(xbus_tag_i);
-  m_axi_arvalid <= std_logic(xbus_cyc_i and (not xbus_we_i) and (not axi_radr_received));
+  m_axi_arvalid <= std_logic(xbus_cyc_i and (not xbus_we_i) and (not ready(0)));
 
-  -- read data channel --
+  -- AXI read data channel --
   m_axi_rready  <= std_logic(xbus_cyc_i and (not xbus_we_i));
   xbus_dat_o    <= std_ulogic_vector(m_axi_rdata);
+  xbus_rd_ack   <= '1' when (m_axi_rvalid = '1') and (m_axi_rresp  = "00") else '0';
+  xbus_rd_err   <= '1' when (m_axi_rvalid = '1') and (m_axi_rresp /= "00") else '0';
 
-  -- write address channel --
+  -- AXI write address channel --
   m_axi_awaddr  <= std_logic_vector(xbus_adr_i);
   m_axi_awprot  <= std_logic_vector(xbus_tag_i);
-  m_axi_awvalid <= std_logic(xbus_cyc_i and xbus_we_i and (not axi_wadr_received));
+  m_axi_awvalid <= std_logic(xbus_cyc_i and xbus_we_i and (not ready(1)));
 
-  -- write data channel --
+  -- AXI write data channel --
   m_axi_wdata   <= std_logic_vector(xbus_dat_i);
   m_axi_wstrb   <= std_logic_vector(xbus_sel_i);
-  m_axi_wvalid  <= std_logic(xbus_cyc_i and xbus_we_i and (not axi_wdat_received));
+  m_axi_wvalid  <= std_logic(xbus_cyc_i and xbus_we_i and (not ready(2)));
 
-  -- write response channel --
+  -- AXI write response channel --
   m_axi_bready  <= std_logic(xbus_cyc_i and xbus_we_i);
+  xbus_wr_ack   <= '1' when (m_axi_bvalid = '1') and (m_axi_bresp  = "00") else '0';
+  xbus_wr_err   <= '1' when (m_axi_bvalid = '1') and (m_axi_bresp /= "00") else '0';
 
-
-  -- read/write response --
-  axi_response: process(xbus_we_i, m_axi_bvalid, m_axi_bresp, m_axi_rvalid, m_axi_rresp)
-  begin
-    xbus_ack_o <= '0'; -- default
-    xbus_err_o <= '0'; -- default
-    if (xbus_we_i = '1') then -- write operation
-      if (m_axi_bvalid = '1') then -- valid write response
-        if (m_axi_bresp = "00") then -- status check
-          xbus_ack_o <= '1'; -- OK
-        else
-          xbus_err_o <= '1'; -- ERROR
-        end if;
-      end if;
-    else -- read operation
-      if (m_axi_rvalid = '1') then -- valid read response
-        if (m_axi_rresp = "00") then -- status check
-          xbus_ack_o <= '1'; -- OK
-        else
-          xbus_err_o <= '1'; -- ERROR
-        end if;
-      end if;
-    end if;
-  end process axi_response;
+  -- XBUS response --
+  xbus_ack_o <= xbus_rd_ack when (xbus_we_i = '0') else xbus_wr_ack;
+  xbus_err_o <= xbus_rd_err when (xbus_we_i = '0') else xbus_wr_err;
 
 end architecture xbus2axi4lite_bridge_rtl;


### PR DESCRIPTION
* remove CFU's port defaults
* update TRNG's simulation mode
* cleanup XBUS-to-AXI4Lite bridge
* add explicit module generic to enable/disable UART simulation mode support (enabled by default)