### PR TITLE
fix: increment location counter with heap size

### DIFF
--- a/sw/common/neorv32.ld
+++ b/sw/common/neorv32.ld
@@ -190,7 +190,7 @@ SECTIONS
     PROVIDE(__heap_start = .);
     /* start section on WORD boundary */
     . = ALIGN(4);
-    . = __neorv32_heap_size;
+    . += __neorv32_heap_size;
     /* finish section on WORD boundary */
     . = ALIGN(4);
     PROVIDE(__heap_end = .);


### PR DESCRIPTION
The heap section **sets** the location counter to `__neorv32_heap_size` instead of incrementing it. 

I discovered this one when `rust-lld` failed with an error while creating a runtime support crate for neorv32 in Rust.

