### PR TITLE
[bus] add explicit burst signal to internal processor bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 12.05.2025 | 1.11.4.5 | add excplicit "burst" signal to processor-internal bus; clean-up CPU "fence" decoding | [#1265](https://github.com/stnolting/neorv32/pull/1265) |
 | 10.05.2025 | 1.11.4.4 | :sparkles: add cache burst transfers (read-only) | [#1263](https://github.com/stnolting/neorv32/pull/1263) |
 | 10.05.2025 | 1.11.4.3 | minor edits and optimizations | [#1262](https://github.com/stnolting/neorv32/pull/1262) |
 | 09.05.2025 | 1.11.4.2 | rework locking of processor-internal bus; bus locking is now implemented for the entire bus infrastructure | [#1260](https://github.com/stnolting/neorv32/pull/1260) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
-| 12.05.2025 | 1.11.4.5 | add excplicit "burst" signal to processor-internal bus; clean-up CPU "fence" decoding | [#1265](https://github.com/stnolting/neorv32/pull/1265) |
+| 12.05.2025 | 1.11.4.5 | add explicit "burst" signal to processor-internal bus; clean-up CPU "fence" decoding | [#1265](https://github.com/stnolting/neorv32/pull/1265) |
 | 10.05.2025 | 1.11.4.4 | :sparkles: add cache burst transfers (read-only) | [#1263](https://github.com/stnolting/neorv32/pull/1263) |
 | 10.05.2025 | 1.11.4.3 | minor edits and optimizations | [#1262](https://github.com/stnolting/neorv32/pull/1262) |
 | 09.05.2025 | 1.11.4.2 | rework locking of processor-internal bus; bus locking is now implemented for the entire bus infrastructure | [#1260](https://github.com/stnolting/neorv32/pull/1260) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -393,7 +393,8 @@ additional latency). However, _all_ bus signals (request and response) need to b
 | `debug` |     1 | Set if debug-mode access (access from the on-chip debugger).
 | `amo`   |     1 | Set if current access is an atomic memory operation.
 | `amoop` |     4 | Actual type of atomic memory operation. Irrelevant if `amo` is not set.
-| `lock`  |     1 | Set if contiguous transfer; the current transfer is part of a group of transfers that should not be interleaved. This signal is relevant for the interconnect / bus system only.
+| `burst` |     1 | Set during a burst transaction (always set together with `lock`).
+| `lock`  |     1 | Set if locked access; allow exclusive access to the bus system.
 3+^| **Out-Of-Band Signals**
 | `fence` |     1 | Data (load/store; `fence`) or instruction (instruction-fetch; `fence.i`) fence request; single-shot; see <<_memory_coherence>>.
 |=======================
@@ -445,6 +446,7 @@ The figure below shows three exemplary single-access bus transactions:
     {name: 'amo',   wave: 'x0.|.x0.x0.|.x'},
     {name: 'amoop', wave: 'x..|.......|..'},
     {name: 'lock',  wave: 'x0.|.......|.x'},
+    {name: 'burst', wave: 'x0.|.......|.x'},
     {name: 'fence', wave: '0..|.......|..'},
   ],
   {},
@@ -474,7 +476,7 @@ exclusive bus access and a 4-word incrementing-address read burst.
 [wavedrom, format="svg", align="center"]
 ----
 {signal: [
-  {name: 'clk', wave: 'p................'},
+  {name: 'clk', wave: 'p.................'},
   [
     "request",
     {name: 'addr',  wave: 'x3...x.|.4.567x..', data: ['addr', '0', '4', '8', '12']},
@@ -487,6 +489,7 @@ exclusive bus access and a 4-word incrementing-address read burst.
     {name: 'debug', wave: 'x......|.........'},
     {name: 'amo',   wave: 'x1...x.|.........'},
     {name: 'amoop', wave: 'x3...x.|.........'},
+    {name: 'burst', wave: 'x0....x|.1.....0x'},
     {name: 'lock',  wave: 'x1...0x|.1.....0x', node: '.b...f...i.....m'},
     {name: 'fence', wave: '0................'},
   ],
@@ -515,12 +518,12 @@ exclusive bus access and a 4-word incrementing-address read burst.
 **Burst Read Transfer**
 
 [start=1]
-. The locked burst request is sent by setting `lock` together with the first `stb` ("h"). The address applied to `addr`
-defines the base/start address of the burst. `lock` stays high until the end of the burst ("m").
+. The locked burst request is sent by setting `lock` and `burst` together with the first `stb` ("h"). The address applied to `addr`
+defines the base/start address of the burst. `lock` and `burst` stay high until the end of the burst ("m").
 . The bus is locked when the host received the first `ack` ("j"). Now the host has exclusive bus access and can
 request the remaining burst strobes ("k").
 . The burst is completed when all required `stb` pulses are sent and when all corresponding `ack` have been received ("n").
-`lock` is cleared and has to be low for at least one cycle to release the bus lock.
+`burst` is cleared. `lock` is cleared and has to be low for at least one cycle to release the bus lock.
 
 .Fast Burst Response
 [TIP]

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -137,24 +137,22 @@ begin
 
   -- Request Switch -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  x_req_o.addr  <= a_req_i.addr  when (sel = '0') else b_req_i.addr;
-  x_req_o.amo   <= a_req_i.amo   when (sel = '0') else b_req_i.amo;
-  x_req_o.amoop <= a_req_i.amoop when (sel = '0') else b_req_i.amoop;
-  x_req_o.lock  <= a_req_i.lock  when (sel = '0') else b_req_i.lock;
-  x_req_o.priv  <= a_req_i.priv  when (sel = '0') else b_req_i.priv;
-  x_req_o.debug <= a_req_i.debug when (sel = '0') else b_req_i.debug;
-  x_req_o.src   <= a_req_i.src   when (sel = '0') else b_req_i.src;
-  x_req_o.rw    <= a_req_i.rw    when (sel = '0') else b_req_i.rw;
-  x_req_o.fence <= a_req_i.fence or b_req_i.fence;
-
+  x_req_o.addr  <= a_req_i.addr  when (sel = '0')      else b_req_i.addr;
   x_req_o.data  <= b_req_i.data  when PORT_A_READ_ONLY else
                    a_req_i.data  when PORT_B_READ_ONLY else
                    a_req_i.data  when (sel = '0')      else b_req_i.data;
-
   x_req_o.ben   <= b_req_i.ben   when PORT_A_READ_ONLY else
                    a_req_i.ben   when PORT_B_READ_ONLY else
                    a_req_i.ben   when (sel = '0')      else b_req_i.ben;
-
+  x_req_o.rw    <= a_req_i.rw    when (sel = '0')      else b_req_i.rw;
+  x_req_o.src   <= a_req_i.src   when (sel = '0')      else b_req_i.src;
+  x_req_o.priv  <= a_req_i.priv  when (sel = '0')      else b_req_i.priv;
+  x_req_o.debug <= a_req_i.debug when (sel = '0')      else b_req_i.debug;
+  x_req_o.amo   <= a_req_i.amo   when (sel = '0')      else b_req_i.amo;
+  x_req_o.amoop <= a_req_i.amoop when (sel = '0')      else b_req_i.amoop;
+  x_req_o.burst <= a_req_i.burst when (sel = '0')      else b_req_i.burst;
+  x_req_o.lock  <= a_req_i.lock  when (sel = '0')      else b_req_i.lock;
+  x_req_o.fence <= a_req_i.fence or b_req_i.fence;
   x_req_o.stb   <= stb;
 
 
@@ -819,6 +817,7 @@ begin
   sys_req_o.debug <= core_req_i.debug;
   sys_req_o.amo   <= core_req_i.amo;
   sys_req_o.amoop <= core_req_i.amoop;
+  sys_req_o.burst <= core_req_i.burst;
   sys_req_o.lock  <= core_req_i.lock;
   sys_req_o.fence <= core_req_i.fence;
 

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -468,15 +468,12 @@ begin
 
           -- memory fence operations --
           when opcode_fence_c =>
-            if (exe_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_fencei_c) then -- instruction fence
-              ctrl_nxt.if_fence    <= '1';
-              exe_engine_nxt.state <= EX_RESTART; -- reset instruction fetch + IPB
-            elsif (exe_engine.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_fence_c) then -- data fence
-              ctrl_nxt.lsu_fence   <= '1'; -- load/store fence
-              exe_engine_nxt.state <= EX_DISPATCH;
-            else -- illegal
-              exe_engine_nxt.state <= EX_DISPATCH;
+            if (exe_engine.ir(instr_funct3_lsb_c) = '0') then -- data fence
+              ctrl_nxt.lsu_fence <= '1';
+            else -- instruction fence
+              ctrl_nxt.if_fence <= '1';
             end if;
+            exe_engine_nxt.state <= EX_RESTART; -- reset instruction fetch + IPB (actually only required for fence.i)
 
           -- FPU: floating-point operations --
           when opcode_fop_c =>

--- a/rtl/core/neorv32_cpu_frontend.vhd
+++ b/rtl/core/neorv32_cpu_frontend.vhd
@@ -130,7 +130,8 @@ begin
   ibus_req_o.debug <= ctrl_i.cpu_debug; -- CPU is in debug mode
   ibus_req_o.amo   <= '0';              -- cannot be an atomic memory operation
   ibus_req_o.amoop <= (others => '0');  -- cannot be an atomic memory operation
-  ibus_req_o.lock  <= '0';              -- always unlocked/single access
+  ibus_req_o.burst <= '0';              -- only single-access
+  ibus_req_o.lock  <= '0';              -- always unlocked access
   ibus_req_o.fence <= ctrl_i.if_fence;  -- fence request, valid without STB being set ("out-of-band" signal)
 
   -- IPB instruction data and status --

--- a/rtl/core/neorv32_cpu_lsu.vhd
+++ b/rtl/core/neorv32_cpu_lsu.vhd
@@ -108,7 +108,8 @@ begin
   end process mem_do_reg;
 
   -- hardwired signals --
-  dbus_req_o.src <= '0'; -- always data access
+  dbus_req_o.src   <= '0'; -- always data access
+  dbus_req_o.burst <= '0'; -- only single-access
 
   -- out-of-band signals --
   dbus_req_o.fence <= ctrl_i.lsu_fence;

--- a/rtl/core/neorv32_dma.vhd
+++ b/rtl/core/neorv32_dma.vhd
@@ -260,15 +260,16 @@ begin
   engine.busy <= '0' when (engine.state = S_IDLE) else '1';
 
   -- bus output --
+  dma_req_o.addr  <= engine.dst_addr when (engine.state = S_WRITE) else engine.src_addr;
   dma_req_o.stb   <= engine.stb;
   dma_req_o.rw    <= engine.rw;
-  dma_req_o.addr  <= engine.dst_addr when (engine.state = S_WRITE) else engine.src_addr;
   dma_req_o.src   <= '0'; -- source = data access
-  dma_req_o.lock  <= '0'; -- always single access
   dma_req_o.priv  <= priv_mode_m_c; -- DMA accesses are always privileged
   dma_req_o.debug <= '0'; -- can never ever be in debug mode
   dma_req_o.amo   <= '0'; -- no atomic memory operation possible
   dma_req_o.amoop <= (others => '0'); -- no atomic memory operation possible
+  dma_req_o.burst <= '0'; -- always single access
+  dma_req_o.lock  <= '0'; -- always unlocked access
   dma_req_o.fence <= '0';
 
   -- address increment --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110404"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110405"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -129,7 +129,8 @@ package neorv32_package is
     debug : std_ulogic; -- set if debug mode access
     amo   : std_ulogic; -- set if atomic memory operation
     amoop : std_ulogic_vector(3 downto 0); -- type of atomic memory operation
-    lock  : std_ulogic; -- set if contiguous transfer
+    burst : std_ulogic; -- set if part of burst access
+    lock  : std_ulogic; -- set if exclusive access request
     -- out-of-band signals --
     fence : std_ulogic; -- set if fence(.i) operation, single-shot
   end record;
@@ -146,6 +147,7 @@ package neorv32_package is
     debug => '0',
     amo   => '0',
     amoop => (others => '0'),
+    burst => '0',
     lock  => '0',
     fence => '0'
   );

--- a/rtl/core/neorv32_xbus.vhd
+++ b/rtl/core/neorv32_xbus.vhd
@@ -148,7 +148,7 @@ begin
 
   -- cycle type identifier (for the ENTIRE access; no burst termination type supported!) --
   xbus_cti_o <= "001" when (bus_req.amo = '1') else -- constant address burst
-                "010" when (bus_req.lock = '1') else -- incrementing address burst
+                "010" when (bus_req.burst = '1') else -- incrementing address burst
                 "000"; -- single access
 
   -- access meta data (compatible to AXI4 "xPROT") --


### PR DESCRIPTION
This PR adds an explicit "this is a burst"-signal to the processor-internal bus system. The `burst` signal is set when the `lock` signal is set (but not the other way around). This makes burst detection logic easier.