### PR TITLE
🧪 rework DMA controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 31.05.2025 | 1.11.5.7 | :test_tube: rework DMA controller | [#1279](https://github.com/stnolting/neorv32/pull/1279) |
 | 31.05.2025 | 1.11.5.6 | rework instruction exception logic; fix: no execution of instruction words that returned as bus access exception | [#1278](https://github.com/stnolting/neorv32/pull/1278) |
 | 31.05.2025 | 1.11.5.5 | rework IMEM/DMEM RAM HDL style to prevent DRC errors on Vivado 24.1 when cascading many BRAM blocks | [#1277](https://github.com/stnolting/neorv32/pull/1277) |
 | 26.05.2025 | 1.11.5.4 | :warning: remove cyclic redundancy check unit (CRC) | [#1275](https://github.com/stnolting/neorv32/pull/1275) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -294,6 +294,7 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `IO_ONEWIRE_EN`         | boolean   | false         | Implement the <<_one_wire_serial_interface_controller_onewire>>.
 | `IO_ONEWIRE_FIFO`       | natural   | 1             | Depth of the <<_one_wire_serial_interface_controller_onewire>> FIFO. Has to be a power of two, min 1, max 32768.
 | `IO_DMA_EN`             | boolean   | false         | Implement the <<_direct_memory_access_controller_dma>>.
+| `IO_DMA_DSC_FIFO`       | natural   | 4             | Depth of the DMA transfer descriptor FIFO. Has to be a power of two, min 4, max 512.
 | `IO_SLINK_EN`           | boolean   | false         | Implement the <<_stream_link_interface_slink>> (AXI4-Stream).
 | `IO_SLINK_RX_FIFO`      | natural   | 1             | SLINK RX FIFO depth, has to be a power of two, minimum value is 1, max 32768.
 | `IO_SLINK_TX_FIFO`      | natural   | 1             | SLINK TX FIFO depth, has to be a power of two, minimum value is 1, max 32768.

--- a/docs/datasheet/soc_dma.adoc
+++ b/docs/datasheet/soc_dma.adoc
@@ -5,31 +5,34 @@
 [cols="<3,<3,<4"]
 [grid="none"]
 |=======================
-| Hardware source files:  | neorv32_dma.vhd |
-| Software driver files:  | neorv32_dma.c | link:https://stnolting.github.io/neorv32/sw/neorv32__dma_8c.html[Online software reference (Doxygen)]
-|                         | neorv32_dma.h | link:https://stnolting.github.io/neorv32/sw/neorv32__dma_8h.html[Online software reference (Doxygen)]
-| Top entity ports:       | none |
-| Configuration generics: | `IO_DMA_EN` | implement DMA when `true`
-| CPU interrupts:         | fast IRQ channel 10 | DMA transfer done (see <<_processor_interrupts>>)
+| Hardware source files:  | neorv32_dma.vhd     |
+| Software driver files:  | neorv32_dma.c       | link:https://stnolting.github.io/neorv32/sw/neorv32__dma_8c.html[Online software reference (Doxygen)]
+|                         | neorv32_dma.h       | link:https://stnolting.github.io/neorv32/sw/neorv32__dma_8h.html[Online software reference (Doxygen)]
+| Top entity ports:       | none                |
+| Configuration generics: | `IO_DMA_EN`         | implement DMA when `true`
+|                         | `IO_DMA_DSC_FIFO`   | descriptor FIFO depth, has to be a power of 2, min 4, max 512
+| CPU interrupts:         | fast IRQ channel 10 | DMA transfer(s) done (see <<_processor_interrupts>>)
 |=======================
 
 
 **Overview**
 
-The NEORV32 DMA provides a lightweight direct memory access controller that allows to transfer and
-modify data independently of the CPU. A single read/write channel is implemented that is configured via
-memory-mapped registers.
+The NEORV32 DMA features a lightweight direct memory access controller that allows to move and modify data independently
+of the CPU. Only a single read/write channel is implemented. So only one programmed transfer can be in progress at a time.
+However, a configurable descriptor FIFO is provided which allows to program several transfers so the DMA can execute them
+one after the other.
 
-The DMA is connected to the central processor-internal bus system (see section <<_address_space>>) and can access the same
-address space as the CPU core. It uses _interleaving mode_ accessing the central processor bus only if the CPU does not
-currently request and bus access. The controller can handle different data quantities (e.g. read bytes and write them
-back as sign-extend words) and can also change the Endianness of data while transferring.
+The DMA is connected to the central processor-internal bus system (see section <<_address_space>>) and can access the
+entire/same address space as the CPU core. It uses _interleaving mode_ accessing the central processor bus only if the CPU
+does not currently request a bus access. The DMA controller can handle different data quantities (e.g. read bytes and write
+them back as zero-extended words) and can also change the Endianness of data while transferring. It supports reading/writing
+data from/to fixed or auto-incrementing addresses.
 
-
-.DMA Access Privilege Level
-[WARNING]
+.DMA Bus Access
+[NOTE]
 Transactions performed by the DMA are executed as bus transactions with elevated **machine-mode** privilege level.
 Note that any physical memory protection rules (<<_smpmp_isa_extension>>) are not applied to DMA transfers.
+Furthermore, the DMA uses single-transfers only (.e. no burst transfers).
 
 .DMA Demo Program
 [TIP]
@@ -38,60 +41,75 @@ A DMA example program can be found in `sw/example/demo_dma`.
 
 **Theory of Operation**
 
-The DMA provides four memory-mapped interface registers: A status and control register `CTRL` and three registers for
-configuring the actual DMA transfer. The base address of the source data is programmed via the `SRC_BASE` register.
-Vice versa, the base address of the destination data is programmed via the `DST_BASE`. The third configuration register
-`TTYPE` is use to configure the actual transfer type and the number of elements to transfer.
+The DMA provides just two memory-mapped interface registers: A status and control register `CTRL` and
+another one for writing the transfer descriptor(s) to the internal descriptor FIFO.
 
-The DMA is enabled by setting the `DMA_CTRL_EN` bit of the control register. A programmed DMA transfer is initiated
-by setting the control register's `DMA_CTRL_START` bit.
+The DMA is enabled by setting the `DMA_CTRL_EN` bit of the control register. Clearing this flag will abort any outstanding
+transfer and will also reset/clear the descriptor FIFO. A programmed DMA transfer is initiated by setting the control
+register's `DMA_CTRL_START` bit. Setting this bit while the descriptor FIFO is empty has no effect. The current status
+of the FIFO can be checked via the `DMA_CTRL_D*` flags.
 
-The DMA uses a load-modify-write data transfer process. Data is read from the bus system, internally modified and then written
-back to the bus system. This combination is implemented as an atomic progress, so canceling the current transfer by clearing the
-`DMA_CTRL_EN` bit will stop the DMA after the current load-modify-write operation.
+The DMA uses an atomic read-modify-write transfer process. Data is read from the current source address, modified/aligned
+internally and then written back to the current destination address. If the DMA controller detects a bus error during operation,
+it will set the `DMA_CTRL_ERROR` and terminate the current transfer waiting in idle state for the user to acknowledge/clear
+`DMA_CTRL_ERROR`. This also happens if there are further descriptor in the FIFO that have not yet been executed.
 
-If the DMA controller detects a bus error during operation, it will set either the `DMA_CTRL_ERROR_RD` (error during
-last read access) or `DMA_CTRL_ERROR_WR` (error during last write access) and will terminate the current transfer.
-Software can read the `SRC_BASE` or `DST_BASE` register to retrieve the address that caused the according error.
-The error bits are automatically cleared when starting a new transfer. The error flags auto-clear when starting a new
-DMA transfer.
-
-When the `DMA_CTRL_DONE` flag is set the DMA has actually executed a transfer. However, the `DMA_CTRL_ERROR_*` flags
-should also be checked to verify that the executed transfer completed without errors. The `DMA_CTRL_DONE` flag is
-automatically cleared when writing the `CTRL` register.
+When the `DMA_CTRL_DONE` flag is set the DMA has completed all programmed transfers, i.e. all descriptors from the FIFO
+were executed. This flag also triggers the DMA controller's interrupt request signal. The application software has to
+clear `DMA_CTRL_DONE` in order to acknowledge the interrupt and to start further transfers.
 
 
-**Transfer Configuration**
+**DMA Descriptor**
 
-Once started, the DMA will read one data quantity from the source address, processes it internally
-and then will write it back to the destination address. The `DMA_TTYPE_NUM` bits of the `TTYPE` register define how many
-times this process is repeated by specifying the number of elements to transfer.
+All DMA transfers are executed based on _descriptors_. A descriptor contains the data source and destination base addresses
+as well as the number of elements to transfer and the data type and handling configuration. A complete descriptor is
+encoded as 3 consecutive 32-bit words:
 
-Optionally, the source and/or destination addresses can be automatically increments according to the data quantities
-by setting the according `DMA_TTYPE_SRC_INC` and/or `DMA_TTYPE_DST_INC` bit.
+.DMA Descriptor
+[cols="<1,<2,<7"]
+[options="header",grid="all"]
+|=======================
+| Index | Size | Description
+| 0 | 32-bit | Source data base address
+| 1 | 32-bit | Destination data base address
+| 2 | 32-bit | Transfer configuration word (see next table)
+|=======================
 
-Four different transfer quantities are available, which are configured via the `DMA_TTYPE_QSEL` bits:
+.Descriptor FIFO Size
+[NOTE]
+The descriptor FIFO has a minimal size of 4 entries. This can be extended by the `IO_DMA_DSC_FIFO` generic.
 
-* `00`: Read source data as byte, write destination data as byte
-* `01`: Read source data as byte, write destination data as zero-extended word
-* `10`: Read source data as byte, write destination data as sign-extended word
-* `11`: Read source data as word, write destination data as word
+.Incomplete Descriptors
+[NOTE]
+The DMA controller consumes 3 entries from the FIFO for each transfer. If the FIFO does not provide a complete
+DMA descriptor, the controller will remove the incomplete descriptor and will set the `DMA_CTRL_ERROR` status flag
+without executing the incomplete transfer descriptor.
 
-Optionally, the DMA controller can automatically convert Endianness of the transferred data if the `DMA_TTYPE_ENDIAN`
-bit is set.
+The source and destination data addresses can target any memory location in the entire 32-bit address space including
+memory-mapped peripherals. The number of elements to transfer as well as incrementing or constant byte- or word-level
+transfers are configured via the transfer configuration word (3rd descriptor word):
 
-.Address Alignment
-[IMPORTANT]
-Make sure to align the source and destination base addresses to the according transfer data quantities. For instance,
-word-to-word transfers require that the two LSB of `SRC_BASE` and `DST_BASE` are cleared.
+.DMA Descriptor - Transfer Configuration Word
+[cols="<1,<2,<6"]
+[options="header",grid="all"]
+|=======================
+| Bit(s) | Name | Description
+| `23:0`  | `DMA_CONF_NUM`   | Number of elements to transfer; must be greater than zero
+| `26:24` | -                | _reserved_, set to zero
+| `27`    | `DMA_CONF_BSWAP` | Set to swap byte order ("Endianness" conversion)
+| `29:28` | `DMA_CONF_SRC`   | Source data configuration (see list below)
+| `31:30` | `DMA_CONF_DST`   | Destination data configuration (see list below)
+|=======================
 
+Source and destination data accesses are configured by a 2-bit selector individually for the source and the destination data:
 
-**DMA Interrupt**
+* `00`: Constant byte - transfer data as byte (8-bit); do not alter address during transfer
+* `01`: Constant word - transfer data as word (32-bit); do not alter address during transfer
+* `10`: Incrementing byte - transfer data as byte (8-bit); increment the source address by 1
+* `11`: Incrementing word - transfer data as word (32-bit); increment the source address by 4
 
-The DMA features a single CPU interrupt that is triggered when the programmed transfer has completed. This
-interrupt is also triggered if the DMA encounters a bus error during operation. The interrupt will remain pending
-until the control register's `DMA_CTRL_DONE` is cleared (this will happen upon any write access to the control
-register).
+optionally, the controller automatically swaps the logical byte order ("Endianness") of the transferred data
+when the `DMA_CONF_BSWAP` bit is set.
 
 
 **Register Map**
@@ -101,19 +119,15 @@ register).
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.7+<| `0xffed0000` .7+<| `CTRL` <|`0`    `DMA_CTRL_EN`       ^| r/w <| DMA module enable
-                                <|`1`    `DMA_CTRL_START`    ^| r/s <| Start programmed DMA transfer (reads as zero)
-                                <|`7:27` _reserved_          ^| r/- <| reserved, read as zero
-                                <|`28`   `DMA_CTRL_ERROR_RD` ^| r/- <| Error during read access, clears when starting a new transfer
-                                <|`29`   `DMA_CTRL_ERROR_WR` ^| r/- <| Error during write access, clears when starting a new transfer
-                                <|`30`   `DMA_CTRL_DONE`     ^| r/c <| Set if a transfer was executed; auto-clears on write-access
-                                <|`31`   `DMA_CTRL_BUSY`     ^| r/- <| DMA transfer in progress
-| `0xffed0004` | `SRC_BASE` |`31:0` | r/w | Source base address (shows the last-accessed source address when read)
-| `0xffed0008` | `DST_BASE` |`31:0` | r/w | Destination base address (shows the last-accessed destination address when read)
-.6+<| `0xffed000c` .6+<| `TTYPE` <|`23:0`  `DMA_TTYPE_NUM_MSB : DMA_TTYPE_NUM_LSB`   ^| r/w <| Number of elements to transfer (shows the last-transferred element index when read)
-                                 <|`26:24` _reserved_                                ^| r/- <| reserved, read as zero
-                                 <|`28:27` `DMA_TTYPE_QSEL_MSB : DMA_TTYPE_QSEL_LSB` ^| r/w <| Transfer type (`00` = byte -> byte, `01` = byte -> zero-extended-word, `10` = byte -> sign-extended-word, `11` = word -> word)
-                                 <|`29`    `DMA_TTYPE_SRC_INC`                       ^| r/w <| Constant (`0`) or incrementing (`1`) source address
-                                 <|`30`    `DMA_TTYPE_DST_INC`                       ^| r/w <| Constant (`0`) or incrementing (`1`) destination address
-                                 <|`31`    `DMA_TTYPE_ENDIAN`                        ^| r/w <| Convert Endianness when set
+.10+<| `0xffed0000` .10+<| `CTRL` <|`0`     `DMA_CTRL_EN`                             ^| r/w <| DMA module enable; reset module when cleared
+                                  <|`1`     `DMA_CTRL_START`                          ^| -/w <| Start programmed DMA transfer(s)
+                                  <|`15:2`  _reserved_                                ^| r/- <| _reserved_, read as zero
+                                  <|`19:16` `DMA_CTRL_DFIFO_MSB : DMA_CTRL_DFIFO_LSB` ^| r/- <|
+                                  <|`26:20` _reserved_                                ^| r/- <| _reserved_, read as zero
+                                  <|`27`    `DMA_CTRL_DEMPTY``                        ^| r/- <| Descriptor FIFO is empty
+                                  <|`28`    `DMA_CTRL_DFULL`                          ^| r/- <| Descriptor FIFO is full
+                                  <|`29`    `DMA_CTRL_ERROR`                          ^| r/c <| Bus access error during transfer or incomplete descriptor data; clear by writing `1`
+                                  <|`30`    `DMA_CTRL_DONE`                           ^| r/c <| All transfers executed; clear by writing `1`
+                                  <|`31`    `DMA_CTRL_BUSY`                           ^| r/- <| DMA transfer(s) in progress
+| `0xffed0004` | `DESC` |`31:0` | -/w | Descriptor FIFO write access
 |=======================

--- a/rtl/core/neorv32_dma.vhd
+++ b/rtl/core/neorv32_dma.vhd
@@ -16,6 +16,9 @@ library neorv32;
 use neorv32.neorv32_package.all;
 
 entity neorv32_dma is
+  generic (
+    DSC_FIFO : natural range 4 to 512 := 4 -- descriptor FIFO depth (1 descriptor = 3 entries)
+  );
   port (
     clk_i     : in  std_ulogic; -- global clock line
     rstn_i    : in  std_ulogic; -- global reset line, low-active, async
@@ -29,142 +32,145 @@ end neorv32_dma;
 
 architecture neorv32_dma_rtl of neorv32_dma is
 
-  -- transfer type register bits --
-  constant type_num_lo_c  : natural :=  0; -- r/w: Number of elements to transfer, LSB
-  constant type_num_hi_c  : natural := 23; -- r/w: Number of elements to transfer, MSB
-  --
-  constant type_qsel_lo_c : natural := 27; -- r/w: Data quantity select, LSB, see below
-  constant type_qsel_hi_c : natural := 28; -- r/w: Data quantity select, MSB, see below
-  constant type_src_inc_c : natural := 29; -- r/w: SRC constant (0) or incrementing (1) address
-  constant type_dst_inc_c : natural := 30; -- r/w: DST constant (0) or incrementing (1) address
-  constant type_endian_c  : natural := 31; -- r/w: Convert Endianness when set
+  -- FIFO size helper --
+  constant log2_fifo_size_c : natural := index_size_f(DSC_FIFO); -- extend to next power of two
+  constant fifo_size_c      : natural := 2**log2_fifo_size_c; -- actual FIFO size
+
+  -- transfer configuration (part of the descriptor) --
+  constant conf_num_lo_c : natural :=  0; -- r/w: number of elements to transfer, LSB
+  constant conf_num_hi_c : natural := 23; -- r/w: number of elements to transfer, MSB
+  constant conf_bswap_c  : natural := 27; -- r/w: swap byte order
+  constant conf_src_lo_c : natural := 28; -- r/w: source addressing (0=byte, 1=word)
+  constant conf_src_hi_c : natural := 29; -- r/w: source addressing (0=const, 1=inc)
+  constant conf_dst_lo_c : natural := 30; -- r/w: destination addressing (0=byte, 1=word)
+  constant conf_dst_hi_c : natural := 31; -- r/w: destination addressing (0=const, 1=inc)
 
   -- control and status register bits --
-  constant ctrl_en_c       : natural :=  0; -- r/w: DMA enable
-  constant ctrl_start_c    : natural :=  1; -- -/s: start DMA operation
-  --
-  constant ctrl_error_rd_c : natural := 28; -- r/-: error during read transfer
-  constant ctrl_error_wr_c : natural := 29; -- r/-: error during write transfer
-  constant ctrl_done_c     : natural := 30; -- r/c: transfer has completed
-  constant ctrl_busy_c     : natural := 31; -- r/-: DMA transfer in progress
+  constant ctrl_en_c     : natural :=  0; -- r/w: DMA enable
+  constant ctrl_start_c  : natural :=  1; -- -/w: start DMA transfer(s)
+  constant ctrl_fifo0_c  : natural := 16; -- r/-: log2(FIFO descriptor depth), LSB
+  constant ctrl_fifo3_c  : natural := 19; -- r/-: log2(FIFO descriptor depth), MSB
+  constant ctrl_dempty_c : natural := 27; -- r/-: descriptor buffer is empty
+  constant ctrl_dfull_c  : natural := 28; -- r/-: descriptor buffer is full
+  constant ctrl_error_c  : natural := 29; -- r/-: bus access error during transfer
+  constant ctrl_done_c   : natural := 30; -- r/c: transfer has completed
+  constant ctrl_busy_c   : natural := 31; -- r/-: DMA transfer in progress
 
-  -- transfer quantities --
-  constant qsel_b2b_c  : std_ulogic_vector(1 downto 0) := "00"; -- byte to byte
-  constant qsel_b2uw_c : std_ulogic_vector(1 downto 0) := "01"; -- byte to unsigned word
-  constant qsel_b2sw_c : std_ulogic_vector(1 downto 0) := "10"; -- byte to signed word
-  constant qsel_w2w_c  : std_ulogic_vector(1 downto 0) := "11"; -- word to word
-
-  -- configuration registers --
-  type cfg_t is record
-    enable   : std_ulogic; -- DMA enabled when set
-    start    : std_ulogic; -- transfer start trigger
-    done     : std_ulogic; -- transfer was executed (but might have failed)
-    src_base : std_ulogic_vector(31 downto 0); -- source base address
-    dst_base : std_ulogic_vector(31 downto 0); -- destination base address
-    num      : std_ulogic_vector(23 downto 0); -- number of elements
-    qsel     : std_ulogic_vector(1 downto 0);  -- data quantity select
-    src_inc  : std_ulogic; -- constant (0) or incrementing (1) source address
-    dst_inc  : std_ulogic; -- constant (0) or incrementing (1) destination address
-    endian   : std_ulogic; -- convert endianness when set
+  -- control and status register --
+  type ctrl_t is record
+    enable, start, err, done : std_ulogic;
   end record;
-  signal cfg : cfg_t;
+  signal ctrl : ctrl_t;
+
+  -- descriptor FIFO interface --
+  type fifo_t is record
+    clr   : std_ulogic;
+    we    : std_ulogic;
+    re    : std_ulogic;
+    rdata : std_ulogic_vector(31 downto 0);
+    avail : std_ulogic;
+    free  : std_ulogic;
+  end record;
+  signal fifo : fifo_t;
 
   -- bus access engine --
-  type state_t is (S_IDLE, S_READ, S_WRITE, S_NEXT);
+  type state_t is (S_IDLE, S_GET_0, S_GET_1, S_READ_REQ, S_READ_RSP, S_WRITE_REQ, S_WRITE_RSP, S_NEXT);
   type engine_t is record
     state    : state_t;
-    stb      : std_ulogic;
-    rw       : std_ulogic;
+    run      : std_ulogic;
+    run_ff   : std_ulogic;
+    done     : std_ulogic;
+    err      : std_ulogic;
+    src_add  : unsigned(31 downto 0);
+    dst_add  : unsigned(31 downto 0);
     src_addr : std_ulogic_vector(31 downto 0);
     dst_addr : std_ulogic_vector(31 downto 0);
     num      : std_ulogic_vector(23 downto 0);
-    err_rd   : std_ulogic;
-    err_wr   : std_ulogic;
-    src_add  : unsigned(31 downto 0);
-    dst_add  : unsigned(31 downto 0);
-    busy     : std_ulogic;
-    done     : std_ulogic;
+    bswap    : std_ulogic; -- swap byte order
+    src_type : std_ulogic_vector(1 downto 0);
+    dst_type : std_ulogic_vector(1 downto 0);
   end record;
   signal engine : engine_t;
 
-  -- data alignment --
-  signal align_buf, align_end : std_ulogic_vector(31 downto 0);
+  -- data buffer --
+  signal rdata, data_buf : std_ulogic_vector(31 downto 0);
 
 begin
 
-  -- Bus Access -----------------------------------------------------------------------------
+  -- Control and Status Register ------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  ctrl_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o    <= rsp_terminate_c;
-      cfg.enable   <= '0';
-      cfg.start    <= '0';
-      cfg.done     <= '0';
-      cfg.src_base <= (others => '0');
-      cfg.dst_base <= (others => '0');
-      cfg.num      <= (others => '0');
-      cfg.qsel     <= (others => '0');
-      cfg.src_inc  <= '0';
-      cfg.dst_inc  <= '0';
-      cfg.endian   <= '0';
+      bus_rsp_o   <= rsp_terminate_c;
+      ctrl.enable <= '0';
+      ctrl.start  <= '0';
+      ctrl.err    <= '0';
+      ctrl.done   <= '0';
     elsif rising_edge(clk_i) then
       -- bus handshake --
       bus_rsp_o.ack  <= bus_req_i.stb;
       bus_rsp_o.err  <= '0';
       bus_rsp_o.data <= (others => '0');
-
       -- defaults --
-      cfg.start <= '0'; -- default
-      cfg.done  <= cfg.enable and (cfg.done or engine.done); -- set if enabled and transfer done
-
+      ctrl.start <= '0';
+      ctrl.err   <= ctrl.enable and (ctrl.err  or engine.err);
+      ctrl.done  <= ctrl.enable and (ctrl.done or engine.done);
       -- bus access --
-      if (bus_req_i.stb = '1') then
+      if (bus_req_i.stb = '1') and (bus_req_i.addr(2) = '0') then
         if (bus_req_i.rw = '1') then -- write access
-          if (bus_req_i.addr(3 downto 2) = "00") then -- control and status register
-            cfg.enable <= bus_req_i.data(ctrl_en_c);
-            cfg.start  <= bus_req_i.data(ctrl_start_c); -- start transfer
-            cfg.done   <= '0'; -- clear on write access
-          end if;
-          if (bus_req_i.addr(3 downto 2) = "01") then -- source base address
-            cfg.src_base <= bus_req_i.data;
-          end if;
-          if (bus_req_i.addr(3 downto 2) = "10") then -- destination base address
-            cfg.dst_base <= bus_req_i.data;
-          end if;
-          if (bus_req_i.addr(3 downto 2) = "11") then -- transfer type register
-            cfg.num     <= bus_req_i.data(type_num_hi_c downto type_num_lo_c);
-            cfg.qsel    <= bus_req_i.data(type_qsel_hi_c downto type_qsel_lo_c);
-            cfg.src_inc <= bus_req_i.data(type_src_inc_c);
-            cfg.dst_inc <= bus_req_i.data(type_dst_inc_c);
-            cfg.endian  <= bus_req_i.data(type_endian_c);
-          end if;
+          ctrl.enable <= bus_req_i.data(ctrl_en_c);
+          ctrl.start  <= bus_req_i.data(ctrl_start_c);
+          ctrl.err    <= ctrl.err and (not bus_req_i.data(ctrl_error_c)); -- write 1 to clear
+          ctrl.done   <= ctrl.done and (not bus_req_i.data(ctrl_done_c)); -- write 1 to clear
         else -- read access
-          case bus_req_i.addr(3 downto 2) is
-            when "00" => -- control and status register
-              bus_rsp_o.data(ctrl_en_c)       <= cfg.enable;
-              bus_rsp_o.data(ctrl_error_rd_c) <= engine.err_rd;
-              bus_rsp_o.data(ctrl_error_wr_c) <= engine.err_wr;
-              bus_rsp_o.data(ctrl_done_c)     <= cfg.done;
-              bus_rsp_o.data(ctrl_busy_c)     <= engine.busy;
-            when "01" => -- address of last read access
-              bus_rsp_o.data <= engine.src_addr;
-            when "10" => -- address of last write access
-              bus_rsp_o.data <= engine.dst_addr;
-            when others => -- transfer type register
-              bus_rsp_o.data(type_num_hi_c downto type_num_lo_c)   <= engine.num;
-              bus_rsp_o.data(type_qsel_hi_c downto type_qsel_lo_c) <= cfg.qsel;
-              bus_rsp_o.data(type_src_inc_c)                       <= cfg.src_inc;
-              bus_rsp_o.data(type_dst_inc_c)                       <= cfg.dst_inc;
-              bus_rsp_o.data(type_endian_c)                        <= cfg.endian;
-          end case;
+          bus_rsp_o.data(ctrl_en_c)     <= ctrl.enable;
+          bus_rsp_o.data(ctrl_fifo3_c downto ctrl_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
+          bus_rsp_o.data(ctrl_dempty_c) <= not fifo.avail;
+          bus_rsp_o.data(ctrl_dfull_c)  <= not fifo.free;
+          bus_rsp_o.data(ctrl_error_c)  <= ctrl.err;
+          bus_rsp_o.data(ctrl_done_c)   <= ctrl.done;
+          bus_rsp_o.data(ctrl_busy_c)   <= engine.run;
         end if;
       end if;
     end if;
-  end process bus_access;
+  end process ctrl_access;
 
   -- transfer-done interrupt --
-  irq_o <= cfg.done;
+  irq_o <= ctrl.done;
+
+
+  -- Descriptor Buffer (FIFO) ---------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  descriptor_buffer: entity neorv32.neorv32_fifo
+  generic map (
+    FIFO_DEPTH => fifo_size_c,
+    FIFO_WIDTH => 32,
+    FIFO_RSYNC => false,
+    FIFO_SAFE  => true,
+    FULL_RESET => false
+  )
+  port map (
+    -- control and status --
+    clk_i   => clk_i,
+    rstn_i  => rstn_i,
+    clear_i => fifo.clr,
+    half_o  => open,
+    level_o => open,
+    -- write port --
+    wdata_i => bus_req_i.data,
+    we_i    => fifo.we,
+    free_o  => fifo.free,
+    -- read port --
+    re_i    => fifo.re,
+    rdata_o => fifo.rdata,
+    avail_o => fifo.avail
+  );
+
+  -- FIFO control --
+  fifo.clr <= '1' when (ctrl.enable = '0') else '0';
+  fifo.we  <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '1') else '0';
+  fifo.re  <= engine.run when (engine.state = S_IDLE) or (engine.state = S_GET_0) or (engine.state = S_GET_1) else '0';
 
 
   -- Bus Access Engine ----------------------------------------------------------------------
@@ -173,79 +179,87 @@ begin
   begin
     if (rstn_i = '0') then
       engine.state    <= S_IDLE;
-      engine.stb      <= '0';
-      engine.rw       <= '0';
+      engine.run      <= '0';
+      engine.run_ff   <= '0';
+      engine.err      <= '0';
       engine.src_addr <= (others => '0');
       engine.dst_addr <= (others => '0');
       engine.num      <= (others => '0');
-      engine.err_rd   <= '0';
-      engine.err_wr   <= '0';
-      engine.done     <= '0';
+      engine.bswap    <= '0';
+      engine.src_type <= (others => '0');
+      engine.dst_type <= (others => '0');
     elsif rising_edge(clk_i) then
-      -- defaults --
-      engine.done <= '0';
-      engine.stb  <= '0';
-
-      -- state machine --
+      engine.run_ff <= engine.run;
       case engine.state is
 
         when S_IDLE => -- idle, waiting for trigger
         -- ------------------------------------------------------------
-          engine.src_addr <= cfg.src_base;
-          engine.dst_addr <= cfg.dst_base;
-          engine.num      <= cfg.num;
-          engine.rw       <= '0';
-          if (cfg.enable = '0') and (cfg.start = '1') then -- disabled or start
-            engine.err_rd <= '0';
-            engine.err_wr <= '0';
-          end if;
-          if (cfg.enable = '1') and (cfg.start = '1') then -- start
-            engine.stb    <= '1';
-            engine.state  <= S_READ;
+          engine.err <= '0';
+          if (engine.run = '1') and (fifo.avail = '1') and (engine.err = '0') then
+            engine.src_addr <= fifo.rdata; -- get descriptor: source base address
+            engine.state    <= S_GET_0;
+          else
+            engine.run <= ctrl.enable and ctrl.start and fifo.avail and (not ctrl.err);
           end if;
 
-        when S_READ => -- pending read access
+        when S_GET_0 => -- get descriptor: destination base address
         -- ------------------------------------------------------------
-          if (dma_rsp_i.ack = '1') then
-            if (dma_rsp_i.err = '1') then
-              engine.done   <= '1';
-              engine.err_rd <= '1';
-              engine.state  <= S_IDLE;
-            else
-              engine.rw    <= '1'; -- write
-              engine.stb   <= '1'; -- issue write request
-              engine.state <= S_WRITE;
-            end if;
+          if (fifo.avail = '1') then
+            engine.dst_addr <= fifo.rdata;
+            engine.state    <= S_GET_1;
+          else
+            engine.err   <= '1'; -- error - no descriptor data available
+            engine.state <= S_NEXT;
           end if;
 
-        when S_WRITE => -- pending write access
+        when S_GET_1 => -- get descriptor: transfer configuration
+        -- ------------------------------------------------------------
+          if (fifo.avail = '1') then
+            engine.num      <= fifo.rdata(conf_num_hi_c downto conf_num_lo_c);
+            engine.bswap    <= fifo.rdata(conf_bswap_c);
+            engine.src_type <= fifo.rdata(conf_src_hi_c downto conf_src_lo_c);
+            engine.dst_type <= fifo.rdata(conf_dst_hi_c downto conf_dst_lo_c);
+            engine.state    <= S_READ_REQ;
+          else
+            engine.err   <= '1'; -- error - no descriptor data available
+            engine.state <= S_NEXT;
+          end if;
+
+        when S_READ_REQ => -- read request
+        -- ------------------------------------------------------------
+          engine.state <= S_READ_RSP;
+
+        when S_READ_RSP => -- read response
         -- ------------------------------------------------------------
           if (dma_rsp_i.ack = '1') then
-            engine.num <= std_ulogic_vector(unsigned(engine.num) - 1);
+            engine.err <= dma_rsp_i.err;
             if (dma_rsp_i.err = '1') then
-              engine.done   <= '1';
-              engine.err_wr <= '1';
-              engine.state  <= S_IDLE;
-            else
               engine.state <= S_NEXT;
+            else
+              engine.state <= S_WRITE_REQ;
             end if;
+          end if;
+
+        when S_WRITE_REQ => -- write request
+        -- ------------------------------------------------------------
+          engine.num   <= std_ulogic_vector(unsigned(engine.num) - 1);
+          engine.state <= S_WRITE_RSP;
+
+        when S_WRITE_RSP => -- write response
+        -- ------------------------------------------------------------
+          if (dma_rsp_i.ack = '1') then
+            engine.err   <= dma_rsp_i.err;
+            engine.state <= S_NEXT;
           end if;
 
         when S_NEXT => -- check if done; prepare next access
         -- ------------------------------------------------------------
-          if (or_reduce_f(engine.num) = '0') or (cfg.enable = '0') then -- transfer done or aborted?
-            engine.done  <= '1';
+          engine.src_addr <= std_ulogic_vector(unsigned(engine.src_addr) + engine.src_add);
+          engine.dst_addr <= std_ulogic_vector(unsigned(engine.dst_addr) + engine.dst_add);
+          if (or_reduce_f(engine.num) = '0') or (ctrl.enable = '0') or (engine.err = '1') then -- all elements done? abort?
             engine.state <= S_IDLE;
           else
-            if (cfg.src_inc = '1') then -- incrementing source address
-              engine.src_addr <= std_ulogic_vector(unsigned(engine.src_addr) + engine.src_add);
-            end if;
-            if (cfg.dst_inc = '1') then -- incrementing destination address
-              engine.dst_addr <= std_ulogic_vector(unsigned(engine.dst_addr) + engine.dst_add);
-            end if;
-            engine.rw    <= '0';
-            engine.stb   <= '1'; -- issue read request
-            engine.state <= S_READ;
+            engine.state <= S_READ_REQ;
           end if;
 
         when others => -- undefined
@@ -256,82 +270,99 @@ begin
     end if;
   end process bus_engine;
 
-  -- transfer in progress? --
-  engine.busy <= '0' when (engine.state = S_IDLE) else '1';
+  -- transfer(s) done --
+  engine.done <= '1' when (engine.run = '0') and (engine.run_ff = '1') else '0';
 
-  -- bus output --
-  dma_req_o.addr  <= engine.dst_addr when (engine.state = S_WRITE) else engine.src_addr;
-  dma_req_o.stb   <= engine.stb;
-  dma_req_o.rw    <= engine.rw;
-  dma_req_o.src   <= '0'; -- source = data access
-  dma_req_o.priv  <= priv_mode_m_c; -- DMA accesses are always privileged
-  dma_req_o.debug <= '0'; -- can never ever be in debug mode
-  dma_req_o.amo   <= '0'; -- no atomic memory operation possible
-  dma_req_o.amoop <= (others => '0'); -- no atomic memory operation possible
-  dma_req_o.burst <= '0'; -- always single access
-  dma_req_o.lock  <= '0'; -- always unlocked access
-  dma_req_o.fence <= '0';
 
-  -- address increment --
-  address_inc: process(cfg.qsel)
+  -- Bus Output Control ---------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  bus_control: process(engine, data_buf)
   begin
-    case cfg.qsel is
-      when qsel_b2b_c => -- byte -> byte
-        engine.src_add <= to_unsigned(1, 32);
-        engine.dst_add <= to_unsigned(1, 32);
-      when qsel_w2w_c => -- word -> word
-        engine.src_add <= to_unsigned(4, 32);
-        engine.dst_add <= to_unsigned(4, 32);
-      when others => -- byte -> word
-        engine.src_add <= to_unsigned(1, 32);
-        engine.dst_add <= to_unsigned(4, 32);
+    dma_req_o <= req_terminate_c; -- all-zero by default
+    -- meta data --
+    dma_req_o.priv  <= priv_mode_m_c; -- transfers execute with highest privilege level
+    dma_req_o.src   <= '0'; -- "data" transfer
+    dma_req_o.amo   <= '0'; -- no atomic operations
+    dma_req_o.burst <= '0'; -- no burst transfers
+    dma_req_o.lock  <= '0'; -- no locked accesses
+    -- read/write --
+    if (engine.state = S_READ_REQ) or (engine.state = S_READ_RSP) then -- read access
+      dma_req_o.addr <= engine.src_addr(31 downto 2) & "00";
+      dma_req_o.rw   <= '0';
+      if (engine.src_type(0) = '0') then -- byte
+        dma_req_o.ben(to_integer(unsigned(engine.src_addr(1 downto 0)))) <= '1';
+      else -- word
+        dma_req_o.ben <= (others => '1');
+      end if;
+    else -- write access
+      dma_req_o.addr <= engine.dst_addr(31 downto 2) & "00";
+      dma_req_o.rw   <= '1';
+      if (engine.dst_type(0) = '0') then -- byte
+        dma_req_o.ben(to_integer(unsigned(engine.dst_addr(1 downto 0)))) <= '1';
+      else -- word
+        dma_req_o.ben <= (others => '1');
+      end if;
+    end if;
+    -- output data alignment --
+    if (engine.dst_type(0) = '0') then -- byte
+      dma_req_o.data <= data_buf(7 downto 0) & data_buf(7 downto 0) & data_buf(7 downto 0) & data_buf(7 downto 0);
+    else -- word
+      dma_req_o.data <= data_buf;
+    end if;
+    -- request strobe --
+    if (engine.state = S_READ_REQ) or (engine.state = S_WRITE_REQ) then
+      dma_req_o.stb <= '1';
+    end if;
+  end process bus_control;
+
+
+  -- Address Increment ----------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  address_inc: process(engine)
+  begin
+    -- source --
+    case engine.src_type is
+      when "10"   => engine.src_add <= to_unsigned(1, 32); -- incrementing byte
+      when "11"   => engine.src_add <= to_unsigned(4, 32); -- incrementing word
+      when others => engine.src_add <= to_unsigned(0, 32); -- constant byte/word
+    end case;
+    -- destination --
+    case engine.dst_type is
+      when "10"   => engine.dst_add <= to_unsigned(1, 32); -- incrementing byte
+      when "11"   => engine.dst_add <= to_unsigned(4, 32); -- incrementing word
+      when others => engine.dst_add <= to_unsigned(0, 32); -- constant byte/word
     end case;
   end process address_inc;
 
 
-  -- Data Transformer -----------------------------------------------------------------------
+  -- Input Data Alignment -------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-
-  -- endianness conversion --
-  byte_swap_gen:
-  for i in 0 to (XLEN/8)-1 generate -- byte loop
-    align_end(i*8+7 downto i*8) <= dma_rsp_i.data(i*8+7 downto i*8) when (cfg.endian = '0') else
-                                   dma_rsp_i.data((XLEN-i*8)-1 downto XLEN-(i+1)*8);
-  end generate;
-
-  -- source data alignment --
   src_align: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      align_buf <= (others => '0');
+      data_buf <= (others => '0');
     elsif rising_edge(clk_i) then
-      if (engine.state = S_READ) then
-        if (cfg.qsel = qsel_w2w_c) then -- word
-          align_buf <= align_end;
-        else -- byte
+      if (engine.state = S_READ_RSP) then
+        if (engine.src_type(0) = '0') then -- byte
           case engine.src_addr(1 downto 0) is
-            when "00"   => align_buf <= replicate_f(cfg.qsel(1) and align_end(7),  24) & align_end(7 downto 0);
-            when "01"   => align_buf <= replicate_f(cfg.qsel(1) and align_end(15), 24) & align_end(15 downto 8);
-            when "10"   => align_buf <= replicate_f(cfg.qsel(1) and align_end(23), 24) & align_end(23 downto 16);
-            when others => align_buf <= replicate_f(cfg.qsel(1) and align_end(31), 24) & align_end(31 downto 24);
+            when "00"   => data_buf <= x"000000" & rdata(7 downto 0);
+            when "01"   => data_buf <= x"000000" & rdata(15 downto 8);
+            when "10"   => data_buf <= x"000000" & rdata(23 downto 16);
+            when others => data_buf <= x"000000" & rdata(31 downto 24);
           end case;
+        else -- word
+          data_buf <= rdata;
         end if;
       end if;
     end if;
   end process src_align;
 
-  -- destination data alignment --
-  dst_align: process(cfg.qsel, align_buf, engine.dst_addr)
-  begin
-    dma_req_o.ben <= (others => '0'); -- default
-    if (cfg.qsel = qsel_b2b_c) then -- byte
-      dma_req_o.data <= align_buf(7 downto 0) & align_buf(7 downto 0) & align_buf(7 downto 0) & align_buf(7 downto 0);
-      dma_req_o.ben(to_integer(unsigned(engine.dst_addr(1 downto 0)))) <= '1';
-    else -- word
-      dma_req_o.data <= align_buf;
-      dma_req_o.ben  <= (others => '1');
-    end if;
-  end process dst_align;
+  -- swap byte order (Endianness conversion) --
+  bswap_gen:
+  for i in 0 to 3 generate
+    rdata(i*8+7 downto i*8) <= dma_rsp_i.data(i*8+7 downto i*8) when (engine.bswap = '0') else
+                               dma_rsp_i.data((32-i*8)-1 downto 32-(i+1)*8);
+  end generate;
 
 
 end neorv32_dma_rtl;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110506"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110507"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -867,6 +867,7 @@ package neorv32_package is
       IO_ONEWIRE_EN         : boolean                        := false;
       IO_ONEWIRE_FIFO       : natural range 1 to 2**15       := 1;
       IO_DMA_EN             : boolean                        := false;
+      IO_DMA_DSC_FIFO       : natural range 4 to 512         := 4;
       IO_SLINK_EN           : boolean                        := false;
       IO_SLINK_RX_FIFO      : natural range 1 to 2**15       := 1;
       IO_SLINK_TX_FIFO      : natural range 1 to 2**15       := 1

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -127,6 +127,7 @@ entity neorv32_top is
     IO_ONEWIRE_EN         : boolean                        := false;       -- implement 1-wire interface (ONEWIRE)
     IO_ONEWIRE_FIFO       : natural range 1 to 2**15       := 1;           -- RTX FIFO depth, has to be zero or a power of two, min 1
     IO_DMA_EN             : boolean                        := false;       -- implement direct memory access controller (DMA)
+    IO_DMA_DSC_FIFO       : natural range 4 to 512         := 4;           -- DMA descriptor FIFO depth, has to be a power of two, min 4
     IO_SLINK_EN           : boolean                        := false;       -- implement stream link interface (SLINK)
     IO_SLINK_RX_FIFO      : natural range 1 to 2**15       := 1;           -- RX FIFO depth, has to be a power of two, min 1
     IO_SLINK_TX_FIFO      : natural range 1 to 2**15       := 1            -- TX FIFO depth, has to be a power of two, min 1
@@ -649,6 +650,9 @@ begin
     -- DMA Controller -------------------------------------------------------------------------
     -- -------------------------------------------------------------------------------------------
     neorv32_dma_inst: entity neorv32.neorv32_dma
+    generic map (
+      DSC_FIFO => IO_DMA_DSC_FIFO
+    )
     port map (
       clk_i     => clk_i,
       rstn_i    => rstn_sys,

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -426,7 +426,8 @@ proc setup_ip_gui {} {
 
   set group [add_group $page {Direct Memory Access Controller (DMA)}]
   add_params $group {
-    { IO_DMA_EN {Enable DMA} }
+    { IO_DMA_EN       {Enable DMA} }
+    { IO_DMA_DSC_FIFO {Descriptor FIFO depth} {Number of entries (use a power of two)} {$IO_DMA_EN} }
   }
 }
 

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -119,6 +119,7 @@ entity neorv32_vivado_ip is
     IO_GPTMR_EN           : boolean                        := false;
     IO_ONEWIRE_EN         : boolean                        := false;
     IO_DMA_EN             : boolean                        := false;
+    IO_DMA_DSC_FIFO       : natural range 4 to 512         := 4;
     IO_SLINK_EN           : boolean                        := false;
     IO_SLINK_RX_FIFO      : natural range 1 to 2**15       := 1;
     IO_SLINK_TX_FIFO      : natural range 1 to 2**15       := 1
@@ -441,6 +442,7 @@ begin
     IO_GPTMR_EN         => IO_GPTMR_EN,
     IO_ONEWIRE_EN       => IO_ONEWIRE_EN,
     IO_DMA_EN           => IO_DMA_EN,
+    IO_DMA_DSC_FIFO     => IO_DMA_DSC_FIFO,
     IO_SLINK_EN         => IO_SLINK_EN,
     IO_SLINK_RX_FIFO    => IO_SLINK_RX_FIFO,
     IO_SLINK_TX_FIFO    => IO_SLINK_TX_FIFO

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -211,6 +211,7 @@ begin
     IO_ONEWIRE_EN       => true,
     IO_ONEWIRE_FIFO     => 8,
     IO_DMA_EN           => true,
+    IO_DMA_DSC_FIFO     => 8,
     IO_SLINK_EN         => true,
     IO_SLINK_RX_FIFO    => 4,
     IO_SLINK_TX_FIFO    => 4

--- a/sw/lib/include/neorv32_dma.h
+++ b/sw/lib/include/neorv32_dma.h
@@ -23,10 +23,8 @@
 /**@{*/
 /** DMA module prototype */
 typedef volatile struct __attribute__((packed,aligned(4))) {
-  uint32_t CTRL;     /**< offset  0: control and status register (#NEORV32_DMA_CTRL_enum) */
-  uint32_t SRC_BASE; /**< offset  4: source base address register */
-  uint32_t DST_BASE; /**< offset  8: destination base address register */
-  uint32_t TTYPE;    /**< offset 12: transfer type configuration register & manual trigger (#NEORV32_DMA_TTYPE_enum) */
+  uint32_t CTRL; /**< control and status register (#NEORV32_DMA_CTRL_enum) */
+  uint32_t DESC; /**< descriptor FIFO */
 } neorv32_dma_t;
 
 /** DMA module hardware handle (#neorv32_dma_t) */
@@ -34,45 +32,55 @@ typedef volatile struct __attribute__((packed,aligned(4))) {
 
 /** DMA control and status register bits */
 enum NEORV32_DMA_CTRL_enum {
-  DMA_CTRL_EN           =  0, /**< DMA control register(0) (r/w): DMA enable */
-  DMA_CTRL_START        =  1, /**< DMA control register(1) (-/s): Start configured DMA transfer */
+  DMA_CTRL_EN        =  0, /**< DMA control register(0) (r/w): DMA enable */
+  DMA_CTRL_START     =  1, /**< DMA control register(1) (-/w): Start DMA transfer(s) */
 
-  DMA_CTRL_ERROR_RD     = 28, /**< DMA control register(28) (r/-): Error during read access; SRC_BASE shows the faulting address */
-  DMA_CTRL_ERROR_WR     = 29, /**< DMA control register(29) (r/-): Error during write access; DST_BASE shows the faulting address */
-  DMA_CTRL_DONE         = 30, /**< DMA control register(30) (r/c): A transfer has been executed when set */
-  DMA_CTRL_BUSY         = 31  /**< DMA control register(32) (r/-): DMA busy / transfer in progress */
+  DMA_CTRL_DFIFO_LSB = 16, /**< DMA control register(16) (r/-): log2(descriptor FIFO size), LSB */
+  DMA_CTRL_DFIFO_MSB = 19, /**< DMA control register(19) (r/-): log2(descriptor FIFO size), MSB */
+
+  DMA_CTRL_DEMPTY    = 27, /**< DMA control register(27) (r/-): Descriptor FIFO is empty */
+  DMA_CTRL_DFULL     = 28, /**< DMA control register(28) (r/-): Descriptor FIFO is full */
+  DMA_CTRL_ERROR     = 29, /**< DMA control register(29) (r/c): Bus access error during transfer */
+  DMA_CTRL_DONE      = 30, /**< DMA control register(30) (r/c): A transfer has been executed when set */
+  DMA_CTRL_BUSY      = 31  /**< DMA control register(32) (r/-): DMA busy / transfer in progress */
 };
 
-/** DMA transfer type bits */
-enum NEORV32_DMA_TTYPE_enum {
-  DMA_TTYPE_NUM_LSB  =  0, /**< DMA transfer type register(0)  (r/w): Number of elements to transfer, LSB */
-  DMA_TTYPE_NUM_MSB  = 23, /**< DMA transfer type register(23) (r/w): Number of elements to transfer, MSB */
+/** DMA transfer configuration */
+enum NEORV32_DMA_CONF_enum {
+  DMA_CONF_NUM_LSB =  0, /**< DMA transfer type register(0)  (r/w): Number of elements to transfer, LSB */
+  DMA_CONF_NUM_MSB = 23, /**< DMA transfer type register(23) (r/w): Number of elements to transfer, MSB */
 
-  DMA_TTYPE_QSEL_LSB = 27, /**< DMA transfer type register(27) (r/w): Data quantity select, LSB */
-  DMA_TTYPE_QSEL_MSB = 28, /**< DMA transfer type register(28) (r/w): Data quantity select, MSB */
-  DMA_TTYPE_SRC_INC  = 29, /**< DMA transfer type register(29) (r/w): SRC constant (0) or incrementing (1) address */
-  DMA_TTYPE_DST_INC  = 30, /**< DMA transfer type register(30) (r/w): SRC constant (0) or incrementing (1) address */
-  DMA_TTYPE_ENDIAN   = 31  /**< DMA transfer type register(31) (r/w): Convert Endianness when set */
+  DMA_CONF_BSWAP   = 27, /**< DMA transfer type register(27) (r/w): Swap byte order when set */
+  DMA_CONF_SRC_LSB = 28, /**< DMA transfer type register(28) (r/w): SRC transfer type select (#NEORV32_DMA_TYPE_enum), LSB */
+  DMA_CONF_SRC_MSB = 29, /**< DMA transfer type register(29) (r/w): SRC transfer type select (#NEORV32_DMA_TYPE_enum), MSB */
+  DMA_CONF_DST_LSB = 30, /**< DMA transfer type register(30) (r/w): DST transfer type select (#NEORV32_DMA_TYPE_enum), LSB */
+  DMA_CONF_DST_MSB = 31  /**< DMA transfer type register(31) (r/w): DST transfer type select (#NEORV32_DMA_TYPE_enum), MSB */
 };
 /**@}*/
 
 
 /**********************************************************************//**
- * DMA transfer type commands
+ * DMA transfer type select / commands
  **************************************************************************/
 /**@{*/
-#define DMA_CMD_B2B  (0b00 << DMA_TTYPE_QSEL_LSB) // byte to byte
-#define DMA_CMD_B2UW (0b01 << DMA_TTYPE_QSEL_LSB) // byte to unsigned word
-#define DMA_CMD_B2SW (0b10 << DMA_TTYPE_QSEL_LSB) // byte to signed word
-#define DMA_CMD_W2W  (0b11 << DMA_TTYPE_QSEL_LSB) // word to word
-
-#define DMA_CMD_SRC_CONST (0b0 << DMA_TTYPE_SRC_INC) // constant source address
-#define DMA_CMD_SRC_INC   (0b1 << DMA_TTYPE_SRC_INC) // incrementing source address
-
-#define DMA_CMD_DST_CONST (0b0 << DMA_TTYPE_DST_INC) // constant destination address
-#define DMA_CMD_DST_INC   (0b1 << DMA_TTYPE_DST_INC) // incrementing destination address
-
-#define DMA_CMD_ENDIAN (0b1 << DMA_TTYPE_ENDIAN) // convert endianness
+enum NEORV32_DMA_TYPE_enum {
+  DMA_TYPE_CONST_BYTE = 0b00, /**< constant byte */
+  DMA_TYPE_CONST_WORD = 0b01, /**< constant word */
+  DMA_TYPE_INC_BYTE   = 0b10, /**< incrementing byte */
+  DMA_TYPE_INC_WORD   = 0b11  /**< incrementing word */
+};
+/** source aliases */
+#define DMA_SRC_CONST_BYTE (DMA_TYPE_CONST_BYTE << DMA_CONF_SRC_LSB)
+#define DMA_SRC_CONST_WORD (DMA_TYPE_CONST_WORD << DMA_CONF_SRC_LSB)
+#define DMA_SRC_INC_BYTE   (DMA_TYPE_INC_BYTE   << DMA_CONF_SRC_LSB)
+#define DMA_SRC_INC_WORD   (DMA_TYPE_INC_WORD   << DMA_CONF_SRC_LSB)
+/** destination aliases */
+#define DMA_DST_CONST_BYTE (DMA_TYPE_CONST_BYTE << DMA_CONF_DST_LSB)
+#define DMA_DST_CONST_WORD (DMA_TYPE_CONST_WORD << DMA_CONF_DST_LSB)
+#define DMA_DST_INC_BYTE   (DMA_TYPE_INC_BYTE   << DMA_CONF_DST_LSB)
+#define DMA_DST_INC_WORD   (DMA_TYPE_INC_WORD   << DMA_CONF_DST_LSB)
+/** Endianness conversion */
+#define DMA_BSWAP (1 << DMA_CONF_BSWAP)
 /**@}*/
 
 
@@ -80,23 +88,11 @@ enum NEORV32_DMA_TTYPE_enum {
  * DMA status
  **************************************************************************/
 enum NEORV32_DMA_STATUS_enum {
-  DMA_STATUS_ERR_WR = -2, /**< write access error during last transfer (-2) */
-  DMA_STATUS_ERR_RD = -1, /**< read access error during last transfer (-1) */
-  DMA_STATUS_IDLE   =  0, /**< DMA idle (0) */
-  DMA_STATUS_BUSY   =  1, /**< DMA busy (1) */
-  DMA_STATUS_DONE   =  2  /**< transfer done (2) */
+  DMA_STATUS_ERROR = -1, /**< bus access error during last transfer (-1) */
+  DMA_STATUS_IDLE  =  0, /**< DMA idle (0) */
+  DMA_STATUS_BUSY  =  1, /**< DMA busy (1) */
+  DMA_STATUS_DONE  =  2  /**< transfer done (2) */
 };
-
-
-/**********************************************************************//**
- * DMA transfer descriptor
- **************************************************************************/
-typedef struct __attribute__((packed,aligned(4))) {
-  uint32_t src; /**< 32-bit source base address */
-  uint32_t dst; /**< 32-bit destination base address */
-  uint32_t num; /**< 24-bit (LSB-aligned) number of elements to transfer */
-  uint32_t cmd; /**< transfer type */
-} neorv32_dma_desc_t;
 
 
 /**********************************************************************//**
@@ -104,9 +100,15 @@ typedef struct __attribute__((packed,aligned(4))) {
  **************************************************************************/
 /**@{*/
 int  neorv32_dma_available(void);
+int  neorv32_dma_get_descriptor_fifo_depth(void);
+int  neorv32_dma_descriptor_fifo_full(void);
+int  neorv32_dma_descriptor_fifo_empty(void);
 void neorv32_dma_enable(void);
 void neorv32_dma_disable(void);
-void neorv32_dma_transfer(neorv32_dma_desc_t *desc);
+void neorv32_dma_err_ack(void);
+void neorv32_dma_done_ack(void);
+int  neorv32_dma_program(uint32_t src_addr, uint32_t dst_addr, uint32_t config);
+void neorv32_dma_start(void);
 int  neorv32_dma_status(void);
 /**@}*/
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -399,7 +399,7 @@
       <registers>
         <register>
           <name>CTRL</name>
-          <description>Control register</description>
+          <description>Control and status register</description>
           <addressOffset>0x00</addressOffset>
           <fields>
             <field>
@@ -410,74 +410,50 @@
             <field>
               <name>DMA_CTRL_START</name>
               <bitRange>[1:1]</bitRange>
-              <description>Start programmed DMA transfer</description>
+              <access>write-only</access>
+              <description>Start programmed DMA transfer(s)</description>
             </field>
             <field>
-              <name>DMA_CTRL_ERROR_RD</name>
+              <name>DMA_CTRL_FIFO</name>
+              <bitRange>[19:16]</bitRange>
+              <access>read-only</access>
+              <description>log2(descriptor FIFO depth)</description>
+            </field>
+            <field>
+              <name>DMA_CTRL_DEMPTY</name>
+              <bitRange>[27:27]</bitRange>
+              <access>read-only</access>
+              <description>Descriptor FIFO is empty</description>
+            </field>
+            <field>
+              <name>DMA_CTRL_DFULL</name>
               <bitRange>[28:28]</bitRange>
               <access>read-only</access>
-              <description>Error during last read access</description>
+              <description>Descriptor FIFO is full</description>
             </field>
             <field>
-              <name>DMA_CTRL_ERROR_WR</name>
+              <name>DMA_CTRL_ERROR</name>
               <bitRange>[29:29]</bitRange>
-              <access>read-only</access>
-              <description>Error during last write access</description>
+              <description>Error during last transfer; clear by writing one</description>
             </field>
             <field>
               <name>DMA_CTRL_DONE</name>
               <bitRange>[30:30]</bitRange>
-              <description>Transfer done; auto-clears on write access</description>
+              <description>Transfer(s) done; clear by writing one</description>
             </field>
             <field>
               <name>DMA_CTRL_BUSY</name>
               <bitRange>[31:31]</bitRange>
               <access>read-only</access>
-              <description>Transfer in progress</description>
+              <description>Transfer(s) in progress</description>
             </field>
           </fields>
         </register>
         <register>
-          <name>SRC_BASE</name>
-          <description>Source base address; shows the last accessed read address on read access</description>
+          <name>DESC</name>
+          <description>Descriptor FIFO</description>
+          <access>write-only</access>
           <addressOffset>0x04</addressOffset>
-        </register>
-        <register>
-          <name>DST_BASE</name>
-          <description>Destination base address; shows the last accessed write address on read access</description>
-          <addressOffset>0x08</addressOffset>
-        </register>
-        <register>
-          <name>TTYPE</name>
-          <description>Destination base address; shows the last accessed write address on read access</description>
-          <addressOffset>0x0c</addressOffset>
-          <fields>
-            <field>
-              <name>DMA_TTYPE_NUM</name>
-              <bitRange>[23:0]</bitRange>
-              <description>Number of elements to transfer</description>
-            </field>
-            <field>
-              <name>DMA_TTYPE_QSEL</name>
-              <bitRange>[28:27]</bitRange>
-              <description>Data quantity select</description>
-            </field>
-            <field>
-              <name>DMA_TTYPE_SRC_INC</name>
-              <bitRange>[29:29]</bitRange>
-              <description>Source constant (0) or incrementing (1) address</description>
-            </field>
-            <field>
-              <name>DMA_TTYPE_DST_INC</name>
-              <bitRange>[30:30]</bitRange>
-              <description>Destination constant (0) or incrementing (1) address</description>
-            </field>
-            <field>
-              <name>DMA_TTYPE_ENDIAN</name>
-              <bitRange>[31:31]</bitRange>
-              <description>Convert Endianness when set</description>
-            </field>
-          </fields>
         </register>
       </registers>
     </peripheral>


### PR DESCRIPTION
* :bug: fix DMA's byte-enable issues (-> #1269)
* add a configurable descriptor FIFO: program several transfers and execute them at once
* new top generic `IO_DMA_DSC_FIFO` - number of entries in the DMA descriptor FIFO

Example:

```c
// program two DMA transfers
neorv32_dma_program(
  (uint32_t)&src_array_a,
  (uint32_t)&dst_array_a,
  DMA_SRC_INC_BYTE | DMA_DST_INC_BYTE | DMA_BSWAP | 32 // 32 bytes, convert Endianness
);

neorv32_dma_program(
  (uint32_t)&src_array_b,
  (uint32_t)&dst_array_b,
  DMA_SRC_CONST_WORD | DMA_DST_CONST_WORD | 4 // words
);

// start transfers and wait in sleep mode for completion
neorv32_dma_start();
neorv32_cpu_sleep();
```