### PR TITLE
🐛 Fix crt0's main entry address being overridden by constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 28.01.2025 | 1.11.0.4 | :bug: fix crt0's entry address being overridden by core0's constructors (that do not backup any registers) | [#1172](https://github.com/stnolting/neorv32/pull/1172) |
 | 28.01.2025 | 1.11.0.3 | :bug: fix BOOTROM addressing (index was out-of-range) | [#1171](https://github.com/stnolting/neorv32/pull/1171) |
 | 24.01.2025 | 1.11.0.2 | :warning: rename JEDEC ID generic; minor rtl edits and optimizations | [#1168](https://github.com/stnolting/neorv32/pull/1168) |
 | 23.01.2025 | 1.11.0.1 | reset SDA and SCL of TWI and TWD modules to `1` | [#1167](https://github.com/stnolting/neorv32/pull/1167) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110003"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110004"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/sw/common/crt0.S
+++ b/sw/common/crt0.S
@@ -43,11 +43,10 @@ __crt0_entry:
   la    x9,  __crt0_copy_data_dst_end   // .data: end of actual data region
   la    x10, __crt0_bss_start           // .bss: start address
   la    x11, __crt0_bss_end             // .bss: end address (not part of bss)
-
-  la    x12, main                       // primary core's (core0) entry point
 .option pop
 
-  // initialize rest of register file
+  // initialize remaining registers
+  addi  x12, zero, 0
   addi  x13, zero, 0
   addi  x14, zero, 0
   addi  x15, zero, 0
@@ -137,6 +136,7 @@ __crt0_bss_clear_end:
 
 // ************************************************************************************************
 // Call constructors (not supported for bootloader).
+// WARNING! Constructors do not preserve any registers on the stack.
 // ************************************************************************************************
 #ifndef MAKE_BOOTLOADER
   la    x8, __init_array_start
@@ -156,6 +156,7 @@ __crt0_constructors_end:
 // ************************************************************************************************
 // Setup arguments and call main function.
 // ************************************************************************************************
+  la    x12, main        // primary core's (core0) entry point (#1169)
 __crt0_main_entry:
   fence                  // reload data cache
   fence.i                // reload instruction cache
@@ -174,6 +175,7 @@ __crt0_main_exit:        // main's "return" and "exit" will arrive here
 
 // ************************************************************************************************
 // Call destructors (not supported for bootloader).
+// WARNING! Destructors do not preserve any registers on the stack.
 // ************************************************************************************************
 #ifndef MAKE_BOOTLOADER
   csrr  x8, mhartid

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -80,7 +80,7 @@ volatile uint32_t num_hpm_cnts_global = 0; // global number of available hpms
 volatile int vectored_mei_handler_ack = 0; // vectored mei trap handler acknowledge
 volatile uint32_t gpio_trap_handler_ack = 0; // gpio trap handler acknowledge
 volatile uint32_t hw_brk_mscratch_ok = 0; // set when mepc was correct in trap handler
-volatile uint32_t constr_test = 0; // for constructor test
+
 
 volatile uint32_t dma_src; // dma source & destination data
 volatile uint32_t store_access_addr[2]; // variable to test store accesses
@@ -88,13 +88,28 @@ volatile uint32_t __attribute__((aligned(4))) pmp_access[2]; // variable to test
 volatile uint32_t trap_cnt; // number of triggered traps
 volatile uint32_t pmp_num_regions; // number of implemented pmp regions
 volatile uint8_t core1_stack[512]; // stack for core1
-
+volatile unsigned char constr_src[16] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+volatile uint32_t constr_res = 0; // for constructor test
 
 /**********************************************************************//**
  * Constructor; should be called before entering main.
+ * @warning Constructors do not preserve any registers on the stack (issue #1169).
  **************************************************************************/
 void __attribute__((constructor)) neorv32_constructor() {
-  constr_test = 0x1234abcdu;
+
+  int i;
+  volatile unsigned char tmp[16];
+
+  // do some dummy copying (just to ensure we are using a lot of UNSAVED registers)
+  for (i=0; i<16; i++) {
+    tmp[i] = constr_src[i];
+  }
+
+  // simple hash
+  constr_res = 0;
+  for (i=0; i<16; i++) {
+    constr_res = (31 * constr_res) + tmp[i];
+  }
 }
 
 
@@ -404,13 +419,12 @@ int main() {
 
 
   // ----------------------------------------------------------
-  // External memory interface test
-  // (and iCache block-/word-wise error check)
+  // External memory interface test (and I-cache block-/word-wise error check)
   // ----------------------------------------------------------
   neorv32_cpu_csr_write(CSR_MCAUSE, mcause_never_c);
   PRINT_STANDARD("[%i] Ext. memory (@0x%x) ", cnt_test, (uint32_t)EXT_MEM_BASE);
 
-  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_XBUS)) {
+  if ((NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_XBUS)) && (neorv32_cpu_csr_read(CSR_MXISA) & (1 << CSR_MXISA_IS_SIM))) {
     cnt_test++;
 
     // clear scratch CSR
@@ -1775,7 +1789,7 @@ int main() {
   PRINT_STANDARD("[%i] Constructor ", cnt_test);
   cnt_test++;
 
-  if (constr_test == 0x1234abcdu) { // has constructor been executed?
+  if (constr_res == 0xb4459108) { // has constructor been executed (correct hash)?
     test_ok();
   }
   else {


### PR DESCRIPTION
Fixes #1169.

⚠️ The default C constructors do not preserve any registers on the stack.