### PR TITLE
:warning: rename SPI & TWI transfer functions

### DIFF
--- a/sw/bootloader/bootloader.c
+++ b/sw/bootloader/bootloader.c
@@ -767,7 +767,7 @@ void spi_flash_wakeup(void) {
 
 #if (SPI_EN != 0)
   neorv32_spi_cs_en(SPI_FLASH_CS);
-  neorv32_spi_trans(SPI_FLASH_CMD_WAKE);
+  neorv32_spi_transfer(SPI_FLASH_CMD_WAKE);
   neorv32_spi_cs_dis();
 #endif
 }
@@ -815,9 +815,9 @@ uint8_t spi_flash_read_byte(uint32_t addr) {
 #if (SPI_EN != 0)
   neorv32_spi_cs_en(SPI_FLASH_CS);
 
-  neorv32_spi_trans(SPI_FLASH_CMD_READ);
+  neorv32_spi_transfer(SPI_FLASH_CMD_READ);
   spi_flash_write_addr(addr);
-  uint8_t rdata = neorv32_spi_trans(0);
+  uint8_t rdata = neorv32_spi_transfer(0);
 
   neorv32_spi_cs_dis();
 
@@ -841,9 +841,9 @@ void spi_flash_write_byte(uint32_t addr, uint8_t wdata) {
 
   neorv32_spi_cs_en(SPI_FLASH_CS);
 
-  neorv32_spi_trans(SPI_FLASH_CMD_PAGE_PROGRAM);
+  neorv32_spi_transfer(SPI_FLASH_CMD_PAGE_PROGRAM);
   spi_flash_write_addr(addr);
-  neorv32_spi_trans(wdata);
+  neorv32_spi_transfer(wdata);
 
   neorv32_spi_cs_dis();
 
@@ -893,7 +893,7 @@ void spi_flash_erase_sector(uint32_t addr) {
 
   neorv32_spi_cs_en(SPI_FLASH_CS);
 
-  neorv32_spi_trans(SPI_FLASH_CMD_SECTOR_ERASE);
+  neorv32_spi_transfer(SPI_FLASH_CMD_SECTOR_ERASE);
   spi_flash_write_addr(addr);
 
   neorv32_spi_cs_dis();
@@ -914,7 +914,7 @@ void spi_flash_write_enable(void) {
 
 #if (SPI_EN != 0)
   neorv32_spi_cs_en(SPI_FLASH_CS);
-  neorv32_spi_trans(SPI_FLASH_CMD_WRITE_ENABLE);
+  neorv32_spi_transfer(SPI_FLASH_CMD_WRITE_ENABLE);
   neorv32_spi_cs_dis();
 #endif
 }
@@ -927,7 +927,7 @@ void spi_flash_write_disable(void) {
 
 #if (SPI_EN != 0)
   neorv32_spi_cs_en(SPI_FLASH_CS);
-  neorv32_spi_trans(SPI_FLASH_CMD_WRITE_DISABLE);
+  neorv32_spi_transfer(SPI_FLASH_CMD_WRITE_DISABLE);
   neorv32_spi_cs_dis();
 #endif
 }
@@ -943,8 +943,8 @@ uint8_t spi_flash_read_status(void) {
 #if (SPI_EN != 0)
   neorv32_spi_cs_en(SPI_FLASH_CS);
 
-  neorv32_spi_trans(SPI_FLASH_CMD_READ_STATUS);
-  uint8_t res = neorv32_spi_trans(0);
+  neorv32_spi_transfer(SPI_FLASH_CMD_READ_STATUS);
+  uint8_t res = neorv32_spi_transfer(0);
 
   neorv32_spi_cs_dis();
 
@@ -974,17 +974,17 @@ void spi_flash_write_addr(uint32_t addr) {
   address.uint32 = addr;
 
 #if (SPI_FLASH_ADDR_BYTES == 2)
-  neorv32_spi_trans(address.uint8[1]);
-  neorv32_spi_trans(address.uint8[0]);
+  neorv32_spi_transfer(address.uint8[1]);
+  neorv32_spi_transfer(address.uint8[0]);
 #elif (SPI_FLASH_ADDR_BYTES == 3)
-  neorv32_spi_trans(address.uint8[2]);
-  neorv32_spi_trans(address.uint8[1]);
-  neorv32_spi_trans(address.uint8[0]);
+  neorv32_spi_transfer(address.uint8[2]);
+  neorv32_spi_transfer(address.uint8[1]);
+  neorv32_spi_transfer(address.uint8[0]);
 #elif (SPI_FLASH_ADDR_BYTES == 4)
-  neorv32_spi_trans(address.uint8[3]);
-  neorv32_spi_trans(address.uint8[2]);
-  neorv32_spi_trans(address.uint8[1]);
-  neorv32_spi_trans(address.uint8[0]);
+  neorv32_spi_transfer(address.uint8[3]);
+  neorv32_spi_transfer(address.uint8[2]);
+  neorv32_spi_transfer(address.uint8[1]);
+  neorv32_spi_transfer(address.uint8[0]);
 #else
   #error "Unsupported SPI_FLASH_ADDR_BYTES configuration!"
 #endif
@@ -1023,17 +1023,17 @@ uint32_t twi_read_addr(uint32_t addr) {
 
   // Send device addr
   transfer = device_id << 1;
-  device_nack |= neorv32_twi_trans(&transfer, 0);
+  device_nack |= neorv32_twi_transfer(&transfer, 0);
 
   // Send read address
 #if (TWI_ADDR_BYTES == 1)
   transfer = address.uint8[0];
-  device_nack |= neorv32_twi_trans(&transfer, 0);
+  device_nack |= neorv32_twi_transfer(&transfer, 0);
 #elif (TWI_ADDR_BYTES == 2)
   transfer = address.uint8[1];
-  device_nack |= neorv32_twi_trans(&transfer, 0);
+  device_nack |= neorv32_twi_transfer(&transfer, 0);
   transfer = address.uint8[0];
-  device_nack |= neorv32_twi_trans(&transfer, 0);
+  device_nack |= neorv32_twi_transfer(&transfer, 0);
 #else
   #error "Unsupported TWI_ADDR_BYTES configuration!"
 #endif
@@ -1047,7 +1047,7 @@ uint32_t twi_read_addr(uint32_t addr) {
   // Send device addr with read flag
   transfer = device_id << 1;
   transfer |= 0x01;
-  device_nack |= neorv32_twi_trans(&transfer, 0);
+  device_nack |= neorv32_twi_transfer(&transfer, 0);
 
   if (device_nack)
   {
@@ -1058,12 +1058,12 @@ uint32_t twi_read_addr(uint32_t addr) {
   for (uint8_t i = 0; i <= 2; i++)
   {
     transfer = 0xFF;
-    neorv32_twi_trans(&transfer, 1); // ACK by master
+    neorv32_twi_transfer(&transfer, 1); // ACK by master
     data.uint8[i] = transfer;
   }
   // Last read with NACK by master
   transfer = 0xFF;
-  neorv32_twi_trans(&transfer, 0); // NACK by master
+  neorv32_twi_transfer(&transfer, 0); // NACK by master
   data.uint8[3] = transfer;
 
   neorv32_twi_generate_stop();

--- a/sw/example/demo_spi/main.c
+++ b/sw/example/demo_spi/main.c
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,7 +9,6 @@
 
 /**********************************************************************//**
  * @file demo_spi/main.c
- * @author Stephan Nolting
  * @brief SPI bus explorer (execute SPI transactions by hand).
  **************************************************************************/
 
@@ -31,7 +30,7 @@ uint32_t spi_configured;
 
 // Prototypes
 void spi_cs(uint32_t type);
-void spi_trans(void);
+void spi_transfer(void);
 void spi_setup(void);
 void aux_print_hex_byte(uint8_t byte);
 
@@ -111,7 +110,7 @@ int main() {
       spi_cs(0);
     }
     else if (!strcmp(buffer, "trans")) {
-      spi_trans();
+      spi_transfer();
     }
     else {
       neorv32_uart0_printf("Invalid command. Type 'help' to see all commands.\n");
@@ -163,7 +162,7 @@ void spi_cs(uint32_t type) {
 /**********************************************************************//**
  * SPI data transfer
  **************************************************************************/
-void spi_trans(void) {
+void spi_transfer(void) {
 
   char terminal_buffer[4];
 
@@ -176,7 +175,7 @@ void spi_trans(void) {
   neorv32_uart0_scan(terminal_buffer, 2+1, 1);
   uint32_t tx_data = (uint32_t)neorv32_aux_hexstr2uint64(terminal_buffer, strlen(terminal_buffer));
 
-  uint32_t rx_data = neorv32_spi_trans(tx_data);
+  uint32_t rx_data = neorv32_spi_transfer(tx_data);
 
   neorv32_uart0_printf("\nTX data: 0x");
   aux_print_hex_byte(tx_data);

--- a/sw/example/demo_twi/main.c
+++ b/sw/example/demo_twi/main.c
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -9,7 +9,6 @@
 
 /**********************************************************************//**
  * @file demo_twi/main.c
- * @author Stephan Nolting
  * @brief TWI bus explorer.
  **************************************************************************/
 
@@ -197,7 +196,7 @@ void scan_twi(void) {
   for (i=0; i<128; i++) {
     neorv32_twi_generate_start();
     uint8_t tmp = 2*i + 1;
-    twi_ack = neorv32_twi_trans(&tmp, 0);
+    twi_ack = neorv32_twi_transfer(&tmp, 0);
     neorv32_twi_generate_stop();
 
     if (twi_ack == 0) {
@@ -241,7 +240,7 @@ void send_twi(void) {
   }
 
   // execute transmission (blocking)
-  device_ack = neorv32_twi_trans(&data, host_ack);
+  device_ack = neorv32_twi_transfer(&data, host_ack);
 
   neorv32_uart0_printf("\n RX data:  0x");
   print_hex_byte(data);

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -9,7 +9,6 @@
 
 /**********************************************************************//**
  * @file processor_check/main.c
- * @author Stephan Nolting
  * @brief CPU/Processor test/verification program.
  **************************************************************************/
 
@@ -1539,7 +1538,7 @@ int main() {
 
     // trigger SDI IRQ by sending data via SPI
     neorv32_spi_cs_en(7); // select SDI
-    tmp_a = neorv32_spi_trans(0x83);
+    tmp_a = neorv32_spi_transfer(0x83);
     neorv32_spi_cs_dis();
 
     // wait for interrupt

--- a/sw/lib/include/neorv32_spi.h
+++ b/sw/lib/include/neorv32_spi.h
@@ -85,7 +85,7 @@ void     neorv32_spi_enable(void);
 int      neorv32_spi_get_fifo_depth(void);
 void     neorv32_spi_cs_en(int cs);
 void     neorv32_spi_cs_dis(void);
-uint8_t  neorv32_spi_trans(uint8_t tx_data);
+uint8_t  neorv32_spi_transfer(uint8_t tx_data);
 void     neorv32_spi_put_nonblocking(uint8_t tx_data);
 uint8_t  neorv32_spi_get_nonblocking(void);
 void     neorv32_spi_cs_en_nonblocking(int cs);

--- a/sw/lib/include/neorv32_twi.h
+++ b/sw/lib/include/neorv32_twi.h
@@ -90,7 +90,7 @@ int  neorv32_twi_sense_sda(void);
 int  neorv32_twi_busy(void);
 int  neorv32_twi_get(uint8_t *data);
 
-int  neorv32_twi_trans(uint8_t *data, int mack);
+int  neorv32_twi_transfer(uint8_t *data, int mack);
 void neorv32_twi_generate_stop(void);
 void neorv32_twi_generate_start(void);
 

--- a/sw/lib/source/neorv32_spi.c
+++ b/sw/lib/source/neorv32_spi.c
@@ -165,7 +165,7 @@ void neorv32_spi_cs_dis(void) {
  * @param tx_data Transmit data (8-bit, LSB-aligned).
  * @return Receive data (8-bit, LSB-aligned).
  **************************************************************************/
-uint8_t neorv32_spi_trans(uint8_t tx_data) {
+uint8_t neorv32_spi_transfer(uint8_t tx_data) {
 
   neorv32_spi_put_nonblocking(tx_data);
   while (neorv32_spi_busy()); // wait for current transfer to finish

--- a/sw/lib/source/neorv32_twi.c
+++ b/sw/lib/source/neorv32_twi.c
@@ -155,7 +155,7 @@ int neorv32_twi_get(uint8_t *data) {
  * @param[in] mack Generate ACK by host controller when set.
  * @return 0: ACK received, 1: NACK received.
  **************************************************************************/
-int neorv32_twi_trans(uint8_t *data, int mack) {
+int neorv32_twi_transfer(uint8_t *data, int mack) {
 
   uint8_t rx_data = 0;
   int device_ack = 0;


### PR DESCRIPTION
* `neorv32_twi_trans() -> neorv32_twi_transfer()`
* `neorv32_spi_trans() -> neorv32_spi_transfer()`