### PR TITLE
[rtl] use past SDA in twd FSM transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 22.01.2025 | 1.10.9.10 | :bug: fix TWD ACK/NACK sampling | [#1165](https://github.com/stnolting/neorv32/pull/1165) |
 | 18.01.2025 | 1.10.9.9 | atomic memory access updates and improvements | [#1163](https://github.com/stnolting/neorv32/pull/1163) |
 | 16.01.2025 | 1.10.9.8 | :bug: fix several TWD design flaws | [#1161](https://github.com/stnolting/neorv32/pull/1161) |
 | 15.01.2025 | 1.10.9.7 | :sparkles: add GPIO interrupt(s); :warning: remove XIRQ controller, constrain GPIO input/output ports from 64-bit to 32-bit | [#1159](https://github.com/stnolting/neorv32/pull/1159) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100909"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01100910"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_twd.vhd
+++ b/rtl/core/neorv32_twd.vhd
@@ -417,7 +417,7 @@ begin
           if (ctrl.enable = '0') or (smp.stop = '1') then -- disabled or stop-condition
             engine.state <= S_IDLE;
           elsif (smp.scl_fall = '1') then -- end of this time slot
-            if (engine.cmd = '0') or ((engine.cmd = '1') and (smp.sda = '0')) then -- WRITE or READ with ACK
+            if (engine.cmd = '0') or ((engine.cmd = '1') and (smp.sda_sreg(2) = '0')) then -- WRITE or READ with ACK (read sda "from the past")
               engine.state <= S_RTX;
             end if;
           end if;


### PR DESCRIPTION
Since the SDA has to have a valid value only during high SCL, I had the case where with the fall of SCL the SDA also changed and thus a wrong state transition happened. But the protocol should guarantee a valid input during high SCL, so this should be a valid fix?

The image shows such a transition, which would fail with the old implementation.

![image](https://github.com/user-attachments/assets/fcda1495-3960-4226-88bf-7a2a183a6291)
