### PR TITLE
✨ add double-trap exception

### DIFF
--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110701"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110702"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -652,6 +652,7 @@ package neorv32_package is
   constant trap_sma_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00110"; -- 6: store address misaligned
   constant trap_saf_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00111"; -- 7: store access fault
   constant trap_env_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "01000"; -- 8..11: environment call
+  constant trap_dbt_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "10000"; -- 16: double-trap
   -- RISC-V compliant asynchronous exceptions (interrupts) --
   constant trap_msi_c      : std_ulogic_vector(6 downto 0) := "1" & "0" & "00011"; -- 3:  machine software interrupt
   constant trap_mti_c      : std_ulogic_vector(6 downto 0) := "1" & "0" & "00111"; -- 7:  machine timer interrupt
@@ -691,9 +692,10 @@ package neorv32_package is
   constant exc_lalign_c   : natural :=  6; -- load address misaligned
   constant exc_saccess_c  : natural :=  7; -- store access fault
   constant exc_laccess_c  : natural :=  8; -- load access fault
-  constant exc_db_break_c : natural :=  9; -- enter debug mode via ebreak instruction
-  constant exc_db_hw_c    : natural := 10; -- enter debug mode via hw trigger
-  constant exc_width_c    : natural := 11; -- length of this list in bits
+  constant exc_doublet_c  : natural :=  9; -- double-trap
+  constant exc_db_break_c : natural := 10; -- enter debug mode via ebreak instruction
+  constant exc_db_hw_c    : natural := 11; -- enter debug mode via hw trigger
+  constant exc_width_c    : natural := 12; -- length of this list in bits
   -- interrupt source list --
   constant irq_msi_irq_c  : natural :=  0; -- machine software interrupt
   constant irq_mti_irq_c  : natural :=  1; -- machine timer interrupt


### PR DESCRIPTION
The NEORV32 CPU now features a mechanism to detect unintended nested traps which is derived from the RISC-V `Smdbltrp` specification:

When a trap is to be taken into M-mode, if the `MDT` bit (machine-mode disable trap) in `mstatush` is currently 0, it is then set to 1, and the trap is delivered as expected. However, if `MDT` is already set to 1, then this is an unexpected _double trap_ exception (a nested trap). The RISC-V-compliant "double-trap" exception code 16 (`mcause`) is used to signal this event.

`MDT` can be cleared manually to allow nesting of traps. However, _unexpected_ nested / double traps lead to a loss of the trap context (`mcause`, `mepc`, `mtval`, stack frame, etc.) and can therefore not be resumed.