### PR TITLE
⚠️ rename JEDEC ID generic; minor rtl edits and optimizations

### DIFF
--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -119,7 +119,6 @@ The generic type "suv(x:y)" represents a `std_ulogic_vector(x downto y)`.
 | Name | Type | Description
 | `HART_ID`          | natural   | ID of the core (for <<_mhartid>> CSR).
 | `NUM_HARTS`        | natural   | Total number of cores in the system.
-| `VENDOR_ID`        | suv(31:0) | Vendor identification (for <<_mvendorid>> CSR).
 | `BOOT_ADDR`        | suv(31:0) | CPU reset address. See section <<_address_space>>.
 | `DEBUG_PARK_ADDR`  | suv(31:0) | "Park loop" entry address for the <<_on_chip_debugger_ocd>>, has to be 4-byte aligned.
 | `DEBUG_EXC_ADDR`   | suv(31:0) | "Exception" entry address for the <<_on_chip_debugger_ocd>>, has to be 4-byte aligned.

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -834,9 +834,9 @@ and are not accessible for lower-privileged software.
 |=======================
 | Name        | Machine vendor ID
 | Address     | `0xf11`
-| Reset value | `DEFINED`
+| Reset value | `0x00000000`
 | ISA         | `Zicsr`
-| Description | Vendor ID (JEDEC identifier, lowest 11 bits), assigned via the `JEDEC_ID` top generic (<<_processor_top_entity_generics>>).
+| Description | Hardwired to zero; read accesses are ignored.
 |=======================
 
 

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -212,14 +212,13 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `CLOCK_FREQUENCY`       | natural   | 0             | The clock frequency of the processor's `clk_i` input port in Hertz (Hz).
 4+^| **<<_dual_core_configuration>>**
 | `DUAL_CORE_EN`          | boolean   | false         | Enable the SMP dual-core configuration.
-4+^| **Core Identification**
-| `JEDEC_ID`              | suv(10:0) | "00000000000" | JEDEC ID; continuation codes plus vendor ID (passed to <<_mvendorid>> CSR and to the <<_debug_transport_module_dtm>>).
 4+^| **<<_boot_configuration>>**
 | `BOOT_MODE_SELECT`      | natural   | 0             | Boot mode select; see <<_boot_configuration>>.
 | `BOOT_ADDR_CUSTOM`      | suv(31:0) | x"00000000"   | Custom CPU boot address (available if `BOOT_MODE_SELECT` = 1).
 4+^| **<<_on_chip_debugger_ocd>>**
 | `OCD_EN`                | boolean   | false         | Implement the on-chip debugger and the CPU debug mode.
 | `OCD_AUTHENTICATION`    | boolean   | false         | Implement <<_debug_authentication>> module.
+| `OCD_JEDEC_ID`          | suv(10:0) | "00000000000" | JEDEC ID; continuation codes plus vendor ID (passed to the JTAG <<_debug_transport_module_dtm>>).
 4+^| **CPU <<_instruction_sets_and_extensions>>**
 | `RISCV_ISA_C`           | boolean   | false         | Enable <<_c_isa_extension>> (compressed instructions).
 | `RISCV_ISA_E`           | boolean   | false         | Enable <<_e_isa_extension>> (reduced register file size).
@@ -554,7 +553,7 @@ by a global constant in the processor's VHDL package file (`rtl/core/neorv323_pa
 .Internal Bus Timeout Configuration
 [source,vhdl]
 ----
-constant bus_timeout_c : natural := 15;
+constant bus_timeout_c : natural := 16;
 ----
 
 This constant defines the _maximum_ number of cycles after which a non-responding bus request (i.e. no `ack`

--- a/docs/datasheet/soc_xbus.adoc
+++ b/docs/datasheet/soc_xbus.adoc
@@ -44,12 +44,16 @@ see section <<_address_space>>) are **redirected** to the external bus interface
 .AXI4-Lite Interface Bridge
 [TIP]
 A simple bridge that converts the processor's XBUS into an AXI4-lite-compatible host interface can
-be found in in `rtl/system_inegration` (`xbus2axi4lite_bridge.vhd`).
+be found in in `rtl/system_inegration` (`xbus2axi4lite_bridge.vhd`). Note that the AXI specifications
+do not allow any bus timeouts. Hence, `XBUS_TIMEOUT` should be set to zero (disabling the bus timeout)
+when using the XBUS-AXI bridge.
 
 .AHB3-Lite Interface Bridge
 [TIP]
 A simple bridge that converts the processor's XBUS into an AHB3-lite-compatible host interface can
