### PR TITLE
Fix: quote readlink to fix windows make check

### DIFF
--- a/sw/common/common.mk
+++ b/sw/common/common.mk
@@ -281,7 +281,7 @@ endif
 	@echo "NEORV32_HOME: $(NEORV32_HOME)"
 	@echo "---------------- Check: Shell ----------------"
 	@echo ${SHELL}
-	@readlink -f ${SHELL}
+	@readlink -f "${SHELL}"
 	@echo "---------------- Check: $(CC) ----------------"
 	@$(CC) -v
 	@echo "---------------- Check: $(OBJDUMP) ----------------"


### PR DESCRIPTION
`@readlink -f ${SHELL}` means `@readlink -f C:\Program Files\Git\usr\bin\sh.exe` on windows, so we need to escape the path to account for the space