### PR TITLE
:warning: combine SLINK's RX and TX interrupts into a single interrupt

### DIFF
--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110603"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110604"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -308,7 +308,7 @@ architecture neorv32_top_rtl of neorv32_top is
   -- IRQs --
   type firq_enum_t is (
     FIRQ_TWD, FIRQ_UART0_RX, FIRQ_UART0_TX, FIRQ_UART1_RX, FIRQ_UART1_TX, FIRQ_SPI, FIRQ_SDI, FIRQ_TWI,
-    FIRQ_CFS, FIRQ_NEOLED, FIRQ_GPIO, FIRQ_GPTMR, FIRQ_ONEWIRE, FIRQ_DMA, FIRQ_SLINK_RX, FIRQ_SLINK_TX
+    FIRQ_CFS, FIRQ_NEOLED, FIRQ_GPIO, FIRQ_GPTMR, FIRQ_ONEWIRE, FIRQ_DMA, FIRQ_SLINK
   );
   type firq_t is array (firq_enum_t) of std_ulogic;
   signal firq      : firq_t;
@@ -460,8 +460,8 @@ begin
   cpu_firq(11) <= firq(FIRQ_SDI);
   cpu_firq(12) <= firq(FIRQ_GPTMR);
   cpu_firq(13) <= firq(FIRQ_ONEWIRE);
-  cpu_firq(14) <= firq(FIRQ_SLINK_RX);
-  cpu_firq(15) <= firq(FIRQ_SLINK_TX); -- lowest priority
+  cpu_firq(14) <= firq(FIRQ_SLINK);
+  cpu_firq(15) <= '0'; -- lowest priority
 
   -- CPU core(s) + optional caches + bus switch --
   core_complex_gen:
@@ -1450,8 +1450,7 @@ begin
         rstn_i           => rstn_sys,
         bus_req_i        => iodev_req(IODEV_SLINK),
         bus_rsp_o        => iodev_rsp(IODEV_SLINK),
-        rx_irq_o         => firq(FIRQ_SLINK_RX),
-        tx_irq_o         => firq(FIRQ_SLINK_TX),
+        irq_o            => firq(FIRQ_SLINK),
         slink_rx_data_i  => slink_rx_dat_i,
         slink_rx_src_i   => slink_rx_src_i,
         slink_rx_valid_i => slink_rx_val_i,
@@ -1468,13 +1467,12 @@ begin
     neorv32_slink_disabled:
     if not IO_SLINK_EN generate
       iodev_rsp(IODEV_SLINK) <= rsp_terminate_c;
-      firq(FIRQ_SLINK_RX)    <= '0';
-      firq(FIRQ_SLINK_TX)    <= '0';
-      slink_rx_rdy_o         <= '0';
-      slink_tx_dat_o         <= (others => '0');
-      slink_tx_dst_o         <= (others => '0');
-      slink_tx_val_o         <= '0';
-      slink_tx_lst_o         <= '0';
+      firq(FIRQ_SLINK) <= '0';
+      slink_rx_rdy_o   <= '0';
+      slink_tx_dat_o   <= (others => '0');
+      slink_tx_dst_o   <= (others => '0');
+      slink_tx_val_o   <= '0';
+      slink_tx_lst_o   <= '0';
     end generate;
 
 

--- a/sw/example/demo_slink/main.c
+++ b/sw/example/demo_slink/main.c
@@ -1,7 +1,7 @@
 // ================================================================================ //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -15,14 +15,8 @@
 #include <neorv32.h>
 #include <string.h>
 
-
-/**********************************************************************//**
- * @name User configuration
- **************************************************************************/
-/**@{*/
-/** UART BAUD rate */
+// UART BAUD rate
 #define BAUD_RATE 19200
-/**@}*/
 
 // Prototypes
 void slink_firq_handler(void);
