### PR TITLE
:bug: fix byte-enable bus signal for instruction fetch accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 22.05.2025 | 1.11.5.1 | :bug: fix instruction fetch `ben`/`stb` signaling (has to be all-one -> always request full 32-bit words) | [#1272](https://github.com/stnolting/neorv32/pull/1272) |
 | 22.05.2025 | [**:rocket:1.11.5**](https://github.com/stnolting/neorv32/releases/tag/v1.11.5) | **New release** | |
 | 17.05.2025 | 1.11.4.9 | :bug: fix CPU's `lock` being cleared too early during atomic read-modify-write operations; :bug: fix cache's `ben` signal generation | [#1270](https://github.com/stnolting/neorv32/pull/1270) |
 | 16.05.2025 | 1.11.4.8 | :warning: remove hardware spinlocks and CPU's inter-core communication links | [#1268](https://github.com/stnolting/neorv32/pull/1268) |

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -141,9 +141,7 @@ begin
   x_req_o.data  <= b_req_i.data  when PORT_A_READ_ONLY else
                    a_req_i.data  when PORT_B_READ_ONLY else
                    a_req_i.data  when (sel = '0')      else b_req_i.data;
-  x_req_o.ben   <= b_req_i.ben   when PORT_A_READ_ONLY else
-                   a_req_i.ben   when PORT_B_READ_ONLY else
-                   a_req_i.ben   when (sel = '0')      else b_req_i.ben;
+  x_req_o.ben   <= a_req_i.ben   when (sel = '0')      else b_req_i.ben;
   x_req_o.rw    <= a_req_i.rw    when (sel = '0')      else b_req_i.rw;
   x_req_o.src   <= a_req_i.src   when (sel = '0')      else b_req_i.src;
   x_req_o.priv  <= a_req_i.priv  when (sel = '0')      else b_req_i.priv;

--- a/rtl/core/neorv32_cpu_frontend.vhd
+++ b/rtl/core/neorv32_cpu_frontend.vhd
@@ -123,7 +123,7 @@ begin
   ibus_req_o.addr  <= fetch.pc(XLEN-1 downto 2) & "00"; -- word aligned
   ibus_req_o.stb   <= '1' when (fetch.state = S_REQUEST) and (ipb.free = "11") else '0';
   ibus_req_o.data  <= (others => '0');  -- read-only
-  ibus_req_o.ben   <= (others => '0');  -- read-only
+  ibus_req_o.ben   <= (others => '1');  -- always full-word access
   ibus_req_o.rw    <= '0';              -- read-only
   ibus_req_o.src   <= '1';              -- always "instruction fetch" access
   ibus_req_o.priv  <= fetch.priv;       -- current effective privilege level

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110500"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110501"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 


### PR DESCRIPTION
Instruction fetch always has to request a full 32-bit word (-> `ben = 1111`).

This bug only affects the external bus interface (XBUS). The processor-internal modules ignore `ben` for read accesses and always output a full 32-bit word.