### PR TITLE
🐛 Fix missing burst signal in bus register stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 12.05.2025 | 1.11.4.6 | :bug: fix missing burst signal in bus register stage (introduced in previous version / v1.11.4.5) | [#1266](https://github.com/stnolting/neorv32/pull/1266) |
 | 12.05.2025 | 1.11.4.5 | add explicit "burst" signal to processor-internal bus; clean-up CPU "fence" decoding | [#1265](https://github.com/stnolting/neorv32/pull/1265) |
 | 10.05.2025 | 1.11.4.4 | :sparkles: add cache burst transfers (read-only) | [#1263](https://github.com/stnolting/neorv32/pull/1263) |
 | 10.05.2025 | 1.11.4.3 | minor edits and optimizations | [#1262](https://github.com/stnolting/neorv32/pull/1262) |

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -219,9 +219,12 @@ begin
         if (host_req_i.stb = '1') then -- reduce switching activity on downstream bus system
           device_req_o <= host_req_i;
         end if;
-        device_req_o.stb   <= host_req_i.stb; -- access control signal
-        device_req_o.lock  <= host_req_i.lock; -- access control signal
-        device_req_o.fence <= host_req_i.fence; -- out-of-band signal
+        -- pass-through access control signals --
+        device_req_o.stb   <= host_req_i.stb;
+        device_req_o.burst <= host_req_i.burst;
+        device_req_o.lock  <= host_req_i.lock;
+        -- pass-through out-of-band signals --
+        device_req_o.fence <= host_req_i.fence;
       end if;
     end process request_reg;
   end generate;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110405"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110406"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 


### PR DESCRIPTION
Bug introduced in previous version (v1.11.4.5, #1265).