### PR TITLE
Optimize cache system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 28.04.2025 | 1.11.3.5 | optimize cache block replacement logic and block transfers | [#1248](https://github.com/stnolting/neorv32/pull/1248) |
 | 26.04.2025 | 1.11.3.4 | :sparkles: add bus lock feature | [#1245](https://github.com/stnolting/neorv32/pull/1245) |
 | 26.04.2025 | 1.11.3.3 | optimize round-robin bus switch: remove idle cycles | [#1244](https://github.com/stnolting/neorv32/pull/1244) |
 | 22.04.2025 | 1.11.3.2 | :bug: fix the privilege level with which the bootloader boots an application image | [#1241](https://github.com/stnolting/neorv32/pull/1241) |

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -213,7 +213,7 @@ begin
         host_rsp_o.data  <= cache_i.data; -- cache response data (for hit)
         addr_nxt.ofs     <= (others => '0'); -- align block base address for upload/download
         addr_nxt.idx     <= host_req_i.addr((offset_size_c+2+index_size_c)-1 downto offset_size_c+2); -- index of referenced block
-        ctrl_nxt.stret   <= S_DOWNLOAD_REQ; -- start block download immediately after upload has completed
+        ctrl_nxt.stret   <= S_LOOKUP; -- come back here after upload has completed
         --
         if (cache_i.sta_hit = '1') then -- cache hit
           if (host_req_i.rw = '0') or (READ_ONLY = true) then -- read access

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110304"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110305"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 


### PR DESCRIPTION
### Optimize Cache Replacement Logic

In the current version the block replacement logic is highly inefficient. If a dirty block _x_ is replaced by a new block _y_ the following operations are performed:

1. upload the diry block _x_ to main memory
2. download block _x_ from memory
3. download new block _y_

Obviously, step 2. is redundant and is removed by this PR.

### Optimize Cache Bus Accesses

The bus switch, which connects the CPU's instruction and data ports (that might be cached) to the rest of the system, now uses a "lockable" round-robin scheduling if any CPU cache (D$ or I$) is enabled. This lockable scheduling prevent interleaving of cache block transfers leading to less wait states.