### PR TITLE
remove WDT "strict" bit; minor code edits and cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 20.06.2025 | 1.11.7.1 | remove WDT's "strict" configuration bit; minor rtl cleanups | [#1293](https://github.com/stnolting/neorv32/pull/1293) |
 | 20.06.2025 | [**:rocket:1.11.7**](https://github.com/stnolting/neorv32/releases/tag/v1.11.7) | **New release** | |
 | 18.06.2025 | 1.11.6.8 | minor rtl edits and optimizations | [#1291](https://github.com/stnolting/neorv32/pull/1291) |
 | 08.06.2025 | 1.11.6.7 | :warning: combine individual UART RX/TX interrupt requests into a single (programmable) interrupt request | [#1289](https://github.com/stnolting/neorv32/pull/1289) |

--- a/docs/datasheet/soc_wdt.adoc
+++ b/docs/datasheet/soc_wdt.adoc
@@ -6,19 +6,19 @@
 [grid="none"]
 |=======================
 | Hardware source files:  | neorv32_wdt.vhd |
-| Software driver files:  | neorv32_wdt.c | link:https://stnolting.github.io/neorv32/sw/neorv32__wdt_8c.html[Online software reference (Doxygen)]
-|                         | neorv32_wdt.h | link:https://stnolting.github.io/neorv32/sw/neorv32__wdt_8h.html[Online software reference (Doxygen)]
-| Top entity ports:       | `rstn_wdt_o` | synchronous watchdog reset output, low-active
-| Configuration generics: | `IO_WDT_EN` | implement watchdog when `true`
-| CPU interrupts:         | none |
+| Software driver files:  | neorv32_wdt.c   | link:https://stnolting.github.io/neorv32/sw/neorv32__wdt_8c.html[Online software reference (Doxygen)]
+|                         | neorv32_wdt.h   | link:https://stnolting.github.io/neorv32/sw/neorv32__wdt_8h.html[Online software reference (Doxygen)]
+| Top entity ports:       | `rstn_wdt_o`    | synchronous watchdog reset output, low-active
+| Configuration generics: | `IO_WDT_EN`     | implement watchdog when `true`
+| CPU interrupts:         | none            |
 |=======================
 
 
 **Overview**
 
-The watchdog (WDT) provides a last resort for safety-critical applications. When a pre-programmed timeout value is reached
-a system-wide hardware reset is generated. The internal counter has to be reset explicitly by the application
-program every now and then to prevent a timeout.
+The watchdog (WDT) provides a last resort for safety-critical applications. When a pre-programmed timeout value
+is reached a system-wide hardware reset is generated. The internal counter has to be reset explicitly by the
+application program every now and then to prevent a timeout.
 
 
 **Theory of Operation**
@@ -26,12 +26,10 @@ program every now and then to prevent a timeout.
 The watchdog is enabled by setting the control register's `WDT_CTRL_EN` bit. When this bit is cleared, the internal
 timeout counter is reset to zero and no system reset can be triggered by this module.
 
-The internal 32-bit timeout counter is clocked at 1/4096th of the processor's main clock (f~WDT~[Hz] = f~main~[Hz] / 4096).
+The internal 32-bit timeout counter is clocked at 1/4096 of the processor's main clock (f~WDT~[Hz] = f~main~[Hz] / 4096).
 Whenever this counter reaches the programmed timeout value (`WDT_CTRL_TIMEOUT` bits in the control register) a
-hardware reset is triggered.
-
-The watchdog's timeout counter is reset ("feeding the watchdog") by writing the reset **PASSWORD** to the `RESET` register.
-The password is hardwired to hexadecimal `0x709D1AB3`.
+hardware reset is triggered. The timeout counter is reset by writing the reset **PASSWORD** to the `RESET` register
+("feeding the watchdog"). The password is hardwired to hexadecimal `0x709D1AB3`.
 
 [IMPORTANT]
 Once enabled, the watchdog keeps operating even if the CPU is in <<_sleep_mode>> or if the processor is being
@@ -41,31 +39,22 @@ debugged via the <<_on_chip_debugger_ocd>>.
 **Configuration Lock**
 
 The watchdog control register can be _locked_ to protect the current configuration from being modified. The lock is
-activated by setting the `WDT_CTRL_LOCK` bit. In the locked state any write access to the control register is entirely
-ignored (see table below, "writable if locked"). However, read accesses to the control register as well as watchdog resets
-are further possible.
+activated by setting the `WDT_CTRL_LOCK` bit. The lock bit can only be set if the WDT is already enabled (`WDT_CTRL_EN`
+has to be set). Furthermore, the lock bit can only be cleared by a _hardware_ reset
 
-The lock bit can only be set if the WDT is already enabled (`WDT_CTRL_EN` is set). Furthermore, the lock bit can
-only be cleared again by a system-wide hardware reset.
-
-
-**Strict Mode**
-
-The _strict operation mode_ provides additional safety functions. If the strict mode is enabled by the `WDT_CTRL_STRICT`
-control register bit an **immediate hardware** reset if enforced if
-
-* the `RESET` register is written with an incorrect password or
-* the `CTRL` register is written and the `WDT_CTRL_LOCK` bit is set.
+In the locked state any write access to the control register will trigger an immediate hardware reset (read accesses
+are still possible and have no side effects). Additionally, writing an incorrect password to the `RESET` register will
+also trigger an immediate hardware reset.
 
 
 **Cause of last Hardware Reset**
 
-The cause of the last system hardware reset can be determined via the `WDT_CTRL_RCAUSE_*` bits:
+The cause of the last system hardware reset can be determined via the two `WDT_CTRL_RCAUSE` bits:
 
-* `WDT_RCAUSE_EXT` (0b00): Reset caused by external reset signal/pin
+* `WDT_RCAUSE_EXT` (0b00): Reset caused by external reset signal pin
 * `WDT_RCAUSE_OCD` (0b01): Reset caused by on-chip debugger
 * `WDT_RCAUSE_TMO` (0b10): Reset caused by watchdog timeout
-* `WDT_RCAUSE_ACC` (0b11): Reset caused by illegal watchdog access (strict mode)
+* `WDT_RCAUSE_ACC` (0b11): Reset caused by illegal watchdog access
 
 
 **External Reset Output**
@@ -83,11 +72,10 @@ processor's main reset signal is active (even if the watchdog is deactivated or 
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Reset value | Writable if locked | Function
-.6+<| `0xfffb0000` .6+<| `CTRL` <|`0` `WDT_CTRL_EN`     ^| r/w ^| `0` ^| no  <| watchdog enable
-                                <|`1` `WDT_CTRL_LOCK`   ^| r/w ^| `0` ^| no  <| lock configuration when set, clears only on system reset, can only be set if enable bit is set already
-                                <|`2` `WDT_CTRL_STRICT` ^| r/w ^| `0` ^| no  <| set to enable strict mode (force hardware reset if reset password is incorrect or if write access to locked CTRL register)
-                                <|`4:3` `WDT_CTRL_RCAUSE_HI : WDT_CTRL_RCAUSE_LO` ^| r/- ^| `0` ^| -   <| cause of last system reset; 0=external reset, 1=ocd-reset, 2=watchdog reset
-                                <|`7` -                 ^| r/- ^| -   ^| -   <| _reserved_, reads as zero
-                                <|`31:8` `WDT_CTRL_TIMEOUT_MSB : WDT_CTRL_TIMEOUT_LSB` ^| r/w ^| 0 ^| no <| 24-bit watchdog timeout value
-| `0xfffb0004` | `RESET`         |`31:0`                 | -/w  | -    | yes  | Write _PASSWORD_ to reset WDT timeout counter
+.5+<| `0xfffb0000` .5+<| `CTRL` <|`0`    `WDT_CTRL_EN`                                 ^| r/w ^| `0` ^| no  <| Watchdog enable
+                                <|`1`    `WDT_CTRL_LOCK`                               ^| r/w ^| `0` ^| no  <| Lock configuration when set, clears only on system reset, can only be set if enable bit is set already
+                                <|`3:2`  `WDT_CTRL_RCAUSE_HI : WDT_CTRL_RCAUSE_LO`     ^| r/- ^| `0` ^| -   <| Cause of last system reset
+                                <|`7:4`  -                                             ^| r/- ^| -   ^| -   <| _reserved_, reads as zero
+                                <|`31:8` `WDT_CTRL_TIMEOUT_MSB : WDT_CTRL_TIMEOUT_LSB` ^| r/w ^| 0   ^| no  <| Timeout value (24-bit)
+| `0xfffb0004` | `RESET`         |`31:0`                                                | -/w  | -    | yes  | Write _PASSWORD_ to reset WDT timeout counter
 |=======================

--- a/rtl/core/neorv32_cpu_cp_cond.vhd
+++ b/rtl/core/neorv32_cpu_cp_cond.vhd
@@ -3,7 +3,7 @@
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -31,8 +31,7 @@ end neorv32_cpu_cp_cond;
 
 architecture neorv32_cpu_cp_cond_rtl of neorv32_cpu_cp_cond is
 
-  constant zero_c : std_ulogic_vector(XLEN-1 downto 0) := (others => '0');
-  signal valid_cmd, rs2_zero, condition : std_ulogic;
+  signal valid_cmd, condition : std_ulogic;
 
 begin
 
@@ -50,7 +49,7 @@ begin
     if (rstn_i = '0') then
       res_o <= (others => '0');
     elsif rising_edge(clk_i) then
-      if (valid_cmd = '1') and (condition = '1') then -- unit triggered and condition true
+      if (valid_cmd = '1') and (condition = '1') then -- unit triggered and move-condition is true
         res_o <= rs1_i;
       else
         res_o <= (others => '0');
@@ -58,9 +57,8 @@ begin
     end if;
   end process cond_out;
 
-  -- condition check --
-  rs2_zero  <= '1' when (rs2_i = zero_c) else '0';
-  condition <= rs2_zero xnor ctrl_i.ir_funct3(1); -- equal zero / non equal zero
+  -- condition check: equal zero / non equal zero --
+  condition <= or_reduce_f(rs2_i) xor ctrl_i.ir_funct3(1);
 
   -- processing done --
   valid_o <= valid_cmd;

--- a/rtl/core/neorv32_debug_auth.vhd
+++ b/rtl/core/neorv32_debug_auth.vhd
@@ -46,7 +46,7 @@ begin
 
   -- Exemplary Authentication Mechanism -----------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  dm_controller: process(rstn_i, clk_i)
+  auth_ctrl: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
       authenticated_q <= '0';
@@ -57,7 +57,7 @@ begin
         authenticated_q <= wdata_i(0); -- just write a "1" to authenticate
       end if;
     end if;
-  end process dm_controller;
+  end process auth_ctrl;
 
   -- authenticator busy --
   busy_o <= '0'; -- this simple authenticator is always ready

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110700"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110701"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -332,32 +332,32 @@ begin
       cond_sel_string_f(boolean(num_cores_c = 1), "(single-core) ",   "") &
       cond_sel_string_f(boolean(num_cores_c = 2), "(smp-dual-core) ", "") &
       cond_sel_string_f(IMEM_EN,         cond_sel_string_f(imem_as_rom_c, "IMEM-ROM ", "IMEM "), "") &
-      cond_sel_string_f(DMEM_EN,         "DMEM ",       "") &
-      cond_sel_string_f(bootrom_en_c,    "BOOTROM ",    "") &
-      cond_sel_string_f(ICACHE_EN,       "I-CACHE ",    "") &
-      cond_sel_string_f(DCACHE_EN,       "D-CACHE ",    "") &
-      cond_sel_string_f(XBUS_EN,         "XBUS ",       "") &
-      cond_sel_string_f(IO_CLINT_EN,     "CLINT ",      "") &
-      cond_sel_string_f(io_gpio_en_c,    "GPIO ",       "") &
-      cond_sel_string_f(IO_UART0_EN,     "UART0 ",      "") &
-      cond_sel_string_f(IO_UART1_EN,     "UART1 ",      "") &
-      cond_sel_string_f(IO_SPI_EN,       "SPI ",        "") &
-      cond_sel_string_f(IO_SDI_EN,       "SDI ",        "") &
-      cond_sel_string_f(IO_TWI_EN,       "TWI ",        "") &
-      cond_sel_string_f(IO_TWD_EN,       "TWD ",        "") &
-      cond_sel_string_f(io_pwm_en_c,     "PWM ",        "") &
-      cond_sel_string_f(IO_WDT_EN,       "WDT ",        "") &
-      cond_sel_string_f(IO_TRNG_EN,      "TRNG ",       "") &
-      cond_sel_string_f(IO_CFS_EN,       "CFS ",        "") &
-      cond_sel_string_f(IO_NEOLED_EN,    "NEOLED ",     "") &
-      cond_sel_string_f(IO_GPTMR_EN,     "GPTMR ",      "") &
-      cond_sel_string_f(IO_ONEWIRE_EN,   "ONEWIRE ",    "") &
-      cond_sel_string_f(IO_DMA_EN,       "DMA ",        "") &
-      cond_sel_string_f(IO_SLINK_EN,     "SLINK ",      "") &
-      cond_sel_string_f(io_sysinfo_en_c, "SYSINFO ",    "") &
-      cond_sel_string_f(OCD_EN,          "OCD ",        "") &
-      cond_sel_string_f(OCD_EN,          "OCD-AUTH ",   "") &
-      cond_sel_string_f(OCD_EN,          "OCD-HWBP ",   "") &
+      cond_sel_string_f(DMEM_EN,         "DMEM ",     "") &
+      cond_sel_string_f(bootrom_en_c,    "BOOTROM ",  "") &
+      cond_sel_string_f(ICACHE_EN,       "I-CACHE ",  "") &
+      cond_sel_string_f(DCACHE_EN,       "D-CACHE ",  "") &
+      cond_sel_string_f(XBUS_EN,         "XBUS ",     "") &
+      cond_sel_string_f(IO_CLINT_EN,     "CLINT ",    "") &
+      cond_sel_string_f(io_gpio_en_c,    "GPIO ",     "") &
+      cond_sel_string_f(IO_UART0_EN,     "UART0 ",    "") &
+      cond_sel_string_f(IO_UART1_EN,     "UART1 ",    "") &
+      cond_sel_string_f(IO_SPI_EN,       "SPI ",      "") &
+      cond_sel_string_f(IO_SDI_EN,       "SDI ",      "") &
+      cond_sel_string_f(IO_TWI_EN,       "TWI ",      "") &
+      cond_sel_string_f(IO_TWD_EN,       "TWD ",      "") &
+      cond_sel_string_f(io_pwm_en_c,     "PWM ",      "") &
+      cond_sel_string_f(IO_WDT_EN,       "WDT ",      "") &
+      cond_sel_string_f(IO_TRNG_EN,      "TRNG ",     "") &
+      cond_sel_string_f(IO_CFS_EN,       "CFS ",      "") &
+      cond_sel_string_f(IO_NEOLED_EN,    "NEOLED ",   "") &
+      cond_sel_string_f(IO_GPTMR_EN,     "GPTMR ",    "") &
+      cond_sel_string_f(IO_ONEWIRE_EN,   "ONEWIRE ",  "") &
+      cond_sel_string_f(IO_DMA_EN,       "DMA ",      "") &
+      cond_sel_string_f(IO_SLINK_EN,     "SLINK ",    "") &
+      cond_sel_string_f(io_sysinfo_en_c, "SYSINFO ",  "") &
+      cond_sel_string_f(OCD_EN,          "OCD ",      "") &
+      cond_sel_string_f(OCD_EN,          "OCD-AUTH ", "") &
+      cond_sel_string_f(OCD_EN,          "OCD-HWBP ", "") &
       ""
       severity note;
 

--- a/sw/example/demo_wdt/main.c
+++ b/sw/example/demo_wdt/main.c
@@ -27,7 +27,7 @@
 
 
 /**********************************************************************//**
- * Simple bus-wait helper.
+ * Simple busy-wait helper.
  *
  * @param[in] time_ms Time in ms to wait (unsigned 32-bit).
  **************************************************************************/
@@ -41,7 +41,7 @@ void delay_ms(uint32_t time_ms) {
  *
  * @note This program requires the WDT and UART0 to be synthesized.
  *
- * @return 0 if execution was successful
+ * @return Should never return.
  **************************************************************************/
 int main() {
 
@@ -51,14 +51,15 @@ int main() {
   // setup UART at default baud rate, no interrupts
   neorv32_uart0_setup(BAUD_RATE, 0);
 
-  // check if WDT is implemented at all
-  if (neorv32_wdt_available() == 0) {
-    return 1; // WDT not synthesized
-  }
-
   // check if UART0 is implemented at all
   if (neorv32_uart0_available() == 0) {
-    return 1; // UART0 not synthesized
+    return -1; // UART0 not synthesized
+  }
+
+  // check if WDT is implemented at all
+  if (neorv32_wdt_available() == 0) {
+    neorv32_uart0_puts("\nWDT not synthesized!\n");
+    return -1;
   }
 
 
@@ -92,9 +93,9 @@ int main() {
     return -1;
   }
 
-  // setup watchdog: no lock, enable strict mode
+  // setup watchdog: no lock
   neorv32_uart0_puts("Starting WDT...\n");
-  neorv32_wdt_setup(timeout, 0, 1);
+  neorv32_wdt_setup(timeout, 0);
 
 
   // feed the watchdog

--- a/sw/lib/include/neorv32_wdt.h
+++ b/sw/lib/include/neorv32_wdt.h
@@ -34,9 +34,8 @@ typedef volatile struct __attribute__((packed,aligned(4))) {
 enum NEORV32_WDT_CTRL_enum {
   WDT_CTRL_EN          =  0, /**< WDT control register(0) (r/w): Watchdog enable */
   WDT_CTRL_LOCK        =  1, /**< WDT control register(1) (r/w): Lock write access to control register, clears on reset only */
-  WDT_CTRL_STRICT      =  2, /**< WDT control register(2) (r/w): Force hardware reset if reset password is incorrect or if write attempt to locked CTRL register */
-  WDT_CTRL_RCAUSE_LO   =  3, /**< WDT control register(3) (r/-): Cause of last system reset - low */
-  WDT_CTRL_RCAUSE_HI   =  4, /**< WDT control register(4) (r/-): Cause of last system reset - high */
+  WDT_CTRL_RCAUSE_LO   =  2, /**< WDT control register(2) (r/-): Cause of last system reset - low */
+  WDT_CTRL_RCAUSE_HI   =  3, /**< WDT control register(3) (r/-): Cause of last system reset - high */
 
   WDT_CTRL_TIMEOUT_LSB =  8, /**< WDT control register(8)  (r/w): Timeout value, LSB */
   WDT_CTRL_TIMEOUT_MSB = 31  /**< WDT control register(31) (r/w): Timeout value, MSB */
@@ -66,7 +65,7 @@ enum NEORV32_WDT_RCAUSE_enum {
  **************************************************************************/
 /**@{*/
 int  neorv32_wdt_available(void);
-void neorv32_wdt_setup(uint32_t timeout, int lock, int strict);
+void neorv32_wdt_setup(uint32_t timeout, int lock);
 int  neorv32_wdt_disable(void);
 void neorv32_wdt_feed(uint32_t password);
 void neorv32_wdt_force_hwreset(void);

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -4,7 +4,7 @@
   <vendor>github.com/stnolting/neorv32</vendor>
   <name>neorv32</name>
   <series>RISC-V</series>
-  <version>1.11.6</version>
+  <version>1.11.7</version>
   <description>The NEORV32 RISC-V Processor</description>
 
   <!-- CPU core -->
@@ -1439,13 +1439,8 @@
               <description>Lock write access to control register, clears on reset (HW or WDT) only</description>
             </field>
             <field>
-              <name>WDT_CTRL_STRICT</name>
-              <bitRange>[2:2]</bitRange>
-              <description>Force hardware reset if reset password is incorrect or if write attempt to locked CTRL register</description>
-            </field>
-            <field>
               <name>WDT_CTRL_RCAUSE</name>
-              <bitRange>[4:3]</bitRange>
+              <bitRange>[3:2]</bitRange>
               <access>read-only</access>
               <description>Cause of last system reset: 0=external reset, 1=OCD reset, 2=WDT reset, 3=WDT access violation</description>
             </field>


### PR DESCRIPTION
### Watchdog

* remove control register's `strict` bit
* if the configuration register is locked, the WDT will be in "strict" mode:
  * write access to the control register triggers a hardware reset of the system
  * writing an incorrect password to the reset register triggers a hardware reset of the system

### RTL

* minor code edits and cleanups