-be found in in `rtl/system_inegration` (`xbus2ahblite_bridge.vhd`).
+be found in in `rtl/system_inegration` (`xbus2ahblite_bridge.vhd`). Note that the AHB specifications
+do not allow any bus timeouts. Hence, `XBUS_TIMEOUT` should be set to zero (disabling the bus timeout)
+when using the XBUS-AHB bridge.
 
 
 **Wishbone Bus Protocol**

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -460,11 +460,11 @@ begin
       keeper.err  <= '0'; -- default
       keeper.halt <= or_reduce_f(port_sel and (not tmo_en_list_c)); -- no timeout if *_TMO_EN = false
       if (keeper.busy = '0') then -- bus idle
-        keeper.cnt  <= std_ulogic_vector(to_unsigned(TIMEOUT, keeper.cnt'length));
+        keeper.cnt  <= (others => '0');
         keeper.busy <= req_i.stb;
       else -- bus access in progress
-        keeper.cnt <= std_ulogic_vector(unsigned(keeper.cnt) - 1);
-        if (int_rsp.err = '1') or ((or_reduce_f(keeper.cnt) = '0') and (keeper.halt = '0')) then -- bus error or timeout
+        keeper.cnt <= std_ulogic_vector(unsigned(keeper.cnt) + 1);
+        if (int_rsp.err = '1') or ((keeper.cnt(keeper.cnt'left) = '1') and (keeper.halt = '0')) then -- bus error or timeout
           keeper.err  <= '1';
           keeper.busy <= '0';
         elsif (int_rsp.ack = '1') then -- normal access termination

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -23,7 +23,6 @@ entity neorv32_cpu is
   generic (
     -- General --
     HART_ID             : natural range 0 to 1023; -- hardware thread ID
-    VENDOR_ID           : std_ulogic_vector(31 downto 0); -- vendor's JEDEC ID
     BOOT_ADDR           : std_ulogic_vector(31 downto 0); -- cpu boot address
     DEBUG_PARK_ADDR     : std_ulogic_vector(31 downto 0); -- cpu debug mode parking loop entry address
     DEBUG_EXC_ADDR      : std_ulogic_vector(31 downto 0); -- cpu debug mode exception entry address
@@ -214,7 +213,6 @@ begin
   generic map (
     -- General --
     HART_ID             => HART_ID,             -- hardware thread ID
-    VENDOR_ID           => VENDOR_ID,           -- vendor's JEDEC ID
     BOOT_ADDR           => BOOT_ADDR,           -- cpu boot address
     DEBUG_PARK_ADDR     => DEBUG_PARK_ADDR,     -- cpu debug mode parking loop entry address
     DEBUG_EXC_ADDR      => DEBUG_EXC_ADDR,      -- cpu debug mode exception entry address

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -30,7 +30,6 @@ entity neorv32_cpu_control is
   generic (
     -- General --
     HART_ID             : natural range 0 to 1023; -- hardware thread ID
-    VENDOR_ID           : std_ulogic_vector(31 downto 0); -- vendor's JEDEC ID
     BOOT_ADDR           : std_ulogic_vector(31 downto 0); -- cpu boot address
     DEBUG_PARK_ADDR     : std_ulogic_vector(31 downto 0); -- cpu debug-mode parking loop entry address, 4-byte aligned
     DEBUG_EXC_ADDR      : std_ulogic_vector(31 downto 0); -- cpu debug-mode exception entry address, 4-byte aligned
@@ -1824,7 +1823,7 @@ begin
           -- --------------------------------------------------------------------
           -- machine information registers
           -- --------------------------------------------------------------------
-          when csr_mvendorid_c  => csr.rdata <= VENDOR_ID; -- vendor's JEDEC ID
+--        when csr_mvendorid_c  => csr.rdata <= (others => '0'); -- vendor's JEDEC ID
           when csr_marchid_c    => csr.rdata(4 downto 0) <= "10011"; -- architecture ID - official RISC-V open-source arch ID
           when csr_mimpid_c     => csr.rdata <= hw_version_c; -- implementation ID -- NEORV32 hardware version
           when csr_mhartid_c    => csr.rdata(9 downto 0) <= std_ulogic_vector(to_unsigned(HART_ID, 10)); -- hardware thread ID

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -22,14 +22,14 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   -- max response time for processor-internal bus transactions --
   -- cycles after which an unacknowledged internal bus access will timeout raising a bus fault exception
-  constant bus_timeout_c : natural := 15; -- default = 15
+  constant bus_timeout_c : natural := 16; -- has to be a power of two
 
   -- instruction monitor: raise exception if multi-cycle operation times out --
   constant monitor_mc_tmo_c : natural := 9; -- = log2 of max execution cycles; default = 2^9 = 512 cycles
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110001"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110002"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -732,14 +732,13 @@ package neorv32_package is
       CLOCK_FREQUENCY       : natural                        := 0;
       -- Dual-Core Configuration --
       DUAL_CORE_EN          : boolean                        := false;
-      -- Core Identification --
-      JEDEC_ID              : std_ulogic_vector(10 downto 0) := "00000000000";
       -- Boot Configuration --
       BOOT_MODE_SELECT      : natural range 0 to 2           := 0;
       BOOT_ADDR_CUSTOM      : std_ulogic_vector(31 downto 0) := x"00000000";
       -- On-Chip Debugger (OCD) --
       OCD_EN                : boolean                        := false;
       OCD_AUTHENTICATION    : boolean                        := false;
+      OCD_JEDEC_ID          : std_ulogic_vector(10 downto 0) := "00000000000";
       -- RISC-V CPU Extensions --
       RISCV_ISA_C           : boolean                        := false;
       RISCV_ISA_E           : boolean                        := false;

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -27,9 +27,6 @@ entity neorv32_top is
     -- Dual-Core Configuration --
     DUAL_CORE_EN          : boolean                        := false;       -- enable dual-core homogeneous SMP
 
-    -- Core Identification --
-    JEDEC_ID              : std_ulogic_vector(10 downto 0) := "00000000000"; -- JEDEC ID: continuation codes + vendor ID
-
     -- Boot Configuration --
     BOOT_MODE_SELECT      : natural range 0 to 2           := 0;           -- boot configuration select (default = 0 = bootloader)
     BOOT_ADDR_CUSTOM      : std_ulogic_vector(31 downto 0) := x"00000000"; -- custom CPU boot address (if boot_config = 1)
@@ -37,6 +34,7 @@ entity neorv32_top is
     -- On-Chip Debugger (OCD) --
     OCD_EN                : boolean                        := false;       -- implement on-chip debugger
     OCD_AUTHENTICATION    : boolean                        := false;       -- implement on-chip debugger authentication
+    OCD_JEDEC_ID          : std_ulogic_vector(10 downto 0) := "00000000000"; -- JEDEC ID: continuation codes + vendor ID
 
     -- RISC-V CPU Extensions --
     RISCV_ISA_C           : boolean                        := false;       -- implement compressed extension
@@ -277,9 +275,6 @@ architecture neorv32_top_rtl of neorv32_top is
   constant cpu_smpmp_c     : boolean := boolean(PMP_NUM_REGIONS > 0);
   constant io_sysinfo_en_c : boolean := not IO_DISABLE_SYSINFO;
 
-  -- convert JEDEC ID to MVENDORID CSR --
-  constant vendorid_c : std_ulogic_vector(31 downto 0) := x"00000" & "0" & JEDEC_ID;
-
   -- make sure physical memory sizes are a power of two --
   constant imem_size_c : natural := cond_sel_natural_f(is_power_of_two_f(MEM_INT_IMEM_SIZE), MEM_INT_IMEM_SIZE, 2**index_size_f(MEM_INT_IMEM_SIZE));
   constant dmem_size_c : natural := cond_sel_natural_f(is_power_of_two_f(MEM_INT_DMEM_SIZE), MEM_INT_DMEM_SIZE, 2**index_size_f(MEM_INT_DMEM_SIZE));
@@ -500,7 +495,6 @@ begin
     generic map (
       -- General --
       HART_ID             => i,
-      VENDOR_ID           => vendorid_c,
       BOOT_ADDR           => cpu_boot_addr_c,
       DEBUG_PARK_ADDR     => dm_park_entry_c,
       DEBUG_EXC_ADDR      => dm_exc_entry_c,
@@ -1703,7 +1697,7 @@ begin
     generic map (
       IDCODE_VERSION => (others => '0'), -- yet unused
       IDCODE_PARTID  => (others => '0'), -- yet unused
-      IDCODE_MANID   => JEDEC_ID
+      IDCODE_MANID   => OCD_JEDEC_ID
     )
     port map (
       clk_i      => clk_i,

--- a/rtl/core/neorv32_xbus.vhd
+++ b/rtl/core/neorv32_xbus.vhd
@@ -76,24 +76,18 @@ begin
   arbiter: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      timecnt <= (others => '0');
       pending <= (others => '0');
-      timeout <= '0';
     elsif rising_edge(clk_i) then
-
-      -- access control --
       case pending is
 
         when "10" => -- single access / atomic access (2nd access: store)
         -- ------------------------------------------------------------
-          timecnt <= std_ulogic_vector(unsigned(timecnt) + 1);
           if (xbus_ack_i = '1') or (xbus_err_i = '1') or (timeout = '1') then
             pending <= "00";
           end if;
 
         when "11" => -- atomic access (1st access: load)
         -- ------------------------------------------------------------
-          timecnt <= std_ulogic_vector(unsigned(timecnt) + 1);
           if (xbus_err_i = '1') or (timeout = '1') then -- abort if error
             pending <= "00";
           elsif (xbus_ack_i = '1') then
@@ -102,7 +96,6 @@ begin
 
         when others => -- "0-": idle; waiting for request
         -- ------------------------------------------------------------
-          timecnt <= (others => '0');
           if (bus_req.stb = '1') then
             if (bus_req.amo = '1') then
               pending <= "11";
@@ -112,22 +105,45 @@ begin
           end if;
 
       end case;
-
-      -- access timeout --
-      if (TIMEOUT_VAL /= 0) and (unsigned(timecnt) = TIMEOUT_VAL) then
-        timeout <= '1';
-      else
-        timeout <= '0';
-      end if;
-
     end if;
   end process arbiter;
+
+
+  -- Bus Timeout ----------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  timeout_enabled:
+  if TIMEOUT_VAL /= 0 generate
+    timeout_counter: process(rstn_i, clk_i)
+    begin
+      if (rstn_i = '0') then
+        timecnt <= (others => '0');
+        timeout <= '0';
+      elsif rising_edge(clk_i) then
+        if (pending(1) = '0') then
+          timecnt <= (others => '0');
+        else
+          timecnt <= std_ulogic_vector(unsigned(timecnt) + 1);
+        end if;
+        if (unsigned(timecnt) = TIMEOUT_VAL) then
+          timeout <= '1';
+        else
+          timeout <= '0';
+        end if;
+      end if;
+    end process timeout_counter;
+  end generate;
+
+  timeout_disabled:
+  if TIMEOUT_VAL = 0 generate
+    timecnt <= (others => '0');
+    timeout <= '0';
+  end generate;
 
   -- no-timeout warning --
   assert not (TIMEOUT_VAL = 0) report "[NEORV32] XBUS: NO auto-timeout configured!" severity warning;
 
 
-  -- XBUS ("Pipelined" Wishbone b4) ---------------------------------------------------------
+  -- XBUS (Compatible to "pipelined" Wishbone b4 protocol) ----------------------------------
   -- -------------------------------------------------------------------------------------------
   xbus_adr_o <= bus_req.addr;
   xbus_dat_o <= bus_req.data;

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -185,21 +185,16 @@ proc setup_ip_gui {} {
   set_property value_validation_type pairs [ipx::get_user_parameters BOOT_MODE_SELECT -of_objects [ipx::current_core]]
   set_property value_validation_pairs {{Internal bootloader} 0 {Custom address} 1 {Internal IMEM image} 2} [ipx::get_user_parameters BOOT_MODE_SELECT -of_objects [ipx::current_core]]
 
-  set group [add_group $page {Core Identification}]
-  add_params $group {
-    { JEDEC_ID              {JEDEC ID}              {For JTAG tap identification and mvendorid CSR} }
-  }
-
   set group [add_group $page {On-Chip Debugger (OCD)}]
   add_params $group {
-    { OCD_EN                {Enable OCD}            {Implement the on-chip debugger, the CPU debug mode and the JTAG port} }
+    { OCD_EN                {Enable OCD}            {Implement JTAG-based on-chip debugger} }
     { OCD_AUTHENTICATION    {OCD Authentication}    {Implement Debug Authentication module}                   {$OCD_EN} {$OCD_EN ? $OCD_AUTHENTICATION : false}}
+    { OCD_JEDEC_ID          {JEDEC ID}              {JTAG tap identification}                                 {$OCD_EN}}
   }
 
   set group [add_group $page {External Bus Interface (XBUS / AXI4-Lite-MM Host)}]
   add_params $group {
     { XBUS_EN               {Enable XBUS}           {} }
-    { XBUS_TIMEOUT          {Timeout}               {Max number of clock cycles before AXI access times out}  {$XBUS_EN} }
     { XBUS_REGSTAGE_EN      {Add register stages}   {Relaxes timing, but will increase latency}               {$XBUS_EN} }
   }
 

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -29,14 +29,13 @@ entity neorv32_vivado_ip is
     CLOCK_FREQUENCY       : natural                        := 100_000_000;
     -- Dual-Core Configuration --
     DUAL_CORE_EN          : boolean                        := false;
-    -- Identification --
-    JEDEC_ID              : std_logic_vector(10 downto 0)  := "00000000000";
     -- Boot Configuration --
     BOOT_MODE_SELECT      : natural range 0 to 2           := 0;
     BOOT_ADDR_CUSTOM      : std_ulogic_vector(31 downto 0) := x"00000000";
     -- On-Chip Debugger (OCD) --
     OCD_EN                : boolean                        := false;
     OCD_AUTHENTICATION    : boolean                        := false;
+    OCD_JEDEC_ID          : std_logic_vector(10 downto 0)  := "00000000000";
     -- RISC-V CPU Extensions --
     RISCV_ISA_C           : boolean                        := false;
     RISCV_ISA_E           : boolean                        := false;
@@ -88,7 +87,6 @@ entity neorv32_vivado_ip is
     DCACHE_BLOCK_SIZE     : natural range 4 to 2**16       := 64;
     -- External Bus Interface --
     XBUS_EN               : boolean                        := true;
-    XBUS_TIMEOUT          : natural range 8 to 65536       := 64;
     XBUS_REGSTAGE_EN      : boolean                        := false;
     XBUS_CACHE_EN         : boolean                        := false;
     XBUS_CACHE_NUM_BLOCKS : natural range 1 to 256         := 8;
@@ -353,14 +351,13 @@ begin
     CLOCK_FREQUENCY       => CLOCK_FREQUENCY,
     -- Dual-Core Configuration --
     DUAL_CORE_EN          => DUAL_CORE_EN,
-    -- Identification --
-    JEDEC_ID              => std_ulogic_vector(JEDEC_ID),
     -- Boot Configuration --
     BOOT_MODE_SELECT      => BOOT_MODE_SELECT,
     BOOT_ADDR_CUSTOM      => BOOT_ADDR_CUSTOM,
     -- On-Chip Debugger --
     OCD_EN                => OCD_EN,
     OCD_AUTHENTICATION    => OCD_AUTHENTICATION,
+    OCD_JEDEC_ID          => std_ulogic_vector(OCD_JEDEC_ID),
     -- RISC-V CPU Extensions --
     RISCV_ISA_C           => RISCV_ISA_C,
     RISCV_ISA_E           => RISCV_ISA_E,
@@ -413,7 +410,7 @@ begin
     DCACHE_BLOCK_SIZE     => DCACHE_BLOCK_SIZE,
     -- External bus interface --
     XBUS_EN               => XBUS_EN,
-    XBUS_TIMEOUT          => XBUS_TIMEOUT,
+    XBUS_TIMEOUT          => 0, -- AXI does not allow any timeouts
     XBUS_REGSTAGE_EN      => XBUS_REGSTAGE_EN,
     XBUS_CACHE_EN         => XBUS_CACHE_EN,
     XBUS_CACHE_NUM_BLOCKS => XBUS_CACHE_NUM_BLOCKS,

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -120,8 +120,6 @@ begin
     CLOCK_FREQUENCY       => CLOCK_FREQUENCY,
     -- Dual-Core Configuration --
     DUAL_CORE_EN          => DUAL_CORE_EN,
-    -- Identification --
-    JEDEC_ID              => "00000000000",
     -- Boot Configuration --
     BOOT_MODE_SELECT      => BOOT_MODE_SELECT,
     BOOT_ADDR_CUSTOM      => BOOT_ADDR_CUSTOM,

--- a/sw/lib/source/neorv32_aux.c
+++ b/sw/lib/source/neorv32_aux.c
@@ -297,11 +297,9 @@ void neorv32_aux_print_hw_config(void) {
 
   // IDs
   neorv32_uart0_printf("Hart ID:             0x%x\n"
-                       "Vendor ID:           0x%x\n"
                        "Architecture ID:     0x%x\n"
                        "Implementation ID:   0x%x",
                        neorv32_cpu_csr_read(CSR_MHARTID),
-                       neorv32_cpu_csr_read(CSR_MVENDORID),
                        neorv32_cpu_csr_read(CSR_MARCHID),
                        neorv32_cpu_csr_read(CSR_MIMPID));
   // hardware version


### PR DESCRIPTION
* :warning: `mvendorid` CSR is now hardwired to all-zero
* :warning: rename `JEDEC_ID` generic to `OCD_JEDEC_ID`
* auto-disable timeout of external bus interface to the AXI4 briding (AXI does not allow any timeouts)
* minor rtl edits and optimizations