### PR TITLE
⚠️ Software libraries cleanup

### DIFF
--- a/docs/datasheet/software.adoc
+++ b/docs/datasheet/software.adoc
@@ -92,6 +92,10 @@ The NEORV32 HAL consists of the following files.
 | `neorv32_newlib.c`  | -                      | Platform-specific system calls for _newlib_
 |=======================
 
+.Defines and Macros
+[TIP]
+Macros and defines provides by the NEORV32 software framework are written in capital letters.
+
 .Core Libraries Documentation
 [TIP]
 The Doxygen-based documentation of the software framework including all core libraries is available online at

--- a/sw/example/demo_blink_led/main.c
+++ b/sw/example/demo_blink_led/main.c
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -13,6 +13,16 @@
  * @brief Minimal blinking LED demo program using the lowest 8 bits of the GPIO.output port.
  **************************************************************************/
 #include <neorv32.h>
+
+
+/**********************************************************************//**
+ * Simple bus-wait helper.
+ *
+ * @param[in] time_ms Time in ms to wait (unsigned 32-bit).
+ **************************************************************************/
+void delay_ms(uint32_t time_ms) {
+  neorv32_aux_delay_ms(neorv32_sysinfo_get_clk(), time_ms);
+}
 
 
 /**********************************************************************//**
@@ -31,7 +41,7 @@ int main() {
 
   while (1) {
     neorv32_gpio_port_set(cnt++ & 0xFF); // increment counter and mask for lowest 8 bit
-    neorv32_cpu_delay_ms(250); // wait 250ms using busy wait
+    delay_ms(250); // wait 250ms using busy wait
   }
 
   // this should never be reached

--- a/sw/example/demo_neopixel/main.c
+++ b/sw/example/demo_neopixel/main.c
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -31,6 +31,16 @@
 
 // prototypes
 uint32_t hsv2rgb(int h, int v);
+
+
+/**********************************************************************//**
+ * Simple bus-wait helper.
+ *
+ * @param[in] time_ms Time in ms to wait (unsigned 32-bit).
+ **************************************************************************/
+void delay_ms(uint32_t time_ms) {
+  neorv32_aux_delay_ms(neorv32_sysinfo_get_clk(), time_ms);
+}
 
 
 /**********************************************************************//**
@@ -83,7 +93,7 @@ int main() {
   for (i=0; i<NUM_LEDS_24BIT; i++) {
     neorv32_neoled_write_blocking(0);
   }
-  neorv32_cpu_delay_ms(500);
+  delay_ms(500);
 
 
   // a simple animation example: rotating rainbow
@@ -100,7 +110,7 @@ int main() {
     angle += 1; // rotation increment per frame
 
     neorv32_neoled_strobe_blocking(); // send strobe ("RESET") command
-    neorv32_cpu_delay_ms(10); // delay between frames
+    delay_ms(10); // delay between frames
   }
 
   return 0;

--- a/sw/example/demo_newlib/main.c
+++ b/sw/example/demo_newlib/main.c
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -76,7 +76,7 @@ int main() {
 
 
   // heap size definition
-  uint32_t max_heap = (uint32_t)neorv32_heap_size_c;
+  uint32_t max_heap = (uint32_t)NEORV32_HEAP_SIZE;
   if (max_heap > 0){
     neorv32_uart0_printf("MAX heap size: %u bytes\n", max_heap);
   }

--- a/sw/example/demo_pwm/main.c
+++ b/sw/example/demo_pwm/main.c
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -26,6 +26,15 @@
 #define MAX_DUTY 200
 /**@}*/
 
