### PR TITLE
[rtl] fix some Verilog [sic] issues

### DIFF
--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -33,6 +33,7 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
 
 library neorv32;
 use neorv32.neorv32_package.all;
@@ -176,7 +177,7 @@ begin
   -- Check if Direct/Uncached Access --------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   dir_acc_d <= '1' when UC_ENABLE and -- direct accesses implemented
-                        ((host_req_i.addr(31 downto 28) >= UC_BEGIN) or -- uncached memory page
+                        ((unsigned(host_req_i.addr(31 downto 28)) >= unsigned(UC_BEGIN)) or -- uncached memory page
                          (host_req_i.rvso = '1')) else '0'; -- atomic (reservation set) operation
 
   -- request splitter: cached or direct access --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100606"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100607"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 


### PR DESCRIPTION
Fix some HDL issues that caused problem when converting the code to RTL (https://github.com/stnolting/neorv32-verilog). Identified by @pluseqs in https://github.com/stnolting/neorv32/discussions/1100.

* cache: fix missing type conversion
* dma: `config` seems to be a reserved word in Verilog