### PR TITLE
[rtl] reset SDA and SCL of TWI and TWD to '1'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 23.01.2025 | 1.11.0.1 | reset SDA and SCL of TWI and TWD modules to `1` | [#1167](https://github.com/stnolting/neorv32/pull/1167) |
 | 22.01.2025 | [**:rocket:1.11.0**](https://github.com/stnolting/neorv32/releases/tag/v1.11.0) | **New release** | |
 | 22.01.2025 | 1.10.9.10 | :bug: fix TWD ACK/NACK sampling | [#1165](https://github.com/stnolting/neorv32/pull/1165) |
 | 18.01.2025 | 1.10.9.9 | atomic memory access updates and improvements | [#1163](https://github.com/stnolting/neorv32/pull/1163) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110000"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110001"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_twd.vhd
+++ b/rtl/core/neorv32_twd.vhd
@@ -264,8 +264,8 @@ begin
   synchronizer: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      smp.sda_sreg <= (others => '0');
-      smp.scl_sreg <= (others => '0');
+      smp.sda_sreg <= (others => '1');
+      smp.scl_sreg <= (others => '1');
       smp.valid    <= '0';
     elsif rising_edge(clk_i) then
       -- input register --
@@ -293,8 +293,8 @@ begin
   bus_event: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      smp.sda      <= '0';
-      smp.scl      <= '0';
+      smp.sda      <= '1';
+      smp.scl      <= '1';
       smp.scl_rise <= '0';
       smp.scl_fall <= '0';
       smp.start    <= '0';

--- a/rtl/core/neorv32_twi.vhd
+++ b/rtl/core/neorv32_twi.vhd
@@ -298,8 +298,8 @@ begin
     if (rstn_i = '0') then
       io_con.sda_in_ff <= (others => '0');
       io_con.scl_in_ff <= (others => '0');
-      io_con.sda_out   <= '0';
-      io_con.scl_out   <= '0';
+      io_con.sda_out   <= '1';
+      io_con.scl_out   <= '1';
       engine.state     <= (others => '0');
       engine.bitcnt    <= (others => '0');
       engine.sreg      <= (others => '0');


### PR DESCRIPTION
Should improve compatibly with other TWI devices on the same bus as the reset doesn't pull-down SCL and SDA anymore.