+
+/**********************************************************************//**
+ * Simple bus-wait helper.
+ *
+ * @param[in] time_ms Time in ms to wait (unsigned 32-bit).
+ **************************************************************************/
+void delay_ms(uint32_t time_ms) {
+  neorv32_aux_delay_ms(neorv32_sysinfo_get_clk(), time_ms);
+}
 
 
 /**********************************************************************//**
@@ -115,7 +124,7 @@ int main() {
     }
 
     neorv32_pwm_ch_set_duty(ch, dc); // set new duty cycle for channel
-    neorv32_cpu_delay_ms(3); // wait ~3ms using busy-wait
+    delay_ms(3); // wait ~3ms using busy-wait
   }
 
   return 0;

--- a/sw/example/demo_trng/main.c
+++ b/sw/example/demo_trng/main.c
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -31,6 +31,16 @@ void repetition_count_test(void);
 void adaptive_proportion_test(void);
 void generate_histogram(void);
 void compute_rate(void);
+
+
+/**********************************************************************//**
+ * Simple bus-wait helper.
+ *
+ * @param[in] time_ms Time in ms to wait (unsigned 32-bit).
+ **************************************************************************/
+void delay_ms(uint32_t time_ms) {
+  neorv32_aux_delay_ms(neorv32_sysinfo_get_clk(), time_ms);
+}
 
 
 /**********************************************************************//**
@@ -73,7 +83,7 @@ int main(void) {
   neorv32_uart0_printf("\nTRNG FIFO depth: %i\n", neorv32_trng_get_fifo_depth());
   neorv32_uart0_printf("Starting TRNG...\n");
   neorv32_trng_enable();
-  neorv32_cpu_delay_ms(100); // TRNG "warm up"
+  delay_ms(100); // TRNG "warm up"
   neorv32_trng_fifo_clear(); // discard "warm-up" data
 
   while(1) {

--- a/sw/example/demo_wdt/main.c
+++ b/sw/example/demo_wdt/main.c
@@ -27,6 +27,16 @@
 
 
 /**********************************************************************//**
+ * Simple bus-wait helper.
+ *
+ * @param[in] time_ms Time in ms to wait (unsigned 32-bit).
+ **************************************************************************/
+void delay_ms(uint32_t time_ms) {
+  neorv32_aux_delay_ms(neorv32_sysinfo_get_clk(), time_ms);
+}
+
+
+/**********************************************************************//**
  * Main function
  *
  * @note This program requires the WDT and UART0 to be synthesized.
@@ -91,7 +101,7 @@ int main() {
   neorv32_uart0_puts("Resetting WDT 5 times...\n");
   int i;
   for (i=0; i<5; i++) {
-    neorv32_cpu_delay_ms(750);
+    delay_ms(750);
     neorv32_wdt_feed(WDT_PASSWORD); // reset internal counter using the access password
     neorv32_uart0_puts("WDT reset.\n");
   }

--- a/sw/example/eclipse/main.c
+++ b/sw/example/eclipse/main.c
@@ -5,6 +5,13 @@
 #define BAUD_RATE 19200
 
 
+// Simple bus-wait helper
+void delay_ms(uint32_t time_ms) {
+  neorv32_aux_delay_ms(neorv32_sysinfo_get_clk(), time_ms);
+}
+
+
+// Main function
 int main() {
 
   // setup NEORV32 runtime environment
@@ -23,7 +30,7 @@ int main() {
   while (1) {
     cnt = (cnt + 1) & 0xff; // increment counter and mask for lowest 8 bit
     neorv32_gpio_port_set(cnt); // output via GPIO.out
-    neorv32_cpu_delay_ms(250); // wait 250ms using busy wait
+    delay_ms(250); // wait 250ms using busy wait
   }
 
   // this should never be reached

--- a/sw/example/eclipse/makefile
+++ b/sw/example/eclipse/makefile
@@ -17,14 +17,16 @@ USER_FLAGS += -ggdb -gdwarf-3
 APP_SRC += $(wildcard ./*.c)
 APP_INC += -I .
 
-# Adjust processor IMEM size
+# Adjust processor IMEM size and base address
 USER_FLAGS += -Wl,--defsym,__neorv32_rom_size=16k
+USER_FLAGS += -Wl,--defsym,__neorv32_rom_base=0x00000000
 
-# Adjust processor DMEM size
+# Adjust processor DMEM size and base address
 USER_FLAGS += -Wl,--defsym,__neorv32_ram_size=8k
+USER_FLAGS += -Wl,--defsym,__neorv32_ram_base=0x80000000
 
 # Adjust maximum heap size
-USER_FLAGS += -Wl,--defsym,__neorv32_heap_size=1k
+USER_FLAGS += -Wl,--defsym,__neorv32_heap_size=2k
 
 # Set path to NEORV32 root directory
 NEORV32_HOME ?= ../../..

--- a/sw/example/game_of_life/main.c
+++ b/sw/example/game_of_life/main.c
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -21,17 +21,17 @@
  **************************************************************************/
 /**@{*/
 /** UART BAUD rate */
-#define BAUD_RATE     19200
+#define BAUD_RATE   (19200)
 /** Universe x size (has to be a multiple of 8) */
-#define NUM_CELLS_X   160
+#define NUM_CELLS_X (160)
 /** Universe y size */
-#define NUM_CELLS_Y   40
+#define NUM_CELLS_Y (40)
 /** Delay between generations in ms */
-#define GEN_DELAY     500
+#define GEN_DELAY   (500)
 /** Symbol for dead cell */
-#define CELL_DEAD  (' ')
+#define CELL_DEAD   (' ')
 /** Symbol for alive cell */
-#define CELL_ALIVE ('#')
+#define CELL_ALIVE  ('#')
 /**@}*/
 
 
@@ -48,6 +48,16 @@ int get_cell(int u, int x, int y);
 int get_neighborhood(int u, int x, int y);
 void print_universe(int u);
 int pop_count(int u);
