### PR TITLE
:bug: fix CPU bus issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 17.05.2025 | 1.11.4.9 | :bug: fix CPU's `lock` being cleared too early during atomic read-modify-write operations; :bug: fix cache's `ben` signal generation | [#1270](https://github.com/stnolting/neorv32/pull/1270) |
 | 16.05.2025 | 1.11.4.8 | :warning: remove hardware spinlocks and CPU's inter-core communication links | [#1268](https://github.com/stnolting/neorv32/pull/1268) |
 | 16.05.2025 | 1.11.4.7 | :warning: make `mcause` CSR read-only | [#1267](https://github.com/stnolting/neorv32/pull/1267) |
 | 12.05.2025 | 1.11.4.6 | :bug: fix missing burst signal in bus register stage (introduced in previous version / v1.11.4.5) | [#1266](https://github.com/stnolting/neorv32/pull/1266) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -381,7 +381,7 @@ additional latency). However, _all_ bus signals (request and response) need to b
 3+^| **In-Band Signals**
 | `addr`  |    32 | Access address using byte-wise addressing. Half-word (16-bit) and word (32-bit) addresses are aligned accordingly (e.g. LSB = 0 for half-word accesses).
 | `data`  |    32 | Write data. Writing individual bytes is controlled via `ben`.
-| `ben`   |     4 | Byte-enable for each byte in `data`.
+| `ben`   |     4 | Byte-enable for each byte in `data`. This signal is used for the write-data as well as for the read-data.
 | `stb`   |     1 | Request trigger ("strobe"). This signal is high for exactly one cycle starting a bus request. All other _in-band_ signals are valid only if `stb` is set.
 | `rw`    |     1 | Access direction (`0` = read, `1` = write).
 | `src`   |     1 | Access source (`0` = instruction fetch, `1` = load/store).
@@ -433,7 +433,7 @@ The figure below shows three exemplary single-access bus transactions:
     "request",
     {name: 'addr',  wave: 'x3.|.x4.x5.|.x', data: ['A_addr', 'B_addr', 'C_addr']},
     {name: 'data',  wave: 'x..|..4.x..|..', data: ['wdata']},
-    {name: 'ben',   wave: 'x..|..4.x..|..', data: ['ben']},
+    {name: 'ben',   wave: 'x3.|.x4.x5.|.x', data: ['ben', 'ben', 'ben']},
     {name: 'stb',   wave: '010|..10.10|..', node: '.a....c..e....'},
     {name: 'rw',    wave: 'x0.|.x1.x0.|.x', node: '..............'},
     {name: 'src',   wave: 'x0.|.x0.x0.|.x'},
@@ -475,16 +475,16 @@ exclusive bus access and a 4-word incrementing-address read burst.
   {name: 'clk', wave: 'p.................'},
   [
     "request",
-    {name: 'addr',  wave: 'x3...x.|.4.567x..', data: ['addr', '0', '4', '8', '12']},
-    {name: 'data',  wave: 'x..3.x.|.........', data: ['wdata', '0', '4', '8', '12']},
-    {name: 'ben',   wave: 'x..3.x.|.........'},
+    {name: 'addr',  wave: 'x2...x.|.3.456x..', data: ['addr', '0', '4', '8', '12']},
+    {name: 'data',  wave: 'x..2.x.|.........', data: ['wdata', '0', '4', '8', '12']},
+    {name: 'ben',   wave: 'x2.2.x.|.2....x..', data: ['1111', '1111', '1111']},
     {name: 'stb',   wave: '01010..|.101..0..', node: '.a.d.....h.k.'},
     {name: 'rw',    wave: 'x0.1.x.|.0....x..'},
     {name: 'src',   wave: 'x......|.........'},
     {name: 'priv',  wave: 'x......|.........'},
     {name: 'debug', wave: 'x......|.........'},
     {name: 'amo',   wave: 'x1...x.|.........'},
-    {name: 'amoop', wave: 'x3...x.|.........'},
+    {name: 'amoop', wave: 'x2...x.|.........'},
     {name: 'burst', wave: 'x0....x|.1.....0x'},
     {name: 'lock',  wave: 'x1...0x|.1.....0x', node: '.b...f...i.....m'},
     {name: 'fence', wave: '0................'},

--- a/docs/datasheet/soc_xbus.adoc
+++ b/docs/datasheet/soc_xbus.adoc
@@ -58,7 +58,7 @@ Basically, three types of bus transfer are implemented which are illustrated in 
 . **Single-access** transfers perform a single read or write operation.
 . **Atomic-access** transfers perform a read followed by a write operation. The bus is locked during the entire transfer
 to maintain exclusive bus access. This transfer type is used by the CPU to perform atomic read-modify-write operations.
-* **Burst read** transfers perform several consecutive read accesses. This transfer type is used by cache block operations.
+. **Burst read** transfers perform several consecutive read accesses. This transfer type is used by cache block operations.
 
 .XBUS **Single Access** Transfers: Write (left) and Read (right)
 [wavedrom, format="svg", align="center"]
@@ -70,7 +70,7 @@ to maintain exclusive bus access. This transfer type is used by the CPU to perfo
   {name: 'xbus_cti_o',  wave: 'x3...|.x4...|.x.', data: ['000 (classic cycle)', '000 (classic cycle)']},
   {name: 'xbus_tag_o',  wave: 'x3...|.x4...|.x.', data: ['tag', 'tag']},
   {name: 'xbus_we_o',   wave: 'x1...|.x0...|.x.'},
-  {name: 'xbus_sel_o',  wave: 'x3...|.x....|.x.', data: ['byte_enable']},
+  {name: 'xbus_sel_o',  wave: 'x3...|.x4...|.x.', data: ['byte_enable', 'byte_enable']},
   {name: 'xbus_stb_o',  wave: '010..|..10..|...', node: '.a......d.....'},
   {name: 'xbus_cyc_o',  wave: '01...|.01...|.0.', node: '.b......e.....'},
   {},
@@ -92,7 +92,7 @@ to maintain exclusive bus access. This transfer type is used by the CPU to perfo
   {name: 'xbus_cti_o',  wave: 'x7.....x', data: ['001 (constant address burst)']},
   {name: 'xbus_tag_o',  wave: 'x2.....x'},
   {name: 'xbus_we_o',   wave: 'x0..1..x'},
-  {name: 'xbus_sel_o',  wave: 'x...2..x'},
+  {name: 'xbus_sel_o',  wave: 'x2.....x'},
   {name: 'xbus_stb_o',  wave: '010.10..', node: '.a..c'},
   {name: 'xbus_cyc_o',  wave: '01.....0'},
   {},
@@ -114,7 +114,7 @@ to maintain exclusive bus access. This transfer type is used by the CPU to perfo
   {name: 'xbus_cti_o',  wave: 'x7.....x.', data: ['111 (incrementing address burst)']},
   {name: 'xbus_tag_o',  wave: 'x2.....x.'},
   {name: 'xbus_we_o',   wave: 'x0.....x.'},
-  {name: 'xbus_sel_o',  wave: 'x........'},
+  {name: 'xbus_sel_o',  wave: 'x2.....x.'},
   {name: 'xbus_stb_o',  wave: '0101..0..', node: '.a.c'},
   {name: 'xbus_cyc_o',  wave: '01.....0.', node: '.......d'},
   {},

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -232,6 +232,7 @@ begin
         bus_req_o.stb   <= '1'; -- send initial (burst/locking) request
         bus_req_o.lock  <= '1'; -- this is a locked transfer
         bus_req_o.burst <= '1'; -- this is a burst transfer
+        bus_req_o.ben   <= (others => '1'); -- full-word access
         ctrl_nxt.state  <= S_DOWNLOAD_WAIT;
 
       when S_DOWNLOAD_WAIT => -- wait for exclusive (=locked) bus access
@@ -243,6 +244,7 @@ begin
         bus_req_o.rw    <= '0'; -- read access
         bus_req_o.lock  <= '1'; -- this is a locked transfer
         bus_req_o.burst <= '1'; -- this is a burst transfer
+        bus_req_o.ben   <= (others => '1'); -- full-word access
         -- wait for initial ACK to start actual bursting --
         if (bus_rsp_i.ack = '1') then
           ctrl_nxt.buf_err <= bus_rsp_i.err; -- buffer bus error
@@ -260,6 +262,7 @@ begin
         bus_req_o.rw    <= '0'; -- read access
         bus_req_o.lock  <= '1'; -- this is a locked transfer
         bus_req_o.burst <= '1'; -- this is a burst transfer
+        bus_req_o.ben   <= (others => '1'); -- full-word access
         -- send requests --
         if (ctrl.ofs_ext(offset_size_c) = '0') then
           ctrl_nxt.ofs_ext <= std_ulogic_vector(unsigned(ctrl.ofs_ext) + 1); -- next cache word

--- a/rtl/core/neorv32_cpu_lsu.vhd
+++ b/rtl/core/neorv32_cpu_lsu.vhd
@@ -142,7 +142,7 @@ begin
     elsif rising_edge(clk_i) then
       if (ctrl_i.lsu_mo_we = '1') and (ctrl_i.lsu_amo = '1') and (ctrl_i.ir_funct12(8) = '0') then
         dbus_req_o.lock <= '1'; -- set if Zaamo instruction
-      elsif (pending = '0') then
+      elsif (dbus_rsp_i.ack = '1') or (ctrl_i.cpu_trap = '1') then
         dbus_req_o.lock <= '0'; -- clear at the end of the bus access
       end if;
     end if;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110408"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110409"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/sim/xbus_memory.vhd
+++ b/sim/xbus_memory.vhd
@@ -85,6 +85,7 @@ architecture xbus_memory_rtl of xbus_memory is
   end function init_mem8bv_from_hexfile_f;
 
   -- memory access --
+  signal addr  : unsigned(addr_bits_c-1 downto 0);
   signal rdata : std_ulogic_vector(31 downto 0);
   signal ack   : std_ulogic;
 
@@ -109,26 +110,36 @@ begin
       if (xbus_req_i.cyc = '1') and (xbus_req_i.stb = '1') then
         if (xbus_req_i.we = '1') then
           if (xbus_req_i.sel(0) = '1') then
-            mem8bv_b0_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))) := to_bitvector(xbus_req_i.data(07 downto 00));
+            mem8bv_b0_v(to_integer(addr)) := to_bitvector(xbus_req_i.data(07 downto 00));
           end if;
           if (xbus_req_i.sel(1) = '1') then
-            mem8bv_b1_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))) := to_bitvector(xbus_req_i.data(15 downto 08));
+            mem8bv_b1_v(to_integer(addr)) := to_bitvector(xbus_req_i.data(15 downto 08));
           end if;
           if (xbus_req_i.sel(2) = '1') then
