### PR TITLE
[sw/lib] add restart/reset functions

### DIFF
--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -175,16 +175,18 @@ extern "C" {
 
 
 /**********************************************************************//**
- * @name Export linker script symbols
+ * @name NEORV32 linker symbols
  **************************************************************************/
 /**@{*/
 extern char __heap_start[];    /**< heap start address */
 extern char __heap_end[];      /**< heap last address */
 extern char __crt0_max_heap[]; /**< heap size in bytes */
+extern char __crt0_entry[];    /**< crt0 entry point */
 // aliases
 #define NEORV32_HEAP_BEGIN ((uint32_t)&__heap_start[0])
 #define NEORV32_HEAP_END   ((uint32_t)&__heap_end[0])
 #define NEORV32_HEAP_SIZE  ((uint32_t)&__crt0_max_heap[0])
+#define NEORV32_CRT0_ENTRY ((uint32_t)&__crt0_entry[0])
 /**@}*/
 
 

--- a/sw/lib/include/neorv32_cpu.h
+++ b/sw/lib/include/neorv32_cpu.h
@@ -34,6 +34,20 @@ uint32_t neorv32_cpu_hpm_get_size(void);
 
 
 /**********************************************************************//**
+ * Restart CPU core (jump to boot address).
+ *
+ * @warning This is just a "software reset" that uses the in-code reset/boot/entry address linked at compile time.
+ **************************************************************************/
+inline void __attribute__ ((always_inline)) neorv32_cpu_soft_restart(void) {
+
+  uint32_t sw_boot_addr = NEORV32_CRT0_ENTRY; // linker symbol
+  asm volatile ("jalr x0, 0(%[dst])" : : [dst] "r" (sw_boot_addr));
+  __builtin_unreachable();
+  while(1); // should never be reached
+}
+
+
+/**********************************************************************//**
  * Store unsigned word to address space.
  *
  * @note An unaligned access address will raise an alignment exception.

--- a/sw/lib/include/neorv32_wdt.h
+++ b/sw/lib/include/neorv32_wdt.h
@@ -69,6 +69,7 @@ int  neorv32_wdt_available(void);
 void neorv32_wdt_setup(uint32_t timeout, int lock, int strict);
 int  neorv32_wdt_disable(void);
 void neorv32_wdt_feed(uint32_t password);
+void neorv32_wdt_force_hwreset(void);
 int  neorv32_wdt_get_cause(void);
 /**@}*/
 

--- a/sw/lib/source/neorv32_wdt.c
+++ b/sw/lib/source/neorv32_wdt.c
@@ -91,6 +91,21 @@ void neorv32_wdt_feed(uint32_t password) {
 
 
 /**********************************************************************//**
+ * Force a hardware reset triggered by the watchdog.
+ **************************************************************************/
+void neorv32_wdt_force_hwreset(void) {
+
+  // enable strict mode; if strict mode is already enabled and the WDT
+  // is locked this will already trigger a hardware reset
+  NEORV32_WDT->CTRL |= (uint32_t)(1 << WDT_CTRL_STRICT);
+
+  // try to reset the WDT using an incorrect password;
+  // this will finally trigger a hardware reset
+  NEORV32_WDT->RESET = 0;
+}
+
+
+/**********************************************************************//**
  * Get cause of last system reset.
  *
  * @return Cause of last reset (#NEORV32_WDT_RCAUSE_enum).


### PR DESCRIPTION
This PR adds a function to perform a "soft restart" of a CPU core. For example, this can be used to "park" the secondary CPU core (core1) again so it can be launched again:

```c
int main_core1(void) {

  // setup NEORV32 runtime-environment (RTE) for this core (core1)
  neorv32_rte_setup();

  // do some useful stuff
  stuff();

  // park core1 again in crt0 boot code
  neorv32_cpu_soft_restart();

  // return to crt0 and halt; will never be reached
  return 0;
}
```

> [!WARNING]
> This is just a "software reset" that uses the in-code reset/boot/entry address linked at compile time.

After this core can be re-booted using `neorv32_smp_launch();`.

--------------

A real hardware reset of the entire processor can be triggered via the watchdog (WDT) module by the new new `neorv32_wdt_force_hwreset();` function:

```c
void neorv32_wdt_force_hwreset(void) {

  // enable strict mode; if strict mode is already enabled and the WDT
  // is locked this will already trigger a hardware reset
  NEORV32_WDT->CTRL |= (uint32_t)(1 << WDT_CTRL_STRICT);

  // try to reset the WDT using an incorrect password;
  // this will finally trigger a hardware reset
  NEORV32_WDT->RESET = 0;
}
```