### PR TITLE
rtl: processor_templates: enable Zicntr ISA extension on minimal templates

### DIFF
--- a/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_Minimal.vhd
@@ -51,6 +51,8 @@ begin
     CLOCK_FREQUENCY              => CLOCK_FREQUENCY,   -- clock frequency of clk_i in Hz
     -- Boot Configuration --
     BOOT_MODE_SELECT             => 2,                 -- boot from pre-initialized interal IMEM
+    -- RISC-V CPU Extensions --
+    RISCV_ISA_Zicntr  => true,                         -- implement base counters?
     -- Internal Instruction memory --
     MEM_INT_IMEM_EN              => MEM_INT_IMEM_EN,   -- implement processor-internal instruction memory
     MEM_INT_IMEM_SIZE            => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes

--- a/rtl/processor_templates/neorv32_ProcessorTop_MinimalBoot.vhd
+++ b/rtl/processor_templates/neorv32_ProcessorTop_MinimalBoot.vhd
@@ -57,6 +57,8 @@ begin
     CLOCK_FREQUENCY   => CLOCK_FREQUENCY,   -- clock frequency of clk_i in Hz
     -- Boot Configuration --
     BOOT_MODE_SELECT  => 0,                 -- boot via internal bootloader
+    -- RISC-V CPU Extensions --
+    RISCV_ISA_Zicntr  => true,              -- implement base counters?
     -- Internal Instruction memory --
     MEM_INT_IMEM_EN   => MEM_INT_IMEM_EN,   -- implement processor-internal instruction memory
     MEM_INT_IMEM_SIZE => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes


### PR DESCRIPTION
Re-enable the Zicntr ISA extension on the neorv32_ProcessorTop_Minimal and neorv32_ProcessorTop_MinimalBoot templates to restore RISC-V compliance.

This allows for an easier path for evaluating 3rd party software depending on Zicntr (e.g. the Zephyr RTOS).