### PR TITLE
⚠️ combine UART's RX and TX interrupts into a single interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 08.06.2025 | 1.11.6.7 | :warning: combine individual UART RX/TX interrupt requests into a single (programmable) interrupt request | [#1289](https://github.com/stnolting/neorv32/pull/1289) |
 | 08.06.2025 | 1.11.6.6 | :warning: invert "TX FIFO full" status flag; add interrupt option for "TX FIFO not full" status | [#1288](https://github.com/stnolting/neorv32/pull/1288) |
 | 07.06.2025 | 1.11.6.5 | :sparkles: add TRNG interrupt | [#1287](https://github.com/stnolting/neorv32/pull/1287) |
 | 07.06.2025 | 1.11.6.4 | :warning: combine individual SLINK RX/TX interrupt requests into a single (programmable) interrupt request | [#1286](https://github.com/stnolting/neorv32/pull/1286) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -422,10 +422,10 @@ table (the channel number also corresponds to the according FIRQ priority: 0 = h
 | Channel | Source | Description
 | 0       | <<_two_wire_serial_device_controller_twd,TWD>> | TWD FIFO level interrupt
 | 1       | <<_custom_functions_subsystem_cfs,CFS>> | Custom functions subsystem (CFS) interrupt (user-defined)
-| 2       | <<_primary_universal_asynchronous_receiver_and_transmitter_uart0,UART0>> | UART0 RX FIFO level interrupt
-| 3       | <<_primary_universal_asynchronous_receiver_and_transmitter_uart0,UART0>> | UART0 TX FIFO level interrupt
-| 4       | <<_secondary_universal_asynchronous_receiver_and_transmitter_uart1,UART1>> | UART1 RX FIFO level interrupt
-| 5       | <<_secondary_universal_asynchronous_receiver_and_transmitter_uart1,UART1>> | UART1 TX FIFO level interrupt
+| 2       | <<_primary_universal_asynchronous_receiver_and_transmitter_uart0,UART0>> | UART0 FIFO level interrupt
+| 3       | <<_secondary_universal_asynchronous_receiver_and_transmitter_uart1,UART1>> | UART1 FIFO level interrupt
+| 4       | - | _reserved_
+| 5       | - | _reserved_
 | 6       | <<_serial_peripheral_interface_controller_spi,SPI>> | SPI FIFO level interrupt
 | 7       | <<_two_wire_serial_interface_controller_twi,TWI>> | TWI FIFO level interrupt
 | 8       | <<_general_purpose_input_and_output_port_gpio,GPIO>> | GPIO input pin(s) interrupt
@@ -435,7 +435,7 @@ table (the channel number also corresponds to the according FIRQ priority: 0 = h
 | 12      | <<_general_purpose_timer_gptmr,GPTMR>> | General purpose timer interrupt
 | 13      | <<_one_wire_serial_interface_controller_onewire,ONEWIRE>> | 1-wire idle interrupt
 | 14      | <<_stream_link_interface_slink,SLINK>> | SLINK FIFO level interrupt
-| 15      | <<_true_random_number_generator_trng,TRNG>> | TRNG data available interrupt
+| 15      | <<_true_random_number_generator_trng,TRNG>> | TRNG FIFO level interrupt
 |=======================
 
 

--- a/docs/datasheet/soc_slink.adoc
+++ b/docs/datasheet/soc_slink.adoc
@@ -112,11 +112,10 @@ data. Vice versa, TX routing information has to be set **before** writing the ac
 **Interrupt**
 
 The SLINK module provides a single interrupt request that can be used to signal certain RX/TX data FIFO conditions.
-The according interrupt conditions are based on the RX/TX link FIFO status flags and are configured via the control
-register's `SLINK_CTRL_IRQ_*` bits. The SLINK interrupt will fire when the module is enabled (`SLINK_CTRL_EN`)
-and **any** of the selected interrupt conditions are met. Hence, all enabled interrupt conditions are logically OR-ed.
-If any enable interrupt conditions becomes active the interrupt will become pending until the interrupt-causing
-condition is resolved (e.g. by reading from the RX FIFO).
+The interrupt conditions are based on the RX/TX FIFO status flags `SLINK_CTRL_RX_*` / `SLINK_CTRL_TX_*` and are
+configured via the according `SLINK_CTRL_IRQ_RX_*` / `SLINK_CTRL_IRQ_TX_*` bits. The SLINK interrupt will fire when the
+module is enabled (`SLINK_CTRL_EN`) and **any** of the selected interrupt conditions is met. Hence, all enabled interrupt
+conditions are logically OR-ed. The interrupt remains active until all interrupt-causing conditions are resolved.
 
 
 **Register Map**

--- a/docs/datasheet/soc_uart.adoc
+++ b/docs/datasheet/soc_uart.adoc
@@ -15,8 +15,7 @@
 | Configuration generics: | `IO_UART0_EN`      | implement UART0 when `true`
 |                         | `UART0_RX_FIFO`    | RX FIFO depth (power of 2, min 1)
 |                         | `UART0_TX_FIFO`    | TX FIFO depth (power of 2, min 1)
-| CPU interrupts:         | fast IRQ channel 2 | RX interrupt
-|                         | fast IRQ channel 3 | TX interrupt (see <<_processor_interrupts>>)
+| CPU interrupts:         | fast IRQ channel 2 | Programmable FIFO status interrupt (see <<_processor_interrupts>>)
 |=======================
 
 
@@ -72,14 +71,13 @@ the `UART_CTRL_RX_NEMPTY` flag becomes set. The `UART_CTRL_RX_OVER` will be set 
 is cleared only by disabling the module via `UART_CTRL_EN`.
 
 
-**UART Interrupts**
+**UART Interrupt**
 
-The UART module provides independent interrupt channels for RX and TX. These interrupts are triggered by certain RX and TX
-FIFO levels. The actual configuration is programmed independently for the RX and TX interrupt channel via the control register's
-`UART_CTRL_IRQ_RX_*` and `UART_CTRL_IRQ_TX_*` bits, respectively. The available interrupt conditions correspond to the RX and TX
-FIFO status flags `UART_CTRL_RX_*` and `UART_CTRL_TX_*`. Note that all these programmable conditions are logically OR-ed
-(according interrupt fires if any enabled conditions is met). The according interupt will keep triggering until all enabled
-trigger causes are resolved.
+The UART module provides a single interrupt request that can be used to signal certain RX/TX data FIFO conditions.
+The interrupt conditions are based on the RX/TX FIFO status flags `UART_CTRL_RX_*` / `UART_CTRL_TX_*` and are
+configured via the according `UART_CTRL_IRQ_RX_*` / `UART_CTRL_IRQ_TX_*` bits. The UART interrupt will fire when the
+module is enabled (`SLINK_CTRL_EN`) and **any** of the selected interrupt conditions is met. Hence, all enabled interrupt
+conditions are logically OR-ed. The interrupt remains active until all interrupt-causing conditions are resolved.
 
 
 **RTS/CTS Hardware Flow Control**
@@ -166,8 +164,7 @@ Both file are created in the simulation's home folder.
 | Configuration generics: | `IO_UART1_EN`      | implement UART1 when `true`
 |                         | `UART1_RX_FIFO`    | RX FIFO depth (power of 2, min 1)
 |                         | `UART1_TX_FIFO`    | TX FIFO depth (power of 2, min 1)
-| CPU interrupts:         | fast IRQ channel 4 | RX interrupt
-|                         | fast IRQ channel 5 | TX interrupt (see <<_processor_interrupts>>)
+| CPU interrupts:         | fast IRQ channel 3 | Programmable FIFO status interrupt (see <<_processor_interrupts>>)
 |=======================
 
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110606"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110607"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -307,8 +307,8 @@ architecture neorv32_top_rtl of neorv32_top is
 
   -- IRQs --
   type firq_enum_t is (
-    FIRQ_TWD, FIRQ_UART0_RX, FIRQ_UART0_TX, FIRQ_UART1_RX, FIRQ_UART1_TX, FIRQ_SPI, FIRQ_SDI, FIRQ_TWI,
-    FIRQ_CFS, FIRQ_NEOLED, FIRQ_GPIO, FIRQ_GPTMR, FIRQ_ONEWIRE, FIRQ_DMA, FIRQ_SLINK, FIRQ_TRNG
+    FIRQ_TWD, FIRQ_UART0, FIRQ_UART1, FIRQ_SPI, FIRQ_SDI, FIRQ_TWI, FIRQ_CFS,
+    FIRQ_NEOLED, FIRQ_GPIO, FIRQ_GPTMR, FIRQ_ONEWIRE, FIRQ_DMA, FIRQ_SLINK, FIRQ_TRNG
   );
   type firq_t is array (firq_enum_t) of std_ulogic;
   signal firq      : firq_t;
@@ -448,10 +448,10 @@ begin
   -- fast interrupt requests (FIRQs) --
   cpu_firq(0)  <= firq(FIRQ_TWD); -- highest priority
   cpu_firq(1)  <= firq(FIRQ_CFS);
-  cpu_firq(2)  <= firq(FIRQ_UART0_RX);
-  cpu_firq(3)  <= firq(FIRQ_UART0_TX);
-  cpu_firq(4)  <= firq(FIRQ_UART1_RX);
-  cpu_firq(5)  <= firq(FIRQ_UART1_TX);
+  cpu_firq(2)  <= firq(FIRQ_UART0);
+  cpu_firq(3)  <= firq(FIRQ_UART1);
+  cpu_firq(4)  <= '0'; -- reserved
+  cpu_firq(5)  <= '0'; -- reserved
   cpu_firq(6)  <= firq(FIRQ_SPI);
   cpu_firq(7)  <= firq(FIRQ_TWI);
   cpu_firq(8)  <= firq(FIRQ_GPIO);
@@ -1149,8 +1149,7 @@ begin
         uart_rxd_i  => uart0_rxd_i,
         uart_rtsn_o => uart0_rtsn_o,
         uart_ctsn_i => uart0_ctsn_i,
-        irq_rx_o    => firq(FIRQ_UART0_RX),
-        irq_tx_o    => firq(FIRQ_UART0_TX)
+        irq_o       => firq(FIRQ_UART0)
       );
     end generate;
 
@@ -1160,8 +1159,7 @@ begin
       uart0_txd_o            <= '0';
       uart0_rtsn_o           <= '1';
       clk_gen_en(CG_UART0)   <= '0';
-      firq(FIRQ_UART0_RX)    <= '0';
-      firq(FIRQ_UART0_TX)    <= '0';
+      firq(FIRQ_UART0)       <= '0';
     end generate;
 
 
@@ -1187,8 +1185,7 @@ begin
         uart_rxd_i  => uart1_rxd_i,
         uart_rtsn_o => uart1_rtsn_o,
         uart_ctsn_i => uart1_ctsn_i,
-        irq_rx_o    => firq(FIRQ_UART1_RX),
-        irq_tx_o    => firq(FIRQ_UART1_TX)
+        irq_o       => firq(FIRQ_UART1)
       );
     end generate;
 
@@ -1198,8 +1195,7 @@ begin
       uart1_txd_o            <= '0';
       uart1_rtsn_o           <= '1';
       clk_gen_en(CG_UART1)   <= '0';
-      firq(FIRQ_UART1_RX)    <= '0';
-      firq(FIRQ_UART1_TX)    <= '0';
+      firq(FIRQ_UART1)       <= '0';
     end generate;
 
 

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -257,14 +257,14 @@ begin
     gpio_i         => gpio,
     -- primary UART0 --
     uart0_txd_o    => uart0_txd,
-    uart0_rxd_i    => uart0_txd,
+    uart0_rxd_i    => uart1_txd,
     uart0_rtsn_o   => uart0_ctsn,
-    uart0_ctsn_i   => uart0_ctsn,
+    uart0_ctsn_i   => uart1_ctsn,
     -- secondary UART1 --
     uart1_txd_o    => uart1_txd,
-    uart1_rxd_i    => uart1_txd,
+    uart1_rxd_i    => uart0_txd,
     uart1_rtsn_o   => uart1_ctsn,
-    uart1_ctsn_i   => uart1_ctsn,
+    uart1_ctsn_i   => uart0_ctsn,
     -- SPI --
     spi_clk_o      => spi_clk,
     spi_dat_o      => spi_do,

--- a/sw/lib/include/neorv32.h
+++ b/sw/lib/include/neorv32.h
@@ -83,25 +83,17 @@ extern "C" {
 /**@}*/
 /** @name Primary Universal Asynchronous Receiver/Transmitter (UART0) */
 /**@{*/
-#define UART0_RX_FIRQ_ENABLE   CSR_MIE_FIRQ2E    /**< MIE CSR bit (#NEORV32_CSR_MIE_enum) */
-#define UART0_RX_FIRQ_PENDING  CSR_MIP_FIRQ2P    /**< MIP CSR bit (#NEORV32_CSR_MIP_enum) */
-#define UART0_RX_RTE_ID        RTE_TRAP_FIRQ_2   /**< RTE entry code (#NEORV32_RTE_TRAP_enum) */
-#define UART0_RX_TRAP_CODE     TRAP_CODE_FIRQ_2  /**< MCAUSE CSR trap code (#NEORV32_EXCEPTION_CODES_enum) */
-#define UART0_TX_FIRQ_ENABLE   CSR_MIE_FIRQ3E    /**< MIE CSR bit (#NEORV32_CSR_MIE_enum) */
-#define UART0_TX_FIRQ_PENDING  CSR_MIP_FIRQ3P    /**< MIP CSR bit (#NEORV32_CSR_MIP_enum) */
-#define UART0_TX_RTE_ID        RTE_TRAP_FIRQ_3   /**< RTE entry code (#NEORV32_RTE_TRAP_enum) */
-#define UART0_TX_TRAP_CODE     TRAP_CODE_FIRQ_3  /**< MCAUSE CSR trap code (#NEORV32_EXCEPTION_CODES_enum) */
+#define UART0_FIRQ_ENABLE      CSR_MIE_FIRQ2E    /**< MIE CSR bit (#NEORV32_CSR_MIE_enum) */
+#define UART0_FIRQ_PENDING     CSR_MIP_FIRQ2P    /**< MIP CSR bit (#NEORV32_CSR_MIP_enum) */
+#define UART0_RTE_ID           RTE_TRAP_FIRQ_2   /**< RTE entry code (#NEORV32_RTE_TRAP_enum) */
+#define UART0_TRAP_CODE        TRAP_CODE_FIRQ_2  /**< MCAUSE CSR trap code (#NEORV32_EXCEPTION_CODES_enum) */
 /**@}*/
 /** @name Secondary Universal Asynchronous Receiver/Transmitter (UART1) */
 /**@{*/
-#define UART1_RX_FIRQ_ENABLE   CSR_MIE_FIRQ4E    /**< MIE CSR bit (#NEORV32_CSR_MIE_enum) */
-#define UART1_RX_FIRQ_PENDING  CSR_MIP_FIRQ4P    /**< MIP CSR bit (#NEORV32_CSR_MIP_enum) */
-#define UART1_RX_RTE_ID        RTE_TRAP_FIRQ_4   /**< RTE entry code (#NEORV32_RTE_TRAP_enum) */
-#define UART1_RX_TRAP_CODE     TRAP_CODE_FIRQ_4  /**< MCAUSE CSR trap code (#NEORV32_EXCEPTION_CODES_enum) */
-#define UART1_TX_FIRQ_ENABLE   CSR_MIE_FIRQ5E    /**< MIE CSR bit (#NEORV32_CSR_MIE_enum) */
-#define UART1_TX_FIRQ_PENDING  CSR_MIP_FIRQ5P    /**< MIP CSR bit (#NEORV32_CSR_MIP_enum) */
-#define UART1_TX_RTE_ID        RTE_TRAP_FIRQ_5   /**< RTE entry code (#NEORV32_RTE_TRAP_enum) */
-#define UART1_TX_TRAP_CODE     TRAP_CODE_FIRQ_5  /**< MCAUSE CSR trap code (#NEORV32_EXCEPTION_CODES_enum) */
+#define UART1_FIRQ_ENABLE      CSR_MIE_FIRQ3E    /**< MIE CSR bit (#NEORV32_CSR_MIE_enum) */
+#define UART1_FIRQ_PENDING     CSR_MIP_FIRQ3P    /**< MIP CSR bit (#NEORV32_CSR_MIP_enum) */
+#define UART1_RTE_ID           RTE_TRAP_FIRQ_3   /**< RTE entry code (#NEORV32_RTE_TRAP_enum) */
+#define UART1_TRAP_CODE        TRAP_CODE_FIRQ_3  /**< MCAUSE CSR trap code (#NEORV32_EXCEPTION_CODES_enum) */
 /**@}*/
 /** @name Serial Peripheral Interface (SPI) */
 /**@{*/

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -791,8 +791,7 @@
       <description>Primary universal asynchronous receiver and transmitter</description>
       <baseAddress>0xFFF50000</baseAddress>
 
-      <interrupt><name>UART0_RX_FIRQ</name><value>2</value></interrupt>
-      <interrupt><name>UART0_TX_FIRQ</name><value>3</value></interrupt>
+      <interrupt><name>UART0_FIRQ</name><value>2</value></interrupt>
 
       <addressBlock>
         <offset>0</offset>
@@ -937,8 +936,7 @@
       <description>Secondary universal asynchronous receiver and transmitter</description>
       <baseAddress>0xFFF60000</baseAddress>
 
-      <interrupt><name>UART1_RX_FIRQ</name><value>4</value></interrupt>
-      <interrupt><name>UART1_TX_FIRQ</name><value>5</value></interrupt>
+      <interrupt><name>UART1_FIRQ</name><value>3</value></interrupt>
 
       <addressBlock>
         <offset>0</offset>


### PR DESCRIPTION
Just like in #1286, this PR combines the individual RX and TX interrupt signals of the UART module(s) into a single interrupt signal:

> The UART module provides a single interrupt request that can be used to signal certain RX/TX data FIFO conditions. The according interrupt conditions are based on the RX/TX FIFO status flags `UART_CTRL_RX_*` / `UART_CTRL_TX_*` and are configured via the according `UART_CTRL_IRQ_RX_*` / `UART_CTRL_IRQ_TX_*` bits. The UART interrupt will fire when the module is enabled (`SLINK_CTRL_EN`) and **any** of the selected interrupt conditions is met. Hence, all enabled interrupt conditions are logically OR-ed. The interrupt remains active until all interrupt-causing conditions are resolved.