+
+
+/**********************************************************************//**
+ * Simple bus-wait helper.
+ *
+ * @param[in] time_ms Time in ms to wait (unsigned 32-bit).
+ **************************************************************************/
+void delay_ms(uint32_t time_ms) {
+  neorv32_aux_delay_ms(neorv32_sysinfo_get_clk(), time_ms);
+}
 
 
 /**********************************************************************//**
@@ -168,7 +178,7 @@ int main(void) {
       generation++;
 
       // wait GEN_DELAY ms
-      neorv32_cpu_delay_ms(GEN_DELAY);
+      delay_ms(GEN_DELAY);
     }
 
   }

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -68,6 +68,7 @@ void gpio_trap_handler(void);
 void test_ok(void);
 void test_fail(void);
 int  core1_main(void);
+void goto_user_mode(void);
 
 // MCAUSE value that will be NEVER set by the hardware
 const uint32_t mcause_never_c = 0x80000000UL; // = reserved
@@ -354,7 +355,7 @@ int main() {
     neorv32_cpu_csr_write(CSR_MCOUNTEREN, 1<<CSR_MCOUNTEREN_CY);
 
     // read base counter from user mode
-    neorv32_cpu_goto_user_mode();
+    goto_user_mode();
     {
       asm volatile ("addi      %[cy], zero, 123 \n"
                     "rdcycle   %[cy]            \n"
@@ -426,7 +427,7 @@ int main() {
     cnt_test++;
 
     // switch to user mode (hart will be back in MACHINE mode when trap handler returns)
-    neorv32_cpu_goto_user_mode();
+    goto_user_mode();
     {
       asm volatile ("mret");
     }
@@ -808,7 +809,7 @@ int main() {
     cnt_test++;
 
     // switch to user mode (hart will be back in MACHINE mode when trap handler returns)
-    neorv32_cpu_goto_user_mode();
+    goto_user_mode();
     {
       asm volatile ("ecall");
     }
@@ -1747,7 +1748,7 @@ int main() {
 
   // try to execute service call in user mode
   // hart will be back in MACHINE mode when trap handler returns
-  neorv32_cpu_goto_user_mode();
+  goto_user_mode();
   {
     syscall_a0 = 127;
     syscall_a1 = 12000;
@@ -1777,7 +1778,7 @@ int main() {
   neorv32_cpu_csr_write(CSR_MCAUSE, mcause_never_c);
   PRINT_STANDARD("[%i] Heap/malloc ", cnt_test);
 
-  tmp_a = (uint32_t)neorv32_heap_size_c;
+  tmp_a = (uint32_t)NEORV32_HEAP_SIZE;
 
   if (tmp_a >= 3096) { // sufficient heap for this test?
     cnt_test++;
@@ -1789,7 +1790,7 @@ int main() {
     free(malloc_c);
     free(malloc_a);
 
-    if ((((uint32_t)neorv32_heap_begin_c + tmp_a) == (uint32_t)neorv32_heap_end_c) && // correct heap layout
+    if ((((uint32_t)NEORV32_HEAP_BEGIN + tmp_a) == (uint32_t)NEORV32_HEAP_END) && // correct heap layout
         (malloc_a != NULL) && // malloc successful
         (malloc_b == NULL) && // malloc failed due to exhausted heap
         (malloc_c != NULL) && // malloc successful
@@ -1838,12 +1839,11 @@ int main() {
     // enable CLINT.MTIMER interrupt
     neorv32_cpu_csr_write(CSR_MIE, 1 << CSR_MIE_MTIE);
 
-    // clear mstatus.TW to allow execution of WFI also in user-mode
-    // clear mstatus.MIE and mstatus.MPIE to check if IRQ can still trigger in User-mode
-    neorv32_cpu_csr_clr(CSR_MSTATUS, (1<<CSR_MSTATUS_TW) | (1<<CSR_MSTATUS_MIE) | (1<<CSR_MSTATUS_MPIE));
+    // clear mstatus.MIE and mstatus.MPIE to check if IRQ can still trigger in user-mode
+    neorv32_cpu_csr_clr(CSR_MSTATUS, (1<<CSR_MSTATUS_MIE) | (1<<CSR_MSTATUS_MPIE));
 
     // put CPU into sleep mode (from user mode)
-    neorv32_cpu_goto_user_mode();
+    goto_user_mode();
     {
       asm volatile ("wfi");
     }
@@ -1939,7 +1939,7 @@ int main() {
     cnt_test++;
 
     // switch to user mode (hart will be back in MACHINE mode when trap handler returns)
-    neorv32_cpu_goto_user_mode();
+    goto_user_mode();
     {
       // access to misa not allowed for user-level programs
       asm volatile ("addi %[rd], zero, 234 \n" // this value must not change
@@ -2073,7 +2073,7 @@ int main() {
     cnt_test++;
 
     // switch to user mode (hart will be back in MACHINE mode when trap handler returns)
-    neorv32_cpu_goto_user_mode();
+    goto_user_mode();
     {
       asm volatile ("addi %[rd], zero, 0 \n"
                     "lw   %[rd], 0(%[rs])" : [rd] "=r" (tmp_a) : [rs] "r" ((uint32_t)(&pmp_access[0])) );
@@ -2116,7 +2116,7 @@ int main() {
     cnt_test++;
 
     // switch to user mode (hart will be back in MACHINE mode when trap handler returns)
-    neorv32_cpu_goto_user_mode();
+    goto_user_mode();
     {
       asm volatile ("addi %[rd], zero, 0 \n"
                     "lw   %[rd], 0(%[rs])" : [rd] "=r" (tmp_b) : [rs] "r" ((uint32_t)(&pmp_access[0])) );
@@ -2138,7 +2138,7 @@ int main() {
     cnt_test++;
 
     // switch to user mode (hart will be back in MACHINE mode when trap handler returns)
-    neorv32_cpu_goto_user_mode();
+    goto_user_mode();
     {
       neorv32_cpu_store_unsigned_word((uint32_t)(&pmp_access[0]), 0); // store access -> should fail
     }
@@ -2158,7 +2158,7 @@ int main() {
     cnt_test++;
 
     // switch to user mode (hart will be back in MACHINE mode when trap handler returns)
-    neorv32_cpu_goto_user_mode();
+    goto_user_mode();
     {
       asm volatile ("jalr ra, %[rs]" : : [rs] "r" ((uint32_t)(&pmp_access[0])));
     }
@@ -2481,4 +2481,22 @@ int core1_main(void) {
   neorv32_clint_msi_set(0);
 
   return 0;
+}
+
+
+/**********************************************************************//**
+ * Switch from privilege mode MACHINE to privilege mode USER.
+ **************************************************************************/
+void __attribute__((naked,noinline)) goto_user_mode(void) {
+
+  asm volatile (
+    "csrw mepc, ra     \n" // move return address to mepc so we can return using mret; we can now use ra as temp register
+    "li   ra, 3<<11    \n" // bit mask to clear the two MPP bits
+    "csrc mstatus, ra  \n" // clear MPP bits -> MPP = u-mode
+    "csrr ra, mstatus  \n" // get mstatus
+    "andi ra, ra, 1<<3 \n" // isolate MIE bit
+    "slli ra, ra, 4    \n" // shift to MPIE position
+    "csrs mstatus, ra  \n" // set MPIE if MIE is set
+    "mret              \n" // return and switch to user mode
+  );
 }

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1912,7 +1912,7 @@ int main() {
     neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_TW);
 
     // put CPU into sleep mode (from user mode)
