### PR TITLE
Source-out CPU front-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
-| 14.02.2025 | 1.11.1.2 |minor rtl edits and cleanups (cache optimizations) | [#1182](https://github.com/stnolting/neorv32/pull/1182) |
+| 14.02.2025 | 1.11.1.3 | source-out CPU front-end into new rtl file (`neorv32_cpu_frontend.vhd`) | [#1183](https://github.com/stnolting/neorv32/pull/1183) |
+| 14.02.2025 | 1.11.1.2 | minor rtl edits and cleanups (cache optimizations) | [#1182](https://github.com/stnolting/neorv32/pull/1182) |
 | 08.02.2025 | 1.11.1.1 | :sparkles: add support for `A` and `Zalrsc` ISA extensions | [#1181](https://github.com/stnolting/neorv32/pull/1181) |
 | 07.02.2025 | [**:rocket:1.11.1**](https://github.com/stnolting/neorv32/releases/tag/v1.11.1) | **New release** | |
 | 07.02.2025 | 1.11.0.10 | :warning: rename UART RTS/CTS signals | [#1180](https://github.com/stnolting/neorv32/pull/1180) |

--- a/docs/datasheet/overview.adoc
+++ b/docs/datasheet/overview.adoc
@@ -164,6 +164,13 @@ All core VHDL files from the list below have to be assigned to a **new library**
 [NOTE]
 See section <<_file_list_files>> for more information.
 
+.Replacing Modules for Customization or Optimization
+[TIP]
+Any module of the core can be replaced by the user for customization purpose. For example, the default IMEM and DMEM
+modules as well as the CPU's register file can be replaced by technology-specific primitives to optimize energy, speed
+and area utilization. The module, which are dedicated for customization, i.e. CFS and CFU can be replaced by
+user-defined modules to implement application-specific functionality.
+
 .RTL File List (in alphabetical order)
 ...................................
 rtl/core
@@ -186,6 +193,7 @@ rtl/core
 ├-neorv32_cpu_cp_muldiv.vhd     - Mul/Div co-processor (M ext.)
 ├-neorv32_cpu_cp_shifter.vhd    - Bit-shift co-processor (base ISA)
 ├-neorv32_cpu_decompressor.vhd  - Compressed instructions decoder (C ext.)
+├-neorv32_cpu_frontend.vhd      - Instruction fetch and issue
 ├-neorv32_cpu_icc.vhd           - Inter-core communication unit
 ├-neorv32_cpu_lsu.vhd           - Load/store unit
 ├-neorv32_cpu_pmp.vhd           - Physical memory protection unit (Smpmp ext.)
@@ -217,13 +225,6 @@ rtl/core
 ├-neorv32_wdt.vhd               - Watchdog timer
 └-neorv32_xbus.vhd              - External (Wishbone) bus interface gateways
 ...................................
-
-.Replacing Modules for Customization or Optimization
-[TIP]
-Any module of the core can be replaced by the user for customization purpose. For example, the default IMEM and DMEM
-modules as well as the CPU's register file can be replaced by technology-specific primitives to optimize energy, speed
-and area utilization. The module, which are dedicated for customization, i.e. CFS and CFU can be replaced by
-user-defined modules to implement application-specific functionality.
 
 
 :sectnums:

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -104,36 +104,27 @@ architecture neorv32_cpu_rtl of neorv32_cpu is
   constant riscv_zks_c : boolean := RISCV_ISA_Zbkb and RISCV_ISA_Zbkc and RISCV_ISA_Zbkx and
                                     RISCV_ISA_Zksh and RISCV_ISA_Zksed; -- Zks: ShangMi suite
 
-  -- external CSR interface --
-  signal xcsr_re        : std_ulogic;
-  signal xcsr_we        : std_ulogic;
-  signal xcsr_addr      : std_ulogic_vector(11 downto 0);
-  signal xcsr_wdata     : std_ulogic_vector(XLEN-1 downto 0);
-  signal xcsr_rdata_pmp : std_ulogic_vector(XLEN-1 downto 0);
-  signal xcsr_rdata_alu : std_ulogic_vector(XLEN-1 downto 0);
-  signal xcsr_rdata_res : std_ulogic_vector(XLEN-1 downto 0);
-  signal xcsr_rdata_icc : std_ulogic_vector(XLEN-1 downto 0);
+  -- external CSR interface read-back --
+  signal xcsr_pmp, xcsr_alu, xcsr_res, xcsr_icc : std_ulogic_vector(XLEN-1 downto 0);
 
   -- local signals --
-  signal clk_gated     : std_ulogic; -- switchable clock (clock gating)
-  signal ctrl          : ctrl_bus_t; -- main control bus
-  signal alu_imm       : std_ulogic_vector(XLEN-1 downto 0); -- immediate
-  signal rf_wdata      : std_ulogic_vector(XLEN-1 downto 0); -- register file write data
-  signal rs1, rs2, rs3 : std_ulogic_vector(XLEN-1 downto 0); -- source registers
-  signal alu_res       : std_ulogic_vector(XLEN-1 downto 0); -- alu result
-  signal alu_add       : std_ulogic_vector(XLEN-1 downto 0); -- alu address result
-  signal alu_cmp       : std_ulogic_vector(1 downto 0);      -- comparator result
-  signal lsu_rdata     : std_ulogic_vector(XLEN-1 downto 0); -- lsu memory read data
-  signal alu_cp_done   : std_ulogic;                         -- alu co-processor operation done
-  signal lsu_wait      : std_ulogic;                         -- wait for current data bus access
-  signal csr_rdata     : std_ulogic_vector(XLEN-1 downto 0); -- csr read data
-  signal lsu_mar       : std_ulogic_vector(XLEN-1 downto 0); -- lsu memory address register
-  signal lsu_err       : std_ulogic_vector(3 downto 0);      -- lsu alignment/access errors
-  signal pc_curr       : std_ulogic_vector(XLEN-1 downto 0); -- current pc (for currently executed instruction)
-  signal pc_next       : std_ulogic_vector(XLEN-1 downto 0); -- next PC (corresponding to next instruction)
-  signal pc_ret        : std_ulogic_vector(XLEN-1 downto 0); -- return address
-  signal pmp_fault     : std_ulogic;                         -- pmp permission violation
-  signal irq_machine   : std_ulogic_vector(2 downto 0);      -- risc-v standard machine-level interrupts
+  signal ctrl        : ctrl_bus_t; -- main control bus
+  signal clk_gated   : std_ulogic; -- switchable clock (clock gating)
+  signal rf_wdata    : std_ulogic_vector(XLEN-1 downto 0); -- register file write data
+  signal rs1         : std_ulogic_vector(XLEN-1 downto 0); -- source register 1
+  signal rs2         : std_ulogic_vector(XLEN-1 downto 0); -- source register 2
+  signal rs3         : std_ulogic_vector(XLEN-1 downto 0); -- source register 3
+  signal alu_res     : std_ulogic_vector(XLEN-1 downto 0); -- alu result
+  signal alu_add     : std_ulogic_vector(XLEN-1 downto 0); -- alu address result
+  signal alu_cmp     : std_ulogic_vector(1 downto 0);      -- comparator result
+  signal lsu_rdata   : std_ulogic_vector(XLEN-1 downto 0); -- lsu memory read data
+  signal alu_cp_done : std_ulogic;                         -- alu co-processor operation done
+  signal lsu_wait    : std_ulogic;                         -- wait for current data bus access
+  signal csr_rdata   : std_ulogic_vector(XLEN-1 downto 0); -- csr read data
+  signal lsu_mar     : std_ulogic_vector(XLEN-1 downto 0); -- lsu memory address register
+  signal lsu_err     : std_ulogic_vector(3 downto 0);      -- lsu alignment/access errors
+  signal pmp_fault   : std_ulogic;                         -- pmp permission violation
+  signal irq_machine : std_ulogic_vector(2 downto 0);      -- risc-v standard machine-level interrupts
 
 begin
 
@@ -213,7 +204,7 @@ begin
   end generate;
 
 
-  -- Control Unit (CTRL) --------------------------------------------------------------------
+  -- Control Unit (Back-End) ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_control_inst: entity neorv32.neorv32_cpu_control
   generic map (
@@ -265,51 +256,42 @@ begin
   )
   port map (
     -- global control --
-    clk_i         => clk_gated,      -- global clock, rising edge
-    clk_aux_i     => clk_i,          -- always-on clock, rising edge
-    rstn_i        => rstn_i,         -- global reset, low-active, async
-    ctrl_o        => ctrl,           -- main control bus
+    clk_i         => clk_gated,   -- global clock, rising edge
+    clk_aux_i     => clk_i,       -- always-on clock, rising edge
+    rstn_i        => rstn_i,      -- global reset, low-active, async
+    ctrl_o        => ctrl,        -- main control bus
     -- instruction fetch interface --
-    ibus_req_o    => ibus_req_o,     -- request
-    ibus_rsp_i    => ibus_rsp_i,     -- response
+    ibus_req_o    => ibus_req_o,  -- request
+    ibus_rsp_i    => ibus_rsp_i,  -- response
     -- pmp fault --
-    pmp_fault_i   => pmp_fault,      -- instruction fetch / execute pmp fault
+    pmp_fault_i   => pmp_fault,   -- instruction fetch / execute pmp fault
     -- data path interface --
-    alu_cp_done_i => alu_cp_done,    -- ALU iterative operation done
-    alu_cmp_i     => alu_cmp,        -- comparator status
-    alu_add_i     => alu_add,        -- ALU address result
-    alu_imm_o     => alu_imm,        -- immediate
-    rf_rs1_i      => rs1,            -- rf source 1
-    pc_curr_o     => pc_curr,        -- current PC (corresponding to current instruction)
-    pc_next_o     => pc_next,        -- next PC (corresponding to next instruction)
-    pc_ret_o      => pc_ret,         -- return address
-    csr_rdata_o   => csr_rdata,      -- CSR read data
-    -- external CSR interface --
-    xcsr_we_o     => xcsr_we,        -- global write enable
-    xcsr_re_o     => xcsr_re,        -- global read enable
-    xcsr_addr_o   => xcsr_addr,      -- address
-    xcsr_wdata_o  => xcsr_wdata,     -- write data
-    xcsr_rdata_i  => xcsr_rdata_res, -- read data
+    alu_cp_done_i => alu_cp_done, -- ALU iterative operation done
+    alu_cmp_i     => alu_cmp,     -- comparator status
+    alu_add_i     => alu_add,     -- ALU address result
+    rf_rs1_i      => rs1,         -- rf source 1
+    csr_rdata_o   => csr_rdata,   -- CSR read data
+    xcsr_rdata_i  => xcsr_res,    -- external CSR read data
     -- interrupts --
-    irq_dbg_i     => dbi_i,          -- debug mode (halt) request
-    irq_machine_i => irq_machine,    -- risc-v mti, mei, msi
-    irq_fast_i    => firq_i,         -- fast interrupts
+    irq_dbg_i     => dbi_i,       -- debug mode (halt) request
+    irq_machine_i => irq_machine, -- risc-v mti, mei, msi
+    irq_fast_i    => firq_i,      -- fast interrupts
     -- load/store unit interface --
-    lsu_wait_i    => lsu_wait,       -- wait for data bus
-    lsu_mar_i     => lsu_mar,        -- memory address register
-    lsu_err_i     => lsu_err,        -- alignment/access errors
+    lsu_wait_i    => lsu_wait,    -- wait for data bus
+    lsu_mar_i     => lsu_mar,     -- memory address register
+    lsu_err_i     => lsu_err,     -- alignment/access errors
     -- memory synchronization --
-    mem_sync_i    => mem_sync_i      -- synchronization operation done
+    mem_sync_i    => mem_sync_i   -- synchronization operation done
   );
 
   -- RISC-V machine interrupts --
   irq_machine <= mti_i & mei_i & msi_i;
 
   -- control-external CSR read-back --
-  xcsr_rdata_res <= xcsr_rdata_alu or xcsr_rdata_pmp or xcsr_rdata_icc;
+  xcsr_res <= xcsr_alu or xcsr_pmp or xcsr_icc;
 
 
-  -- Register File (RF) ---------------------------------------------------------------------
+  -- Register File --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_regfile_inst: entity neorv32.neorv32_cpu_regfile
   generic map (
@@ -330,7 +312,7 @@ begin
   );
 
   -- all buses are zero unless there is an according operation --
-  rf_wdata <= alu_res or lsu_rdata or csr_rdata or pc_ret;
+  rf_wdata <= alu_res or lsu_rdata or csr_rdata or ctrl.pc_ret;
 
 
   -- Arithmetic/Logic Unit (ALU) and ALU Co-Processors --------------------------------------
@@ -360,26 +342,20 @@ begin
   )
   port map (
     -- global control --
-    clk_i       => clk_gated,      -- global clock, rising edge
-    rstn_i      => rstn_i,         -- global reset, low-active, async
-    ctrl_i      => ctrl,           -- main control bus
-    -- CSR interface --
-    csr_we_i    => xcsr_we,        -- global write enable
-    csr_addr_i  => xcsr_addr,      -- address
-    csr_wdata_i => xcsr_wdata,     -- write data
-    csr_rdata_o => xcsr_rdata_alu, -- read data
+    clk_i       => clk_gated,  -- global clock, rising edge
+    rstn_i      => rstn_i,     -- global reset, low-active, async
+    ctrl_i      => ctrl,       -- main control bus
     -- data input --
-    rs1_i       => rs1,            -- rf source 1
-    rs2_i       => rs2,            -- rf source 2
-    rs3_i       => rs3,            -- rf source 3
-    pc_i        => pc_curr,        -- current PC
-    imm_i       => alu_imm,        -- immediate
+    rs1_i       => rs1,        -- rf source 1
+    rs2_i       => rs2,        -- rf source 2
+    rs3_i       => rs3,        -- rf source 3
     -- data output --
-    cmp_o       => alu_cmp,        -- comparator status
-    res_o       => alu_res,        -- ALU result
-    add_o       => alu_add,        -- address computation result
+    cmp_o       => alu_cmp,    -- comparator status
+    res_o       => alu_res,    -- ALU result
+    add_o       => alu_add,    -- address computation result
+    csr_o       => xcsr_alu,   -- CSR read data
     -- status --
-    cp_done_o   => alu_cp_done     -- iterative processing units done?
+    cp_done_o   => alu_cp_done -- iterative processing units done?
   );
 
 
@@ -418,25 +394,21 @@ begin
     )
     port map (
       -- global control --
-      clk_i       => clk_gated,      -- global clock, rising edge
-      rstn_i      => rstn_i,         -- global reset, low-active, async
-      ctrl_i      => ctrl,           -- main control bus
+      clk_i       => clk_gated, -- global clock, rising edge
+      rstn_i      => rstn_i,    -- global reset, low-active, async
+      ctrl_i      => ctrl,      -- main control bus
       -- CSR interface --
-      csr_we_i    => xcsr_we,        -- global write enable
-      csr_addr_i  => xcsr_addr,      -- address
-      csr_wdata_i => xcsr_wdata,     -- write data
-      csr_rdata_o => xcsr_rdata_pmp, -- read data
+      csr_rdata_o => xcsr_pmp,  -- read data
       -- address input --
-      addr_if_i   => pc_next,        -- instruction fetch address
-      addr_ls_i   => alu_add,        -- load/store address
+      addr_ls_i   => alu_add,   -- load/store address
       -- access error --
-      fault_o     => pmp_fault       -- permission violation
+      fault_o     => pmp_fault  -- permission violation
     );
   end generate;
 
   pmp_disabled:
   if not RISCV_ISA_Smpmp generate
-    xcsr_rdata_pmp <= (others => '0');
+    xcsr_pmp <= (others => '0');
     pmp_fault      <= '0';
   end generate;
 
@@ -451,11 +423,11 @@ begin
       clk_i       => clk_i,          -- global clock, rising edge
       rstn_i      => rstn_i,         -- global reset, low-active, async
       -- CSR interface --
-      csr_we_i    => xcsr_we,        -- global write enable
-      csr_re_i    => xcsr_re,        -- global read enable
-      csr_addr_i  => xcsr_addr,      -- address
-      csr_wdata_i => xcsr_wdata,     -- write data
-      csr_rdata_o => xcsr_rdata_icc, -- read data
+      csr_we_i    => ctrl.csr_we,    -- global write enable
+      csr_re_i    => ctrl.csr_re,    -- global read enable
+      csr_addr_i  => ctrl.csr_addr,  -- address
+      csr_wdata_i => ctrl.csr_wdata, -- write data
+      csr_rdata_o => xcsr_icc,       -- read data
       -- ICC links --
       icc_tx_o    => icc_tx_o,       -- TX link
       icc_rx_i    => icc_rx_i        -- RX link
@@ -464,7 +436,7 @@ begin
 
   icc_disabled:
   if not ICC_EN generate
-    xcsr_rdata_icc <= (others => '0');
+    xcsr_icc <= (others => '0');
     icc_tx_o       <= icc_terminate_c;
   end generate;
 

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -40,20 +40,20 @@ entity neorv32_cpu_alu is
   );
   port (
     -- global control --
-    clk_i       : in  std_ulogic; -- global clock, rising edge
-    rstn_i      : in  std_ulogic; -- global reset, low-active, async
-    ctrl_i      : in  ctrl_bus_t; -- main control bus
+    clk_i  : in  std_ulogic; -- global clock, rising edge
+    rstn_i : in  std_ulogic; -- global reset, low-active, async
+    ctrl_i : in  ctrl_bus_t; -- main control bus
     -- data input --
-    rs1_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
-    rs2_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
-    rs3_i       : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 3
+    rs1_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 1
+    rs2_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 2
+    rs3_i  : in  std_ulogic_vector(XLEN-1 downto 0); -- rf source 3
     -- data output --
-    cmp_o       : out std_ulogic_vector(1 downto 0); -- comparator status
-    res_o       : out std_ulogic_vector(XLEN-1 downto 0); -- ALU result
-    add_o       : out std_ulogic_vector(XLEN-1 downto 0); -- address computation result
-    csr_o       : out std_ulogic_vector(XLEN-1 downto 0); -- CSR read data
+    cmp_o  : out std_ulogic_vector(1 downto 0); -- comparator status
+    res_o  : out std_ulogic_vector(XLEN-1 downto 0); -- ALU result
+    add_o  : out std_ulogic_vector(XLEN-1 downto 0); -- address computation result
+    csr_o  : out std_ulogic_vector(XLEN-1 downto 0); -- CSR read data
     -- status --
-    cp_done_o   : out std_ulogic  -- co-processor operation done?
+    done_o : out std_ulogic -- co-processor operation done?
   );
 end neorv32_cpu_alu;
 
@@ -108,7 +108,7 @@ begin
   opb <= ctrl_i.alu_imm when (ctrl_i.alu_opb_mux = '1') else rs2_i;
 
 
-  -- Adder/Subtracter Core ------------------------------------------------------------------
+  -- Adder/Subtractor Core ------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   opa_x <= (opa(opa'left) and (not ctrl_i.alu_unsigned)) & opa; -- sign-extend
   opb_x <= (opb(opb'left) and (not ctrl_i.alu_unsigned)) & opb; -- sign-extend
@@ -144,7 +144,7 @@ begin
 
   -- multi-cycle co-processor operation done? --
   -- > "cp_valid" signal has to be set (for one cycle) one cycle before CP output data (cp_result) is valid
-  cp_done_o <= cp_valid(0) or cp_valid(1) or cp_valid(2) or cp_valid(3) or cp_valid(4) or cp_valid(5) or cp_valid(6);
+  done_o <= cp_valid(0) or cp_valid(1) or cp_valid(2) or cp_valid(3) or cp_valid(4) or cp_valid(5) or cp_valid(6);
 
   -- co-processor result --
   -- > "cp_result" data has to be always zero unless the specific co-processor has been actually triggered

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -567,7 +567,7 @@ begin
       -- ------------------------------------------------------------
         exe_engine_nxt.ra <= exe_engine.pc2(XLEN-1 downto 1) & '0'; -- output return address
         ctrl_nxt.rf_wb_en <= opcode(2); -- save return address if link operation (won't happen if exception)
-        if (trap_ctrl.exc_buf(exc_illegal_c) = '0') and (branch_taken = '1') then -- valid taken branch
+        if (trap_ctrl.exc_buf(exc_illegal_c) = '0') and (branch_taken = '1') then -- valid taken branch / jump
           trap_ctrl.instr_ma   <= alu_add_i(1) and bool_to_ulogic_f(not RISCV_ISA_C); -- branch destination is misaligned?
           if_reset             <= '1'; -- reset instruction fetch to restart at modified PC
           exe_engine_nxt.pc2   <= alu_add_i(XLEN-1 downto 1) & '0';
@@ -1814,8 +1814,8 @@ begin
   end process counter_event;
 
   -- RISC-V-compliant counter events --
-  cnt_event(hpmcnt_event_cy_c) <= '1' when (sleep_mode = '0')              else '0'; -- cycle: active cycle
-  cnt_event(hpmcnt_event_tm_c) <=                                               '0'; -- time: not available
+  cnt_event(hpmcnt_event_cy_c) <= '1' when (sleep_mode = '0') else '0'; -- cycle: active cycle
+  cnt_event(hpmcnt_event_tm_c) <= '0'; -- time: not available
   cnt_event(hpmcnt_event_ir_c) <= '1' when (exe_engine.state = EX_EXECUTE) else '0'; -- instret: retired (==executed!) instruction
 
   -- NEORV32-specific counter events --

--- a/rtl/core/neorv32_cpu_frontend.vhd
+++ b/rtl/core/neorv32_cpu_frontend.vhd
@@ -1,0 +1,285 @@
+-- ================================================================================ --
+-- NEORV32 CPU - Front End (Instruction Fetch)                                      --
+-- -------------------------------------------------------------------------------- --
+-- + Fetch engine:    Fetches aligned 32-bit chunks of instruction words            --
+-- + Prefetch buffer: Buffers pre-fetched 32-bit instruction data                   --
+-- + Issue engine:    Decodes RVC instructions, aligns & issues instruction words   --
+-- -------------------------------------------------------------------------------- --
+-- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
+-- Copyright (c) NEORV32 contributors.                                              --
+-- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
+-- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
+-- SPDX-License-Identifier: BSD-3-Clause                                            --
+-- ================================================================================ --
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library neorv32;
+use neorv32.neorv32_package.all;
+
+entity neorv32_cpu_frontend is
+  generic (
+    RVC_EN : boolean -- implement compressed extension
+  );
+  port (
+    -- global control --
+    clk_i      : in  std_ulogic; -- global clock, rising edge
+    rstn_i     : in  std_ulogic; -- global reset, low-active, async
+    ctrl_i     : in  ctrl_bus_t; -- main control bus
+    -- instruction fetch interface --
+    ibus_req_o : out bus_req_t; -- request
+    ibus_rsp_i : in  bus_rsp_t; -- response
+    -- back-end interface --
+    frontend_o : out if_bus_t
+  );
+end neorv32_cpu_frontend;
+
+architecture neorv32_cpu_frontend_rtl of neorv32_cpu_frontend is
+
+  -- instruction fetch engine --
+  type fetch_state_t is (IF_RESTART, IF_REQUEST, IF_PENDING);
+  type fetch_t is record
+    state   : fetch_state_t;
+    restart : std_ulogic; -- buffered restart request (after branch)
+    pc      : std_ulogic_vector(XLEN-1 downto 0);
+    resp    : std_ulogic; -- bus response
+    priv    : std_ulogic; -- fetch privilege level
+  end record;
+  signal fetch : fetch_t;
+
+  -- instruction prefetch buffer (FIFO) interface --
+  type ipb_data_t is array (0 to 1) of std_ulogic_vector(16 downto 0); -- bus_error & 16-bit instruction
+  type ipb_t is record
+    wdata, rdata : ipb_data_t;
+    we,    re    : std_ulogic_vector(1 downto 0);
+    free,  avail : std_ulogic_vector(1 downto 0);
+  end record;
+  signal ipb : ipb_t;
+
+  -- instruction issue engine --
+  type issue_t is record
+    align : std_ulogic;
+    alset : std_ulogic;
+    alclr : std_ulogic;
+    cmd16 : std_ulogic_vector(15 downto 0);
+    cmd32 : std_ulogic_vector(31 downto 0);
+    valid : std_ulogic_vector(1 downto 0);
+    instr : std_ulogic_vector(31 downto 0);
+    compr : std_ulogic;
+    error : std_ulogic;
+  end record;
+  signal issue : issue_t;
+
+begin
+
+  -- ******************************************************************************************************************
+  -- Instruction Fetch (always fetch 32-bit-aligned 32-bit chunks of data)
+  -- ******************************************************************************************************************
+
+  -- Fetch Engine FSM -----------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  fetch_fsm: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      fetch.state   <= IF_RESTART;
+      fetch.restart <= '1'; -- reset IPB and issue engine
+      fetch.pc      <= (others => '0');
+      fetch.priv    <= priv_mode_m_c;
+    elsif rising_edge(clk_i) then
+      case fetch.state is
+
+        when IF_REQUEST => -- request next 32-bit-aligned instruction word
+        -- ------------------------------------------------------------
+          fetch.restart <= fetch.restart or ctrl_i.if_reset; -- buffer restart request
+          if (ipb.free = "11") then -- free IPB space?
+            fetch.state <= IF_PENDING;
+          elsif (fetch.restart = '1') or (ctrl_i.if_reset = '1') then -- restart because of branch
+            fetch.state <= IF_RESTART;
+          end if;
+
+        when IF_PENDING => -- wait for bus response and write instruction data to prefetch buffer
+        -- ------------------------------------------------------------
+          fetch.restart <= fetch.restart or ctrl_i.if_reset; -- buffer restart request
+          if (fetch.resp = '1') then -- wait for bus response
+            fetch.pc    <= std_ulogic_vector(unsigned(fetch.pc) + 4); -- next word
+            fetch.pc(1) <= '0'; -- (re-)align to 32-bit
+            if (fetch.restart = '1') or (ctrl_i.if_reset = '1') then -- restart request due to branch
+              fetch.state <= IF_RESTART;
+            else -- request next linear instruction word
+              fetch.state <= IF_REQUEST;
+            end if;
+          end if;
+
+        when others => -- IF_RESTART: set new start address
+        -- ------------------------------------------------------------
+          fetch.restart <= '0'; -- restart done
+          fetch.pc      <= ctrl_i.pc_nxt; -- initialize from PC incl. 16-bit-alignment bit
+          fetch.priv    <= ctrl_i.cpu_priv; -- set new privilege level
+          fetch.state   <= IF_REQUEST;
+
+      end case;
+    end if;
+  end process fetch_fsm;
+
+  -- PC output for instruction fetch --
+  ibus_req_o.addr <= fetch.pc(XLEN-1 downto 2) & "00"; -- word aligned
+
+  -- instruction fetch (read) request if IPB not full --
+  ibus_req_o.stb <= '1' when (fetch.state = IF_REQUEST) and (ipb.free = "11") else '0';
+
+  -- instruction bus response --
+  fetch.resp <= ibus_rsp_i.ack or ibus_rsp_i.err;
+
+  -- IPB instruction data and status --
+  ipb.wdata(0) <= ibus_rsp_i.err & ibus_rsp_i.data(15 downto 0);
+  ipb.wdata(1) <= ibus_rsp_i.err & ibus_rsp_i.data(31 downto 16);
+
+  -- IPB write enable --
+  ipb.we(0) <= '1' when (fetch.state = IF_PENDING) and (fetch.resp = '1') and ((fetch.pc(1) = '0') or (not RVC_EN)) else '0';
+  ipb.we(1) <= '1' when (fetch.state = IF_PENDING) and (fetch.resp = '1') else '0';
+
+  -- bus access meta data --
+  ibus_req_o.data  <= (others => '0'); -- read-only
+  ibus_req_o.ben   <= (others => '0'); -- read-only
+  ibus_req_o.rw    <= '0'; -- read-only
+  ibus_req_o.src   <= '1'; -- always "instruction fetch" access
+  ibus_req_o.priv  <= fetch.priv; -- current effective privilege level
+  ibus_req_o.debug <= ctrl_i.cpu_debug; -- debug mode, valid without STB being set
+  ibus_req_o.amo   <= '0'; -- cannot be an atomic memory operation
+  ibus_req_o.amoop <= (others => '0'); -- cannot be an atomic memory operation
+  ibus_req_o.fence <= ctrl_i.if_fence; -- fence operation, valid without STB being set
+
+
+  -- Instruction Prefetch Buffer (FIFO) -----------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  prefetch_buffer:
+  for i in 0 to 1 generate -- low half-word + high half-word (incl. status bits)
+    prefetch_buffer_inst: entity neorv32.neorv32_fifo
+    generic map (
+      FIFO_DEPTH => 2,                   -- number of IPB entries; has to be a power of two, min 2
+      FIFO_WIDTH => ipb.wdata(i)'length, -- size of data elements in FIFO
+      FIFO_RSYNC => false,               -- we NEED to read data asynchronously
+      FIFO_SAFE  => false,               -- no safe access required (ensured by FIFO-external logic)
+      FULL_RESET => false                -- no need for a full hardware reset
+    )
+    port map (
+      -- control and status --
+      clk_i   => clk_i,         -- clock, rising edge
+      rstn_i  => rstn_i,        -- async reset, low-active
+      clear_i => fetch.restart, -- sync reset, high-active
+      half_o  => open,          -- at least half full
+      level_o => open,          -- fill level, zero-extended
+      -- write port --
+      wdata_i => ipb.wdata(i),  -- write data
+      we_i    => ipb.we(i),     -- write enable
+      free_o  => ipb.free(i),   -- at least one entry is free when set
+      -- read port --
+      re_i    => ipb.re(i),     -- read enable
+      rdata_o => ipb.rdata(i),  -- read data
+      avail_o => ipb.avail(i)   -- data available when set
+    );
+  end generate;
+
+  -- read access --
+  ipb.re(0) <= issue.valid(0) and ctrl_i.if_ack;
+  ipb.re(1) <= issue.valid(1) and ctrl_i.if_ack;
+
+
+  -- ******************************************************************************************************************
+  -- Instruction Issue (decompress 16-bit instruction and/or assemble a 32-bit instruction word)
+  -- ******************************************************************************************************************
+
+  issue_enabled:
+  if RVC_EN generate
+
+    -- Compressed Instructions Decoder --------------------------------------------------------
+    -- -------------------------------------------------------------------------------------------
+    neorv32_cpu_decompressor_inst: entity neorv32.neorv32_cpu_decompressor
+    port map (
+      instr_i => issue.cmd16,
+      instr_o => issue.cmd32
+    );
+
+    -- half-word select --
+    issue.cmd16 <= ipb.rdata(0)(15 downto 0) when (issue.align = '0') else ipb.rdata(1)(15 downto 0);
+
+
+    -- Issue Engine FSM -----------------------------------------------------------------------
+    -- -------------------------------------------------------------------------------------------
+    issue_fsm_sync: process(rstn_i, clk_i)
+    begin
+      if (rstn_i = '0') then
+        issue.align <= '0'; -- start aligned after reset
+      elsif rising_edge(clk_i) then
+        if (fetch.restart = '1') then
+          issue.align <= ctrl_i.pc_nxt(1); -- branch to unaligned address?
+        elsif (ctrl_i.if_ack = '1') then
+          issue.align <= (issue.align and (not issue.alclr)) or issue.alset; -- "rs flip-flop"
+        end if;
+      end if;
+    end process issue_fsm_sync;
+
+    issue_fsm_comb: process(issue, ipb)
+    begin
+      -- defaults --
+      issue.alset <= '0';
+      issue.alclr <= '0';
+      issue.valid <= "00";
+      -- start with LOW half-word --
+      if (issue.align = '0')  then
+        issue.error <= ipb.rdata(0)(16);
+        if (ipb.rdata(0)(1 downto 0) /= "11") then -- compressed, use IPB(0) entry
+          issue.alset <= ipb.avail(0); -- start of next instruction word is NOT 32-bit-aligned
+          issue.valid <= '0' & ipb.avail(0);
+          issue.instr <= issue.cmd32;
+          issue.compr <= '1';
+        else -- aligned uncompressed
+          issue.valid <= (others => (ipb.avail(0) and ipb.avail(1)));
+          issue.instr <= ipb.rdata(1)(15 downto 0) & ipb.rdata(0)(15 downto 0);
+          issue.compr <= '0';
+        end if;
+      -- start with HIGH half-word --
+      else
+        issue.error <= ipb.rdata(1)(16);
+        if (ipb.rdata(1)(1 downto 0) /= "11") then -- compressed, use IPB(1) entry
+          issue.alclr <= ipb.avail(1); -- start of next instruction word is 32-bit-aligned again
+          issue.valid <= ipb.avail(1) & '0';
+          issue.instr <= issue.cmd32;
+          issue.compr <= '1';
+        else -- unaligned uncompressed
+          issue.valid <= (others => (ipb.avail(0) and ipb.avail(1)));
+          issue.instr <= ipb.rdata(0)(15 downto 0) & ipb.rdata(1)(15 downto 0);
+          issue.compr <= '0';
+        end if;
+      end if;
+    end process issue_fsm_comb;
+
+  end generate; -- /issue_enabled
+
+
+  -- issue engine disabled --
+  issue_disabled:
+  if not RVC_EN generate
+    issue.align <= '0';
+    issue.alset <= '0';
+    issue.alclr <= '0';
+    issue.cmd16 <= (others => '0');
+    issue.cmd32 <= (others => '0');
+    issue.valid <= (others => ipb.avail(0)); -- use IPB(0) status flags only
+    issue.instr <= ipb.rdata(1)(15 downto 0) & ipb.rdata(0)(15 downto 0);
+    issue.compr <= '0';
+    issue.error <= ipb.rdata(0)(16);
+  end generate;
+
+
+  -- assemble output bus --
+  frontend_o.valid  <= issue.valid(1) or issue.valid(0);
+  frontend_o.instr  <= issue.instr;
+  frontend_o.compr  <= issue.compr;
+  frontend_o.error  <= issue.error;
+  frontend_o.halted <= '1' when (fetch.state = IF_REQUEST) and (ipb.free /= "11") else '0';
+
+
+end neorv32_cpu_frontend_rtl;

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -241,7 +241,7 @@ begin
   -- -------------------------------------------------------------------------------------------
 
   -- access switch (check I/D in time-multiplex) --
-  acc_addr <= ctrl_i.pc_nxt  when (ctrl_i.lsu_mo_we = '0') else addr_ls_i;
+  acc_addr <= ctrl_i.pc_nxt   when (ctrl_i.lsu_mo_we = '0') else addr_ls_i;
   acc_priv <= ctrl_i.cpu_priv when (ctrl_i.lsu_mo_we = '0') else ctrl_i.lsu_priv;
 
   region_gen:

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -504,6 +504,9 @@ package neorv32_package is
   type ctrl_bus_t is record
     -- instruction fetch --
     if_fence     : std_ulogic;                     -- fence.i operation
+    if_reset     : std_ulogic;                     -- restart instruction fetch
+    if_ack       : std_ulogic;                     -- consume data from instruction fetch
+    -- program counter --
     pc_cur       : std_ulogic_vector(31 downto 0); -- address of current instruction
     pc_nxt       : std_ulogic_vector(31 downto 0); -- address of next instruction
     pc_ret       : std_ulogic_vector(31 downto 0); -- return address
@@ -549,6 +552,8 @@ package neorv32_package is
   -- control bus reset initializer --
   constant ctrl_bus_zero_c : ctrl_bus_t := (
     if_fence     => '0',
+    if_reset     => '0',
+    if_ack       => '0',
     pc_cur       => (others => '0'),
     pc_nxt       => (others => '0'),
     pc_ret       => (others => '0'),
@@ -584,6 +589,16 @@ package neorv32_package is
     cpu_trap     => '0',
     cpu_debug    => '0'
   );
+
+  -- Instruction Fetch Interface ------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  type if_bus_t is record
+    valid  : std_ulogic;                     -- bus signals are valid
+    instr  : std_ulogic_vector(31 downto 0); -- instruction word
+    compr  : std_ulogic;                     -- instruction is decompressed
+    error  : std_ulogic;                     -- instruction-fetch error
+    halted : std_ulogic;                     -- instruction fetch has halted
+  end record;
 
   -- Comparator Bus -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110102"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110103"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -504,6 +504,9 @@ package neorv32_package is
   type ctrl_bus_t is record
     -- instruction fetch --
     if_fence     : std_ulogic;                     -- fence.i operation
+    pc_cur       : std_ulogic_vector(31 downto 0); -- address of current instruction
+    pc_nxt       : std_ulogic_vector(31 downto 0); -- address of next instruction
+    pc_ret       : std_ulogic_vector(31 downto 0); -- return address
     -- register file --
     rf_wb_en     : std_ulogic; -- write back enable
     rf_rs1       : std_ulogic_vector(4 downto 0);  -- source register 1 address
@@ -516,6 +519,7 @@ package neorv32_package is
     alu_opa_mux  : std_ulogic;                     -- operand A select (0=rs1, 1=PC)
     alu_opb_mux  : std_ulogic;                     -- operand B select (0=rs2, 1=IMM)
     alu_unsigned : std_ulogic;                     -- is unsigned ALU operation
+    alu_imm      : std_ulogic_vector(31 downto 0); -- immediate
     alu_cp_alu   : std_ulogic;                     -- ALU.base co-processor trigger (one-shot)
     alu_cp_cfu   : std_ulogic;                     -- CFU co-processor trigger (one-shot)
     alu_cp_fpu   : std_ulogic;                     -- FPU co-processor trigger (one-shot)
@@ -526,6 +530,11 @@ package neorv32_package is
     lsu_mo_we    : std_ulogic;                     -- memory address and data output register write enable
     lsu_fence    : std_ulogic;                     -- fence operation
     lsu_priv     : std_ulogic;                     -- effective privilege mode for load/store
+    -- control and status registers --
+    csr_we       : std_ulogic;                     -- global write-enable
+    csr_re       : std_ulogic;                     -- global read-enable
+    csr_addr     : std_ulogic_vector(11 downto 0); -- address
+    csr_wdata    : std_ulogic_vector(31 downto 0); -- write data
     -- instruction word --
     ir_funct3    : std_ulogic_vector(2 downto 0);  -- funct3 bit field
     ir_funct12   : std_ulogic_vector(11 downto 0); -- funct12 bit field
@@ -540,6 +549,9 @@ package neorv32_package is
   -- control bus reset initializer --
   constant ctrl_bus_zero_c : ctrl_bus_t := (
     if_fence     => '0',
+    pc_cur       => (others => '0'),
+    pc_nxt       => (others => '0'),
+    pc_ret       => (others => '0'),
     rf_wb_en     => '0',
     rf_rs1       => (others => '0'),
     rf_rs2       => (others => '0'),
@@ -550,6 +562,7 @@ package neorv32_package is
     alu_opa_mux  => '0',
     alu_opb_mux  => '0',
     alu_unsigned => '0',
+    alu_imm      => (others => '0'),
     alu_cp_alu   => '0',
     alu_cp_cfu   => '0',
     alu_cp_fpu   => '0',
@@ -559,6 +572,10 @@ package neorv32_package is
     lsu_mo_we    => '0',
     lsu_fence    => '0',
     lsu_priv     => '0',
+    csr_we       => '0',
+    csr_re       => '0',
+    csr_addr     => (others => '0'),
+    csr_wdata    => (others => '0'),
     ir_funct3    => (others => '0'),
     ir_funct12   => (others => '0'),
     ir_opcode    => (others => '0'),

--- a/rtl/file_list_cpu.f
+++ b/rtl/file_list_cpu.f
@@ -2,6 +2,7 @@ NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_package.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_clockgate.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_fifo.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_decompressor.vhd
+NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_frontend.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_control.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_regfile.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_cp_shifter.vhd

--- a/rtl/file_list_soc.f
+++ b/rtl/file_list_soc.f
@@ -3,6 +3,7 @@ NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_sys.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_clockgate.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_fifo.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_decompressor.vhd
+NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_frontend.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_control.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_regfile.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_cp_shifter.vhd

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -623,6 +623,7 @@ int main() {
   asm volatile (".word 0xf0a01013"); // illegal slli funct7
   asm volatile (".word 0xde000033"); // illegal mul funct7
   asm volatile (".word 0x80002163"); // illegal branch funct3 (misaligned DST if C not available)
+  asm volatile (".word 0x00001067"); // illegal jalr funct3
   asm volatile (".word 0x0000200f"); // illegal fence funct3
   asm volatile (".word 0xfe002fe3"); // illegal store funct3
   if (neorv32_cpu_csr_read(CSR_MISA) & (1<<CSR_MISA_C)) { // C extension enabled
@@ -636,11 +637,11 @@ int main() {
   // number of traps we are expecting + expected instruction word of last illegal instruction
   uint32_t invalid_instr;
   if (neorv32_cpu_csr_read(CSR_MISA) & (1<<CSR_MISA_C)) { // C extension enabled
-    tmp_a += 17;
+    tmp_a += 18;
     invalid_instr = 0x08812681; // mtinst: pre-decompressed; clear bit 1 if compressed instruction
   }
   else { // C extension disabled
-    tmp_a += 15;
+    tmp_a += 16;
     invalid_instr = 0xfe002fe3;
   }
 


### PR DESCRIPTION
Add new module: `neorv32_cpu_frontend.vhd`:
* Fetch engine - fetches aligned 32-bit chunks of instruction words
* Prefetch buffer - buffers pre-fetched 32-bit instruction data
* Issue engine - decodes RVC instructions, aligns & issues instruction words