-            mem8bv_b2_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))) := to_bitvector(xbus_req_i.data(23 downto 16));
+            mem8bv_b2_v(to_integer(addr)) := to_bitvector(xbus_req_i.data(23 downto 16));
           end if;
           if (xbus_req_i.sel(3) = '1') then
-            mem8bv_b3_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))) := to_bitvector(xbus_req_i.data(31 downto 24));
+            mem8bv_b3_v(to_integer(addr)) := to_bitvector(xbus_req_i.data(31 downto 24));
           end if;
         else
-          rdata(07 downto 00) <= to_stdulogicvector(mem8bv_b0_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))));
-          rdata(15 downto 08) <= to_stdulogicvector(mem8bv_b1_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))));
-          rdata(23 downto 16) <= to_stdulogicvector(mem8bv_b2_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))));
-          rdata(31 downto 24) <= to_stdulogicvector(mem8bv_b3_v(to_integer(unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2)))));
+          if (xbus_req_i.sel(0) = '1') then
+            rdata(07 downto 00) <= to_stdulogicvector(mem8bv_b0_v(to_integer(addr)));
+          end if;
+          if (xbus_req_i.sel(1) = '1') then
+            rdata(15 downto 08) <= to_stdulogicvector(mem8bv_b1_v(to_integer(addr)));
+          end if;
+          if (xbus_req_i.sel(2) = '1') then
+            rdata(23 downto 16) <= to_stdulogicvector(mem8bv_b2_v(to_integer(addr)));
+          end if;
+          if (xbus_req_i.sel(3) = '1') then
+            rdata(31 downto 24) <= to_stdulogicvector(mem8bv_b3_v(to_integer(addr)));
+          end if;
         end if;
       end if;
     end if;
   end process memory_data;
+
+  addr <= unsigned(xbus_req_i.addr(addr_bits_c+1 downto 2));
 
   memory_ack: process(rstn_i, clk_i)
   begin


### PR DESCRIPTION
* 🐛 For atomic read-modify-write operations the CPU's `lock` signal is cleared too early.
* 🐛 Previously, the `ben` bus signal was only used internally for write accesses. Read accesses were always expected to return a complete 32-bit word. However, this is a problem for the XBUS interface, as the `sel` (= `ben`) Wishbone signal is also used for read accesses (-> #1269). This PR fixes this issue; `sel` and `ben` now correctly indicate which read/write data bytes are actually valid/required.

These errors were introduced with the introduction of the locking infrastructure / cache burst.