### PR TITLE
Rework caches; use "write-through" strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 04.05.2025 | 1.11.4.1 | rework I/D-cache architecture: switch from "write-allocate & write-back" to "write-through" | [#1259](https://github.com/stnolting/neorv32/pull/1259) |
 | 04.05.2025 | [**:rocket:1.11.4**](https://github.com/stnolting/neorv32/releases/tag/v1.11.4) | **New release** | |
 | 03.05.2025 | 1.11.3.10 | :warning: rework cache configuration options | [#1257](https://github.com/stnolting/neorv32/pull/1257) |
 | 03.05.2025 | 1.11.3.9 | :warning: remove external bus interface cache (xbus-cache) | [#1256](https://github.com/stnolting/neorv32/pull/1256) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -85,8 +85,6 @@ direction as seen from the CPU.
 4+^| **Data <<_bus_interface>>**
 | `dbus_req_o`   | `bus_req_t` | out | Data access (load/store) bus request.
 | `dbus_rsp_i`   | `bus_rsp_t` | in  | Data access (load/store) bus response.
-4+^| **<<_memory_coherence>> status**
-| `mem_sync_i`   | 1           | in  | Requested coherence established when set (single-shot)
 |=======================
 
 .Bus Interface Protocol
@@ -653,10 +651,9 @@ The `I` ISA extensions is the base RISC-V integer ISA that is always enabled.
 .`fence` Instruction
 [NOTE]
 Analogous to the `fence.i` instruction (<<_zifencei_isa_extension>>) the `fence` instruction triggers
-a load/store memory synchronization operation. The CPU will stall until the requested coherence is
-established (`mem_sync_i` goes high). See section <<_memory_coherence>> for more information.
-NEORV32 ignores the predecessor and successor fields and always executes a conservative fence on all
-operations.
+a load/store memory synchronization operation by flushing the CPU's data cache. See section
+<<_memory_coherence>> for more information. NEORV32 ignores the predecessor and successor fields and
+always executes a conservative fence on all operations.
 
 .`wfi` Instruction
 [NOTE]
@@ -748,10 +745,9 @@ The instruction word's `aq` and `lr` memory ordering bits are not evaluated by t
 
 ==== `Zifencei` ISA Extension
 
-The `Zifencei` CPU extension allows manual synchronization of the instruction stream. This extension is always enabled.
 This instruction is the only standard mechanism to ensure that stores visible to a hart will also be visible to its
-instruction fetches. The CPU will stall until the requested coherence is established (`mem_sync_i` goes high).
-See section <<_memory_coherence>> for more information.
+instruction fetches. When executed, the CPU flushes the instruction prefetch buffer and reloads the CPU's
+instruction cache (if enabled). See section <<_memory_coherence>> for more information.
 
 .Instructions and Timing
 [cols="<2,<4,<3"]

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -648,14 +648,17 @@ of caches, buffers and storage.
 . Internal and external memories
 
 All caches and buffers operate transparently for the software. Hence, special attention must therefore be
-paid to maintain coherence. Note that coherence and cache _synchronization_ is **not** automatically performed
-by the hardware itself as there is no snooping implemented.
+paid to maintain memory coherence. Note that coherence and cache _synchronization_ is **not** performed
+automatically by the hardware itself as there is no snooping implemented.
 
 NEORV32 uses two instructions for manual memory synchronization which are always available
 regardless of the actual CPU/ISA configuration:
 
-* `fence` (<<_i_isa_extension>> / <<_e_isa_extension>>)
-* `fence.i` (<<_zifencei_isa_extension>>)
+* `fence.i` (<<_zifencei_isa_extension>>): flush the CPU's instruction prefetch buffer and
+clear the CPU's <<_processor_internal_instruction_cache_icache, instruction cache>>.
+* `fence` (<<_i_isa_extension>> / <<_e_isa_extension>>): clear and reload the CPU's
+<<_processor_internal_data_cache_dcache, data cache>>. Flushing is not required as the data cache
+uses the **write-through** strategy. Hence, write operations are always synchronized with main memory.
 
 .Weak Coherence Model
 [IMPORTANT]
@@ -663,29 +666,6 @@ The NEORV32-specific implementation of the `fence[.i]` ordering instructions onl
 coherence model. A core's `fence` just orders all memory accesses towards main memory. Hence, they _can_ become
 visible by other agents (the secondary CPU core, the DMA, processor-external modules) if these agents also
 synchronize (e.g. reload) their cache(s).
-
-By executing the "data" `fence` instruction the CPU's load/store operations are ordered
-and synchronized across the entire system:
-
-[start=1]
-. The CPU data cache (if enabled) is flushed and invalidated: all local modifications are copied to
-the next higher memory level.
-. The CPU data cache is cleared invalidating so the next load/store access will cause a cache miss
-that will fetch up-to-date data from the memory system.
-. The synchronization request is forwarded to the next-higher memory level.
-
-By executing the "instruction" `fence.i` instruction the CPU's instruction-fetch cache is are ordered
-and synchronized across the entire system:
-
-[start=1]
-. Perform all the steps that are performed by the `fence` instruction.
-. The CPU instruction cache is cleared invalidating all local entries so the next instruction fetch access
-will cause a cache miss that will fetch up-to-date data from the memory system.
-
-.CPU Stall While Synchronizing
-[IMPORTANT]
-Executing any fence instruction will stall the CPU until all the requested ordering/synchronization
-steps are completed.
 
 ===== Coherence Example
 
@@ -700,10 +680,6 @@ counter = 3;
 counter++;
 ----
 
-The initial assignment `counter = 0` is translated into a store-word instruction (`sw`) that is
-automatically encapsulated within two `fence` instructions. This guarantees <<_memory_coherence>> as each
-FENCE will synchronize the CPU's data cache cache with upstream/main memory.
-
 .Atomic Variables - According RISC-V Assembly Code
 [source, assembly]
 ----
@@ -717,7 +693,11 @@ fence rw,rw
 amoadd.w.aqrl zero,a4,(a2)
 ----
 
-The increment (`counter++`) is implemented as RISC-V atomic memory operation (`amoadd`). However, the
+The initial assignment `counter = 0` is translated into a store-word instruction (`sw`) that is
+automatically encapsulated within two `fence` instructions. This guarantees memory coherence as each
+`fence` will synchronize the CPU's data cache with upstream/main memory.
+
+The counter increment (`counter++`) is implemented as RISC-V atomic memory operation (`amoadd`). However, the
 compiler does not encapsulate this in within FENCE instructions. Hence, the altered atomic variable
 is **not** updated in the CPU's data cache (but in upstream/main memory).
 

--- a/docs/datasheet/soc_dcache.adoc
+++ b/docs/datasheet/soc_dcache.adoc
@@ -1,7 +1,7 @@
 <<<
 <<<
 :sectnums:
-==== Processor-Internal Data Cache (dCACHE)
+==== Processor-Internal Data Cache (dCache)
 
 [cols="<3,<3,<4"]
 [grid="none"]
@@ -9,7 +9,7 @@
 | Hardware source files:  | neorv32_cache.vhd   | Generic cache module
 | Software driver files:  | none                |
 | Top entity ports:       | none                |
-| Configuration generics: | `DCACHE_EN`         | implement processor-internal data cache (D$) when `true`
+| Configuration generics: | `DCACHE_EN`         | implement processor-internal, CPU-exclusive data cache (D$) when `true`
 |                         | `DCACHE_NUM_BLOCKS` | number of cache blocks ("cache lines"); has to be a power of two
 |                         | `CACHE_BLOCK_SIZE`  | size of a cache block in bytes; has to be a power of two (global configuration for I$ and D$)
 | CPU interrupts:         | none |
@@ -19,7 +19,7 @@
 **Overview**
 
 The processor features an optional CPU data cache. The cache is connected directly to the CPU's data access interface
-and provides full-transparent accesses. The cache is direct-mapped and uses "write-allocate" and "write-back" strategies.
+and provides full-transparent accesses. The cache is direct-mapped and uses "write-through" as write strategy.
 In the <<_dual_core_configuration>> each CPU core is equipped with a private data cache.
 
 The data cache is implemented if `DCACHE_EN` it _true_. The total cache memory size in bytes is defined by

--- a/docs/datasheet/soc_icache.adoc
+++ b/docs/datasheet/soc_icache.adoc
@@ -1,7 +1,7 @@
 <<<
 <<<
 :sectnums:
-==== Processor-Internal Instruction Cache (iCACHE)
+==== Processor-Internal Instruction Cache (iCache)
 
 [cols="<3,<3,<4"]
 [grid="none"]
@@ -9,7 +9,7 @@
 | Hardware source files:  | neorv32_cache.vhd   | Generic cache module
 | Software driver files:  | none                |
 | Top entity ports:       | none                |
-| Configuration generics: | `ICACHE_EN`         | implement processor-internal instruction cache (I$) when `true`
+| Configuration generics: | `ICACHE_EN`         | implement processor-internal, CPU-exclusive instruction cache (I$) when `true`
 |                         | `ICACHE_NUM_BLOCKS` | number of cache blocks ("cache lines"); has to be a power of two
 |                         | `CACHE_BLOCK_SIZE`  | size of a cache block in bytes; has to be a power of two (global configuration for I$ and D$)
 | CPU interrupts:         | none |

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -85,9 +85,7 @@ entity neorv32_cpu is
     ibus_rsp_i : in  bus_rsp_t; -- response bus
     -- data bus interface --
     dbus_req_o : out bus_req_t; -- request bus
-    dbus_rsp_i : in  bus_rsp_t; -- response bus
-    -- memory synchronization --
-    mem_sync_i : in  std_ulogic -- synchronization operation done
+    dbus_rsp_i : in  bus_rsp_t  -- response bus
   );
 end neorv32_cpu;
 
@@ -271,9 +269,7 @@ begin
     -- load/store unit interface --
     lsu_wait_i    => lsu_wait,    -- wait for data bus
     lsu_mar_i     => lsu_mar,     -- memory address register
-    lsu_err_i     => lsu_err,     -- alignment/access errors
-    -- memory synchronization --
-    mem_sync_i    => mem_sync_i   -- synchronization operation done
+    lsu_err_i     => lsu_err      -- alignment/access errors
   );
 
   -- RISC-V machine interrupts --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110400"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110401"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -311,9 +311,6 @@ architecture neorv32_top_rtl of neorv32_top is
   signal iodev_req : iodev_req_t;
   signal iodev_rsp : iodev_rsp_t;
 
-  -- memory synchronization / ordering / coherence --
-  signal dcache_clean : std_ulogic_vector(num_cores_c-1 downto 0);
-
   -- IRQs --
   type firq_enum_t is (
     FIRQ_TWD, FIRQ_UART0_RX, FIRQ_UART0_TX, FIRQ_UART1_RX, FIRQ_UART1_TX, FIRQ_SPI, FIRQ_SDI, FIRQ_TWI,
@@ -546,9 +543,7 @@ begin
       ibus_rsp_i => cpu_i_rsp(i),
       -- data bus interface --
       dbus_req_o => cpu_d_req(i),
-      dbus_rsp_i => cpu_d_rsp(i),
-      -- memory synchronization --
-      mem_sync_i => dcache_clean(i)
+      dbus_rsp_i => cpu_d_rsp(i)
     );
 
 
@@ -566,7 +561,6 @@ begin
       port map (
         clk_i      => clk_i,
         rstn_i     => rstn_sys,
-        clean_o    => open, -- cache is read-only so it cannot be dirty
         host_req_i => cpu_i_req(i),
         host_rsp_o => cpu_i_rsp(i),
         bus_req_o  => icache_req(i),
@@ -595,7 +589,6 @@ begin
       port map (
         clk_i      => clk_i,
         rstn_i     => rstn_sys,
-        clean_o    => dcache_clean(i),
         host_req_i => cpu_d_req(i),
         host_rsp_o => cpu_d_rsp(i),
         bus_req_o  => dcache_req(i),
@@ -605,9 +598,8 @@ begin
 
     neorv32_dcache_disabled:
     if not DCACHE_EN generate
-      dcache_clean(i) <= '1';
-      dcache_req(i)   <= cpu_d_req(i);
-      cpu_d_rsp(i)    <= dcache_rsp(i);
+      dcache_req(i) <= cpu_d_req(i);
+      cpu_d_rsp(i)  <= dcache_rsp(i);
     end generate;
 
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -10,6 +10,7 @@
 /**********************************************************************//**
  * @file processor_check/main.c
  * @brief CPU/Processor test/verification program.
+ * @note This test program is written for simulation using the default testbench only.
  **************************************************************************/
 
 #include <neorv32.h>
@@ -22,16 +23,16 @@
 /**@{*/
 //** UART BAUD rate */
 #define BAUD_RATE        (19200)
-//** Reachable but unaligned address */
-#define ADDR_UNALIGNED_1 (0x00000001UL)
-//** Reachable but unaligned address */
-#define ADDR_UNALIGNED_3 (0x00000003UL)
-//** Unreachable word-aligned address */
-#define ADDR_UNREACHABLE (NEORV32_DM_BASE)
+//** Reachable but unaligned cached address */
+#define ADDR_UNALIGNED_1 (0x00000001U)
+//** Reachable but unaligned cached address */
+#define ADDR_UNALIGNED_3 (0x00000003U)
+//** Unreachable word-aligned cached address */
+#define ADDR_UNREACHABLE (0x70000000U)
 //** External memory base address */
-#define EXT_MEM_BASE     (0xF0000000UL)
+#define EXT_MEM_BASE     (0xF0000000U)
 //** External IRQ trigger base address */
-#define SIM_TRIG_BASE    (0xFF000000UL)
+#define SIM_TRIG_BASE    (0xFF000000U)
 /**@}*/
 
 


### PR DESCRIPTION
Moving back the to the "write-through" strategy.

* simpler memory synchronization: write to the data cache are always sync with main memory
* only main memory -> cache block transfers; this will make it easier to implement memory bursts
* write-allocate / write-back strategies might be re-implemented later when burst support is available 