-    neorv32_cpu_goto_user_mode();
+    goto_user_mode();
     {
       asm volatile ("wfi"); // this has to fail
     }

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -11,8 +11,8 @@
  * @brief Main NEORV32 core library / driver / HAL include file.
  */
 
-#ifndef neorv32_h
-#define neorv32_h
+#ifndef NEORV32_H
+#define NEORV32_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -182,9 +182,9 @@ extern char __heap_start[];    /**< heap start address */
 extern char __heap_end[];      /**< heap last address */
 extern char __crt0_max_heap[]; /**< heap size in bytes */
 // aliases
-#define neorv32_heap_begin_c ((uint32_t)&__heap_start[0])
-#define neorv32_heap_end_c   ((uint32_t)&__heap_end[0])
-#define neorv32_heap_size_c  ((uint32_t)&__crt0_max_heap[0])
+#define NEORV32_HEAP_BEGIN ((uint32_t)&__heap_start[0])
+#define NEORV32_HEAP_END   ((uint32_t)&__heap_end[0])
+#define NEORV32_HEAP_SIZE  ((uint32_t)&__crt0_max_heap[0])
 /**@}*/
 
 
@@ -273,4 +273,4 @@ typedef union {
 }
 #endif
 
-#endif // neorv32_h
+#endif // NEORV32_H

--- a/sw/lib/include/neorv32_aux.h
+++ b/sw/lib/include/neorv32_aux.h
@@ -11,19 +11,10 @@
  * @brief General auxiliary functions header file.
  */
 
-#ifndef neorv32_aux_h
-#define neorv32_aux_h
+#ifndef NEORV32_AUX_H
+#define NEORV32_AUX_H
 
 #include <stdint.h>
-
-
-/**********************************************************************//**
- * @name Select minimum/maximum
- **************************************************************************/
-/**@{*/
-#define neorv32_aux_min(a, b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a < _b ? _a : _b; })
-#define neorv32_aux_max(a, b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a > _b ? _a : _b; })
-/**@}*/
 
 
 /**********************************************************************//**
@@ -44,6 +35,7 @@ typedef struct {
  * @name AUX prototypes
  **************************************************************************/
 /**@{*/
+void     neorv32_aux_delay_ms(uint32_t clock_hz, uint32_t time_ms);
 uint64_t neorv32_aux_date2unixtime(date_t* date);
 void     neorv32_aux_unixtime2date(uint64_t unixtime, date_t* date);
 uint64_t neorv32_aux_hexstr2uint64(char *buffer, unsigned int length);
@@ -57,4 +49,4 @@ void     neorv32_aux_print_license(void);
 /**@}*/
 
 
-#endif // neorv32_aux_h
+#endif // NEORV32_AUX_H

--- a/sw/lib/include/neorv32_cfs.h
+++ b/sw/lib/include/neorv32_cfs.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -12,13 +12,10 @@
  *
  * @warning There are no "real" CFS driver functions available here, because these functions are defined by the actual hardware.
  * @warning The CFS designer has to provide the actual driver functions.
- *
- * @note These functions should only be used if the CFS was synthesized (IO_CFS_EN = true).
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_cfs_h
-#define neorv32_cfs_h
+#ifndef NEORV32_CFS_H
+#define NEORV32_CFS_H
 
 #include <stdint.h>
 
@@ -45,4 +42,4 @@ int neorv32_cfs_available(void);
 /**@}*/
 
 
