### PR TITLE
Make hardware breakpoint optional; constrain to debug-mode only

### DIFF
--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -799,14 +799,15 @@ return to the address stored in `dpc` by automatically moving `dpc` to the progr
 :sectnums:
 === Trigger Module
 
-"Normal" software breakpoints (using GDB's `b`/`break` command) are implemented by temporarily replacing the according
+Normal software breakpoints (using GDB's `b`/`break` command) are implemented by temporarily replacing the according
 instruction word by an `[c.]ebreak` instruction. However, this is not possible when debugging code that is executed from
 read-only memory. To circumvent this limitation a hardware trigger logic allows to (re-)enter debug-mode when instruction
 execution reaches a programmable address. These "hardware-assisted breakpoints" are used by GDB's `hb`/`hbreak` commands.
 
-The RISC-V `Sdtrig` ISA extension adds a programmable _trigger module_ to the CPU core that is enabled via the
-<<_sdtrig_isa_extension>> generic. The trigger module implements a subset of the features described in the
-"RISC-V Debug Specification / Trigger Module" and complies to version v1.0 of the `Sdtrig` spec.
+The RISC-V `Sdtrig` ISA extension adds a programmable _trigger module_ to the CPU core that is enabled via the top's
+<<_processor_top_entity_generics, `OCD_HW_BREAKPOINT`>> which enabled the <<_sdtrig_isa_extension>>. The trigger module
+implements a subset of the features described in the "RISC-V Debug Specification / Trigger Module" and complies to version
+v1.0 of the `Sdtrig` spec.
 
 The NEORV32 trigger module features only a _single_ trigger implementing a "type 6 - instruction address match" trigger.
 This limitation is granted by the RISC-V debug spec and is sufficient to **debug code executed from read-only memory (ROM)**.
@@ -830,8 +831,6 @@ of the actual `ebreak` instruction itself.
 ==== Trigger Module CSRs
 
 The `Sdtrig` ISA extension adds 4 additional CSRs that are accessible from debug-mode and also from machine-mode.
-Machine-mode write accesses can be ignored by setting ´dmode´ in <<_tdata1>>. This is automatically done by the debugger
-if it uses the trigger module for implementing a "hardware breakpoint"
 
 :sectnums!:
 ===== **`tselect`**
@@ -866,7 +865,7 @@ if it uses the trigger module for implementing a "hardware breakpoint"
 |=======================
 | Bit   | Name [RISC-V] | R/W | Description
 | 31:28 | `type`        | r/- | `0100`: address match trigger type 6
-| 27    | `dmode`       | r/w | set to ignore write accesses to <<_tdata1>> and <<_tdata2>> from machine-mode; writable from debug-mode only
+| 27    | `dmode`       | r/- | '1': ignore write accesses to <<_tdata1>> and <<_tdata2>> from machine-mode
 | 26    | `uncertain`   | r/- | `0`: trigger satisfies the configured conditions
 | 25    | `hit1`        | r/- | `0`: hardwired to zero, only `hit0` is used
 | 24    | `vs`          | r/- | `0`: VS-mode not supported

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -43,7 +43,7 @@ image::neorv32_processor.png[align=center]
 * _optional_ stream link interface (<<_stream_link_interface_slink,**SLINK**>>), AXI4-Stream compatible
 * _optional_ cyclic redundancy check unit (<<_cyclic_redundancy_check_crc,**CRC**>>)
 * _optional_ hardware spinlocks (32x) (<<_hardware_spinlocks_hwspinlock,**HWSPINLOCK**>>)
-* _optional_ on-chip debugger with JTAG TAP (<<_on_chip_debugger_ocd,**OCD**>>)
+* _optional_ on-chip debugger with JTAG TAP (<<_on_chip_debugger_ocd,**OCD**>>), optional authentication and hardware breakpoint
 * _optional_ system configuration information memory to determine hardware configuration via software (<<_system_configuration_information_memory_sysinfo,**SYSINFO**>>)
 
 
@@ -210,7 +210,8 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `BOOT_MODE_SELECT`      | natural   | 0             | Boot mode select; see <<_boot_configuration>>.
 | `BOOT_ADDR_CUSTOM`      | suv(31:0) | x"00000000"   | Custom CPU boot address (available if `BOOT_MODE_SELECT` = 1).
 4+^| **<<_on_chip_debugger_ocd>>**
-| `OCD_EN`                | boolean   | false         | Implement the on-chip debugger and the CPU debug mode.
+| `OCD_EN`                | boolean   | false         | Implement the on-chip debugger and the CPU debug mode (<<_sdext_isa_extension>>).
+| `OCD_HW_BREAKPOINT `    | boolean   | false         | Implement debug <<_trigger_module>> module (<<_sdtrig_isa_extension>>).
 | `OCD_AUTHENTICATION`    | boolean   | false         | Implement <<_debug_authentication>> module.
 | `OCD_JEDEC_ID`          | suv(10:0) | "00000000000" | JEDEC ID; continuation codes plus vendor ID (passed to the JTAG <<_debug_transport_module_dtm>>).
 4+^| **CPU <<_instruction_sets_and_extensions>>**

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -427,8 +427,8 @@ begin
 
   pmp_disabled:
   if not RISCV_ISA_Smpmp generate
-    xcsr_pmp <= (others => '0');
-    pmp_fault      <= '0';
+    xcsr_pmp  <= (others => '0');
+    pmp_fault <= '0';
   end generate;
 
 
@@ -456,7 +456,7 @@ begin
   icc_disabled:
   if not ICC_EN generate
     xcsr_icc <= (others => '0');
-    icc_tx_o       <= icc_terminate_c;
+    icc_tx_o <= icc_terminate_c;
   end generate;
 
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110300"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110301"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -796,6 +796,7 @@ package neorv32_package is
       BOOT_ADDR_CUSTOM      : std_ulogic_vector(31 downto 0) := x"00000000";
       -- On-Chip Debugger (OCD) --
       OCD_EN                : boolean                        := false;
+      OCD_HW_BREAKPOINT     : boolean                        := false;
       OCD_AUTHENTICATION    : boolean                        := false;
       OCD_JEDEC_ID          : std_ulogic_vector(10 downto 0) := "00000000000";
       -- RISC-V CPU Extensions --

--- a/rtl/core/neorv32_sysinfo.vhd
+++ b/rtl/core/neorv32_sysinfo.vhd
@@ -37,7 +37,7 @@ entity neorv32_sysinfo is
     XBUS_CACHE_NUM_BLOCKS : natural; -- x-cache: number of blocks (min 1), has to be a power of 2
     XBUS_CACHE_BLOCK_SIZE : natural; -- x-cache: block size in bytes (min 4), has to be a power of 2
     OCD_EN                : boolean; -- implement OCD
-    OCD_AUTHENTICATION    : boolean; -- implement OCD authenticator
+    OCD_AUTH              : boolean; -- implement OCD authenticator
     IO_GPIO_EN            : boolean; -- implement general purpose IO port (GPIO)
     IO_CLINT_EN           : boolean; -- implement machine local interruptor (CLINT)
     IO_UART0_EN           : boolean; -- implement primary universal asynchronous receiver/transmitter (UART0)
@@ -72,7 +72,6 @@ architecture neorv32_sysinfo_rtl of neorv32_sysinfo is
   constant int_imem_en_c    : boolean := MEM_INT_IMEM_EN and boolean(MEM_INT_IMEM_SIZE > 0);
   constant int_dmem_en_c    : boolean := MEM_INT_DMEM_EN and boolean(MEM_INT_DMEM_SIZE > 0);
   constant xcache_en_c      : boolean := XBUS_EN and XBUS_CACHE_EN;
-  constant ocd_auth_en_c    : boolean := OCD_EN and OCD_AUTHENTICATION;
   constant int_imem_rom_c   : boolean := int_imem_en_c and MEM_INT_IMEM_ROM;
   constant log2_imem_size_c : natural := index_size_f(MEM_INT_IMEM_SIZE);
   constant log2_dmem_size_c : natural := index_size_f(MEM_INT_DMEM_SIZE);
@@ -126,7 +125,7 @@ begin
   sysinfo(2)(8)  <= '1' when xcache_en_c       else '0'; -- external bus interface cache implemented
   sysinfo(2)(9)  <= '0';                                 -- reserved
   sysinfo(2)(10) <= '0';                                 -- reserved
-  sysinfo(2)(11) <= '1' when ocd_auth_en_c     else '0'; -- on-chip debugger authentication implemented
+  sysinfo(2)(11) <= '1' when OCD_AUTH          else '0'; -- on-chip debugger authentication implemented
   sysinfo(2)(12) <= '1' when int_imem_rom_c    else '0'; -- processor-internal instruction memory implemented as pre-initialized ROM
   sysinfo(2)(13) <= '1' when IO_TWD_EN         else '0'; -- two-wire device (TWD) implemented
   sysinfo(2)(14) <= '1' when IO_DMA_EN         else '0'; -- direct memory access controller (DMA) implemented

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -169,7 +169,7 @@ proc setup_ip_gui {} {
 
   set group [add_group $page {Core Complex}]
   add_params $group {
-    { DUAL_CORE_EN {Number of CPU cores} {} }
+    { DUAL_CORE_EN {CPU core(s))} {} }
   }
   set_property widget {comboBox} [ipgui::get_guiparamspec -name "DUAL_CORE_EN" -component [ipx::current_core] ]
   set_property value_validation_type pairs [ipx::get_user_parameters DUAL_CORE_EN -of_objects [ipx::current_core]]
@@ -186,9 +186,10 @@ proc setup_ip_gui {} {
 
   set group [add_group $page {On-Chip Debugger (OCD)}]
   add_params $group {
-    { OCD_EN             {Enable OCD}         {Implement JTAG-based on-chip debugger} }
-    { OCD_AUTHENTICATION {OCD authentication} {Implement Debug Authentication module} {$OCD_EN} {$OCD_EN ? $OCD_AUTHENTICATION : false} }
-    { OCD_JEDEC_ID       {JEDEC ID}           {JTAG tap identification}               {$OCD_EN}}
+    { OCD_EN             {Enable OCD}          {Implement JTAG-based on-chip debugger} }
+    { OCD_HW_BREAKPOINT  {Hardware breakpoint} {Implement a single hardware-assistet breakpoint} {$OCD_EN} {$OCD_EN ? $OCD_HW_BREAKPOINT  : false} }
+    { OCD_AUTHENTICATION {OCD authentication}  {Implement debug authentication module}           {$OCD_EN} {$OCD_EN ? $OCD_AUTHENTICATION : false} }
+    { OCD_JEDEC_ID       {JEDEC ID}            {JTAG tap identification}                         {$OCD_EN}}
   }
 
   set group [add_group $page {External Bus Interface (XBUS / AXI4-Lite-MM Host)}]

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -34,6 +34,7 @@ entity neorv32_vivado_ip is
     BOOT_ADDR_CUSTOM      : std_ulogic_vector(31 downto 0) := x"00000000";
     -- On-Chip Debugger (OCD) --
     OCD_EN                : boolean                        := false;
+    OCD_HW_BREAKPOINT     : boolean                        := false;
     OCD_AUTHENTICATION    : boolean                        := false;
     OCD_JEDEC_ID          : std_logic_vector(10 downto 0)  := "00000000000";
     -- RISC-V CPU Extensions --
@@ -347,6 +348,7 @@ begin
     BOOT_ADDR_CUSTOM      => BOOT_ADDR_CUSTOM,
     -- On-Chip Debugger --
     OCD_EN                => OCD_EN,
+    OCD_HW_BREAKPOINT     => OCD_HW_BREAKPOINT,
     OCD_AUTHENTICATION    => OCD_AUTHENTICATION,
     OCD_JEDEC_ID          => std_ulogic_vector(OCD_JEDEC_ID),
     -- RISC-V CPU Extensions --

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -129,6 +129,7 @@ begin
     BOOT_ADDR_CUSTOM      => BOOT_ADDR_CUSTOM,
     -- On-Chip Debugger (OCD) --
     OCD_EN                => true,
+    OCD_HW_BREAKPOINT     => true,
     OCD_AUTHENTICATION    => true,
     -- RISC-V CPU Extensions --
     RISCV_ISA_C           => RISCV_ISA_C,


### PR DESCRIPTION
* ✨ Add a new top generic to enable/disable the hardware-assisted breakpoint (RISC-V `Sdtrig` ISA extenion). A furture PR might use this generic to specify a variable amount of hardware triggers.

```vhdl
OCD_HW_BREAKPOINT : boolean := false; -- implement on-chip-debugger hardware breakpoint
```

* ⚠️ only allow debug-mode to use the trigger module; write accesses from machine mode are ignore (`tdata.dmode` CSR bit is hardwired to `1`; simplifies trigger logic)