### PR TITLE
:bug: Fix `Zbb` shift instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 14.03.2025 | 1.11.1.9 | :bug: fix broken shift instructions of `Zbb` ISA extension (when `Zbkc` and `CPU_FAST_SHIFT_EN` are both disabled) | [#1206](https://github.com/stnolting/neorv32/pull/1206) |
 | 02.03.2025 | 1.11.1.8 | :warning: remove DMA FIRQ-triggered auto mode; :warning: remove GPTMR mode configuration bit | [#1194](https://github.com/stnolting/neorv32/pull/1194) |
 | 01.03.2025 | 1.11.1.7 | minor rtl / coding style edits (fixing a Vivado 2024.2 synthesis issue) | [#1193](https://github.com/stnolting/neorv32/pull/1193) |
 | 23.02.2025 | 1.11.1.6 | source-out CPU counters into a new rtl file (`neorv32_cpu_counters.vhd`) | [#1192](https://github.com/stnolting/neorv32/pull/1192) |

--- a/rtl/core/neorv32_cpu_cp_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_cp_bitmanip.vhd
@@ -379,7 +379,7 @@ begin
   if not EN_ZBKC generate
     clmul.cnt <= (others => '0');
     clmul.res <= (others => '0');
-    clmul.run <= '1';
+    clmul.run <= '0';
   end generate;
 
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110108"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110109"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 


### PR DESCRIPTION
The shift operations of the `Zbb` instructions caused a permanent ALU stall (and thus, a timeout leading to an illegal instruction exception) when `CPU_FAST_SHIFT_EN` and `RISCV_ISA_Zbkc` are both disabled.

Bug discovered by @ecstrema in https://github.com/stnolting/neorv32/issues/640#issuecomment-2724946979.