-#endif // neorv32_cfs_h
+#endif // NEORV32_CFS_H

--- a/sw/lib/include/neorv32_clint.h
+++ b/sw/lib/include/neorv32_clint.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,12 +9,10 @@
 /**
  * @file neorv32_clint.h
  * @brief Hardware Local Interruptor (CLINT) HW driver header file.
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_clint_h
-#define neorv32_clint_h
+#ifndef NEORV32_CLINT_H
+#define NEORV32_CLINT_H
 
 #include <stdint.h>
 
@@ -51,4 +49,5 @@ void     neorv32_clint_unixtime_set(uint64_t unixtime);
 uint64_t neorv32_clint_unixtime_get(void);
 /**@}*/
 
-#endif // neorv32_clint_h
+
+#endif // NEORV32_CLINT_H

--- a/sw/lib/include/neorv32_cpu.h
+++ b/sw/lib/include/neorv32_cpu.h
@@ -11,8 +11,8 @@
  * @brief CPU Core Functions HW driver header file.
  */
 
-#ifndef neorv32_cpu_h
-#define neorv32_cpu_h
+#ifndef NEORV32_CPU_H
+#define NEORV32_CPU_H
 
 #include <stdint.h>
 
@@ -25,14 +25,11 @@ uint64_t neorv32_cpu_get_cycle(void);
 void     neorv32_cpu_set_mcycle(uint64_t value);
 uint64_t neorv32_cpu_get_instret(void);
 void     neorv32_cpu_set_minstret(uint64_t value);
-void     neorv32_cpu_delay_ms(uint32_t time_ms);
-uint32_t neorv32_cpu_get_clk_from_prsc(int prsc);
 uint32_t neorv32_cpu_pmp_get_num_regions(void);
 uint32_t neorv32_cpu_pmp_get_granularity(void);
 int      neorv32_cpu_pmp_configure_region(int index, uint32_t addr, uint8_t config);
 uint32_t neorv32_cpu_hpm_get_num_counters(void);
 uint32_t neorv32_cpu_hpm_get_size(void);
-void     neorv32_cpu_goto_user_mode(void);
 /**@}*/
 
 
@@ -283,4 +280,4 @@ inline uint32_t __attribute__ ((always_inline)) neorv32_cpu_amosc(uint32_t addr,
 }
 
 
-#endif // neorv32_cpu_h
+#endif // NEORV32_CPU_H

--- a/sw/lib/include/neorv32_cpu_cfu.h
+++ b/sw/lib/include/neorv32_cpu_cfu.h
@@ -9,12 +9,10 @@
 /**
  * @file neorv32_cpu_cfu.h
  * @brief CPU Core custom functions unit HW driver header file.
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_cpu_cfu_h
-#define neorv32_cpu_cfu_h
+#ifndef NEORV32_CPU_CFU_H
+#define NEORV32_CPU_CFU_H
 
 #include <stdint.h>
 
@@ -36,4 +34,5 @@ int neorv32_cpu_cfu_available(void);
 #define neorv32_cfu_r4_instr(funct3, rs1, rs2, rs3) CUSTOM_INSTR_R4_TYPE(rs3, rs2, rs1, funct3, 0b0101011)
 /**@}*/
 
-#endif // neorv32_cpu_cfu_h
+
+#endif // NEORV32_CPU_CFU_H

--- a/sw/lib/include/neorv32_cpu_csr.h
+++ b/sw/lib/include/neorv32_cpu_csr.h
@@ -11,8 +11,8 @@
  * @brief Control and Status Registers (CSR) definitions.
  */
 
-#ifndef neorv32_cpu_csr_h
-#define neorv32_cpu_csr_h
+#ifndef NEORV32_CPU_CSR_H
+#define NEORV32_CPU_CSR_H
 
 #include <stdint.h>
 
@@ -431,4 +431,4 @@ enum NEORV32_EXCEPTION_CODES_enum {
 };
 
 
-#endif // neorv32_cpu_csr_h
+#endif // NEORV32_CPU_CSR_H

--- a/sw/lib/include/neorv32_crc.h
+++ b/sw/lib/include/neorv32_crc.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,14 +9,10 @@
 /**
  * @file neorv32_crc.h
  * @brief Cyclic redundancy check unit (CRC) HW driver header file.
- *
- * @note These functions should only be used if the CRC unit was synthesized (IO_CRC_EN = true).
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_crc_h
-#define neorv32_crc_h
+#ifndef NEORV32_CRC_H
+#define NEORV32_CRC_H
 
 #include <stdint.h>
 
@@ -57,4 +53,4 @@ uint32_t neorv32_crc_get(void);
 /**@}*/
 
 
-#endif // neorv32_crc_h
+#endif // NEORV32_CRC_H

--- a/sw/lib/include/neorv32_dma.h
+++ b/sw/lib/include/neorv32_dma.h
@@ -11,8 +11,8 @@
  * @brief Direct Memory Access Controller (DMA) HW driver header file.
  */
 
-#ifndef neorv32_dma_h
-#define neorv32_dma_h
+#ifndef NEORV32_DMA_H
+#define NEORV32_DMA_H
 
 #include <stdint.h>
 
