### PR TITLE
🐛 fix bug in Zalrsc ISA extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 20.02.2025 | 1.11.1.4 | :bug: fix bug in `Zalrsc` ISA extension's bus request decoding | [#1190](https://github.com/stnolting/neorv32/pull/1190) |
 | 14.02.2025 | 1.11.1.3 | source-out CPU front-end into new rtl file (`neorv32_cpu_frontend.vhd`) | [#1183](https://github.com/stnolting/neorv32/pull/1183) |
 | 14.02.2025 | 1.11.1.2 | minor rtl edits and cleanups (cache optimizations) | [#1182](https://github.com/stnolting/neorv32/pull/1182) |
 | 08.02.2025 | 1.11.1.1 | :sparkles: add support for `A` and `Zalrsc` ISA extensions | [#1181](https://github.com/stnolting/neorv32/pull/1181) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -178,7 +178,8 @@ optimize the system for certain design goals like minimal area or maximum perfor
 
 .Default Values
 [NOTE]
-All _optional_ configuration generics provide default values in case they are not explicitly assigned during instantiation.
+All configuration generics provide default values in case they are not explicitly assigned during instantiation.
+By default, all configuration options are **disabled**.
 
 .Software Discovery of Configuration
 [TIP]
@@ -194,7 +195,6 @@ and do not impact timing.
 .Table Abbreviations
 [NOTE]
 The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downto y)`".
-
 
 .NEORV32 Processor Generic List
 [cols="<3,^2,^2,<8"]
@@ -226,7 +226,7 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `RISCV_ISA_Zbkx`        | boolean   | false         | Enable <<_zbkx_isa_extension>> (scalar cryptography crossbar permutations).
 | `RISCV_ISA_Zbs`         | boolean   | false         | Enable <<_zbs_isa_extension>> (single-bit bit-manipulation instructions).
 | `RISCV_ISA_Zfinx`       | boolean   | false         | Enable <<_zfinx_isa_extension>> (single-precision floating-point unit).
-| `RISCV_ISA_Zicntr`      | boolean   | true          | Enable <<_zicntr_isa_extension>> (CPU base counters).
+| `RISCV_ISA_Zicntr`      | boolean   | false         | Enable <<_zicntr_isa_extension>> (CPU base counters).
 | `RISCV_ISA_Zicond`      | boolean   | false         | Enable <<_zicond_isa_extension>> (integer conditional instructions).
 | `RISCV_ISA_Zihpm`       | boolean   | false         | Enable <<_zihpm_isa_extension>> (hardware performance monitors).
 | `RISCV_ISA_Zknd`        | boolean   | false         | Enable <<_zknd_isa_extension>> (scalar cryptography NIST AES decryption instructions).
@@ -244,8 +244,8 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 4+^| **Physical Memory Protection (<<_smpmp_isa_extension>>)**
 | `PMP_NUM_REGIONS`       | natural   | 0             | Number of implemented PMP regions (0..16).
 | `PMP_MIN_GRANULARITY`   | natural   | 4             | Minimal region granularity in bytes. Has to be a power of two, min 4.
-| `PMP_TOR_MODE_EN`       | boolean   | true          | Implement support for top-of-region (TOR) mode.
-| `PMP_NAP_MODE_EN`       | boolean   | true          | Implement support for naturally-aligned power-of-two (NAPOT & NA4) modes.
+| `PMP_TOR_MODE_EN`       | boolean   | false         | Implement support for top-of-region (TOR) mode.
+| `PMP_NAP_MODE_EN`       | boolean   | false         | Implement support for naturally-aligned power-of-two (NAPOT & NA4) modes.
 4+^| **Hardware Performance Monitors (<<_zihpm_isa_extension>>)**
 | `HPM_NUM_CNTS`          | natural   | 0             | Number of implemented hardware performance monitor counters (0..13).
 | `HPM_CNT_WIDTH`         | natural   | 40            | Total LSB-aligned size of each HPM counter. Min 0, max 64.
@@ -271,7 +271,7 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `XBUS_CACHE_NUM_BLOCKS` | natural   | 64            | Number of blocks ("lines"). Has to be a power of two.
 | `XBUS_CACHE_BLOCK_SIZE` | natural   | 32            | Size in bytes of each block. Has to be a power of two.
 4+^| **Peripheral/IO Modules**
-| `IO_DISABLE_SYSINFO`    | boolean   | false         | Disable <<_system_configuration_information_memory_sysinfo>> module; ⚠️ not recommended - for advanced users only!
+| `IO_DISABLE_SYSINFO`    | boolean   | false         | Disable <<_system_configuration_information_memory_sysinfo>> module; not recommended - for advanced users only!
 | `IO_GPIO_NUM`           | natural   | 0             | Number of general purpose input/output pairs of the <<_general_purpose_input_and_output_port_gpio>>, max 32.
 | `IO_CLINT_EN`           | boolean   | false         | Implement the <<_core_local_interruptor_clint>>.
 | `IO_UART0_EN`           | boolean   | false         | Implement the <<_primary_universal_asynchronous_receiver_and_transmitter_uart0>>.
@@ -646,10 +646,10 @@ The reservation-set controller implements the _strong semnatics_. An active rese
 :sectnums:
 ==== Memory Coherence
 
-Depending on the configuration, the NEORV32 processor provides several _layer_ of memory consisting
+Depending on the configuration, the NEORV32 processor provides several _layers_ of memory consisting
 of caches, buffers and storage.
 
-* The CPU instruction prefetch buffer ("level-0")
+* The CPU pipeline and its instruction prefetch buffer (level-0)
 * The <<_processor_internal_data_cache_dcache>> (level-1)
 * The <<_processor_internal_instruction_cache_icache>> (level-1)
 * The cache of the <<_processor_external_bus_interface_xbus>> (level-2)
@@ -664,6 +664,13 @@ regardless of the actual CPU/ISA configuration:
 
 * `fence` (<<_i_isa_extension>> / <<_e_isa_extension>>)
 * `fence.i` (<<_zifencei_isa_extension>>)
+
+.Weak Coherence Model
+[IMPORTANT]
+The NEORV32-specific implementation of the `fence[.i]` ordering instructions only provides a rather **weak**
+coherence model. A core's `fence` just orders all memory accesses towards main memory. Hence, they _can_ become
+visible by other agents (the secondary CPU core, the DMA, processor-external modules) if these agents also
+synchronize (e.g. reload) their cache(s).
 
 By executing the "data" `fence` instruction the CPU's load/store operations are ordered
 and synchronized across the entire system:

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -117,7 +117,6 @@ begin
     begin
       -- defaults --
       state_nxt <= state;
-      sel       <= '0';
       stb       <= '0';
 
       -- state machine --
@@ -125,7 +124,6 @@ begin
 
         when S_CHECK_A => -- check if access from port A
         -- ------------------------------------------------------------
-          sel <= '0';
           if (a_req_i.stb = '1') or (a_req = '1') then
             stb       <= '1';
             state_nxt <= S_BUSY_A;
@@ -135,14 +133,12 @@ begin
 
         when S_BUSY_A => -- port B access in progress
         -- ------------------------------------------------------------
-          sel <= '0';
           if (x_rsp_i.err = '1') or (x_rsp_i.ack = '1') then
             state_nxt <= S_CHECK_B;
           end if;
 
         when S_CHECK_B => -- check if access from port B
         -- ------------------------------------------------------------
-          sel <= '1';
           if (b_req_i.stb = '1') or (b_req = '1') then
             stb       <= '1';
             state_nxt <= S_BUSY_B;
@@ -152,7 +148,6 @@ begin
 
         when S_BUSY_B => -- port B access in progress
         -- ------------------------------------------------------------
-          sel <= '1';
           if (x_rsp_i.err = '1') or (x_rsp_i.ack = '1') then
             state_nxt <= S_CHECK_A;
           end if;
@@ -163,6 +158,9 @@ begin
 
       end case;
     end process arbiter_fsm;
+ 
+    -- port select --
+    sel <= '1' when (state = S_CHECK_B) or (state = S_BUSY_B) else '0';
   end generate;
 
 
@@ -955,7 +953,7 @@ begin
   end process rvs_control;
 
   -- check if reservation-set operation --
-  rvso <= '1' when (core_req_i.amoop(3 downto 2) = "10") else '0';
+  rvso <= '1' when (core_req_i.amo = '1') and (core_req_i.amoop(3 downto 2) = "10") else '0';
 
 
   -- System Bus Interface -------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110103"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110104"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -783,7 +783,7 @@ package neorv32_package is
       RISCV_ISA_Zbkx        : boolean                        := false;
       RISCV_ISA_Zbs         : boolean                        := false;
       RISCV_ISA_Zfinx       : boolean                        := false;
-      RISCV_ISA_Zicntr      : boolean                        := true;
+      RISCV_ISA_Zicntr      : boolean                        := false;
       RISCV_ISA_Zicond      : boolean                        := false;
       RISCV_ISA_Zihpm       : boolean                        := false;
       RISCV_ISA_Zmmul       : boolean                        := false;
@@ -801,8 +801,8 @@ package neorv32_package is
       -- Physical Memory Protection (PMP) --
       PMP_NUM_REGIONS       : natural range 0 to 16          := 0;
       PMP_MIN_GRANULARITY   : natural                        := 4;
-      PMP_TOR_MODE_EN       : boolean                        := true;
-      PMP_NAP_MODE_EN       : boolean                        := true;
+      PMP_TOR_MODE_EN       : boolean                        := false;
+      PMP_NAP_MODE_EN       : boolean                        := false;
       -- Hardware Performance Monitors (HPM) --
       HPM_NUM_CNTS          : natural range 0 to 13          := 0;
       HPM_CNT_WIDTH         : natural range 0 to 64          := 40;

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -49,7 +49,7 @@ entity neorv32_top is
     RISCV_ISA_Zbkx        : boolean                        := false;       -- implement cryptography crossbar permutation extension
     RISCV_ISA_Zbs         : boolean                        := false;       -- implement single-bit bit-manipulation extension
     RISCV_ISA_Zfinx       : boolean                        := false;       -- implement 32-bit floating-point extension
-    RISCV_ISA_Zicntr      : boolean                        := true;        -- implement base counters
+    RISCV_ISA_Zicntr      : boolean                        := false;       -- implement base counters
     RISCV_ISA_Zicond      : boolean                        := false;       -- implement integer conditional operations
     RISCV_ISA_Zihpm       : boolean                        := false;       -- implement hardware performance monitors
     RISCV_ISA_Zknd        : boolean                        := false;       -- implement cryptography NIST AES decryption extension
@@ -69,8 +69,8 @@ entity neorv32_top is
     -- Physical Memory Protection (PMP) --
     PMP_NUM_REGIONS       : natural range 0 to 16          := 0;           -- number of regions (0..16)
     PMP_MIN_GRANULARITY   : natural                        := 4;           -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
-    PMP_TOR_MODE_EN       : boolean                        := true;        -- implement TOR mode
-    PMP_NAP_MODE_EN       : boolean                        := true;        -- implement NAPOT/NA4 modes
+    PMP_TOR_MODE_EN       : boolean                        := false;       -- implement TOR mode
+    PMP_NAP_MODE_EN       : boolean                        := false;       -- implement NAPOT/NA4 modes
 
     -- Hardware Performance Monitors (HPM) --
     HPM_NUM_CNTS          : natural range 0 to 13          := 0;           -- number of implemented HPM counters (0..13)


### PR DESCRIPTION
Some _normal_ memory operations were treated as `LR.W` / `SC.W` instructions. This PR fixes the incomplete bus type decoding.

As a minor edit, this PR also disables all optional CPU extensions by default (primarily `Zicntr`).