### PR TITLE
Rework IMEM & DMEM RAM style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 31.05.2025 | 1.11.5.5 | rework IMEM/DMEM RAM HDL style to prevent DRC errors on Vivado 24.1 when cascading many BRAM blocks | [#1277](https://github.com/stnolting/neorv32/pull/1277) |
 | 26.05.2025 | 1.11.5.4 | :warning: remove cyclic redundancy check unit (CRC) | [#1275](https://github.com/stnolting/neorv32/pull/1275) |
 | 24.05.2025 | 1.11.5.3 | :warning: rework CFS IO conduits; remove CFS generics | [#1274](https://github.com/stnolting/neorv32/pull/1274) |
 | 23.05.2025 | 1.11.5.2 | minor rtl edits and cleanups | [#1273](https://github.com/stnolting/neorv32/pull/1273) |

--- a/rtl/core/neorv32_dmem.vhd
+++ b/rtl/core/neorv32_dmem.vhd
@@ -53,21 +53,21 @@ begin
   mem_access: process(clk_i)
   begin
     if rising_edge(clk_i) then
-      if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') then
-        if (bus_req_i.ben(0) = '1') then -- byte 0
+      if (bus_req_i.stb = '1') then
+        -- write access --
+        if (bus_req_i.ben(0) = '1') and (bus_req_i.rw = '1') then -- byte 0
           mem_ram_b0(to_integer(addr)) <= bus_req_i.data(7 downto 0);
         end if;
-        if (bus_req_i.ben(1) = '1') then -- byte 1
+        if (bus_req_i.ben(1) = '1') and (bus_req_i.rw = '1') then -- byte 1
           mem_ram_b1(to_integer(addr)) <= bus_req_i.data(15 downto 8);
         end if;
-        if (bus_req_i.ben(2) = '1') then -- byte 2
+        if (bus_req_i.ben(2) = '1') and (bus_req_i.rw = '1') then -- byte 2
           mem_ram_b2(to_integer(addr)) <= bus_req_i.data(23 downto 16);
         end if;
-        if (bus_req_i.ben(3) = '1') then -- byte 3
+        if (bus_req_i.ben(3) = '1') and (bus_req_i.rw = '1') then -- byte 3
           mem_ram_b3(to_integer(addr)) <= bus_req_i.data(31 downto 24);
         end if;
-      end if;
-      if (bus_req_i.stb = '1') and (bus_req_i.rw = '0') then
+        -- read access --
         rdata(7  downto 0)  <= mem_ram_b0(to_integer(addr));
         rdata(15 downto 8)  <= mem_ram_b1(to_integer(addr));
         rdata(23 downto 16) <= mem_ram_b2(to_integer(addr));
@@ -76,7 +76,7 @@ begin
     end if;
   end process mem_access;
 
-  -- word aligned access address --
+  -- word access address --
   addr <= unsigned(bus_req_i.addr(addr_hi_c downto 2));
 
 

--- a/rtl/core/neorv32_imem.vhd
+++ b/rtl/core/neorv32_imem.vhd
@@ -79,7 +79,7 @@ begin
     end process mem_access;
   end generate;
 
-  -- word aligned access address --
+  -- word access address --
   addr <= unsigned(bus_req_i.addr(addr_hi_c downto 2));
 
 
@@ -90,21 +90,21 @@ begin
     mem_access: process(clk_i)
     begin
       if rising_edge(clk_i) then
-        if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') then
-          if (bus_req_i.ben(0) = '1') then -- byte 0
+        if (bus_req_i.stb = '1') then
+          -- write access --
+          if (bus_req_i.ben(0) = '1') and (bus_req_i.rw = '1') then -- byte 0
             mem_ram_b0(to_integer(addr)) <= bus_req_i.data(7 downto 0);
           end if;
-          if (bus_req_i.ben(1) = '1') then -- byte 1
+          if (bus_req_i.ben(1) = '1') and (bus_req_i.rw = '1') then -- byte 1
             mem_ram_b1(to_integer(addr)) <= bus_req_i.data(15 downto 8);
           end if;
-          if (bus_req_i.ben(2) = '1') then -- byte 2
+          if (bus_req_i.ben(2) = '1') and (bus_req_i.rw = '1') then -- byte 2
             mem_ram_b2(to_integer(addr)) <= bus_req_i.data(23 downto 16);
           end if;
-          if (bus_req_i.ben(3) = '1') then -- byte 3
+          if (bus_req_i.ben(3) = '1') and (bus_req_i.rw = '1') then -- byte 3
             mem_ram_b3(to_integer(addr)) <= bus_req_i.data(31 downto 24);
           end if;
-        end if;
-        if (bus_req_i.stb = '1') and (bus_req_i.rw = '0') then
+          -- read access --
           rdata(7  downto 0)  <= mem_ram_b0(to_integer(addr));
           rdata(15 downto 8)  <= mem_ram_b1(to_integer(addr));
           rdata(23 downto 16) <= mem_ram_b2(to_integer(addr));

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110504"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110505"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -684,7 +684,7 @@ package neorv32_package is
 
   -- Trap System ----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  -- exception source list --
+  -- exception source list (do not change order!) --
   constant exc_iaccess_c  : natural :=  0; -- instruction access fault
   constant exc_illegal_c  : natural :=  1; -- illegal instruction
   constant exc_ialign_c   : natural :=  2; -- instruction address misaligned


### PR DESCRIPTION
The previous version caused DRC errors (cascading BRAMs) on Vivado 24.1 when using large IMEM/DMEM configuration (> 256kB).