@@ -105,4 +105,4 @@ int  neorv32_dma_done(void);
 /**@}*/
 
 
-#endif // neorv32_dma_h
+#endif // NEORV32_DMA_H

--- a/sw/lib/include/neorv32_gpio.h
+++ b/sw/lib/include/neorv32_gpio.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -11,8 +11,8 @@
  * @brief General purpose input/output port unit (GPIO) HW driver header file.
  */
 
-#ifndef neorv32_gpio_h
-#define neorv32_gpio_h
+#ifndef NEORV32_GPIO_H
+#define NEORV32_GPIO_H
 
 #include <stdint.h>
 
@@ -67,4 +67,4 @@ void     neorv32_gpio_irq_clr(uint32_t pin_mask);
 /**@}*/
 
 
-#endif // neorv32_gpio_h
+#endif // NEORV32_GPIO_H

--- a/sw/lib/include/neorv32_gptmr.h
+++ b/sw/lib/include/neorv32_gptmr.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,14 +9,10 @@
 /**
  * @file neorv32_gptmr.h
  * @brief General purpose timer (GPTMR) HW driver header file.
- *
- * @note These functions should only be used if the GPTMR unit was synthesized (IO_GPTMR_EN = true).
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_gptmr_h
-#define neorv32_gptmr_h
+#ifndef NEORV32_GPTMR_H
+#define NEORV32_GPTMR_H
 
 #include <stdint.h>
 
@@ -61,4 +57,4 @@ void neorv32_gptmr_irq_ack(void);
 /**@}*/
 
 
-#endif // neorv32_gptmr_h
+#endif // NEORV32_GPTMR_H

--- a/sw/lib/include/neorv32_intrinsics.h
+++ b/sw/lib/include/neorv32_intrinsics.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,12 +9,10 @@
 /**
  * @file neorv32_intrinsics.h
  * @brief Helper macros for custom "intrinsics" / instructions.
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_intrinsics_h
-#define neorv32_intrinsics_h
+#ifndef NEORV32_INTRINSICS_H
+#define NEORV32_INTRINSICS_H
 
 #include <stdint.h>
 
@@ -204,4 +202,4 @@ asm (
 })
 
 
-#endif // neorv32_intrinsics_h
+#endif // NEORV32_INTRINSICS_H

--- a/sw/lib/include/neorv32_neoled.h
+++ b/sw/lib/include/neorv32_neoled.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,14 +9,10 @@
 /**
  * @file neorv32_neoled.h
  * @brief Smart LED Interface (NEOLED) HW driver header file.
- *
- * @note These functions should only be used if the NEOLED unit was synthesized (IO_NEOLED_EN = true).
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_neoled_h
-#define neorv32_neoled_h
+#ifndef NEORV32_NEOLED_H
+#define NEORV32_NEOLED_H
 
 #include <stdint.h>
 
@@ -104,4 +100,4 @@ inline void __attribute__ ((always_inline)) neorv32_neoled_write_nonblocking(uin
   NEORV32_NEOLED->DATA = data; // send new LED data
 }
 
-#endif // neorv32_neoled_h
+#endif // NEORV32_NEOLED_H

--- a/sw/lib/include/neorv32_onewire.h
+++ b/sw/lib/include/neorv32_onewire.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,14 +9,10 @@
 /**
  * @file neorv32_onewire.h
  * @brief 1-Wire Interface Controller (ONEWIRE) HW driver header file.
- *
- * @note These functions should only be used if the ONEWIRE unit was synthesized (IO_ONEWIRE_EN = true).
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_onewire_h
-#define neorv32_onewire_h
+#ifndef NEORV32_ONEWIRE_H
+#define NEORV32_ONEWIRE_H
 
 #include <stdint.h>
 
@@ -104,4 +100,4 @@ void    neorv32_onewire_write_byte_blocking(uint8_t byte);
 /**@}*/
 
 
-#endif // neorv32_onewire_h
+#endif // NEORV32_ONEWIRE_H

--- a/sw/lib/include/neorv32_pwm.h
+++ b/sw/lib/include/neorv32_pwm.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,14 +9,10 @@
 /**
  * @file neorv32_pwm.h
  * @brief Pulse-Width Modulation Controller (PWM) HW driver header file.
- *
- * @note These functions should only be used if the PWM unit was synthesized (IO_PWM_EN = true).
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_pwm_h
-#define neorv32_pwm_h
+#ifndef NEORV32_PWM_H
+#define NEORV32_PWM_H
 
 #include <stdint.h>
 
@@ -59,4 +55,4 @@ void neorv32_pwm_ch_set_clock(int channel, int prsc, int cdiv);
 void neorv32_pwm_ch_set_duty(int channel, int duty);
 /**@}*/
 
-#endif // neorv32_pwm_h
+#endif // NEORV32_PWM_H

