### PR TITLE
[sim] rework default testbench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 12.12.2024 | 1.10.7.2 | add external memory configuration/initialization options to testbench | [#1119](https://github.com/stnolting/neorv32/pull/1119) |
 | 11.12.2024 | 1.10.7.1 | :test_tube: shrink bootloader's minimal ISA (`rv32e`) and RAM (256 bytes) requirements | [#1118](https://github.com/stnolting/neorv32/pull/1118) |
 | 10.12.2024 | [**:rocket:1.10.7**](https://github.com/stnolting/neorv32/releases/tag/v1.10.7) | **New release** | |
 | 03.12.2024 | 1.10.6.9 | :sparkles: add ONEWIRE command and data FIFO; :warning: rework ONEWIRE interface register layout; :bug: fix regression: busy flag was stuck at zero | [#1113](https://github.com/stnolting/neorv32/pull/1113) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100701"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100702"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -193,6 +193,17 @@ package neorv32_package is
     stb  : std_ulogic; -- strobe
     cyc  : std_ulogic; -- valid cycle
   end record;
+
+  -- source (request) termination --
+  constant xbus_req_terminate_c : xbus_req_t := (
+    addr => (others => '0'),
+    data => (others => '0'),
+    tag  => (others => '0'),
+    we   => '0',
+    sel  => (others => '0'),
+    stb  => '0',
+    cyc  => '0'
+  );
 
   -- xbus response --
   type xbus_rsp_t is record

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -18,8 +18,10 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_tb is
   generic (
+    -- processor --
     CLOCK_FREQUENCY   : natural                        := 100_000_000; -- clock frequency of clk_i in Hz
     BOOT_MODE_SELECT  : natural range 0 to 2           := 2;           -- boot from pre-initialized IMEM
+    BOOT_ADDR_CUSTOM  : std_ulogic_vector(31 downto 0) := x"00000000"; -- custom CPU boot address (if boot_config = 1)
     RISCV_ISA_C       : boolean                        := false;       -- implement compressed extension
     RISCV_ISA_E       : boolean                        := false;       -- implement embedded RF extension
     RISCV_ISA_M       : boolean                        := true;        -- implement mul/div extension
@@ -54,7 +56,17 @@ entity neorv32_tb is
     ICACHE_BLOCK_SIZE : natural range 4 to 2**16       := 32;          -- i-cache: block size in bytes (min 4), has to be a power of 2
     DCACHE_EN         : boolean                        := true;        -- implement data cache
     DCACHE_NUM_BLOCKS : natural range 1 to 256         := 32;          -- d-cache: number of blocks (min 1), has to be a power of 2
-    DCACHE_BLOCK_SIZE : natural range 4 to 2**16       := 32           -- d-cache: block size in bytes (min 4), has to be a power of 2
+    DCACHE_BLOCK_SIZE : natural range 4 to 2**16       := 32;          -- d-cache: block size in bytes (min 4), has to be a power of 2
+    -- external memory A --
+    EXT_MEM_A_EN      : boolean                        := true;        -- enable memory
+    EXT_MEM_A_BASE    : std_ulogic_vector(31 downto 0) := x"00000000"; -- base address, has to be word-aligned
+    EXT_MEM_A_SIZE    : natural                        := 64;          -- memory size in bytes, min 4
+    EXT_MEM_A_FILE    : string                         := "";          -- memory initialization file (plain HEX), no initialization if empty
+    -- external memory B --
+    EXT_MEM_B_EN      : boolean                        := true;        -- enable memory
+    EXT_MEM_B_BASE    : std_ulogic_vector(31 downto 0) := x"80000000"; -- base address, has to be word-aligned
+    EXT_MEM_B_SIZE    : natural                        := 64;          -- memory size in bytes, min 4
+    EXT_MEM_B_FILE    : string                         := ""           -- memory initialization file (plain HEX), no initialization if empty
   );
 end neorv32_tb;
 
@@ -79,8 +91,8 @@ architecture neorv32_tb_rtl of neorv32_tb is
   signal slink_tx, slink_rx : slink_t;
 
   -- XBUS (Wishbone b4) bus --
-  signal xbus_core_req, xbus_imem_req, xbus_dmem_req, xbus_mmio_req, xbus_trig_req : xbus_req_t;
-  signal xbus_core_rsp, xbus_imem_rsp, xbus_dmem_rsp, xbus_mmio_rsp, xbus_trig_rsp : xbus_rsp_t;
+  signal xbus_core_req, xbus_ext_mem_a_req, xbus_ext_mem_b_req, xbus_mmio_req, xbus_trig_req : xbus_req_t;
+  signal xbus_core_rsp, xbus_ext_mem_a_rsp, xbus_ext_mem_b_rsp, xbus_mmio_rsp, xbus_trig_rsp : xbus_rsp_t;
 
 begin
 
@@ -102,7 +114,7 @@ begin
     JEDEC_ID              => "00000000000",
     -- Boot Configuration --
     BOOT_MODE_SELECT      => BOOT_MODE_SELECT,
-    BOOT_ADDR_CUSTOM      => x"00000000",
+    BOOT_ADDR_CUSTOM      => BOOT_ADDR_CUSTOM,
     -- On-Chip Debugger (OCD) --
     OCD_EN                => true,
     OCD_AUTHENTICATION    => true,
@@ -142,7 +154,7 @@ begin
     HPM_NUM_CNTS          => 12,
     HPM_CNT_WIDTH         => 40,
     -- Internal Instruction memory --
-    MEM_INT_IMEM_EN       => MEM_INT_IMEM_EN ,
+    MEM_INT_IMEM_EN       => MEM_INT_IMEM_EN,
     MEM_INT_IMEM_SIZE     => MEM_INT_IMEM_SIZE,
     -- Internal Data memory --
     MEM_INT_DMEM_EN       => MEM_INT_DMEM_EN,
@@ -352,9 +364,9 @@ begin
   -- -------------------------------------------------------------------------------------------
   sim_rx_uart0: entity work.sim_uart_rx
   generic map (
-    name => "uart0",
-    fclk => real(CLOCK_FREQUENCY),
-    baud => real(19200)
+    NAME => "uart0",
+    FCLK => real(CLOCK_FREQUENCY),
+    BAUD => real(19200)
   )
   port map (
     clk => clk_gen,
@@ -363,9 +375,9 @@ begin
 
   sim_rx_uart1: entity work.sim_uart_rx
   generic map (
-    name => "uart1",
-    fclk => real(CLOCK_FREQUENCY),
-    baud => real(19200)
+    NAME => "uart1",
+    FCLK => real(CLOCK_FREQUENCY),
+    BAUD => real(19200)
   )
   port map (
     clk => clk_gen,
@@ -378,51 +390,69 @@ begin
   xbus_interconnect: entity work.xbus_gateway
   generic map (
     -- device address size in bytes and base address --
-    DEV_0_SIZE => MEM_INT_IMEM_SIZE, DEV_0_BASE => mem_imem_base_c,
-    DEV_1_SIZE => MEM_INT_DMEM_SIZE, DEV_1_BASE => mem_dmem_base_c,
-    DEV_2_SIZE =>                64, DEV_2_BASE => x"F0000000",
-    DEV_3_SIZE =>                 4, DEV_3_BASE => x"FF000000"
+    DEV_0_EN => EXT_MEM_A_EN, DEV_0_SIZE => EXT_MEM_A_SIZE, DEV_0_BASE => EXT_MEM_A_BASE,
+    DEV_1_EN => EXT_MEM_B_EN, DEV_1_SIZE => EXT_MEM_B_SIZE, DEV_1_BASE => EXT_MEM_B_BASE,
+    DEV_2_EN => true,         DEV_2_SIZE =>             64, DEV_2_BASE => x"F0000000",
+    DEV_3_EN => true,         DEV_3_SIZE =>              4, DEV_3_BASE => x"FF000000"
   )
   port map (
     -- host port --
     host_req_i  => xbus_core_req,
     host_rsp_o  => xbus_core_rsp,
     -- device ports --
-    dev_0_req_o => xbus_imem_req, dev_0_rsp_i => xbus_imem_rsp,
-    dev_1_req_o => xbus_dmem_req, dev_1_rsp_i => xbus_dmem_rsp,
-    dev_2_req_o => xbus_mmio_req, dev_2_rsp_i => xbus_mmio_rsp,
-    dev_3_req_o => xbus_trig_req, dev_3_rsp_i => xbus_trig_rsp
+    dev_0_req_o => xbus_ext_mem_a_req, dev_0_rsp_i => xbus_ext_mem_a_rsp,
+    dev_1_req_o => xbus_ext_mem_b_req, dev_1_rsp_i => xbus_ext_mem_b_rsp,
+    dev_2_req_o => xbus_mmio_req,      dev_2_rsp_i => xbus_mmio_rsp,
+    dev_3_req_o => xbus_trig_req,      dev_3_rsp_i => xbus_trig_rsp
   );
 
 
-  -- XBUS: Instruction Memory ---------------------------------------------------------------
+  -- XBUS: External Memory A ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  xbus_imem: entity work.xbus_memory
-  generic map (
-    MEM_SIZE => MEM_INT_IMEM_SIZE,
-    MEM_LATE => 1
-  )
-  port map (
-    clk_i      => clk_gen,
-    rstn_i     => rst_gen,
-    xbus_req_i => xbus_imem_req,
-    xbus_rsp_o => xbus_imem_rsp
-  );
+  xbus_external_memory_a_enable:
+  if EXT_MEM_A_EN generate
+    xbus_external_memory_a: entity work.xbus_memory
+    generic map (
+      MEM_SIZE => EXT_MEM_A_SIZE,
+      MEM_LATE => 1,
+      MEM_FILE => EXT_MEM_A_FILE
+    )
+    port map (
+      clk_i      => clk_gen,
+      rstn_i     => rst_gen,
+      xbus_req_i => xbus_ext_mem_a_req,
+      xbus_rsp_o => xbus_ext_mem_a_rsp
+    );
+  end generate;
+
+  xbus_external_memory_a_disable:
+  if not EXT_MEM_A_EN generate
+    xbus_ext_mem_a_rsp <= xbus_rsp_terminate_c;
+  end generate;
 
 
-  -- XBUS: Data Memory ----------------------------------------------------------------------
+  -- XBUS: External Memory B ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  xbus_dmem: entity work.xbus_memory
-  generic map (
-    MEM_SIZE => MEM_INT_DMEM_SIZE,
-    MEM_LATE => 1
-  )
-  port map (
-    clk_i      => clk_gen,
-    rstn_i     => rst_gen,
-    xbus_req_i => xbus_dmem_req,
-    xbus_rsp_o => xbus_dmem_rsp
-  );
+  xbus_external_memory_b_enable:
+  if EXT_MEM_B_EN generate
+    xbus_external_memory_b: entity work.xbus_memory
+    generic map (
+      MEM_SIZE => EXT_MEM_B_SIZE,
+      MEM_LATE => 1,
+      MEM_FILE => EXT_MEM_B_FILE
+    )
+    port map (
+      clk_i      => clk_gen,
+      rstn_i     => rst_gen,
+      xbus_req_i => xbus_ext_mem_b_req,
+      xbus_rsp_o => xbus_ext_mem_b_rsp
+    );
+  end generate;
+
+  xbus_external_memory_b_disable:
+  if not EXT_MEM_B_EN generate
+    xbus_ext_mem_b_rsp <= xbus_rsp_terminate_c;
+  end generate;
 
 
   -- XBUS: Memory-Mapped IO -----------------------------------------------------------------
@@ -430,7 +460,8 @@ begin
   xbus_mmio: entity work.xbus_memory
   generic map (
     MEM_SIZE => 64,
-    MEM_LATE => 32
+    MEM_LATE => 32,
+    MEM_FILE => "" -- no initialization
   )
   port map (
     clk_i      => clk_gen,

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -58,12 +58,12 @@ entity neorv32_tb is
     DCACHE_NUM_BLOCKS : natural range 1 to 256         := 32;          -- d-cache: number of blocks (min 1), has to be a power of 2
     DCACHE_BLOCK_SIZE : natural range 4 to 2**16       := 32;          -- d-cache: block size in bytes (min 4), has to be a power of 2
     -- external memory A --
-    EXT_MEM_A_EN      : boolean                        := true;        -- enable memory
+    EXT_MEM_A_EN      : boolean                        := false;       -- enable memory
     EXT_MEM_A_BASE    : std_ulogic_vector(31 downto 0) := x"00000000"; -- base address, has to be word-aligned
     EXT_MEM_A_SIZE    : natural                        := 64;          -- memory size in bytes, min 4
     EXT_MEM_A_FILE    : string                         := "";          -- memory initialization file (plain HEX), no initialization if empty
     -- external memory B --
-    EXT_MEM_B_EN      : boolean                        := true;        -- enable memory
+    EXT_MEM_B_EN      : boolean                        := false;       -- enable memory
     EXT_MEM_B_BASE    : std_ulogic_vector(31 downto 0) := x"80000000"; -- base address, has to be word-aligned
     EXT_MEM_B_SIZE    : natural                        := 64;          -- memory size in bytes, min 4
     EXT_MEM_B_FILE    : string                         := ""           -- memory initialization file (plain HEX), no initialization if empty

--- a/sim/sim_uart_rx.vhd
+++ b/sim/sim_uart_rx.vhd
@@ -16,9 +16,9 @@ use std.textio.all;
 
 entity sim_uart_rx is
   generic (
-    name : string; -- receiver name (for log file)
-    fclk : real; -- clock speed of clk_i in Hz
-    baud : real -- baud rate
+    NAME : string; -- receiver name (for log file)
+    FCLK : real; -- clock speed of clk_i in Hz
+    BAUD : real -- baud rate
   );
   port (
     clk : in std_ulogic; -- global clock
@@ -33,8 +33,8 @@ architecture sim_uart_rx_rtl of sim_uart_rx is
   signal sreg : std_ulogic_vector(8 downto 0) := (others => '0');
   signal baudcnt : real;
   signal bitcnt  : natural;
-  constant baud_val_c : real := fclk / baud;
-  file file_out : text open write_mode is "neorv32_tb." & name & "_rx.out";
+  constant baud_val_c : real := FCLK / BAUD;
+  file file_out : text open write_mode is "neorv32_tb." & NAME & "_rx.out";
 
 begin
 
@@ -67,9 +67,9 @@ begin
             c := to_integer(unsigned(sreg(8 downto 1)));
 
             if (c < 32) or (c > 32+95) then -- non-printable character?
-              report name & ".rx: (" & integer'image(c) & ")";
+              report NAME & ".rx: (" & integer'image(c) & ")";
             else
-              report name & ".rx: " & character'val(c);
+              report NAME & ".rx: " & character'val(c);
             end if;
 
             if (c = 10) then -- LF line break

--- a/sim/xbus_memory.vhd
+++ b/sim/xbus_memory.vhd
@@ -11,14 +11,16 @@
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
+use std.textio.all;
 
 library neorv32;
 use neorv32.neorv32_package.all;
 
 entity xbus_memory is
   generic (
-    MEM_SIZE : natural := 1024; -- memory size in bytes; should be a power of two
-    MEM_LATE : natural := 1 -- number of latency cycles (min 1)
+    MEM_SIZE : natural := 4; -- memory size in bytes; min 4; should be a power of two
+    MEM_LATE : natural := 1; -- number of latency cycles (min 1)
+    MEM_FILE : string  := "" -- memory initialization file (plain HEX), no initialization if empty
   );
   port (
     clk_i      : in  std_ulogic;
@@ -30,11 +32,49 @@ end xbus_memory;
 
 architecture xbus_memory_rtl of xbus_memory is
 
+  -- address width --
+  constant addr_bits_c : natural := index_size_f(MEM_SIZE/4);
+
   -- memory type --
-  type mem8_bv_t is array (natural range <>) of bit_vector(7 downto 0); -- bit_vector type for optimized system storage
+  type ram8bv_t is array (natural range <>) of bit_vector(7 downto 0); -- bit_vector type for optimized system storage
+
+  -- initialize ram8bv_t array from ASCII HEX file (no VHDL08 required) --
+  impure function init_mem8bv_from_hexfile_f(file_name : string; num_words : natural; byte_sel : natural) return ram8bv_t is
+    file     hex_file   : text;
+    variable hex_line_v : line;
+    variable hex_char_v : character;
+    variable tmp_v      : natural;
+    variable word_v     : bit_vector(31 downto 0);
+    variable mem_v      : ram8bv_t(0 to num_words-1);
+    variable index_v    : natural;
+  begin
+    mem_v := (others => (others => '0'));
+    if (file_name /= "") then
+      file_open(hex_file, file_name, read_mode);
+      index_v := 0;
+      while (endfile(hex_file) = false) and (index_v < num_words) loop -- not end of file / end of memory
+        readline(hex_file, hex_line_v); -- read one line from file
+        for i in 7 downto 0 loop -- get full 32-bit word
+          read(hex_line_v, hex_char_v);
+          if (hex_char_v >= '0') and (hex_char_v <= '9') then
+            tmp_v := 0 + (character'pos(hex_char_v) - character'pos('0'));
+          elsif (hex_char_v >= 'a') and (hex_char_v <= 'f') then
+            tmp_v := 10 + (character'pos(hex_char_v) - character'pos('a'));
+          elsif (hex_char_v >= 'A') and (hex_char_v <= 'F') then
+            tmp_v := 10 + (character'pos(hex_char_v) - character'pos('A'));
+          else -- invalid character
+            tmp_v := 0;
+          end if;
+          word_v(i*4+3 downto i*4+0) := to_bitvector(std_ulogic_vector((to_unsigned(tmp_v, 4))));
+        end loop;
+        mem_v(index_v) := word_v(byte_sel*8+7 downto byte_sel*8+0); -- extract desired byte
+        index_v := index_v + 1;
+      end loop;
+    end if;
+    return mem_v;
+  end function init_mem8bv_from_hexfile_f;
 
   -- memory access --
-  signal addr  : integer range 0 to (MEM_SIZE/4)-1;
   signal rdata : std_ulogic_vector(31 downto 0);
   signal ack   : std_ulogic;
 
@@ -45,29 +85,36 @@ architecture xbus_memory_rtl of xbus_memory is
 
 begin
 
-  -- word-aligned read/write address --
-  addr <= to_integer(unsigned(xbus_req_i.addr(index_size_f(MEM_SIZE/4)+1 downto 2)));
-
-
-  -- Non-Initialized Memory Core ------------------------------------------------------------
+  -- Pre-Initialized Memory (all-zero or HEX image if specified) ----------------------------
   -- -------------------------------------------------------------------------------------------
   memory_core: process(clk_i)
-    variable mem8_bv_b0_v, mem8_bv_b1_v, mem8_bv_b2_v, mem8_bv_b3_v : mem8_bv_t(0 to (MEM_SIZE/4)-1);
+    variable mem8bv_b0_v : ram8bv_t(0 to (MEM_SIZE/4)-1) := init_mem8bv_from_hexfile_f(MEM_FILE, MEM_SIZE/4, 0);
+    variable mem8bv_b1_v : ram8bv_t(0 to (MEM_SIZE/4)-1) := init_mem8bv_from_hexfile_f(MEM_FILE, MEM_SIZE/4, 1);
+    variable mem8bv_b2_v : ram8bv_t(0 to (MEM_SIZE/4)-1) := init_mem8bv_from_hexfile_f(MEM_FILE, MEM_SIZE/4, 2);
+    variable mem8bv_b3_v : ram8bv_t(0 to (MEM_SIZE/4)-1) := init_mem8bv_from_hexfile_f(MEM_FILE, MEM_SIZE/4, 3);
   begin
     if rising_edge(clk_i) then
       ack <= '0';
       if (xbus_req_i.cyc = '1') and (xbus_req_i.stb = '1') then
         ack <= '1';
         if (xbus_req_i.we = '1') then
-          if (xbus_req_i.sel(0) = '1') then mem8_bv_b0_v(addr) := to_bitvector(xbus_req_i.data(07 downto 00)); end if;
-          if (xbus_req_i.sel(1) = '1') then mem8_bv_b1_v(addr) := to_bitvector(xbus_req_i.data(15 downto 08)); end if;
-          if (xbus_req_i.sel(2) = '1') then mem8_bv_b2_v(addr) := to_bitvector(xbus_req_i.data(23 downto 16)); end if;
-          if (xbus_req_i.sel(3) = '1') then mem8_bv_b3_v(addr) := to_bitvector(xbus_req_i.data(31 downto 24)); end if;
+          if (xbus_req_i.sel(0) = '1') then
+            mem8bv_b0_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))) := to_bitvector(xbus_req_i.data(07 downto 00));
+          end if;
+          if (xbus_req_i.sel(1) = '1') then
+            mem8bv_b1_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))) := to_bitvector(xbus_req_i.data(15 downto 08));
+          end if;
+          if (xbus_req_i.sel(2) = '1') then
+            mem8bv_b2_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))) := to_bitvector(xbus_req_i.data(23 downto 16));
+          end if;
+          if (xbus_req_i.sel(3) = '1') then
+            mem8bv_b3_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))) := to_bitvector(xbus_req_i.data(31 downto 24));
+          end if;
         else
