### PR TITLE
Optimize round-robin bus switch: remove idle cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 26.04.2025 | 1.11.3.3 | optimize round-robin bus switch: remove idle cycles | [#1244](https://github.com/stnolting/neorv32/pull/1244) |
 | 22.04.2025 | 1.11.3.2 | :bug: fix the privilege level with which the bootloader boots an application image | [#1241](https://github.com/stnolting/neorv32/pull/1241) |
 | 22.04.2025 | 1.11.3.1 | add new top generic (`OCD_HW_BREAKPOINT`) to enable/disable OCD's hardware trigger; :warning: hardwire `tdata1.dmode` to `1` - only debug-mode can use the trigger module; hardwire `tdata1.action` to `0001` - debug-mode entry only | [#1239](https://github.com/stnolting/neorv32/pull/1239) |
 | 21.04.2025 | [**:rocket:1.11.3**](https://github.com/stnolting/neorv32/releases/tag/v1.11.3) | **New release** | |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110302"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110303"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/sw/example/demo_dual_core_primes/Makefile
+++ b/sw/example/demo_dual_core_primes/Makefile
@@ -1,0 +1,33 @@
+# Application makefile.
+# Use this makefile to configure all relevant CPU / compiler options.
+
+# Override the default CPU ISA
+MARCH = rv32ia_zicsr_zifencei
+
+# Override the default RISC-V GCC prefix
+#RISCV_PREFIX ?= riscv-none-elf-
+
+# Override default optimization goal
+EFFORT = -Os
+
+# Add extended debug symbols
+USER_FLAGS += -ggdb -gdwarf-3
+
+# Adjust processor IMEM size
+USER_FLAGS += -Wl,--defsym,__neorv32_rom_size=16k
+
+# Adjust processor DMEM size
+USER_FLAGS += -Wl,--defsym,__neorv32_ram_size=8k
+
+# Adjust maximum heap size
+#USER_FLAGS += -Wl,--defsym,__neorv32_heap_size=3k
+
+# Additional sources
+#APP_SRC += $(wildcard ./*.c)
+#APP_INC += -I .
+
+# Set path to NEORV32 root directory
+NEORV32_HOME ?= ../../..
+
+# Include the main NEORV32 makefile
+include $(NEORV32_HOME)/sw/common/common.mk

--- a/sw/example/demo_dual_core_primes/main.c
+++ b/sw/example/demo_dual_core_primes/main.c
@@ -1,0 +1,158 @@
+// ================================================================================ //
+// The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
+// Copyright (c) NEORV32 contributors.                                              //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
+// Licensed under the BSD-3-Clause license, see LICENSE for details.                //
+// SPDX-License-Identifier: BSD-3-Clause                                            //
+// ================================================================================ //
+
+/**********************************************************************//**
+ * @file demo_dual_core_primes/main.c
+ * @brief Find prime numbers by combining the power of both CPU cores.
+ **************************************************************************/
+#include <neorv32.h>
+
+/** User configuration */
+#define BAUD_RATE 19200 // UART0 Baud rate
+#define NUM_MAX   100   // count all prime numbers between 0 and this value
+
+/** Global variables */
+volatile uint8_t __attribute__ ((aligned (16))) core1_stack[2048]; // stack memory for core1
+
+
+/**********************************************************************//**
+ * Check if number is prime.
+ *
+ * @param[in] n Number to check.
+ * @return 1 if number is prime; 0 otherwise.
+ **************************************************************************/
+uint32_t is_prime(uint32_t n) {
+
+  uint32_t i = 0;
+  if (n < 2) {
+    return 0;
+  }
+  for (i = 2; i*i <= n; ++i) {
+    if (n % i == 0) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+
+/**********************************************************************//**
+ * Count all prime numbers in range.
+ *
+ * @param[in] beg Start of number range.
+ * @param[in] end End of number range.
+ * @return Number of primes in range.
+ **************************************************************************/
+uint32_t count_primes(uint32_t beg, uint32_t end) {
+
+  uint32_t i = 0, num_primes = 0;
+  for (i=beg; i<end; ++i) {
+    if (is_prime(i)) {
+      num_primes++;
+    }
+  }
+  return num_primes;
+}
+
+
+/**********************************************************************//**
+ * Main function for core 1 (secondary core).
+ *
+ * @return Irrelevant (but can be inspected by the debugger).
+ **************************************************************************/
+int core1_entry(void) {
+
+  // setup NEORV32 runtime-environment (RTE) for _this_ core (core1)
+  neorv32_rte_setup();
+
+  // get range and find all prime numbers within
+  uint32_t range_begin = neorv32_smp_icc_pop();
+  uint32_t range_end = neorv32_smp_icc_pop();
+  neorv32_smp_icc_push(count_primes(range_begin, range_end));
+
+  return 0;
+}
+
+
+/**********************************************************************//**
+ * Find prime numbers by combining the power of both CPU cores.
+ *
+ * @note This program requires the dual-core configuration, the CLINT and UART0.
+ *
+ * @return Irrelevant (but can be inspected by the debugger).
+ **************************************************************************/
+int main(void) {
+
+  // setup NEORV32 runtime-environment (RTE) for _this_ core (core0)
+  neorv32_rte_setup();
+
+  // setup UART0 at default baud rate, no interrupts
+  if (neorv32_uart0_available() == 0) { // UART0 available?
+    return -1;
+  }
+  neorv32_uart0_setup(BAUD_RATE, 0);
+  neorv32_uart0_printf("\n<< NEORV32 SMP Dual-Core Prime Numbers >>\n\n");
+
+  // check hardware/software configuration
+  if (neorv32_sysinfo_get_numcores() < 2) { // two cores available?
+    neorv32_uart0_printf("[ERROR] dual-core option not enabled!\n");
+    return -1;
+  }
+  if (neorv32_clint_available() == 0) { // CLINT available?
+    neorv32_uart0_printf("[ERROR] CLINT module not available!\n");
+    return -1;
+  }
+
+  // launch secondary CPU core
+  neorv32_uart0_printf("Launching core 1...\n");
+  int smp_launch_rc = neorv32_smp_launch(core1_entry, (uint8_t*)core1_stack, sizeof(core1_stack));
+
+  // check if launching was successful
+  if (smp_launch_rc) {
+    neorv32_uart0_printf("[ERROR] Launching core1 failed (%d)!\n", smp_launch_rc);
+    return -1;
+  }
+
+  // Find all prime number in range 0 to NUM_MAX
+  neorv32_uart0_printf("Counting all prime numbers in range 0 to %u...\n", (uint32_t)NUM_MAX);
+  uint64_t time_delta = 0;
+  uint32_t result = 0;
+
+  // -------------------------------------------
+  // Use a single core only
+  // -------------------------------------------
+
+  time_delta = neorv32_clint_time_get();
+
+  // execute the full workload on core 0 only
+  result = count_primes(0, NUM_MAX);
+
+  time_delta = neorv32_clint_time_get() - time_delta;
+
+  neorv32_uart0_printf("[SINGLE-CORE] %u primes in %u cycles\n", result, (uint32_t)time_delta);
+
+  // -------------------------------------------
+  // Use two cores in parallel - each core gets half of the fun
+  // -------------------------------------------
+
+  time_delta = neorv32_clint_time_get();
+
+  // execute second half of workload on core 1
+  neorv32_smp_icc_push(NUM_MAX/2);
+  neorv32_smp_icc_push(NUM_MAX);
+
+  // execute first half of workload on core 0
+  result = count_primes(0, NUM_MAX/2);
+  result += neorv32_smp_icc_pop(); // this will block until core 1 provides a result
+
+  time_delta = neorv32_clint_time_get() - time_delta;
+
+  neorv32_uart0_printf("[DUAL-CORE]   %u primes in %u cycles\n", result, (uint32_t)time_delta);
+
+  return 0;
+}


### PR DESCRIPTION
* remove the idle cycle that occurs while the bus switch is checking if there is a request from the _other_ core; for the dual-core setup this optimization provides about ~10% more performance
* add a new demo program that shows how to split a workload (counting prime numbers) across the two cores