--- a/sw/lib/include/neorv32_rte.h
+++ b/sw/lib/include/neorv32_rte.h
@@ -9,12 +9,10 @@
 /**
  * @file neorv32_rte.h
  * @brief NEORV32 Runtime Environment.
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_rte_h
-#define neorv32_rte_h
+#ifndef NEORV32_RTE_H
+#define NEORV32_RTE_H
 
 #include <stdint.h>
 
@@ -70,4 +68,4 @@ uint32_t neorv32_rte_context_get(int x);
 void     neorv32_rte_context_put(int x, uint32_t data);
 /**@}*/
 
-#endif // neorv32_rte_h
+#endif // NEORV32_RTE_H

--- a/sw/lib/include/neorv32_sdi.h
+++ b/sw/lib/include/neorv32_sdi.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,14 +9,10 @@
 /**
  * @file neorv32_sdi.h
  * @brief Serial data interface controller (SPPI) HW driver header file.
- *
- * @note These functions should only be used if the SDI unit was synthesized (IO_SDI_EN = true).
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_sdi_h
-#define neorv32_sdi_h
+#ifndef NEORV32_SDI_H
+#define NEORV32_SDI_H
 
 #include <stdint.h>
 
@@ -74,4 +70,4 @@ int  neorv32_sdi_check_cs(void);
 /**@}*/
 
 
-#endif // neorv32_sdi_h
+#endif // NEORV32_SDI_H

--- a/sw/lib/include/neorv32_slink.h
+++ b/sw/lib/include/neorv32_slink.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,12 +9,10 @@
 /**
  * @file neorv32_slink.h
  * @brief Stream Link Interface HW driver header file.
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_slink_h
-#define neorv32_slink_h
+#ifndef NEORV32_SLINK_H
+#define NEORV32_SLINK_H
 
 #include <stdint.h>
 
@@ -99,4 +97,4 @@ int      neorv32_slink_tx_status(void);
 /**@}*/
 
 
-#endif // neorv32_slink_h
+#endif // NEORV32_SLINK_H

--- a/sw/lib/include/neorv32_smp.h
+++ b/sw/lib/include/neorv32_smp.h
@@ -11,8 +11,8 @@
  * @brief Symmetric multiprocessing (SMP) library header file.
  */
 
-#ifndef neorv32_smp_h
-#define neorv32_smp_h
+#ifndef NEORV32_SMP_H
+#define NEORV32_SMP_H
 
 
 /**********************************************************************//**
@@ -81,4 +81,4 @@ inline int __attribute__ ((always_inline)) neorv32_smp_icc_free(void) {
   return neorv32_cpu_csr_read(CSR_MXICCSREG) & (1 << CSR_MXICCSREG_TX_FREE);
 }
 
-#endif // neorv32_smp_h
+#endif // NEORV32_SMP_H

--- a/sw/lib/include/neorv32_spi.h
+++ b/sw/lib/include/neorv32_spi.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,14 +9,10 @@
 /**
  * @file neorv32_spi.h
  * @brief Serial peripheral interface controller (SPI) HW driver header file.
- *
- * @note These functions should only be used if the SPI unit was synthesized (IO_SPI_EN = true).
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_spi_h
-#define neorv32_spi_h
+#ifndef NEORV32_SPI_H
+#define NEORV32_SPI_H
 
 #include <stdint.h>
 
@@ -98,4 +94,4 @@ int      neorv32_spi_check_cs(void);
 int      neorv32_spi_busy(void);
 /**@}*/
 
-#endif // neorv32_spi_h
+#endif // NEORV32_SPI_H

--- a/sw/lib/include/neorv32_sysinfo.h
+++ b/sw/lib/include/neorv32_sysinfo.h
@@ -9,12 +9,10 @@
 /**
  * @file neorv32_sysinfo.h
  * @brief System Information Memory (SYSINFO) HW driver header file.
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_sysinfo_h
-#define neorv32_sysinfo_h
+#ifndef NEORV32_SYSINFO_H
+#define NEORV32_SYSINFO_H
 
 #include <stdint.h>
 
@@ -143,4 +141,4 @@ inline void __attribute__ ((always_inline)) neorv32_sysinfo_set_clk(uint32_t clo
   NEORV32_SYSINFO->CLK = clock;
 }
 
-#endif // neorv32_sysinfo_h
+#endif // NEORV32_SYSINFO_H

--- a/sw/lib/include/neorv32_trng.h
+++ b/sw/lib/include/neorv32_trng.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,14 +9,10 @@
 /**
  * @file neorv32_trng.h
  * @brief True Random Number Generator (TRNG) HW driver header file.
- *
- * @note These functions should only be used if the TRNG unit was synthesized (IO_TRNG_EN = true).
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_trng_h
-#define neorv32_trng_h
+#ifndef NEORV32_TRNG_H
+#define NEORV32_TRNG_H
 
 #include <stdint.h>
 
@@ -66,4 +62,4 @@ int  neorv32_trng_check_sim_mode(void);
 /**@}*/
 
 
-#endif // neorv32_trng_h
+#endif // NEORV32_TRNG_H