-          rdata(07 downto 00) <= to_stdulogicvector(mem8_bv_b0_v(addr));
-          rdata(15 downto 08) <= to_stdulogicvector(mem8_bv_b1_v(addr));
-          rdata(23 downto 16) <= to_stdulogicvector(mem8_bv_b2_v(addr));
-          rdata(31 downto 24) <= to_stdulogicvector(mem8_bv_b3_v(addr));
+          rdata(07 downto 00) <= to_stdulogicvector(mem8bv_b0_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))));
+          rdata(15 downto 08) <= to_stdulogicvector(mem8bv_b1_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))));
+          rdata(23 downto 16) <= to_stdulogicvector(mem8bv_b2_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))));
+          rdata(31 downto 24) <= to_stdulogicvector(mem8bv_b3_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))));
         end if;
       end if;
     end if;

--- a/sim/xbus_memory.vhd
+++ b/sim/xbus_memory.vhd
@@ -54,7 +54,7 @@ architecture xbus_memory_rtl of xbus_memory is
       index_v := 0;
       while (endfile(hex_file) = false) and (index_v < num_words) loop -- not end of file / end of memory
         readline(hex_file, hex_line_v); -- read one line from file
-        for i in 7 downto 0 loop -- get full 32-bit word
+        for i in 7 downto 0 loop -- get full 32-bit word in 'word_v'; no VHDL2008 required
           read(hex_line_v, hex_char_v);
           if (hex_char_v >= '0') and (hex_char_v <= '9') then
             tmp_v := 0 + (character'pos(hex_char_v) - character'pos('0'));


### PR DESCRIPTION
Triggered by @mahdi259 in #1115 this PR adds new generics to the default testbench that control implementation (and initialization) of two processor-external memories.

```vhdl
-- external memory A --
EXT_MEM_A_EN   : boolean                        := true;        -- enable memory
EXT_MEM_A_BASE : std_ulogic_vector(31 downto 0) := x"00000000"; -- base address, has to be word-aligned
EXT_MEM_A_SIZE : natural                        := 64;          -- memory size in bytes, min 4
EXT_MEM_A_FILE : string                         := "";          -- memory initialization file (plain HEX), no initialization if empty
-- external memory B --
EXT_MEM_B_EN   : boolean                        := true;        -- enable memory
EXT_MEM_B_BASE : std_ulogic_vector(31 downto 0) := x"80000000"; -- base address, has to be word-aligned
EXT_MEM_B_SIZE : natural                        := 64;          -- memory size in bytes, min 4
EXT_MEM_B_FILE : string                         := ""           -- memory initialization file (plain HEX), no initialization if empty
```