### PR TITLE
minor rtl edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 01.03.2025 | 1.11.1.7 | minor rtl / coding style edits (fixing a Vivado 2024.2 synthesis issue) | [#1193](https://github.com/stnolting/neorv32/pull/1193) |
 | 23.02.2025 | 1.11.1.6 | source-out CPU counters into a new rtl file (`neorv32_cpu_counters.vhd`) | [#1192](https://github.com/stnolting/neorv32/pull/1192) |
 | 22.02.2025 | 1.11.1.5 | minor rtl edits and cleanups | [#1191](https://github.com/stnolting/neorv32/pull/1191) |
 | 20.02.2025 | 1.11.1.4 | :bug: fix bug in `Zalrsc` ISA extension's bus request decoding | [#1190](https://github.com/stnolting/neorv32/pull/1190) |

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -347,6 +347,9 @@ end neorv32_bus_gateway;
 architecture neorv32_bus_gateway_rtl of neorv32_bus_gateway is
 
   -- port select --
+  constant a_lo_c : natural := index_size_f(A_SIZE);
+  constant b_lo_c : natural := index_size_f(B_SIZE);
+  constant c_lo_c : natural := index_size_f(C_SIZE);
   signal port_sel : std_ulogic_vector(3 downto 0);
 
   -- port enable list --
@@ -375,9 +378,9 @@ begin
 
   -- Address Section Decoder ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  port_sel(0) <= '1' when A_EN and (req_i.addr(31 downto index_size_f(A_SIZE)) = A_BASE(31 downto index_size_f(A_SIZE))) else '0';
-  port_sel(1) <= '1' when B_EN and (req_i.addr(31 downto index_size_f(B_SIZE)) = B_BASE(31 downto index_size_f(B_SIZE))) else '0';
-  port_sel(2) <= '1' when C_EN and (req_i.addr(31 downto index_size_f(C_SIZE)) = C_BASE(31 downto index_size_f(C_SIZE))) else '0';
+  port_sel(0) <= '1' when A_EN and (req_i.addr(31 downto a_lo_c) = A_BASE(31 downto a_lo_c)) else '0';
+  port_sel(1) <= '1' when B_EN and (req_i.addr(31 downto b_lo_c) = B_BASE(31 downto b_lo_c)) else '0';
+  port_sel(2) <= '1' when C_EN and (req_i.addr(31 downto c_lo_c) = C_BASE(31 downto c_lo_c)) else '0';
 
   -- accesses to the "void" are redirected to the X port --
   port_sel(3) <= '1' when X_EN and (port_sel(2 downto 0) = "000") else '0';

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -155,7 +155,7 @@ begin
   csr_o <= csr_rdata_fpu or csr_rdata_cfu;
 
   -- shift amount --
-  cp_shamt <= opb(index_size_f(XLEN)-1 downto 0);
+  cp_shamt <= opb(cp_shamt'left downto 0);
 
 
   -- ALU[I]-Opcode Co-Processor: Shifter Unit (Base ISA) ------------------------------------

--- a/rtl/core/neorv32_cpu_cp_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_cp_bitmanip.vhd
@@ -11,7 +11,7 @@
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -304,7 +304,7 @@ begin
       bs_level(i+1)(XLEN-1 downto XLEN-(2**i)) <= bs_level(i)((2**i)-1 downto 0)  when (bs_shift(i) = '1') else bs_level(i)(XLEN-1 downto XLEN-(2**i));
       bs_level(i+1)((XLEN-(2**i))-1 downto 0)  <= bs_level(i)(XLEN-1 downto 2**i) when (bs_shift(i) = '1') else bs_level(i)((XLEN-(2**i))-1 downto 0);
     end generate;
-    shifter.sreg <= bs_level(index_size_f(XLEN)); -- rol/ror[i]
+    shifter.sreg <= bs_level(bs_level'left); -- rol/ror[i]
 
     -- population count --
     shifter.bcnt <= std_ulogic_vector(to_unsigned(popcount_f(rs1_reg), shifter.bcnt'length)); -- cpop

--- a/rtl/core/neorv32_cpu_cp_shifter.vhd
+++ b/rtl/core/neorv32_cpu_cp_shifter.vhd
@@ -6,7 +6,7 @@
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -135,7 +135,7 @@ begin
       if (rstn_i = '0') then
         bs_result <= (others => '0');
       elsif rising_edge(clk_i) then
-        bs_result <= bs_level(index_size_f(XLEN));
+        bs_result <= bs_level(bs_level'left);
       end if;
     end process barrel_shifter_buf;
 

--- a/rtl/core/neorv32_dmem.vhd
+++ b/rtl/core/neorv32_dmem.vhd
@@ -6,7 +6,7 @@
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -34,6 +34,9 @@ architecture neorv32_dmem_rtl of neorv32_dmem is
 
   -- alternative memory description style --
   constant alt_style_c : boolean := false; -- [TIP] enable this if synthesis fails to infer block RAM
+
+  -- highest address bit --
+  constant addr_hi_c : natural := index_size_f(DMEM_SIZE/4)+1;
 
   -- local signals --
   signal rdata         : std_ulogic_vector(31 downto 0);
@@ -107,7 +110,7 @@ begin
   end generate;
 
   -- word aligned access address --
-  addr <= unsigned(bus_req_i.addr(index_size_f(DMEM_SIZE/4)+1 downto 2));
+  addr <= unsigned(bus_req_i.addr(addr_hi_c downto 2));
 
 
   -- Bus Response ---------------------------------------------------------------------------

--- a/rtl/core/neorv32_imem.vhd
+++ b/rtl/core/neorv32_imem.vhd
@@ -6,7 +6,7 @@
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -36,6 +36,9 @@ architecture neorv32_imem_rtl of neorv32_imem is
 
   -- alternative memory description style --
   constant alt_style_c : boolean := false; -- [TIP] enable this if synthesis fails to infer block RAM
+
+  -- highest address bit --
+  constant addr_hi_c : natural := index_size_f(IMEM_SIZE/4)+1;
 
   -- ROM - initialized with executable code --
   constant mem_rom_c : mem32_t(0 to IMEM_SIZE/4-1) := mem32_init_f(application_init_image_c, IMEM_SIZE/4);
@@ -95,7 +98,7 @@ begin
   end generate;
 
   -- word aligned access address --
-  addr <= unsigned(bus_req_i.addr(index_size_f(IMEM_SIZE/4)+1 downto 2));
+  addr <= unsigned(bus_req_i.addr(addr_hi_c downto 2));
 
 
   -- Implement IMEM as non-initialized RAM --------------------------------------------------

--- a/rtl/core/neorv32_neoled.vhd
+++ b/rtl/core/neorv32_neoled.vhd
@@ -54,6 +54,9 @@ architecture neorv32_neoled_rtl of neorv32_neoled is
   constant ctrl_tx_full_c  : natural := 30; -- r/-: TX FIFO is full
   constant ctrl_tx_busy_c  : natural := 31; -- r/-: serial TX engine busy when set
 
+  -- helpers --
+  constant log2_fifo_size_c : natural := index_size_f(FIFO_DEPTH);
+
   -- control register --
   type ctrl_t is record
     enable   : std_ulogic;
@@ -139,7 +142,7 @@ begin
           bus_rsp_o.data(ctrl_strobe_c)                        <= ctrl.strobe;
           bus_rsp_o.data(ctrl_clksel2_c downto ctrl_clksel0_c) <= ctrl.clk_prsc;
           bus_rsp_o.data(ctrl_irq_conf_c)                      <= ctrl.irq_conf or bool_to_ulogic_f(boolean(FIFO_DEPTH = 1)); -- tie to one if FIFO_DEPTH is 1
-          bus_rsp_o.data(ctrl_bufs_3_c  downto ctrl_bufs_0_c)  <= std_ulogic_vector(to_unsigned(index_size_f(FIFO_DEPTH), 4));
+          bus_rsp_o.data(ctrl_bufs_3_c  downto ctrl_bufs_0_c)  <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
           bus_rsp_o.data(ctrl_t_tot_4_c downto ctrl_t_tot_0_c) <= ctrl.t_total;
           bus_rsp_o.data(ctrl_t_0h_4_c  downto ctrl_t_0h_0_c)  <= ctrl.t0_high;
           bus_rsp_o.data(ctrl_t_1h_4_c  downto ctrl_t_1h_0_c)  <= ctrl.t1_high;

--- a/rtl/core/neorv32_onewire.vhd
+++ b/rtl/core/neorv32_onewire.vhd
@@ -73,6 +73,9 @@ architecture neorv32_onewire_rtl of neorv32_onewire is
   constant cmd_byt_c : std_ulogic_vector(1 downto 0) := "10"; -- trigger full-byte transmission
   constant cmd_rst_c : std_ulogic_vector(1 downto 0) := "11"; -- trigger reset pulse and sample presence
 
+  -- helpers --
+  constant log2_fifo_size_c : natural := index_size_f(ONEWIRE_FIFO);
+
   -- control register --
   type ctrl_t is record
     enable    : std_ulogic;
@@ -148,7 +151,7 @@ begin
           bus_rsp_o.data(ctrl_prsc1_c downto ctrl_prsc0_c)     <= ctrl.clk_prsc;
           bus_rsp_o.data(ctrl_clkdiv7_c downto ctrl_clkdiv0_c) <= ctrl.clk_div;
           --
-          bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(index_size_f(ONEWIRE_FIFO), 4));
+          bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
           --
           bus_rsp_o.data(ctrl_tx_full_c)  <= not fifo.tx_free;
           bus_rsp_o.data(ctrl_rx_avail_c) <= fifo.rx_avail;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110106"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110107"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_sdi.vhd
+++ b/rtl/core/neorv32_sdi.vhd
@@ -57,6 +57,9 @@ architecture neorv32_sdi_rtl of neorv32_sdi is
   --
   constant ctrl_cs_active_c    : natural := 31; -- r/-: chip-select is active when set
 
+  -- helpers --
+  constant log2_fifo_size_c : natural := index_size_f(RTX_FIFO);
+
   -- control register (see bit definitions above) --
   type ctrl_t is record
     enable       : std_ulogic;
@@ -139,7 +142,7 @@ begin
           if (bus_req_i.addr(2) = '0') then -- control register
             bus_rsp_o.data(ctrl_en_c) <= ctrl.enable;
             --
-            bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(index_size_f(RTX_FIFO), 4));
+            bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
             --
             bus_rsp_o.data(ctrl_irq_rx_avail_c) <= ctrl.irq_rx_avail;
             bus_rsp_o.data(ctrl_irq_rx_half_c)  <= ctrl.irq_rx_half;

--- a/rtl/core/neorv32_slink.vhd
+++ b/rtl/core/neorv32_slink.vhd
@@ -79,6 +79,10 @@ architecture neorv32_slink_rtl of neorv32_slink is
   constant ctrl_tx_fifo_size2_c : natural := 30; -- r/-: log2(TX fifo size), bit 2
   constant ctrl_tx_fifo_size3_c : natural := 31; -- r/-: log2(TX fifo size), bit 3 (msb)
 
+  -- helpers --
+  constant log2_rx_fifo_c : natural := index_size_f(SLINK_RX_FIFO);
+  constant log2_tx_fifo_c : natural := index_size_f(SLINK_TX_FIFO);
+
   -- control register --
   type ctrl_t is record
     enable                      : std_ulogic;
@@ -178,8 +182,8 @@ begin
               bus_rsp_o.data(ctrl_irq_tx_nhalf_c)  <= ctrl.irq_tx_nhalf;
               bus_rsp_o.data(ctrl_irq_tx_nfull_c)  <= ctrl.irq_tx_nfull;
               --
-              bus_rsp_o.data(ctrl_rx_fifo_size3_c downto ctrl_rx_fifo_size0_c) <= std_ulogic_vector(to_unsigned(index_size_f(SLINK_RX_FIFO), 4));
-              bus_rsp_o.data(ctrl_tx_fifo_size3_c downto ctrl_tx_fifo_size0_c) <= std_ulogic_vector(to_unsigned(index_size_f(SLINK_TX_FIFO), 4));
+              bus_rsp_o.data(ctrl_rx_fifo_size3_c downto ctrl_rx_fifo_size0_c) <= std_ulogic_vector(to_unsigned(log2_rx_fifo_c, 4));
+              bus_rsp_o.data(ctrl_tx_fifo_size3_c downto ctrl_tx_fifo_size0_c) <= std_ulogic_vector(to_unsigned(log2_tx_fifo_c, 4));
             when "01" => -- routing information
               bus_rsp_o.data(3 downto 0) <= route_dst;
               bus_rsp_o.data(7 downto 4) <= route_src;

--- a/rtl/core/neorv32_spi.vhd
+++ b/rtl/core/neorv32_spi.vhd
@@ -65,6 +65,9 @@ architecture neorv32_spi_rtl of neorv32_spi is
   constant ctrl_cs_active_c    : natural := 30; -- r/-: a chip-select line is active when set
   constant ctrl_busy_c         : natural := 31; -- r/-: spi phy busy or tx fifo not empty yet
 
+  -- helpers --
+  constant log2_fifo_size_c : natural := index_size_f(IO_SPI_FIFO);
+
   -- control register --
   type ctrl_t is record
     enable       : std_ulogic;
@@ -163,7 +166,7 @@ begin
             bus_rsp_o.data(ctrl_irq_tx_nhalf_c) <= ctrl.irq_tx_nhalf;
             bus_rsp_o.data(ctrl_irq_idle_c)     <= ctrl.irq_idle;
             --
-            bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(index_size_f(IO_SPI_FIFO), 4));
+            bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
             --
             bus_rsp_o.data(ctrl_cs_active_c) <= rtx_engine.cs_ctrl(3);
             bus_rsp_o.data(ctrl_busy_c)      <= rtx_engine.busy or tx_fifo.avail;

--- a/rtl/core/neorv32_sysinfo.vhd
+++ b/rtl/core/neorv32_sysinfo.vhd
@@ -73,6 +73,15 @@ architecture neorv32_sysinfo_rtl of neorv32_sysinfo is
   constant xcache_en_c    : boolean := XBUS_EN and XBUS_CACHE_EN;
   constant ocd_auth_en_c  : boolean := OCD_EN and OCD_AUTHENTICATION;
   constant int_imem_rom_c : boolean := int_imem_en_c and MEM_INT_IMEM_ROM;
+  --
+  constant log2_imem_size_c : natural := index_size_f(MEM_INT_IMEM_SIZE);
+  constant log2_dmem_size_c : natural := index_size_f(MEM_INT_DMEM_SIZE);
+  constant log2_ic_bsize_c  : natural := index_size_f(ICACHE_BLOCK_SIZE);
+  constant log2_ic_bnum_c   : natural := index_size_f(ICACHE_NUM_BLOCKS);
+  constant log2_dc_bsize_c  : natural := index_size_f(DCACHE_BLOCK_SIZE);
+  constant log2_dc_bnum_c   : natural := index_size_f(DCACHE_NUM_BLOCKS);
+  constant log2_xc_bsize_c  : natural := index_size_f(XBUS_CACHE_BLOCK_SIZE);
+  constant log2_xc_bnum_c   : natural := index_size_f(XBUS_CACHE_NUM_BLOCKS);
 
   -- system information memory --
   type sysinfo_t is array (0 to 3) of std_ulogic_vector(31 downto 0);
@@ -99,8 +108,8 @@ begin
   end process sysinfo_0_write;
 
   -- SYSINFO(1): Misc --
-  sysinfo(1)(7  downto 0)  <= std_ulogic_vector(to_unsigned(index_size_f(MEM_INT_IMEM_SIZE), 8)); -- log2(IMEM size)
-  sysinfo(1)(15 downto 8)  <= std_ulogic_vector(to_unsigned(index_size_f(MEM_INT_DMEM_SIZE), 8)); -- log2(DMEM size)
+  sysinfo(1)(7  downto 0)  <= std_ulogic_vector(to_unsigned(log2_imem_size_c, 8)); -- log2(IMEM size)
+  sysinfo(1)(15 downto 8)  <= std_ulogic_vector(to_unsigned(log2_dmem_size_c, 8)); -- log2(DMEM size)
   sysinfo(1)(23 downto 16) <= std_ulogic_vector(to_unsigned(NUM_HARTS, 8)); -- number of physical CPU cores
   sysinfo(1)(31 downto 24) <= std_ulogic_vector(to_unsigned(BOOT_MODE_SELECT, 8)); -- boot configuration
 
@@ -139,17 +148,17 @@ begin
   sysinfo(2)(31) <= '1' when IO_CRC_EN         else '0'; -- cyclic redundancy check unit (CRC) implemented?
 
   -- SYSINFO(3): Cache Configuration --
-  sysinfo(3)(3 downto 0)   <= std_ulogic_vector(to_unsigned(index_size_f(ICACHE_BLOCK_SIZE), 4)) when ICACHE_EN else (others => '0'); -- i-cache: log2(block_size_in_bytes)
-  sysinfo(3)(7 downto 4)   <= std_ulogic_vector(to_unsigned(index_size_f(ICACHE_NUM_BLOCKS), 4)) when ICACHE_EN else (others => '0'); -- i-cache: log2(number_of_block)
+  sysinfo(3)(3 downto 0)   <= std_ulogic_vector(to_unsigned(log2_ic_bsize_c, 4)) when ICACHE_EN else (others => '0'); -- i-cache: log2(block_size_in_bytes)
+  sysinfo(3)(7 downto 4)   <= std_ulogic_vector(to_unsigned(log2_ic_bnum_c, 4))  when ICACHE_EN else (others => '0'); -- i-cache: log2(number_of_block)
   --
-  sysinfo(3)(11 downto 8)  <= std_ulogic_vector(to_unsigned(index_size_f(DCACHE_BLOCK_SIZE), 4)) when DCACHE_EN else (others => '0'); -- d-cache: log2(block_size)
-  sysinfo(3)(15 downto 12) <= std_ulogic_vector(to_unsigned(index_size_f(DCACHE_NUM_BLOCKS), 4)) when DCACHE_EN else (others => '0'); -- d-cache: log2(num_blocks)
+  sysinfo(3)(11 downto 8)  <= std_ulogic_vector(to_unsigned(log2_dc_bsize_c, 4)) when DCACHE_EN else (others => '0'); -- d-cache: log2(block_size)
+  sysinfo(3)(15 downto 12) <= std_ulogic_vector(to_unsigned(log2_dc_bnum_c, 4))  when DCACHE_EN else (others => '0'); -- d-cache: log2(num_blocks)
   --
   sysinfo(3)(19 downto 16) <= (others => '0'); -- reserved
   sysinfo(3)(23 downto 20) <= (others => '0'); -- reserved
   --
-  sysinfo(3)(27 downto 24) <= std_ulogic_vector(to_unsigned(index_size_f(XBUS_CACHE_BLOCK_SIZE), 4)) when xcache_en_c else (others => '0'); -- xbus-cache: log2(block_size_in_bytes)
-  sysinfo(3)(31 downto 28) <= std_ulogic_vector(to_unsigned(index_size_f(XBUS_CACHE_NUM_BLOCKS), 4)) when xcache_en_c else (others => '0'); -- xbus-cache: log2(number_of_block)
+  sysinfo(3)(27 downto 24) <= std_ulogic_vector(to_unsigned(log2_xc_bsize_c, 4)) when xcache_en_c else (others => '0'); -- xbus-cache: log2(block_size_in_bytes)
+  sysinfo(3)(31 downto 28) <= std_ulogic_vector(to_unsigned(log2_xc_bnum_c, 4))  when xcache_en_c else (others => '0'); -- xbus-cache: log2(number_of_block)
 
 
   -- Bus Access -----------------------------------------------------------------------------

--- a/rtl/core/neorv32_trng.vhd
+++ b/rtl/core/neorv32_trng.vhd
@@ -48,6 +48,9 @@ architecture neorv32_trng_rtl of neorv32_trng is
   constant ctrl_data_lsb_c : natural := 0; -- r/-: random data bit 0, LSB
   constant ctrl_data_msb_c : natural := 7; -- r/-: random data bit 7, MSB
 
+  -- helpers --
+  constant log2_fifo_size_c : natural := index_size_f(TRNG_FIFO);
+
   -- neoTRNG true random number generator --
   component neoTRNG
     generic (
@@ -104,7 +107,7 @@ begin
         else -- read access
           if (bus_req_i.addr(2) = '0') then -- control register
             bus_rsp_o.data(ctrl_en_c)                                  <= enable;
-            bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(index_size_f(TRNG_FIFO), 4));
+            bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
             bus_rsp_o.data(ctrl_sim_mode_c)                            <= bool_to_ulogic_f(is_simulation_c);
             bus_rsp_o.data(ctrl_avail_c)                               <= fifo.avail;
           else -- data register

--- a/rtl/core/neorv32_twd.vhd
+++ b/rtl/core/neorv32_twd.vhd
@@ -58,6 +58,9 @@ architecture neorv32_twd_rtl of neorv32_twd is
   constant ctrl_sense_sda_c    : natural := 30; -- r/-: current state of the SDA bus line
   constant ctrl_busy_c         : natural := 31; -- r/-: bus engine is busy (transaction in progress)
 
+  -- helpers --
+  constant log2_fifo_size_c : natural := index_size_f(TWD_FIFO);
+
   -- control register --
   type ctrl_t is record
     enable       : std_ulogic;
@@ -159,7 +162,7 @@ begin
             bus_rsp_o.data(ctrl_irq_rx_full_c)                         <= ctrl.irq_rx_full;
             bus_rsp_o.data(ctrl_irq_tx_empty_c)                        <= ctrl.irq_tx_empty;
             --
-            bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(index_size_f(TWD_FIFO), 4));
+            bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
             bus_rsp_o.data(ctrl_rx_avail_c)                            <= rx_fifo.avail;
             bus_rsp_o.data(ctrl_rx_full_c)                             <= not rx_fifo.free;
             bus_rsp_o.data(ctrl_tx_empty_c)                            <= not tx_fifo.avail;

--- a/rtl/core/neorv32_twi.vhd
+++ b/rtl/core/neorv32_twi.vhd
@@ -60,6 +60,9 @@ architecture neorv32_twi_rtl of neorv32_twi is
   constant dcmd_cmd_lo_c : natural :=  9; -- -/w: operation command; 00=NOP, 01=START
   constant dcmd_cmd_hi_c : natural := 10; -- -/w: operation command; 10=STOP, 11=DATA
 
+  -- helpers --
+  constant log2_fifo_size_c : natural := index_size_f(IO_TWI_FIFO);
+
   -- control register --
   type ctrl_t is record
     enable : std_ulogic;
@@ -142,7 +145,7 @@ begin
             bus_rsp_o.data(ctrl_cdiv3_c downto ctrl_cdiv0_c) <= ctrl.cdiv;
             bus_rsp_o.data(ctrl_clkstr_en_c)                 <= ctrl.clkstr;
             --
-            bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(index_size_f(IO_TWI_FIFO), 4));
+            bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
             --
             bus_rsp_o.data(ctrl_sense_scl_c) <= io_con.scl_in_ff(1);
             bus_rsp_o.data(ctrl_sense_sda_c) <= io_con.sda_in_ff(1);

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -83,6 +83,10 @@ architecture neorv32_uart_rtl of neorv32_uart is
   constant data_tx_fifo_size_lsb : natural := 12; -- r/-: log2(TX fifo size) LSB
   constant data_tx_fifo_size_msb : natural := 15; -- r/-: log2(TX fifo size) MSB
 
+  -- helpers --
+  constant log2_rx_fifo_c : natural := index_size_f(UART_RX_FIFO);
+  constant log2_tx_fifo_c : natural := index_size_f(UART_TX_FIFO);
+
   -- clock generator --
   signal uart_clk : std_ulogic;
 
@@ -211,8 +215,8 @@ begin
             bus_rsp_o.data(ctrl_tx_busy_c)                   <= tx_engine.busy or tx_fifo.avail;
           else -- data register
             bus_rsp_o.data(data_rtx_msb_c        downto data_rtx_lsb_c)        <= rx_fifo.rdata;
-            bus_rsp_o.data(data_rx_fifo_size_msb downto data_rx_fifo_size_lsb) <= std_ulogic_vector(to_unsigned(index_size_f(UART_RX_FIFO), 4));
-            bus_rsp_o.data(data_tx_fifo_size_msb downto data_tx_fifo_size_lsb) <= std_ulogic_vector(to_unsigned(index_size_f(UART_TX_FIFO), 4));
+            bus_rsp_o.data(data_rx_fifo_size_msb downto data_rx_fifo_size_lsb) <= std_ulogic_vector(to_unsigned(log2_rx_fifo_c, 4));
+            bus_rsp_o.data(data_tx_fifo_size_msb downto data_tx_fifo_size_lsb) <= std_ulogic_vector(to_unsigned(log2_tx_fifo_c, 4));
           end if;
         end if;
 

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -118,6 +118,7 @@ proc setup_ip_gui {} {
   # **************************************************************
   # Interfaces: Configuration Dependencies
   # **************************************************************
+  set_property enablement_dependency {$OCD_EN}        [ipx::get_ports jtag_*           -of_objects [ipx::current_core]]
   set_property enablement_dependency {$OCD_EN}        [ipx::get_ports ocd_resetn       -of_objects [ipx::current_core]]
   set_property enablement_dependency {$IO_WDT_EN}     [ipx::get_ports wdt_resetn       -of_objects [ipx::current_core]]
   set_property enablement_dependency {$IO_SLINK_EN}   [ipx::get_bus_interfaces s0_axis -of_objects [ipx::current_core]]
@@ -138,23 +139,6 @@ proc setup_ip_gui {} {
   set_property enablement_dependency {!$IO_CLINT_EN}  [ipx::get_ports mtime_irq_i      -of_objects [ipx::current_core]]
   set_property enablement_dependency {!$IO_CLINT_EN}  [ipx::get_ports msw_irq_i        -of_objects [ipx::current_core]]
 
-  # **************************************************************
-  # Interfaces: Add JTAG as standard interface
-  # **************************************************************
-  ipx::add_bus_interface JTAG [ipx::current_core]
-  set_property abstraction_type_vlnv xilinx.com:interface:jtag_rtl:2.0 [ipx::get_bus_interfaces JTAG -of_objects [ipx::current_core]]
-  set_property bus_type_vlnv xilinx.com:interface:jtag:2.0 [ipx::get_bus_interfaces JTAG -of_objects [ipx::current_core]]
-  set_property display_name JTAG [ipx::get_bus_interfaces JTAG -of_objects [ipx::current_core]]
-  set_property description {JTAG tap of the on-chip debugger} [ipx::get_bus_interfaces JTAG -of_objects [ipx::current_core]]
-  set_property enablement_dependency {$OCD_EN} [ipx::get_bus_interfaces JTAG -of_objects [ipx::current_core]]
-  ipx::add_port_map TDI [ipx::get_bus_interfaces JTAG -of_objects [ipx::current_core]]
-  set_property physical_name jtag_tdi_i [ipx::get_port_maps TDI -of_objects [ipx::get_bus_interfaces JTAG -of_objects [ipx::current_core]]]
-  ipx::add_port_map TMS [ipx::get_bus_interfaces JTAG -of_objects [ipx::current_core]]
-  set_property physical_name jtag_tms_i [ipx::get_port_maps TMS -of_objects [ipx::get_bus_interfaces JTAG -of_objects [ipx::current_core]]]
-  ipx::add_port_map TCK [ipx::get_bus_interfaces JTAG -of_objects [ipx::current_core]]
-  set_property physical_name jtag_tck_i [ipx::get_port_maps TCK -of_objects [ipx::get_bus_interfaces JTAG -of_objects [ipx::current_core]]]
-  ipx::add_port_map TDO [ipx::get_bus_interfaces JTAG -of_objects [ipx::current_core]]
-  set_property physical_name jtag_tdo_o [ipx::get_port_maps TDO -of_objects [ipx::get_bus_interfaces JTAG -of_objects [ipx::current_core]]]
 
   # **************************************************************
   # Configuration pages

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -87,7 +87,7 @@ entity neorv32_vivado_ip is
     DCACHE_NUM_BLOCKS     : natural range 1 to 256         := 4;
     DCACHE_BLOCK_SIZE     : natural range 4 to 2**16       := 64;
     -- External Bus Interface --
-    XBUS_EN               : boolean                        := true;
+    XBUS_EN               : boolean                        := false;
     XBUS_REGSTAGE_EN      : boolean                        := false;
     XBUS_CACHE_EN         : boolean                        := false;
     XBUS_CACHE_NUM_BLOCKS : natural range 1 to 256         := 8;


### PR DESCRIPTION
Remove `index_size_f` function from the actual logic. Now it is used for initializing constants only.

The `for i in 0 to natural'high loop` seems to cause synthesis issues with Vivado 2024.2.