--- a/sw/lib/include/neorv32_twd.h
+++ b/sw/lib/include/neorv32_twd.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,14 +9,10 @@
 /**
  * @file neorv32_twd.h
  * @brief Two-Wire Device Controller (TWD) HW driver header file.
- *
- * @note These functions should only be used if the TWD unit was synthesized (IO_TWD_EN = true).
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_twd_h
-#define neorv32_twd_h
+#ifndef NEORV32_TWD_H
+#define NEORV32_TWD_H
 
 #include <stdint.h>
 
@@ -89,4 +85,4 @@ uint8_t neorv32_twd_get(void);
 /**@}*/
 
 
-#endif // neorv32_twd_h
+#endif // NEORV32_TWD_H

--- a/sw/lib/include/neorv32_twi.h
+++ b/sw/lib/include/neorv32_twi.h
@@ -9,14 +9,10 @@
 /**
  * @file neorv32_twi.h
  * @brief Two-Wire Interface Controller (TWI) HW driver header file.
- *
- * @note These functions should only be used if the TWI unit was synthesized (IO_TWI_EN = true).
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_twi_h
-#define neorv32_twi_h
+#ifndef NEORV32_TWI_H
+#define NEORV32_TWI_H
 
 #include <stdint.h>
 
@@ -104,4 +100,4 @@ void neorv32_twi_generate_start_nonblocking(void);
 /**@}*/
 
 
-#endif // neorv32_twi_h
+#endif // NEORV32_TWI_H

--- a/sw/lib/include/neorv32_uart.h
+++ b/sw/lib/include/neorv32_uart.h
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,12 +9,10 @@
 /**
  * @file neorv32_uart.h
  * @brief Universal asynchronous receiver/transmitter (UART0/UART1) HW driver header file
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
-#ifndef neorv32_uart_h
-#define neorv32_uart_h
+#ifndef NEORV32_UART_H
+#define NEORV32_UART_H
 
 #include <stdint.h>
 #include <stdarg.h>
@@ -115,7 +113,7 @@ int  neorv32_uart_scan(neorv32_uart_t *UARTx, char *buffer, int max_size, int ec
 
 
 /**********************************************************************//**
- * @name UART wrappers for easy access
+ * @name UART aliases for easy access
  **************************************************************************/
 /**@{*/
 #define neorv32_uart0_available()                  neorv32_uart_available(NEORV32_UART0)
@@ -158,4 +156,4 @@ int  neorv32_uart_scan(neorv32_uart_t *UARTx, char *buffer, int max_size, int ec
 /**@}*/
 
 
-#endif // neorv32_uart_h
+#endif // NEORV32_UART_H

--- a/sw/lib/include/neorv32_wdt.h
+++ b/sw/lib/include/neorv32_wdt.h
@@ -11,8 +11,8 @@
  * @brief Watchdog Timer (WDT) HW driver header file.
  */
 
-#ifndef neorv32_wdt_h
-#define neorv32_wdt_h
+#ifndef NEORV32_WDT_H
+#define NEORV32_WDT_H
 
 #include <stdint.h>
 
@@ -73,4 +73,4 @@ int  neorv32_wdt_get_cause(void);
 /**@}*/
 
 
-#endif // neorv32_wdt_h
+#endif // NEORV32_WDT_H

--- a/sw/lib/source/neorv32_newlib.c
+++ b/sw/lib/source/neorv32_newlib.c
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,11 +9,8 @@
 /**
  * @file neorv32_newlib.c
  * @brief NEORV32-specific Newlib system calls
- *
  * @note Original source file: https://github.com/openhwgroup/cv32e40p/blob/master/example_tb/core/custom/syscalls.c
  * @note More information was derived from: https://interrupt.memfault.com/blog/boostrapping-libc-with-newlib#implementing-newlib
- *
- * @see https://stnolting.github.io/neorv32/sw/files.html
  */
 
 #include <neorv32.h>
@@ -37,17 +34,17 @@ void *_sbrk(int incr) {
 
   // initialize
   if (curr_heap_ptr == NULL) {
-    curr_heap_ptr = (unsigned char *)neorv32_heap_begin_c;
+    curr_heap_ptr = (unsigned char *)NEORV32_HEAP_BEGIN;
   }
 
   // do we have a heap at all?
-  if ((neorv32_heap_begin_c == neorv32_heap_end_c) || (neorv32_heap_size_c == 0)) {
+  if ((NEORV32_HEAP_BEGIN == NEORV32_HEAP_END) || (NEORV32_HEAP_SIZE == 0)) {
     errno = ENOMEM;
     return (void*)-1; // error - no more memory
   }
 
   // sufficient space left?
-  if ((((uint32_t)curr_heap_ptr) + ((uint32_t)incr)) >= neorv32_heap_end_c) {
+  if ((((uint32_t)curr_heap_ptr) + ((uint32_t)incr)) >= NEORV32_HEAP_END) {
     errno = ENOMEM;
     return (void*)-1; // error - no more memory
   }


### PR DESCRIPTION
* use capital letters for all defines
* remove obsolete functions
  * `neorv32_cpu_get_clk_from_prsc()` (not used at all)
  * `neorv32_cpu_goto_user_mode()` (too specific)
* replace the generic `neorv32_cpu_delay_ms` delay function by a simpler one `neorv32_aux_delay_ms` (that only implements an ASM delay loop and does not rely on any specific hardware being available