### PR TITLE
[cpu] relocate CPU counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 23.02.2025 | 1.11.1.6 | source-out CPU counters into a new rtl file (`neorv32_cpu_counters.vhd`) | [#1192](https://github.com/stnolting/neorv32/pull/1192) |
 | 22.02.2025 | 1.11.1.5 | minor rtl edits and cleanups | [#1191](https://github.com/stnolting/neorv32/pull/1191) |
 | 20.02.2025 | 1.11.1.4 | :bug: fix bug in `Zalrsc` ISA extension's bus request decoding | [#1190](https://github.com/stnolting/neorv32/pull/1190) |
 | 14.02.2025 | 1.11.1.3 | source-out CPU front-end into new rtl file (`neorv32_cpu_frontend.vhd`) | [#1183](https://github.com/stnolting/neorv32/pull/1183) |
@@ -57,7 +58,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 | 10.01.2025 | 1.10.9.2 | clean-up SMP dual-core configuration (HW and SW optimizations) | [#1146](https://github.com/stnolting/neorv32/pull/1146) |
 | 09.01.2025 | 1.10.9.1 | fix side-effects of CSR read instructions | [#1145](https://github.com/stnolting/neorv32/pull/1145) |
 | 08.01.2025 | [**:rocket:1.10.9**](https://github.com/stnolting/neorv32/releases/tag/v1.10.9) | **New release** | |
-| 07.01.2025 | 1.10.8.9 | rtl edits and cleanups; add dedicated "core complex" wrapper (CPU + L1 caches + bus switch) | [#1144](https://github.com/stnolting/neorv32/pull/1144) | 
+| 07.01.2025 | 1.10.8.9 | rtl edits and cleanups; add dedicated "core complex" wrapper (CPU + L1 caches + bus switch) | [#1144](https://github.com/stnolting/neorv32/pull/1144) |
 | 04.01.2025 | 1.10.8.8 | :sparkles: add inter-core communication (ICC) for the SMP dual-core setup | [#1142](https://github.com/stnolting/neorv32/pull/1142) |
 | 03.01.2025 | 1.10.8.7 | :warning: :sparkles: replace `Zalrsc` ISA extensions (reservation-set operations) by `Zaamo` ISA extension (atomic read-modify-write operations) | [#1141](https://github.com/stnolting/neorv32/pull/1141) |
 | 01.01.2025 | 1.10.8.6 | :sparkles: :test_tube: add smp dual-core option | [#1135](https://github.com/stnolting/neorv32/pull/1135) |

--- a/docs/datasheet/overview.adoc
+++ b/docs/datasheet/overview.adoc
@@ -185,6 +185,7 @@ rtl/core
 ├-neorv32_cpu.vhd               - NEORV32 CPU TOP ENTITY
 ├-neorv32_cpu_alu.vhd           - Arithmetic/logic unit
 ├-neorv32_cpu_control.vhd       - CPU control, exception system and CSRs
+├-neorv32_cpu_counters.vhd      - Hardware counters (Zicntr & Zihpm ext.)
 ├-neorv32_cpu_cp_bitmanip.vhd   - Bit-manipulation co-processor (B ext.)
 ├-neorv32_cpu_cp_cfu.vhd        - Custom instructions co-processor (Zxcfu ext.)
 ├-neorv32_cpu_cp_cond.vhd       - Integer conditional co-processor (Zicond ext.)

--- a/rtl/core/neorv32_clint.vhd
+++ b/rtl/core/neorv32_clint.vhd
@@ -215,7 +215,7 @@ end neorv32_clint_rtl;
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -223,9 +223,6 @@ end neorv32_clint_rtl;
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
-
-library neorv32;
-use neorv32.neorv32_package.all;
 
 entity neorv32_clint_mtime is
   port (
@@ -243,10 +240,9 @@ end neorv32_clint_mtime;
 architecture neorv32_clint_mtime_rtl of neorv32_clint_mtime is
 
   signal we_q, re_q : std_ulogic_vector(1 downto 0);
-  signal mtime_q    : std_ulogic_vector(63 downto 0);
-  signal carry_q    : std_ulogic_vector(0 downto 0);
-  signal inc_lo     : std_ulogic_vector(32 downto 0);
-  signal inc_hi     : std_ulogic_vector(32 downto 0);
+  signal mtime_q : std_ulogic_vector(63 downto 0);
+  signal carry_q : std_ulogic_vector(0 downto 0);
+  signal inc_lo, inc_hi : std_ulogic_vector(32 downto 0);
 
 begin
 
@@ -300,7 +296,7 @@ end neorv32_clint_mtime_rtl;
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -308,9 +304,6 @@ end neorv32_clint_mtime_rtl;
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
-
-library neorv32;
-use neorv32.neorv32_package.all;
 
 entity neorv32_clint_mtimecmp is
   port (
@@ -382,22 +375,18 @@ begin
 end neorv32_clint_mtimecmp_rtl;
 
 
-
 -- ================================================================================ --
 -- NEORV32 SoC - CLINT SWI (software interrupt trigger)                             --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
 
 library ieee;
 use ieee.std_logic_1164.all;
-
-library neorv32;
-use neorv32.neorv32_package.all;
 
 entity neorv32_clint_swi is
   port (

--- a/rtl/core/neorv32_clockgate.vhd
+++ b/rtl/core/neorv32_clockgate.vhd
@@ -7,16 +7,13 @@
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
 
 library ieee;
 use ieee.std_logic_1164.all;
-
-library neorv32;
-use neorv32.neorv32_package.all;
 
 entity neorv32_clockgate is
   port (

--- a/rtl/core/neorv32_cpu_counters.vhd
+++ b/rtl/core/neorv32_cpu_counters.vhd
@@ -1,0 +1,355 @@
+-- ================================================================================ --
+-- NEORV32 CPU - Hardware Counters                                                  --
+-- -------------------------------------------------------------------------------- --
+-- Implementing hardware counters for the following RISC-V ISA extensions:          --
+-- + Zicntr: Base Counters -> [m]cycle[h] + [m]time[h] + [m]instret[h] CSRs         --
+-- + Zihpm:  Hardware Performance Monitors -> [m]hpmcntx[h] + mhpmeventx CRSs       --
+-- -------------------------------------------------------------------------------- --
+-- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
+-- Copyright (c) NEORV32 contributors.                                              --
+-- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
+-- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
+-- SPDX-License-Identifier: BSD-3-Clause                                            --
+-- ================================================================================ --
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library neorv32;
+use neorv32.neorv32_package.all;
+
+entity neorv32_cpu_counters is
+  generic (
+    ZICNTR_EN : boolean; -- implement base counters
+    ZIHPM_EN  : boolean; -- implement hardware performance monitors
+    HPM_NUM   : natural range 0 to 13; -- number of implemented HPM counters (0..13)
+    HPM_WIDTH : natural range 0 to 64  -- total size of HPM counters (0..64)
+  );
+  port (
+    -- global control --
+    clk_i   : in  std_ulogic; -- global clock, rising edge
+    rstn_i  : in  std_ulogic; -- global reset, low-active, async
+    ctrl_i  : in  ctrl_bus_t; -- main control bus
+    -- read back --
+    rdata_o : out std_ulogic_vector(XLEN-1 downto 0) -- read data
+  );
+end neorv32_cpu_counters;
+
+architecture neorv32_cpu_counters_rtl of neorv32_cpu_counters is
+
+  -- generic counter module --
+  component neorv32_cpu_counters_cnt
+  generic (
+    CNT_WIDTH : natural range 0 to 64 -- counter width (0..64)
+  );
+  port (
+    -- global control --
+    clk_i   : in  std_ulogic; -- global clock, rising edge
+    rstn_i  : in  std_ulogic; -- global reset, low-active, async
+    inc_i   : in  std_ulogic; -- enable counter increment
+    -- read/write access --
+    sel_i   : in  std_ulogic; -- high word / low word select
+    we_i    : in  std_ulogic; -- write enable
+    re_i    : in  std_ulogic; -- read enable
+    wdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- write data
+    rdata_o : out std_ulogic_vector(XLEN-1 downto 0) -- read data
+  );
+  end component;
+
+  -- global access decoder --
+  signal cnt_acc, cfg_acc : std_ulogic;
+  signal sel, cnt_we, cnt_re, cfg_we, cfg_re : std_ulogic_vector(15 downto 0);
+
+  -- counter increment control --
+  signal cnt_en : std_ulogic_vector(15 downto 0);
+
+  -- individual HPM read-backs --
+  type hpmevent_t is array (3 to 15) of std_ulogic_vector(11 downto 0);
+  type hpmcnt_t   is array (3 to 15) of std_ulogic_vector(XLEN-1 downto 0);
+  signal hpmevent : hpmevent_t;
+  signal hpmcnt   : hpmcnt_t;
+
+  -- global read-backs --
+  signal cycle_rd, time_rd, instret_rd, hpm_rd : std_ulogic_vector(XLEN-1 downto 0);
+
+begin
+
+  -- Access Decoder -------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  acc_gen:
+  for i in 0 to 15 generate
+    sel(i)    <= '1' when (ctrl_i.csr_addr(3 downto 0) = std_ulogic_vector(to_unsigned(i, 4))) else '0';
+    cnt_we(i) <= cnt_acc and sel(i) and ctrl_i.csr_we;
+    cnt_re(i) <= cnt_acc and sel(i) and ctrl_i.csr_re;
+    cfg_we(i) <= cfg_acc and sel(i) and ctrl_i.csr_we;
+    cfg_re(i) <= cfg_acc and sel(i) and ctrl_i.csr_re;
+  end generate;
+
+  -- global access --
+  cnt_acc <= '1' when ZICNTR_EN and ((ctrl_i.csr_addr(11 downto 5) = csr_cycle_c(11 downto 5)) or
+                                     (ctrl_i.csr_addr(11 downto 5) = csr_mcycle_c(11 downto 5)) or
+                                     (ctrl_i.csr_addr(11 downto 5) = csr_cycleh_c(11 downto 5)) or
+                                     (ctrl_i.csr_addr(11 downto 5) = csr_mcycleh_c(11 downto 5))) else '0';
+  cfg_acc <= '1' when ZIHPM_EN and (ctrl_i.csr_addr(11 downto 5) = csr_mhpmevent3_c(11 downto 5)) else '0';
+
+  -- global data read-back --
+  rdata_o <= cycle_rd or time_rd or instret_rd or hpm_rd;
+
+
+  -- Counter Increment Control --------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  cnt_control: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      cnt_en <= (others => '0');
+    elsif rising_edge(clk_i) then
+      -- increment if an (enabled) event fires; do not increment if CPU is in debug mode or if counter is inhibited
+      cnt_en(0) <= ctrl_i.cnt_event(cnt_event_cy_c) and (not ctrl_i.cpu_debug) and (not ctrl_i.cnt_halt(0));
+      cnt_en(1) <= '0'; -- time: not available
+      cnt_en(2) <= ctrl_i.cnt_event(cnt_event_ir_c) and (not ctrl_i.cpu_debug) and (not ctrl_i.cnt_halt(2));
+      for i in 3 to 15 loop
+        cnt_en(i) <= or_reduce_f(ctrl_i.cnt_event and hpmevent(i)) and (not ctrl_i.cpu_debug) and (not ctrl_i.cnt_halt(i));
+      end loop;
+    end if;
+  end process cnt_control;
+
+
+  -- Base Counters (Zicntr) -----------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  base_enabled:
+  if ZICNTR_EN generate
+
+    -- [m]cycle[h] CSR --
+    cycle_inst: neorv32_cpu_counters_cnt
+    generic map (
+      CNT_WIDTH => 2*XLEN
+    )
+    port map (
+      clk_i   => clk_i,
+      rstn_i  => rstn_i,
+      inc_i   => cnt_en(0),
+      sel_i   => ctrl_i.csr_addr(7),
+      we_i    => cnt_we(0),
+      re_i    => cnt_re(0),
+      wdata_i => ctrl_i.csr_wdata,
+      rdata_o => cycle_rd
+    );
+
+    -- [m]time[h] CSR --
+    time_rd <= (others => '0'); -- not implemented (yet?)
+
+    -- [m]instret[h] CSR --
+    instret_inst: neorv32_cpu_counters_cnt
+    generic map (
+      CNT_WIDTH => 2*XLEN
+    )
+    port map (
+      clk_i   => clk_i,
+      rstn_i  => rstn_i,
+      inc_i   => cnt_en(2),
+      sel_i   => ctrl_i.csr_addr(7),
+      we_i    => cnt_we(2),
+      re_i    => cnt_re(2),
+      wdata_i => ctrl_i.csr_wdata,
+      rdata_o => instret_rd
+    );
+
+  end generate; -- /base_enabled
+
+
+  base_disabled:
+  if not ZICNTR_EN generate
+    cycle_rd   <= (others => '0');
+    time_rd    <= (others => '0');
+    instret_rd <= (others => '0');
+  end generate; -- /base__disabled
+
+
+  -- Hardware Performance Monitors (Zihpm) --------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  hpm_enabled:
+  if ZIHPM_EN and (HPM_NUM > 0) generate
+
+    hpm_gen:
+    for i in 3 to (HPM_NUM+3)-1 generate
+
+       -- [m]hpmcntx[h] CSRs --
+      hpmcnt_inst: neorv32_cpu_counters_cnt
+      generic map (
+        CNT_WIDTH => HPM_WIDTH
+      )
+      port map (
+        clk_i   => clk_i,
+        rstn_i  => rstn_i,
+        inc_i   => cnt_en(i),
+        sel_i   => ctrl_i.csr_addr(7),
+        we_i    => cnt_we(i),
+        re_i    => cnt_re(i),
+        wdata_i => ctrl_i.csr_wdata,
+        rdata_o => hpmcnt(i)
+      );
+
+      -- mhpmeventx CSRs --
+      hpmevent_reg: process(rstn_i, clk_i)
+      begin
+        if (rstn_i = '0') then
+          hpmevent(i) <= (others => '0');
+        elsif rising_edge(clk_i) then
+          if (cfg_we(i) = '1') then
+            hpmevent(i) <= ctrl_i.csr_wdata(11 downto 0);
+          end if;
+          hpmevent(i)(cnt_event_tm_c) <= '0'; -- time: not available
+        end if;
+      end process hpmevent_reg;
+
+    end generate; -- /hpm_gen
+
+    -- terminate unused entries --
+    hpm_terminate_gen:
+    for i in HPM_NUM+3 to 15 generate
+      hpmcnt(i)   <= (others => '0');
+      hpmevent(i) <= (others => '0');
+    end generate; -- /hpm_terminate_gen
+
+    -- read-back --
+    hpm_read_back: process(hpmcnt, cfg_re, hpmevent)
+      variable cnt_v, cfg_v : std_ulogic_vector(XLEN-1 downto 0);
+    begin
+      cnt_v := (others => '0');
+      cfg_v := (others => '0');
+      for i in 3 to 15 loop
+        cnt_v := cnt_v or hpmcnt(i);
+        if (cfg_re(i) = '1') then -- gating
+          cfg_v := cfg_v or std_ulogic_vector(resize(unsigned(hpmevent(i)), XLEN));
+        end if;
+      end loop;
+      hpm_rd <= cnt_v or cfg_v;
+    end process hpm_read_back;
+
+  end generate; -- /hpm_enabled
+
+
+  hpm_disabled:
+  if (not ZIHPM_EN) or (HPM_NUM = 0) generate
+    hpmcnt   <= (others => (others => '0'));
+    hpmevent <= (others => (others => '0'));
+    hpm_rd   <= (others => '0');
+  end generate; -- /hpm_disabled
+
+end neorv32_cpu_counters_rtl;
+
+
+-- ================================================================================ --
+-- NEORV32 CPU - Generic Counter Module                                             --
+-- -------------------------------------------------------------------------------- --
+-- If the counter is wider than 32 bit it is split into two sub-word registers in   --
+-- order to shorten the carry chain length by inserting a flip flop stage.          --
+-- -------------------------------------------------------------------------------- --
+-- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
+-- Copyright (c) NEORV32 contributors.                                              --
+-- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
+-- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
+-- SPDX-License-Identifier: BSD-3-Clause                                            --
+-- ================================================================================ --
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library neorv32;
+use neorv32.neorv32_package.all;
+
+entity neorv32_cpu_counters_cnt is
+  generic (
+    CNT_WIDTH : natural range 0 to 64 -- counter width (0..64)
+  );
+  port (
+    -- global control --
+    clk_i   : in  std_ulogic; -- global clock, rising edge
+    rstn_i  : in  std_ulogic; -- global reset, low-active, async
+    inc_i   : in  std_ulogic; -- enable counter increment
+    -- read/write access --
+    sel_i   : in  std_ulogic; -- high word / low word select
+    we_i    : in  std_ulogic; -- write enable
+    re_i    : in  std_ulogic; -- read enable
+    wdata_i : in  std_ulogic_vector(XLEN-1 downto 0); -- write data
+    rdata_o : out std_ulogic_vector(XLEN-1 downto 0) -- read data
+  );
+end neorv32_cpu_counters_cnt;
+
+architecture neorv32_cpu_counters_cnt_rtl of neorv32_cpu_counters_cnt is
+
+  -- sub-word size configuration --
+  constant lo_width_c : natural := min_natural_f(CNT_WIDTH, 32); -- size low word
+  constant hi_width_c : natural := CNT_WIDTH - lo_width_c; -- size high word
+
+  -- core --
+  signal lo_q : std_ulogic_vector(lo_width_c-1 downto 0);
+  signal hi_q : std_ulogic_vector(hi_width_c-1 downto 0);
+  signal cy_q : std_ulogic_vector(0 downto 0);
+  signal nxt  : std_ulogic_vector(lo_width_c downto 0);
+  signal inc  : std_ulogic_vector(0 downto 0);
+
+begin
+
+  -- counter low-word --
+  low_reg: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      lo_q <= (others => '0');
+    elsif rising_edge(clk_i) then
+      if (we_i = '1') and (sel_i = '0') then
+        lo_q <= wdata_i(lo_width_c-1 downto 0);
+      else
+        lo_q <= nxt(lo_width_c-1 downto 0);
+      end if;
+    end if;
+  end process low_reg;
+
+  -- low-word increment --
+  inc <= (others => inc_i);
+  nxt <= std_ulogic_vector(unsigned('0' & lo_q) + unsigned(inc));
+
+
+  -- counter high-word --
+  high_word_enabled:
+  if (CNT_WIDTH > 32) generate
+    high_reg: process(rstn_i, clk_i)
+    begin
+      if (rstn_i = '0') then
+        cy_q <= (others => '0');
+        hi_q <= (others => '0');
+      elsif rising_edge(clk_i) then
+        cy_q <= (others => nxt(lo_width_c)); -- low-word to high-word carry
+        if (we_i = '1') and (sel_i = '1') then
+          hi_q <= wdata_i(hi_width_c-1 downto 0);
+        else
+          hi_q <= std_ulogic_vector(unsigned(hi_q) + unsigned(cy_q));
+        end if;
+      end if;
+    end process high_reg;
+  end generate;
+
+  high_word_disabled:
+  if (CNT_WIDTH <= 32) generate
+    cy_q <= (others => '0');
+    hi_q <= (others => '0');
+  end generate;
+
+
+  -- output selected sub-word --
+  output_select: process(re_i, sel_i, lo_q, hi_q)
+  begin
+    rdata_o <= (others => '0');
+    if (re_i = '1') and (CNT_WIDTH > 0) then
+      if (sel_i = '0') or (CNT_WIDTH <= 32) then
+        rdata_o <= std_ulogic_vector(resize(unsigned(lo_q), XLEN));
+      else
+        rdata_o <= std_ulogic_vector(resize(unsigned(hi_q), XLEN));
+      end if;
+    end if;
+  end process output_select;
+
+end neorv32_cpu_counters_cnt_rtl;
+

--- a/rtl/core/neorv32_debug_auth.vhd
+++ b/rtl/core/neorv32_debug_auth.vhd
@@ -15,10 +15,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.numeric_std.all;
-
-library neorv32;
-use neorv32.neorv32_package.all;
 
 entity neorv32_debug_auth is
   port (

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110105"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110106"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -480,11 +480,37 @@ package neorv32_package is
   constant csr_mxiccdata_c      : std_ulogic_vector(11 downto 0) := x"bc1";
   -- user counters/timers --
   constant csr_cycle_c          : std_ulogic_vector(11 downto 0) := x"c00";
---constant csr_time_c           : std_ulogic_vector(11 downto 0) := x"c01";
+  constant csr_time_c           : std_ulogic_vector(11 downto 0) := x"c01";
   constant csr_instret_c        : std_ulogic_vector(11 downto 0) := x"c02";
+  constant csr_hpmcounter3_c    : std_ulogic_vector(11 downto 0) := x"c03";
+  constant csr_hpmcounter4_c    : std_ulogic_vector(11 downto 0) := x"c04";
+  constant csr_hpmcounter5_c    : std_ulogic_vector(11 downto 0) := x"c05";
+  constant csr_hpmcounter6_c    : std_ulogic_vector(11 downto 0) := x"c06";
+  constant csr_hpmcounter7_c    : std_ulogic_vector(11 downto 0) := x"c07";
+  constant csr_hpmcounter8_c    : std_ulogic_vector(11 downto 0) := x"c08";
+  constant csr_hpmcounter9_c    : std_ulogic_vector(11 downto 0) := x"c09";
+  constant csr_hpmcounter10_c   : std_ulogic_vector(11 downto 0) := x"c0a";
+  constant csr_hpmcounter11_c   : std_ulogic_vector(11 downto 0) := x"c0b";
+  constant csr_hpmcounter12_c   : std_ulogic_vector(11 downto 0) := x"c0c";
+  constant csr_hpmcounter13_c   : std_ulogic_vector(11 downto 0) := x"c0d";
+  constant csr_hpmcounter14_c   : std_ulogic_vector(11 downto 0) := x"c0e";
+  constant csr_hpmcounter15_c   : std_ulogic_vector(11 downto 0) := x"c0f";
   constant csr_cycleh_c         : std_ulogic_vector(11 downto 0) := x"c80";
---constant csr_timeh_c          : std_ulogic_vector(11 downto 0) := x"c81";
+  constant csr_timeh_c          : std_ulogic_vector(11 downto 0) := x"c81";
   constant csr_instreth_c       : std_ulogic_vector(11 downto 0) := x"c82";
+  constant csr_hpmcounter3h_c   : std_ulogic_vector(11 downto 0) := x"c83";
+  constant csr_hpmcounter4h_c   : std_ulogic_vector(11 downto 0) := x"c84";
+  constant csr_hpmcounter5h_c   : std_ulogic_vector(11 downto 0) := x"c85";
+  constant csr_hpmcounter6h_c   : std_ulogic_vector(11 downto 0) := x"c86";
+  constant csr_hpmcounter7h_c   : std_ulogic_vector(11 downto 0) := x"c87";
+  constant csr_hpmcounter8h_c   : std_ulogic_vector(11 downto 0) := x"c88";
+  constant csr_hpmcounter9h_c   : std_ulogic_vector(11 downto 0) := x"c89";
+  constant csr_hpmcounter10h_c  : std_ulogic_vector(11 downto 0) := x"c8a";
+  constant csr_hpmcounter11h_c  : std_ulogic_vector(11 downto 0) := x"c8b";
+  constant csr_hpmcounter12h_c  : std_ulogic_vector(11 downto 0) := x"c8c";
+  constant csr_hpmcounter13h_c  : std_ulogic_vector(11 downto 0) := x"c8d";
+  constant csr_hpmcounter14h_c  : std_ulogic_vector(11 downto 0) := x"c8e";
+  constant csr_hpmcounter15h_c  : std_ulogic_vector(11 downto 0) := x"c8f";
   -- machine information registers --
   constant csr_mvendorid_c      : std_ulogic_vector(11 downto 0) := x"f11";
   constant csr_marchid_c        : std_ulogic_vector(11 downto 0) := x"f12";
@@ -538,6 +564,8 @@ package neorv32_package is
     csr_re       : std_ulogic;                     -- global read-enable
     csr_addr     : std_ulogic_vector(11 downto 0); -- address
     csr_wdata    : std_ulogic_vector(31 downto 0); -- write data
+    cnt_halt     : std_ulogic_vector(15 downto 0); -- counter inhibit
+    cnt_event    : std_ulogic_vector(11 downto 0); -- counter increment events
     -- instruction word --
     ir_funct3    : std_ulogic_vector(2 downto 0);  -- funct3 bit field
     ir_funct12   : std_ulogic_vector(11 downto 0); -- funct12 bit field
@@ -581,6 +609,8 @@ package neorv32_package is
     csr_re       => '0',
     csr_addr     => (others => '0'),
     csr_wdata    => (others => '0'),
+    cnt_halt     => (others => '0'),
+    cnt_event    => (others => '0'),
     ir_funct3    => (others => '0'),
     ir_funct12   => (others => '0'),
     ir_opcode    => (others => '0'),
@@ -724,8 +754,6 @@ package neorv32_package is
   constant cnt_event_store_c    : natural := 9;  -- store operation
   constant cnt_event_wait_lsu_c : natural := 10; -- load-store unit memory wait cycle
   constant cnt_event_trap_c     : natural := 11; -- entered trap
-  --
-  constant cnt_event_width_c    : natural := 12; -- length of this list
 
 -- **********************************************************************************************************
 -- Helper Functions

--- a/rtl/file_list_cpu.f
+++ b/rtl/file_list_cpu.f
@@ -4,6 +4,7 @@ NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_fifo.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_decompressor.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_frontend.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_control.vhd
+NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_counters.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_regfile.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_cp_shifter.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_cp_muldiv.vhd

--- a/rtl/file_list_soc.f
+++ b/rtl/file_list_soc.f
@@ -5,6 +5,7 @@ NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_fifo.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_decompressor.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_frontend.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_control.vhd
+NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_counters.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_regfile.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_cp_shifter.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_cp_muldiv.vhd

--- a/sw/lib/source/neorv32_cpu.c
+++ b/sw/lib/source/neorv32_cpu.c
@@ -124,7 +124,6 @@ void neorv32_cpu_set_minstret(uint64_t value) {
  * Physical memory protection (PMP): Get number of available regions.
  *
  * @warning This function overrides all available PMPCFG* CSRs!
- * @note This function requires the PMP CPU extension.
  *
  * @return Returns number of available PMP regions.
  **************************************************************************/
@@ -169,7 +168,6 @@ uint32_t neorv32_cpu_pmp_get_num_regions(void) {
  * Physical memory protection (PMP): Get minimal region size (granularity).
  *
  * @warning This function overrides PMPCFG0[0] and PMPADDR0 CSRs!
- * @note This function requires the PMP CPU extension.
  *
  * @return Returns minimal region size in bytes. Returns zero on error.
  **************************************************************************/
@@ -205,8 +203,6 @@ uint32_t neorv32_cpu_pmp_get_granularity(void) {
 
 /**********************************************************************//**
  * Physical memory protection (PMP): Configure region.
- *
- * @note This function requires the PMP CPU extension.
  *
  * @warning This function expects a WORD address!
  *
@@ -279,6 +275,8 @@ int neorv32_cpu_pmp_configure_region(int index, uint32_t addr, uint8_t config) {
 /**********************************************************************//**
  * Hardware performance monitors (HPM): Get number of available HPM counters.
  *
+ * @warning This function overrides all available HPMCOUNTER* CSRs!
+ *
  * @return Returns number of available HPM counters.
  **************************************************************************/
 uint32_t neorv32_cpu_hpm_get_num_counters(void) {
@@ -288,24 +286,41 @@ uint32_t neorv32_cpu_hpm_get_num_counters(void) {
     return 0;
   }
 
-  // backup
-  uint32_t mcountinhibit_tmp = neorv32_cpu_csr_read(CSR_MCOUNTINHIBIT);
-
-  // try to set all HPM bits
+  // halt all HPMs
   neorv32_cpu_csr_set(CSR_MCOUNTINHIBIT, 0xfffffff8U);
 
-  // count actually set bits
-  uint32_t cnt = 0;
-  uint32_t tmp = neorv32_cpu_csr_read(CSR_MCOUNTINHIBIT) >> 3; // remove IR, TM and CY
-  while (tmp) {
-    cnt++;
-    tmp >>= 1;
-  }
+  // try to set all HPM counters to 1
+  neorv32_cpu_csr_write(CSR_MHPMCOUNTER3,  1);
+  neorv32_cpu_csr_write(CSR_MHPMCOUNTER4,  1);
+  neorv32_cpu_csr_write(CSR_MHPMCOUNTER5,  1);
+  neorv32_cpu_csr_write(CSR_MHPMCOUNTER6,  1);
+  neorv32_cpu_csr_write(CSR_MHPMCOUNTER7,  1);
+  neorv32_cpu_csr_write(CSR_MHPMCOUNTER8,  1);
+  neorv32_cpu_csr_write(CSR_MHPMCOUNTER9,  1);
+  neorv32_cpu_csr_write(CSR_MHPMCOUNTER10, 1);
+  neorv32_cpu_csr_write(CSR_MHPMCOUNTER11, 1);
+  neorv32_cpu_csr_write(CSR_MHPMCOUNTER12, 1);
+  neorv32_cpu_csr_write(CSR_MHPMCOUNTER13, 1);
+  neorv32_cpu_csr_write(CSR_MHPMCOUNTER14, 1);
+  neorv32_cpu_csr_write(CSR_MHPMCOUNTER15, 1);
 
-  // restore
-  neorv32_cpu_csr_write(CSR_MCOUNTINHIBIT, mcountinhibit_tmp);
+  // sum-up all actually set HPMs
+  uint32_t num_hpm = 0;
+  num_hpm += neorv32_cpu_csr_read(CSR_MHPMCOUNTER3);
+  num_hpm += neorv32_cpu_csr_read(CSR_MHPMCOUNTER4);
+  num_hpm += neorv32_cpu_csr_read(CSR_MHPMCOUNTER5);
+  num_hpm += neorv32_cpu_csr_read(CSR_MHPMCOUNTER6);
+  num_hpm += neorv32_cpu_csr_read(CSR_MHPMCOUNTER7);
+  num_hpm += neorv32_cpu_csr_read(CSR_MHPMCOUNTER8);
+  num_hpm += neorv32_cpu_csr_read(CSR_MHPMCOUNTER9);
+  num_hpm += neorv32_cpu_csr_read(CSR_MHPMCOUNTER10);
+  num_hpm += neorv32_cpu_csr_read(CSR_MHPMCOUNTER11);
+  num_hpm += neorv32_cpu_csr_read(CSR_MHPMCOUNTER12);
+  num_hpm += neorv32_cpu_csr_read(CSR_MHPMCOUNTER13);
+  num_hpm += neorv32_cpu_csr_read(CSR_MHPMCOUNTER14);
+  num_hpm += neorv32_cpu_csr_read(CSR_MHPMCOUNTER15);
 
-  return cnt;
+  return num_hpm;
 }
 
 


### PR DESCRIPTION
This PR further streamlines the CPU control unit by moving the entire CPU counter logic to a new rtl file: `neorv32_cpuc_counters.vhd`. So far, this new file is responsible for implementing the primary logic of the following RISC-V ISA extensions:

* `Zicntr` - base counters (`[m]cylce[h]` and `[m]instret[h]` CSRs)
* `Zihpm` - hardware performance monitors (`[m]hpmcnt*[h]` and `mhpmevent*` CSRs)