### PR TITLE
[sw/lib/neoled] fix neoled "irq_mode" not a applied in "neorv32_neoled_setup" and [sw/lib/neoled] updated doxygen comments

### DIFF
--- a/sw/lib/include/neorv32_neoled.h
+++ b/sw/lib/include/neorv32_neoled.h
@@ -62,7 +62,7 @@ enum NEORV32_NEOLED_CTRL_enum {
   NEOLED_CTRL_T_ONE_H_3  = 23, /**< NEOLED control register(23) (r/w): pulse-clock ticks per ONE high-time bit 3 */
   NEOLED_CTRL_T_ONE_H_4  = 24, /**< NEOLED control register(24) (r/w): pulse-clock ticks per ONE high-time bit 4 */
 
-  NEOLED_CTRL_IRQ_CONF   = 27, /**< NEOLED control register(27) (r/w): TX FIFO interrupt: 1=IRQ if FIFO is empty, 1=IRQ if FIFO is less than half-full */
+  NEOLED_CTRL_IRQ_CONF   = 27, /**< NEOLED control register(27) (r/w): TX FIFO interrupt: 0=IRQ if FIFO is empty, 1=IRQ if FIFO is less than half-full */
   NEOLED_CTRL_TX_EMPTY   = 28, /**< NEOLED control register(28) (r/-): TX FIFO is empty */
   NEOLED_CTRL_TX_HALF    = 29, /**< NEOLED control register(29) (r/-): TX FIFO is at least half-full */
   NEOLED_CTRL_TX_FULL    = 30, /**< NEOLED control register(30) (r/-): TX FIFO is full */

--- a/sw/lib/source/neorv32_neoled.c
+++ b/sw/lib/source/neorv32_neoled.c
@@ -42,7 +42,7 @@ int neorv32_neoled_available(void) {
  * @param[in] t_total Number of pre-scaled clock ticks for total bit period (0..31).
  * @param[in] t_high_zero Number of pre-scaled clock ticks to generate high-time for sending a '0' (0..31).
  * @param[in] t_high_one Number of pre-scaled clock ticks to generate high-time for sending a '1' (0..31).
- * @param[in] irq_mode Interrupt condition (1=IRQ if FIFO is empty, 1=IRQ if FIFO is less than half-full).
+ * @param[in] irq_mode Interrupt condition (0=IRQ if FIFO is empty, 1=IRQ if FIFO is less than half-full).
  **************************************************************************/
 void neorv32_neoled_setup(uint32_t prsc, uint32_t t_total, uint32_t t_high_zero, uint32_t t_high_one, int irq_mode) {
 
@@ -66,7 +66,7 @@ void neorv32_neoled_setup(uint32_t prsc, uint32_t t_total, uint32_t t_high_zero,
  * @note WS2812 timing: T_period = 1.2us, T_high_zero = 0.4us, T_high_one = 0.8us. Change the constants if required.
  * @note This function uses the SYSINFO_CLK value (from the SYSINFO HW module) to do the timing computations.
  *
- * @param[in] irq_mode Interrupt condition (1=IRQ if FIFO is empty, 1=IRQ if FIFO is less than half-full).
+ * @param[in] irq_mode Interrupt condition (0=IRQ if FIFO is empty, 1=IRQ if FIFO is less than half-full).
  **************************************************************************/
 void neorv32_neoled_setup_ws2812(int irq_mode) {
 

--- a/sw/lib/source/neorv32_neoled.c
+++ b/sw/lib/source/neorv32_neoled.c
@@ -54,7 +54,7 @@ void neorv32_neoled_setup(uint32_t prsc, uint32_t t_total, uint32_t t_high_zero,
   tmp |= (uint32_t)((t_total     & 0x1fU) << NEOLED_CTRL_T_TOT_0);    // serial data output: total period length for one bit
   tmp |= (uint32_t)((t_high_zero & 0x1fU) << NEOLED_CTRL_T_ZERO_H_0); // serial data output: high-time for sending a '0'
   tmp |= (uint32_t)((t_high_one  & 0x1fU) << NEOLED_CTRL_T_ONE_H_0);  // serial data output: high-time for sending a '1'
-  tmp |= (uint32_t)((irq_mode    & 0x01U) << NEOLED_CTRL_EN);         // interrupt mode
+  tmp |= (uint32_t)((irq_mode    & 0x01U) << NEOLED_CTRL_IRQ_CONF);   // interrupt mode
   NEORV32_NEOLED->CTRL = tmp;
 }
 


### PR DESCRIPTION
- Fixed "NEOLED_CTRL_IRQ_CONF" bit never being set in the "neorv32_neoled_setup" function.
- Updated corresponding doxygen comments

"irq_mode" parameter was shifted to the "NEOLED_CTRL_EN" position and thus rendered ineffective. This caused the "NEOLED_CTRL_IRQ_CONF" bit to remain 0 at all times, causing the interrupt to always trigger on an empty FIFO.

Tested with current main branch up to commit e1283bc. Interrupt is triggered on both an empty and (less than) half full FIFO.