@@ -47,11 +41,6 @@ int main() {
   // setup UART at default baud rate, no interrupts
   neorv32_uart0_setup(BAUD_RATE, 0);
 
-  // check if UART0 unit is implemented at all
-  if (neorv32_uart0_available() == 0) {
-    return -1; // abort if not implemented
-  }
-
 
   // intro
   neorv32_uart0_printf("\n<<< SLINK Demo Program >>>\n\n");
@@ -71,7 +60,7 @@ int main() {
 
 
   // setup SLINK module, no interrupts
-  neorv32_slink_setup(0, 0);
+  neorv32_slink_setup(0);
 
 
   // TX demo
@@ -124,13 +113,13 @@ int main() {
   neorv32_uart0_printf("\n------ RX IRQ Demo -------\n");
 
   // reconfigure SLINK module
-  neorv32_slink_setup(1 << SLINK_CTRL_IRQ_RX_NEMPTY, 0); // interrupt if RX data available
+  neorv32_slink_setup(1 << SLINK_CTRL_IRQ_RX_NEMPTY); // interrupt if RX data available
   neorv32_slink_rx_clear();
   neorv32_slink_tx_clear();
 
   // NEORV32 runtime environment: install SLINK FIRQ handler
-  neorv32_rte_handler_install(SLINK_RX_RTE_ID, slink_firq_handler);
-  neorv32_cpu_csr_set(CSR_MIE, 1 << SLINK_RX_FIRQ_ENABLE); // enable SLINK FIRQ
+  neorv32_rte_handler_install(SLINK_RTE_ID, slink_firq_handler);
+  neorv32_cpu_csr_set(CSR_MIE, 1 << SLINK_FIRQ_ENABLE); // enable SLINK FIRQ
   neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE); // enable machine-mode interrupts
 
   for (i=0; i<4; i++) {

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1648,11 +1648,11 @@ int main() {
     cnt_test++;
 
     // fire RX interrupt when RX FIFO is at least half full
-    neorv32_slink_setup(1 << SLINK_CTRL_IRQ_RX_HALF, 0);
+    neorv32_slink_setup(1 << SLINK_CTRL_IRQ_RX_HALF);
     tmp_a = neorv32_slink_get_rx_fifo_depth();
 
     // enable SLINK RX FIRQ
-    neorv32_cpu_csr_write(CSR_MIE, 1 << SLINK_RX_FIRQ_ENABLE);
+    neorv32_cpu_csr_write(CSR_MIE, 1 << SLINK_FIRQ_ENABLE);
 
     // send RX_FIFO/2 data words
     neorv32_slink_set_dst(0b1010);
@@ -1667,7 +1667,7 @@ int main() {
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
     // check if IRQ
-    if ((trap_cause == SLINK_RX_TRAP_CODE) && // correct trap code
+    if ((trap_cause == SLINK_TRAP_CODE) && // correct trap code
         (neorv32_slink_rx_status() == SLINK_FIFO_HALF) && // RX FIFO is at least half full
         (neorv32_slink_get() == 0xAABBCCDD) && // correct RX data
         (neorv32_slink_get_src() == 0b1010) && // correct routing information
@@ -1684,46 +1684,11 @@ int main() {
 
 
   // ----------------------------------------------------------
-  // Fast interrupt channel 15 (SLINK TX)
+  // Fast interrupt channel 15 (reserved)
   // ----------------------------------------------------------
-  PRINT_STANDARD("[%i] FIRQ15 (SLINK_TX) ", cnt_test);
-
-  if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IO_SLINK)) {
-    trap_cause = trap_never_c;
-    cnt_test++;
-
-    // fire TX interrupt when TX FIFO is empty
-    neorv32_slink_setup(0, 1 << SLINK_CTRL_IRQ_TX_EMPTY);
-    tmp_a = neorv32_slink_get_rx_fifo_depth();
-
-    // enable SLINK TX FIRQ
-    neorv32_cpu_csr_write(CSR_MIE, 1 << SLINK_TX_FIRQ_ENABLE);
-
-    // send single data word
-    neorv32_slink_set_dst(0b1100);
-    neorv32_slink_put(0x11223344);
-
-    // wait for interrupt
-    asm volatile ("nop");
-    asm volatile ("nop");
-
-    neorv32_cpu_csr_write(CSR_MIE, 0);
-
-    // check if IRQ
-    if ((trap_cause == SLINK_TX_TRAP_CODE) && // correct trap code
-        (neorv32_slink_tx_status() == SLINK_FIFO_EMPTY) && // TX FIFO is empty
-        (neorv32_slink_get() == 0x11223344) && // correct RX data
-        (neorv32_slink_get_src() == 0b1100) && // correct routing information
-        (neorv32_slink_check_last() == 0)) { // is NOT marked as "end of stream"
-      test_ok();
-    }
-    else {
-      test_fail();
-    }
-  }
-  else {
-    PRINT_STANDARD("[n.a.]\n");
-  }
+  PRINT_STANDARD("[%i] FIRQ15 ", cnt_test);
+  trap_cause = trap_never_c;
+  PRINT_STANDARD("[n.a.]\n");
 
 
   // ----------------------------------------------------------

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -161,14 +161,17 @@ extern "C" {
 /**@}*/
 /** @name Stream Link Interface (SLINK) */
 /**@{*/
-#define SLINK_RX_FIRQ_ENABLE   CSR_MIE_FIRQ14E   /**< MIE CSR bit (#NEORV32_CSR_MIE_enum) */
-#define SLINK_RX_FIRQ_PENDING  CSR_MIP_FIRQ14P   /**< MIP CSR bit (#NEORV32_CSR_MIP_enum) */
-#define SLINK_RX_RTE_ID        RTE_TRAP_FIRQ_14  /**< RTE entry code (#NEORV32_RTE_TRAP_enum) */
-#define SLINK_RX_TRAP_CODE     TRAP_CODE_FIRQ_14 /**< MCAUSE CSR trap code (#NEORV32_EXCEPTION_CODES_enum) */
-#define SLINK_TX_FIRQ_ENABLE   CSR_MIE_FIRQ15E   /**< MIE CSR bit (#NEORV32_CSR_MIE_enum) */
-#define SLINK_TX_FIRQ_PENDING  CSR_MIP_FIRQ15P   /**< MIP CSR bit (#NEORV32_CSR_MIP_enum) */
-#define SLINK_TX_RTE_ID        RTE_TRAP_FIRQ_15  /**< RTE entry code (#NEORV32_RTE_TRAP_enum) */
-#define SLINK_TX_TRAP_CODE     TRAP_CODE_FIRQ_15 /**< MCAUSE CSR trap code (#NEORV32_EXCEPTION_CODES_enum) */
+#define SLINK_FIRQ_ENABLE      CSR_MIE_FIRQ14E   /**< MIE CSR bit (#NEORV32_CSR_MIE_enum) */
+#define SLINK_FIRQ_PENDING     CSR_MIP_FIRQ14P   /**< MIP CSR bit (#NEORV32_CSR_MIP_enum) */
+#define SLINK_RTE_ID           RTE_TRAP_FIRQ_14  /**< RTE entry code (#NEORV32_RTE_TRAP_enum) */
+#define SLINK_TRAP_CODE        TRAP_CODE_FIRQ_14 /**< MCAUSE CSR trap code (#NEORV32_EXCEPTION_CODES_enum) */
+/**@}*/
+/** @name Stream Link Interface (SLINK) */
+/**@{*/
+// #define SLINK_TX_FIRQ_ENABLE   CSR_MIE_FIRQ15E   /**< MIE CSR bit (#NEORV32_CSR_MIE_enum) */
+// #define SLINK_TX_FIRQ_PENDING  CSR_MIP_FIRQ15P   /**< MIP CSR bit (#NEORV32_CSR_MIP_enum) */
+// #define SLINK_TX_RTE_ID        RTE_TRAP_FIRQ_15  /**< RTE entry code (#NEORV32_RTE_TRAP_enum) */
+// #define SLINK_TX_TRAP_CODE     TRAP_CODE_FIRQ_15 /**< MCAUSE CSR trap code (#NEORV32_EXCEPTION_CODES_enum) */
 /**@}*/
 /**@}*/
 

--- a/sw/lib/include/neorv32_slink.h
+++ b/sw/lib/include/neorv32_slink.h
@@ -23,10 +23,10 @@
 /**@{*/
 /** SLINK module prototype */
 typedef volatile struct __attribute__((packed,aligned(4))) {
-  uint32_t CTRL;      /**< offset 0: control register (#NEORV32_SLINK_CTRL_enum) */
-  uint32_t ROUTE;     /**< offset 4: routing information (#NEORV32_SLINK_ROUTE_enum) */
-  uint32_t DATA;      /**< offset 8: RX/TX data register */
-  uint32_t DATA_LAST; /**< offset 12: RX/TX data register (+ TX end-of-stream) */
+  uint32_t CTRL;      /**< control register (#NEORV32_SLINK_CTRL_enum) */
+  uint32_t ROUTE;     /**< routing information (#NEORV32_SLINK_ROUTE_enum) */
+  uint32_t DATA;      /**< RX/TX data register */
+  uint32_t DATA_LAST; /**< RX/TX data register (+ TX end-of-stream) */
 } neorv32_slink_t;
 
 /** SLINK module hardware handle (#neorv32_slink_t) */
@@ -47,12 +47,12 @@ enum NEORV32_SLINK_CTRL_enum {
   SLINK_CTRL_TX_HALF       = 12, /**< SLINK control register(12) (r/-): TX FIFO at least half full */
   SLINK_CTRL_TX_FULL       = 13, /**< SLINK control register(13) (r/-): TX FIFO full */
 
-  SLINK_CTRL_IRQ_RX_NEMPTY = 16, /**< SLINK control register(16) (r/w): RX interrupt if RX FIFO not empty */
-  SLINK_CTRL_IRQ_RX_HALF   = 17, /**< SLINK control register(17) (r/w): RX interrupt if RX FIFO at least half full */
-  SLINK_CTRL_IRQ_RX_FULL   = 18, /**< SLINK control register(18) (r/w): RX interrupt if RX FIFO full */
-  SLINK_CTRL_IRQ_TX_EMPTY  = 19, /**< SLINK control register(19) (r/w): TX interrupt if TX FIFO empty */
-  SLINK_CTRL_IRQ_TX_NHALF  = 20, /**< SLINK control register(20) (r/w): TX interrupt if TX FIFO not at least half full */
-  SLINK_CTRL_IRQ_TX_NFULL  = 21, /**< SLINK control register(21) (r/w): TX interrupt if TX FIFO not full */
+  SLINK_CTRL_IRQ_RX_NEMPTY = 16, /**< SLINK control register(16) (r/w): interrupt if RX FIFO not empty */
+  SLINK_CTRL_IRQ_RX_HALF   = 17, /**< SLINK control register(17) (r/w): interrupt if RX FIFO at least half full */
+  SLINK_CTRL_IRQ_RX_FULL   = 18, /**< SLINK control register(18) (r/w): interrupt if RX FIFO full */
+  SLINK_CTRL_IRQ_TX_EMPTY  = 19, /**< SLINK control register(19) (r/w): interrupt if TX FIFO empty */
+  SLINK_CTRL_IRQ_TX_NHALF  = 20, /**< SLINK control register(20) (r/w): interrupt if TX FIFO not at least half full */
+  SLINK_CTRL_IRQ_TX_NFULL  = 21, /**< SLINK control register(21) (r/w): interrupt if TX FIFO not full */
 
   SLINK_CTRL_RX_FIFO_LSB   = 24, /**< SLINK control register(24) (r/-): log2(RX FIFO size) LSB */
   SLINK_CTRL_RX_FIFO_MSB   = 27, /**< SLINK control register(27) (r/-): log2(RX FIFO size) MSB */
@@ -81,7 +81,7 @@ enum NEORV32_SLINK_STATUS_enum {
  **************************************************************************/
 /**@{*/
 int      neorv32_slink_available(void);
-void     neorv32_slink_setup(uint32_t rx_irq, uint32_t tx_irq);
+void     neorv32_slink_setup(uint32_t irq);
 void     neorv32_slink_rx_clear(void);
 void     neorv32_slink_tx_clear(void);
 int      neorv32_slink_get_rx_fifo_depth(void);

--- a/sw/lib/source/neorv32_slink.c
+++ b/sw/lib/source/neorv32_slink.c
@@ -37,24 +37,21 @@ int neorv32_slink_available(void) {
 /**********************************************************************//**
  * Reset, enable and configure SLINK.
  *
- * @param[in] rx_irq Configure RX interrupt conditions (#NEORV32_SLINK_CTRL_enum).
- * @param[in] tx_irq Configure TX interrupt conditions (#NEORV32_SLINK_CTRL_enum).
+ * @param[in] irq Interrupt conditions (#NEORV32_SLINK_CTRL_enum).
  **************************************************************************/
-void neorv32_slink_setup(uint32_t rx_irq, uint32_t tx_irq) {
+void neorv32_slink_setup(uint32_t irq) {
 
   NEORV32_SLINK->CTRL = 0; // reset and disable
 
-  const uint32_t rx_irq_mask = (1 << SLINK_CTRL_IRQ_RX_NEMPTY) |
-                               (1 << SLINK_CTRL_IRQ_RX_HALF) |
-                               (1 << SLINK_CTRL_IRQ_RX_FULL);
-  const uint32_t tx_irq_mask = (1 << SLINK_CTRL_IRQ_TX_EMPTY) |
-                               (1 << SLINK_CTRL_IRQ_TX_NHALF) |
-                               (1 << SLINK_CTRL_IRQ_TX_NFULL);
+  const uint32_t irq_mask = (1 << SLINK_CTRL_IRQ_RX_NEMPTY) |
+                            (1 << SLINK_CTRL_IRQ_RX_HALF)   |
+                            (1 << SLINK_CTRL_IRQ_RX_FULL)   |
+                            (1 << SLINK_CTRL_IRQ_TX_EMPTY)  |
+                            (1 << SLINK_CTRL_IRQ_TX_NHALF)  |
+                            (1 << SLINK_CTRL_IRQ_TX_NFULL);
 
   uint32_t tmp = (uint32_t)(1 << SLINK_CTRL_EN);
-  tmp |= rx_irq & rx_irq_mask;
-  tmp |= tx_irq & tx_irq_mask;
-
+  tmp |= irq & irq_mask;
   NEORV32_SLINK->CTRL = tmp;
 }
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -307,32 +307,32 @@
             <field>
               <name>SLINK_CTRL_IRQ_RX_NEMPTY</name>
               <bitRange>[16:16]</bitRange>
-              <description>RX interrupt if RX FIFO not empty</description>
+              <description>Interrupt if RX FIFO not empty</description>
             </field>
             <field>
               <name>SLINK_CTRL_IRQ_RX_HALF</name>
               <bitRange>[17:17]</bitRange>
-              <description>RX interrupt if RX FIFO at least half full</description>
+              <description>Interrupt if RX FIFO at least half full</description>
             </field>
             <field>
               <name>SLINK_CTRL_IRQ_RX_FULL</name>
               <bitRange>[18:18]</bitRange>
-              <description>RX interrupt if RX FIFO full</description>
+              <description>Interrupt if RX FIFO full</description>
             </field>
             <field>
               <name>SLINK_CTRL_IRQ_TX_EMPTY</name>
               <bitRange>[19:19]</bitRange>
-              <description>TX interrupt if TX FIFO empty</description>
+              <description>Interrupt if TX FIFO empty</description>
             </field>
             <field>
               <name>SLINK_CTRL_IRQ_TX_NHALF</name>
               <bitRange>[20:20]</bitRange>
-              <description>TX interrupt if TX FIFO not at least half full</description>
+              <description>Interrupt if TX FIFO not at least half full</description>
             </field>
             <field>
               <name>SLINK_CTRL_IRQ_TX_NFULL</name>
               <bitRange>[21:21]</bitRange>
-              <description>TX interrupt if TX FIFO not full</description>
+              <description>Interrupt if TX FIFO not full</description>
             </field>
             <field>
               <name>SLINK_CTRL_RX_FIFO</name>


### PR DESCRIPTION
Since we are running out of FIRQ channels, this PR combines the individual RX and TX interrupt signals of the SLINK module into a single interrupt signal:

> The SLINK module provides a single interrupt request that can be used to signal certain RX/TX data FIFO conditions. The according interrupt conditions are based on the RX/TX link FIFO status flags and are configured via the control register's `SLINK_CTRL_IRQ_*` bits. The SLINK interrupt will fire when the module is enabled (`SLINK_CTRL_EN`) and **any** of the selected interrupt conditions are met. Hence, all enabled interrupt conditions are logically OR-ed. If any enable interrupt conditions becomes active the interrupt will become pending until the interrupt-causing condition is resolved (e.g. by reading from the RX FIFO).