### PR TITLE
✨ add configurable number of break-/watchpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 06.07.2025 | 1.11.7.6 | :sparkles: add configurable number of HW triggers (break-/watchpoints) | [#1304](https://github.com/stnolting/neorv32/pull/1304) |
 | 06.07.2025 | 1.11.7.5 | :sparkles: OCD: add support for hardware-assisted watchpoints | [#1303](https://github.com/stnolting/neorv32/pull/1303) |
 | 04.07.2025 | 1.11.7.4 | minor rtl edits and cleanups | [#1302](https://github.com/stnolting/neorv32/pull/1302) |
 | 27.06.2025 | 1.11.7.3 | RTE cleanups; double-trap exception now has highest priority | [#1299](https://github.com/stnolting/neorv32/pull/1299) |

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -5,7 +5,7 @@
 The NEORV32 Processor features an _on-chip debugger_ (OCD) compatible to the **Minimal RISC-V Debug Specification**
 implementing the **execution-based debugging** scheme. A copy of the specification is available in `docs/references`.
 The on-chip debugger is implemented if the <<_processor_top_entity_generics, `OCD_EN`>> processor top generic is set
-to `true`. Optionally, a single hardware trigger can be implemented (<<_sdtrig_isa_extension>>) to support
+to `true`. Optionally, a up to 16 hardware triggers can be implemented (<<_sdtrig_isa_extension>>) to support
 hardware-assisted break- and watchpoints. Furthermore, the OCD supports an optional <<_debug_authentication>>
 module to constrain OCD access to authorized parties.
 
@@ -33,7 +33,7 @@ of the User Guide.
 * indirect access to all core registers and the entire processor address space (via program buffer)
 * execution of arbitrary programs via the program buffer
 * compatible with upstream OpenOCD and GDB
-* optional trigger module for hardware break- and watchpoints
+* optional trigger module for up to 16 hardware break- and watchpoints
 * optional authentication for advanced security
 
 **Configuration Options**
@@ -43,10 +43,10 @@ of the User Guide.
 [options="header",grid="rows"]
 |=======================
 | Name | Type | Default | Description
-| `OCD_EN`             | boolean   | false         | Implement the on-chip debugger and the CPU debug mode..
-| `OCD_HW_BREAKPOINT`  | boolean   | false         | Implement optional debug <<_trigger_module>> module (<<_sdtrig_isa_extension>>).
-| `OCD_AUTHENTICATION` | boolean   | false         | Implement optional <<_debug_authentication>> module.
-| `OCD_JEDEC_ID`       | suv(10:0) | "00000000000" | JEDEC ID; continuation codes plus vendor ID (passed to the JTAG <<_debug_transport_module_dtm>>).
+| `OCD_EN`              | boolean   | false         | Implement the on-chip debugger and the CPU debug mode..
+| `OCD_NUM_HW_TRIGGERS` | natural   | 0             | Number of implemented HW triggers (<<_trigger_module>> / <<_sdtrig_isa_extension>>) for hardware break-/watchpoints (0..16).
+| `OCD_AUTHENTICATION`  | boolean   | false         | Implement optional <<_debug_authentication>> module.
+| `OCD_JEDEC_ID`        | suv(10:0) | "00000000000" | JEDEC ID; continuation codes plus vendor ID (passed to the JTAG <<_debug_transport_module_dtm>>).
 |=======================
 
 **Overview**
@@ -67,8 +67,8 @@ very simple authentication mechanism as example. Users can modify/replace this d
 authentication mechanism.
 . <<_cpu_debug_mode>> ISA extension: This ISA extension provides the "debug execution mode" as another CPU operation mode
 that is used to execute the park loop code from the DM. This mode also provides additional CSRs and instructions.
-. CPU <<_trigger_module>>: This module provides a single hardware trigger that can be used as hardware-assisted break- or
-watchpoint.
+. CPU <<_trigger_module>>: This module provides up to 16 hardware triggers that can be used as hardware-assisted break- or
+watchpoints.
 
 **Theory of Operation**
 
@@ -891,34 +891,34 @@ return to the address stored in `dpc` by automatically moving `dpc` to the progr
 :sectnums:
 === Trigger Module
 
-The RISC-V `Sdtrig` ISA extension adds a programmable _trigger module_ to the CPU core that is enabled via the top's
-<<_processor_top_entity_generics, `OCD_HW_BREAKPOINT`>> generic, which enables the <<_sdtrig_isa_extension>>. The trigger
+The RISC-V `Sdtrig` ISA extension adds a _trigger module_ to the CPU core. The number of hardware triggers is configured
+via the <<_processor_top_entity_generics, `OCD_NUM_HW_TRIGGERS`>> top generic. Up to 16 hardware triggers can be implemented.
+If `OCD_NUM_HW_TRIGGERS` is set to a value greater than 0 the <<_sdtrig_isa_extension>> is automatically enabled. The trigger
 module implements a subset of the features described in the "RISC-V Debug Specification / Trigger Module (`Sdtrig`)" and
-complies to version v1.0 of that spec. Note that the NEORV32 trigger module features only a **single** hardware trigger
-that provides a "type 6 - instruction address match" trigger. This trigger module can be used as hardware-assisted
-breakpoint or as hardware-assisted watchpoint.
+complies to version v1.0 of that spec. Note that the NEORV32 trigger module only supports "type 6 - instruction address match"
+triggers. These triggers can be used as hardware-assisted breakpoints or as hardware-assisted watchpoints.
 
-* A **breakpoint** stops the program whenever a particular point in the program is reached (i.e. executing the instruction
-at the specified address).
-* A **watchpoint** stops the program whenever the value of a variable or expression changes (i.e. a load and/or store
-operation accesses data at the specified address).
+* A **breakpoint** stops the program whenever a particular point in the program is reached (i.e. after executing the
+instruction at the specified address): GDB's `hbreak` command.
+* A **watchpoint** stops the program whenever the value of a variable or expression changes (i.e. after a load and/or
+store operation has accessed data at the specified address): GDB's `[a|r]watch` commands.
 
 From a hardware point of view the trigger modules raises an _asynchronous_ exception right after the triggering
-operation has been retired. The <<_dpc>> CSR `dpc` shows the instruction address where normal execution must be
-resumed to to preserve the program flow
+operation has been retired. The <<_dpc>> CSR shows the instruction address where normal execution must be resumed
+to preserve the program flow
 
 .Debug-Mode Only
 [NOTE]
-The trigger module can be used by debug-mode only. Write accesses from machine-mode are constrained as <<_tdata1>>.`dmode`
-is hardwired to one. However, the <<_smpmp_isa_extension,`Smpmp`>> ISA extension can be used for machine-mode instruction
-or data address traps.
+The trigger module can be used by debug-mode only. Write accesses from machine-mode are
+constrained as <<_tdata1>>.`dmode` is hardwired to one. However, the <<_smpmp_isa_extension>>
+can be used for machine-mode instruction or data address traps.
 
 
 :sectnums:
 ==== Trigger Module CSRs
 
 The `Sdtrig` ISA extension adds 4 additional CSRs. These CSRs can also be read from machine-mode, but
-write-accesses are restricted (because `tdata1.dmode` is hardwired to one).
+write-accesses are restricted because `tdata1.dmode` is hardwired to one.
 
 :sectnums!:
 ===== **`tselect`**
@@ -930,8 +930,9 @@ write-accesses are restricted (because `tdata1.dmode` is hardwired to one).
 | Address     | `0x7a0`
 | Reset value | `0x00000000`
 | ISA         | `Zicsr` & `Sdtrig`
-| Description | Only the lowest bit of this register is writable which is required for trigger enumeration.
-However, only one trigger at `tselect = 0` is available.
+| Description | This CSR is used to select which hardware trigger is available via the <<_tdata1>>, <<_tdata2>> and
+<<_tinfo>> CSRs. Only the lowest `log2(OCD_NUM_HW_TRIGGERS)+1` bit are writable. However, software should check if
+<<_tinfo>> is non-zero for the written `tselect` value to determine if the selected trigger exists.
 |=======================
 
 
@@ -945,11 +946,12 @@ However, only one trigger at `tselect = 0` is available.
 | Address     | `0x7a1`
 | Reset value | `0x60000048`
 | ISA         | `Zicsr` & `Sdtrig`
-| Description | This CSR is used to configure the address match trigger using "type 6" format which is illustrated
-in the table below. Write accesses from machine-mode are ignored (because `tdata1.dmode` is hardwired to one).
+| Description | This CSR provides access to the configuration bits of the currently selected trigger (via <<_tselect>>).
+Note that only "type 6" triggers are supported. The according configuration bits are listed below.
+Write accesses from machine-mode are ignored (because `tdata1.dmode` is hardwired to one).
 |=======================
 
-.Match Control CSR (`tdata1`) Bits
+.Match control CSR (`tdata1`) bits of the trigger selected via `tselect`
 [cols="^1,^2,^1,<8"]
 [options="header",grid="rows"]
 |=======================
@@ -973,9 +975,9 @@ but before any subsequent instructions were executed; the debugger has to write 
 | 5     | `uncertainen` | r/- | `0`: feature not supported, hardwired to zero
 | 4     | `s`           | r/- | `0`: S-mode not supported
 | 3     | `u`           | r/- | trigger enabled when in user-mode, set if `U` ISA extension is enabled
-| 2     | `execute`     | r/w | set to enable trigger on instruction address match (i.e. "breakpoint")
-| 1     | `store`       | r/w | set to enable trigger on data store address match (i.e. "watchpoint")
-| 0     | `load`        | r/w | set to enable trigger on data load address match (i.e. "watchpoint")
+| 2     | `execute`     | r/w | set to enable this trigger to fire on instruction address match (i.e. "breakpoint")
+| 1     | `store`       | r/w | set to enable this trigger to fire on data store address match (i.e. "watchpoint")
+| 0     | `load`        | r/w | set to enable this trigger to fire on data load address match (i.e. "watchpoint")
 |=======================
 
 
@@ -989,8 +991,9 @@ but before any subsequent instructions were executed; the debugger has to write 
 | Address     | `0x7a2`
 | Reset value | `0x00000000`
 | ISA         | `Zicsr` & `Sdtrig`
-| Description | This 32-bit r/w CSRs provides the address for the hardware trigger (instruction address for breakpoints;
-data access address for watchpoints). Write accesses from machine-mode are ignored (because `tdata1.dmode` is hardwired to one).
+| Description | This CSR provides access to the address bits (instruction address for breakpoints;
+data access address for watchpoints) of the currently selected trigger (via <<_tselect>>).
+Write accesses from machine-mode are ignored (because `tdata1.dmode` is hardwired to one).
 |=======================
 
 
@@ -1004,10 +1007,11 @@ data access address for watchpoints). Write accesses from machine-mode are ignor
 | Address     | `0x7a4`
 | Reset value | `0x01000006`
 | ISA         | `Zicsr` & `Sdtrig`
-| Description | The CSR shows additional trigger information (see below). Any write access is ignored.
+| Description | The CSR shows additional trigger information of the currently selected trigger (via <<_tselect>>).
+This CSR is read-only, all write access is ignored.
 |=======================
 
-.Trigger Info CSR (`tinfo`) Bits
+.Trigger info CSR (`tinfo`) bits of the trigger selected via `tselect`
 [cols="^1,^2,^1,<8"]
 [options="header",grid="rows"]
 |=======================

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -209,7 +209,7 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `BOOT_ADDR_CUSTOM`      | suv(31:0) | x"00000000"   | Custom CPU boot address (available if `BOOT_MODE_SELECT` = 1).
 4+^| **<<_on_chip_debugger_ocd>>**
 | `OCD_EN`                | boolean   | false         | Implement the on-chip debugger and the CPU debug mode (<<_sdext_isa_extension>>).
-| `OCD_HW_BREAKPOINT`     | boolean   | false         | Implement debug <<_trigger_module>> module (<<_sdtrig_isa_extension>>).
+| `OCD_NUM_HW_TRIGGERS`   | natural   | 0             | Number of implemented HW triggers (<<_trigger_module>> / <<_sdtrig_isa_extension>>) for hardware break-/watchpoints (0..16).
 | `OCD_AUTHENTICATION`    | boolean   | false         | Implement <<_debug_authentication>> module.
 | `OCD_JEDEC_ID`          | suv(10:0) | "00000000000" | JEDEC ID; continuation codes plus vendor ID (passed to the JTAG <<_debug_transport_module_dtm>>).
 4+^| **CPU <<_instruction_sets_and_extensions>>**

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -64,7 +64,9 @@ entity neorv32_cpu is
     PMP_NAP_MODE_EN     : boolean; -- implement NAPOT/NA4 modes
     -- Hardware Performance Monitors (HPM) --
     HPM_NUM_CNTS        : natural range 0 to 13; -- number of implemented HPM counters (0..13)
-    HPM_CNT_WIDTH       : natural range 0 to 64  -- total size of HPM counters (0..64)
+    HPM_CNT_WIDTH       : natural range 0 to 64; -- total size of HPM counters (0..64)
+    -- Trigger Module (TM) --
+    NUM_HW_TRIGGERS     : natural range 0 to 16 -- number of hardware triggers
   );
   port (
     -- global control --
@@ -281,11 +283,11 @@ begin
   -- Hardware Trigger Module (Sdtrig) -------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   trigger_module_enabled:
-  if (RISCV_ISA_Sdtrig = true) generate
+  if (RISCV_ISA_Sdtrig = true) and (NUM_HW_TRIGGERS > 0) generate
     neorv32_cpu_hwtrig_inst: entity neorv32.neorv32_cpu_hwtrig
     generic map (
-      NUM_TRIGGERS => 1,          -- number of implemented hardware triggers
-      RISCV_ISA_U  => RISCV_ISA_U -- RISC-V user-mode available
+      NUM_TRIGGERS => NUM_HW_TRIGGERS, -- number of implemented hardware triggers
+      RISCV_ISA_U  => RISCV_ISA_U      -- RISC-V user-mode available
     )
     port map (
     -- global control --
@@ -301,7 +303,7 @@ begin
   end generate;
 
   trigger_module_disabled:
-  if (RISCV_ISA_Sdtrig = false) generate
+  if (RISCV_ISA_Sdtrig = false) or (NUM_HW_TRIGGERS = 0) generate
     xcsr_tm <= (others => '0');
     hwtrig  <= '0';
   end generate;

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -634,7 +634,7 @@ begin
 
   -- CSR Access Check -----------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  csr_check: process(exe_engine.ir)
+  csr_check: process(exe_engine.ir, csr, debug_ctrl.run)
     variable csr_addr_v : std_ulogic_vector(11 downto 0);
   begin
     -- shortcut: CSR address right from the instruction word --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110705"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110706"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -794,7 +794,7 @@ package neorv32_package is
       BOOT_ADDR_CUSTOM      : std_ulogic_vector(31 downto 0) := x"00000000";
       -- On-Chip Debugger (OCD) --
       OCD_EN                : boolean                        := false;
-      OCD_HW_BREAKPOINT     : boolean                        := false;
+      OCD_NUM_HW_TRIGGERS   : natural range 0 to 16          := 0;
       OCD_AUTHENTICATION    : boolean                        := false;
       OCD_JEDEC_ID          : std_ulogic_vector(10 downto 0) := "00000000000";
       -- RISC-V CPU Extensions --

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -33,7 +33,7 @@ entity neorv32_top is
 
     -- On-Chip Debugger (OCD) --
     OCD_EN                : boolean                        := false;       -- implement on-chip debugger
-    OCD_HW_BREAKPOINT     : boolean                        := false;       -- implement on-chip-debugger hardware breakpoint
+    OCD_NUM_HW_TRIGGERS   : natural range 0 to 16          := 0;           -- number of hardware break-/watchpoint
     OCD_AUTHENTICATION    : boolean                        := false;       -- implement on-chip debugger authentication
     OCD_JEDEC_ID          : std_ulogic_vector(10 downto 0) := "00000000000"; -- JEDEC ID: continuation codes + vendor ID
 
@@ -259,7 +259,7 @@ architecture neorv32_top_rtl of neorv32_top is
   constant cpu_smpmp_en_c  : boolean := boolean(PMP_NUM_REGIONS > 0);
   constant io_sysinfo_en_c : boolean := not IO_DISABLE_SYSINFO;
   constant ocd_auth_en_c   : boolean := OCD_EN and OCD_AUTHENTICATION;
-  constant ocd_hwbp_en_c   : boolean := OCD_EN and OCD_HW_BREAKPOINT;
+  constant cpu_sdtrig_en_c : boolean := OCD_EN and boolean(OCD_NUM_HW_TRIGGERS > 0);
 
   -- make sure physical memory sizes are a power of two --
   constant imem_size_c : natural := cond_sel_natural_f(is_power_of_two_f(IMEM_SIZE), IMEM_SIZE, 2**index_size_f(IMEM_SIZE));
@@ -490,7 +490,7 @@ begin
       RISCV_ISA_Zmmul     => RISCV_ISA_Zmmul,
       RISCV_ISA_Zxcfu     => RISCV_ISA_Zxcfu,
       RISCV_ISA_Sdext     => OCD_EN,
-      RISCV_ISA_Sdtrig    => ocd_hwbp_en_c,
+      RISCV_ISA_Sdtrig    => cpu_sdtrig_en_c,
       RISCV_ISA_Smpmp     => cpu_smpmp_en_c,
       -- Tuning Options --
       CPU_FAST_MUL_EN     => CPU_FAST_MUL_EN,
@@ -503,7 +503,9 @@ begin
       PMP_NAP_MODE_EN     => PMP_NAP_MODE_EN,
       -- Hardware Performance Monitors (HPM) --
       HPM_NUM_CNTS        => HPM_NUM_CNTS,
-      HPM_CNT_WIDTH       => HPM_CNT_WIDTH
+      HPM_CNT_WIDTH       => HPM_CNT_WIDTH,
+      -- Trigger Module (TM) --
+      NUM_HW_TRIGGERS     => OCD_NUM_HW_TRIGGERS
     )
     port map (
       -- global control --

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -33,7 +33,7 @@ entity neorv32_top is
 
     -- On-Chip Debugger (OCD) --
     OCD_EN                : boolean                        := false;       -- implement on-chip debugger
-    OCD_NUM_HW_TRIGGERS   : natural range 0 to 16          := 0;           -- number of hardware break-/watchpoint
+    OCD_NUM_HW_TRIGGERS   : natural range 0 to 16          := 0;           -- number of hardware break-/watchpoints
     OCD_AUTHENTICATION    : boolean                        := false;       -- implement on-chip debugger authentication
     OCD_JEDEC_ID          : std_ulogic_vector(10 downto 0) := "00000000000"; -- JEDEC ID: continuation codes + vendor ID
 

--- a/rtl/system_integration/neorv32_libero_ip.vhd
+++ b/rtl/system_integration/neorv32_libero_ip.vhd
@@ -1,7 +1,7 @@
 -- ================================================================================ --
 -- NEORV32 - Processor Wrapper with AXI4 & AXI4-Stream Compatible Interfaces        --
 -- -------------------------------------------------------------------------------- --
--- Dedicated for IP packaging/integration using Microchip.                          --
+-- Dedicated for IP packaging/integration using Microchip Libero.                   --
 -- See the NEORV32 Datasheet and User Guide for more information.                   --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
@@ -24,106 +24,106 @@ entity neorv32_libero_ip is
     -- Configuration Generics
     -- ------------------------------------------------------------
     -- Clocking --
-    CLOCK_FREQUENCY       : natural                        := 100_000_000;
+    CLOCK_FREQUENCY        : natural                        := 100_000_000;
     -- Dual-Core Configuration --
-    DUAL_CORE_EN_INT      : integer range 0 to 1           := 0;
+    DUAL_CORE_EN_INT       : integer range 0 to 1           := 0;
     -- Boot Configuration --
-    BOOT_MODE_SELECT      : natural range 0 to 2           := 1;
-    BOOT_ADDR_CUSTOM_UPPER : natural range 0 to 65_535 := 53248;
-    BOOT_ADDR_CUSTOM_LOWER : natural range 0 to 65_535 := 53248;
+    BOOT_MODE_SELECT       : natural range 0 to 2           := 1;
+    BOOT_ADDR_CUSTOM_UPPER : natural range 0 to 65_535      := 53248;
+    BOOT_ADDR_CUSTOM_LOWER : natural range 0 to 65_535      := 53248;
     -- On-Chip Debugger (OCD) --
-    OCD_EN_INT            : integer range 0 to 1           := 0;
-    OCD_HW_BREAKPOINT_INT : integer range 0 to 1           := 0;
-    OCD_AUTHENTICATION_INT: integer range 0 to 1           := 0;
-    OCD_JEDEC_ID          : std_logic_vector(10 downto 0)  := "00000000000";
+    OCD_EN_INT             : integer range 0 to 1           := 0;
+    OCD_NUM_HW_TRIGGERS    : integer range 0 to 16          := 0;
+    OCD_AUTHENTICATION_INT : integer range 0 to 1           := 0;
+    OCD_JEDEC_ID           : std_logic_vector(10 downto 0)  := "00000000000";
     -- RISC-V CPU Extensions --
-    RISCV_ISA_C_INT       : integer range 0 to 1           := 0;
-    RISCV_ISA_E_INT       : integer range 0 to 1           := 0;
-    RISCV_ISA_M_INT       : integer range 0 to 1           := 0;
-    RISCV_ISA_U_INT       : integer range 0 to 1           := 0;
-    RISCV_ISA_Zaamo_INT   : integer range 0 to 1           := 0;
-    RISCV_ISA_Zalrsc_INT  : integer range 0 to 1           := 0;
-    RISCV_ISA_Zba_INT     : integer range 0 to 1           := 0;
-    RISCV_ISA_Zbb_INT     : integer range 0 to 1           := 0;
-    RISCV_ISA_Zbkb_INT    : integer range 0 to 1           := 0;
-    RISCV_ISA_Zbkc_INT    : integer range 0 to 1           := 0;
-    RISCV_ISA_Zbkx_INT    : integer range 0 to 1           := 0;
-    RISCV_ISA_Zbs_INT     : integer range 0 to 1           := 0;
-    RISCV_ISA_Zfinx_INT   : integer range 0 to 1           := 0;
-    RISCV_ISA_Zicntr_INT  : integer range 0 to 1           := 0;
-    RISCV_ISA_Zicond_INT  : integer range 0 to 1           := 0;
-    RISCV_ISA_Zihpm_INT   : integer range 0 to 1           := 0;
-    RISCV_ISA_Zmmul_INT   : integer range 0 to 1           := 0;
-    RISCV_ISA_Zknd_INT    : integer range 0 to 1           := 0;
-    RISCV_ISA_Zkne_INT    : integer range 0 to 1           := 0;
-    RISCV_ISA_Zknh_INT    : integer range 0 to 1           := 0;
-    RISCV_ISA_Zksed_INT   : integer range 0 to 1           := 0;
-    RISCV_ISA_Zksh_INT    : integer range 0 to 1           := 0;
-    RISCV_ISA_Zxcfu_INT   : integer range 0 to 1           := 0;
+    RISCV_ISA_C_INT        : integer range 0 to 1           := 0;
+    RISCV_ISA_E_INT        : integer range 0 to 1           := 0;
+    RISCV_ISA_M_INT        : integer range 0 to 1           := 0;
+    RISCV_ISA_U_INT        : integer range 0 to 1           := 0;
+    RISCV_ISA_Zaamo_INT    : integer range 0 to 1           := 0;
+    RISCV_ISA_Zalrsc_INT   : integer range 0 to 1           := 0;
+    RISCV_ISA_Zba_INT      : integer range 0 to 1           := 0;
+    RISCV_ISA_Zbb_INT      : integer range 0 to 1           := 0;
+    RISCV_ISA_Zbkb_INT     : integer range 0 to 1           := 0;
+    RISCV_ISA_Zbkc_INT     : integer range 0 to 1           := 0;
+    RISCV_ISA_Zbkx_INT     : integer range 0 to 1           := 0;
+    RISCV_ISA_Zbs_INT      : integer range 0 to 1           := 0;
+    RISCV_ISA_Zfinx_INT    : integer range 0 to 1           := 0;
+    RISCV_ISA_Zicntr_INT   : integer range 0 to 1           := 0;
+    RISCV_ISA_Zicond_INT   : integer range 0 to 1           := 0;
+    RISCV_ISA_Zihpm_INT    : integer range 0 to 1           := 0;
+    RISCV_ISA_Zmmul_INT    : integer range 0 to 1           := 0;
+    RISCV_ISA_Zknd_INT     : integer range 0 to 1           := 0;
+    RISCV_ISA_Zkne_INT     : integer range 0 to 1           := 0;
+    RISCV_ISA_Zknh_INT     : integer range 0 to 1           := 0;
+    RISCV_ISA_Zksed_INT    : integer range 0 to 1           := 0;
+    RISCV_ISA_Zksh_INT     : integer range 0 to 1           := 0;
+    RISCV_ISA_Zxcfu_INT    : integer range 0 to 1           := 0;
     -- Tuning Options --
-    CPU_FAST_MUL_EN_INT   : integer range 0 to 1           := 0;
-    CPU_FAST_SHIFT_EN_INT : integer range 0 to 1           := 0;
-    CPU_RF_HW_RST_EN_INT  : integer range 0 to 1           := 0;
+    CPU_FAST_MUL_EN_INT    : integer range 0 to 1           := 0;
+    CPU_FAST_SHIFT_EN_INT  : integer range 0 to 1           := 0;
+    CPU_RF_HW_RST_EN_INT   : integer range 0 to 1           := 0;
     -- Physical Memory Protection (PMP) --
-    PMP_NUM_REGIONS       : natural range 0 to 16          := 0;
-    PMP_MIN_GRANULARITY   : natural                        := 4;
-    PMP_TOR_MODE_EN_INT   : integer range 0 to 1           := 0;
-    PMP_NAP_MODE_EN_INT   : integer range 0 to 1           := 0;
+    PMP_NUM_REGIONS        : natural range 0 to 16          := 0;
+    PMP_MIN_GRANULARITY    : natural                        := 4;
+    PMP_TOR_MODE_EN_INT    : integer range 0 to 1           := 0;
+    PMP_NAP_MODE_EN_INT    : integer range 0 to 1           := 0;
     -- Hardware Performance Monitors (HPM) --
-    HPM_NUM_CNTS          : natural range 0 to 13          := 0;
-    HPM_CNT_WIDTH         : natural range 0 to 64          := 40;
+    HPM_NUM_CNTS           : natural range 0 to 13          := 0;
+    HPM_CNT_WIDTH          : natural range 0 to 64          := 40;
     -- Internal Instruction memory --
-    IMEM_EN_INT           : integer range 0 to 1           := 0;
-    IMEM_SIZE             : natural                        := 16384;
-    IMEM_OUTREG_EN_INT    : integer range 0 to 1           := 0;
+    IMEM_EN_INT            : integer range 0 to 1           := 0;
+    IMEM_SIZE              : natural                        := 16384;
+    IMEM_OUTREG_EN_INT     : integer range 0 to 1           := 0;
     -- Internal Data memory --
-    DMEM_EN_INT           : integer range 0 to 1           := 0;
-    DMEM_SIZE             : natural                        := 8192;
-    DMEM_OUTREG_EN_INT    : integer range 0 to 1           := 0;
+    DMEM_EN_INT            : integer range 0 to 1           := 0;
+    DMEM_SIZE              : natural                        := 8192;
+    DMEM_OUTREG_EN_INT     : integer range 0 to 1           := 0;
     -- CPU Caches --
-    ICACHE_EN_INT         : integer range 0 to 1           := 0;
-    ICACHE_NUM_BLOCKS     : natural range 1 to 4096        := 4;
-    DCACHE_EN_INT         : integer range 0 to 1           := 0;
-    DCACHE_NUM_BLOCKS     : natural range 1 to 4096        := 4;
-    CACHE_BLOCK_SIZE      : natural range 4 to 1024        := 64;
+    ICACHE_EN_INT          : integer range 0 to 1           := 0;
+    ICACHE_NUM_BLOCKS      : natural range 1 to 4096        := 4;
+    DCACHE_EN_INT          : integer range 0 to 1           := 0;
+    DCACHE_NUM_BLOCKS      : natural range 1 to 4096        := 4;
+    CACHE_BLOCK_SIZE       : natural range 4 to 1024        := 64;
     -- External Bus Interface --
-    XBUS_EN_INT           : integer range 0 to 1           := 1;
-    XBUS_REGSTAGE_EN_INT  : integer range 0 to 1           := 1;
+    XBUS_EN_INT            : integer range 0 to 1           := 1;
+    XBUS_REGSTAGE_EN_INT   : integer range 0 to 1           := 1;
     -- Processor peripherals --
-    IO_GPIO_EN_INT        : integer range 0 to 1           := 0;
-    IO_GPIO_IN_NUM        : natural range 1 to 32          := 1;
-    IO_GPIO_OUT_NUM       : natural range 1 to 32          := 1;
-    IO_CLINT_EN_INT       : integer range 0 to 1           := 0;
-    IO_UART0_EN_INT       : integer range 0 to 1           := 0;
-    IO_UART0_RX_FIFO      : natural range 1 to 2**15       := 1;
-    IO_UART0_TX_FIFO      : natural range 1 to 2**15       := 1;
-    IO_UART1_EN_INT       : integer range 0 to 1           := 0;
-    IO_UART1_RX_FIFO      : natural range 1 to 2**15       := 1;
-    IO_UART1_TX_FIFO      : natural range 1 to 2**15       := 1;
-    IO_SPI_EN_INT         : integer range 0 to 1           := 0;
-    IO_SPI_FIFO           : natural range 1 to 2**15       := 1;
-    IO_SDI_EN_INT         : integer range 0 to 1           := 0;
-    IO_SDI_FIFO           : natural range 1 to 2**15       := 1;
-    IO_TWI_EN_INT         : integer range 0 to 1           := 0;
-    IO_TWI_FIFO           : natural range 1 to 2**15       := 1;
-    IO_TWD_EN_INT         : integer range 0 to 1           := 0;
-    IO_TWD_RX_FIFO        : natural range 1 to 2**15       := 1;
-    IO_TWD_TX_FIFO        : natural range 1 to 2**15       := 1;
-    IO_PWM_EN_INT         : integer range 0 to 1           := 0;
-    IO_PWM_NUM_CH         : natural range 1 to 16          := 1;
-    IO_WDT_EN_INT         : integer range 0 to 1           := 0;
-    IO_TRNG_EN_INT        : integer range 0 to 1           := 0;
-    IO_TRNG_FIFO          : natural range 1 to 2**15       := 1;
-    IO_CFS_EN_INT         : integer range 0 to 1           := 0;
-    IO_NEOLED_EN_INT      : integer range 0 to 1           := 0;
-    IO_NEOLED_TX_FIFO     : natural range 1 to 2**15       := 1;
-    IO_GPTMR_EN_INT       : integer range 0 to 1           := 0;
-    IO_ONEWIRE_EN_INT     : integer range 0 to 1           := 0;
-    IO_DMA_EN_INT         : integer range 0 to 1           := 0;
-    IO_DMA_DSC_FIFO       : natural range 4 to 512         := 4;
-    IO_SLINK_EN_INT       : integer range 0 to 1           := 0;
-    IO_SLINK_RX_FIFO      : natural range 1 to 2**15       := 1;
-    IO_SLINK_TX_FIFO      : natural range 1 to 2**15       := 1
+    IO_GPIO_EN_INT         : integer range 0 to 1           := 0;
+    IO_GPIO_IN_NUM         : natural range 1 to 32          := 1;
+    IO_GPIO_OUT_NUM        : natural range 1 to 32          := 1;
+    IO_CLINT_EN_INT        : integer range 0 to 1           := 0;
+    IO_UART0_EN_INT        : integer range 0 to 1           := 0;
+    IO_UART0_RX_FIFO       : natural range 1 to 2**15       := 1;
+    IO_UART0_TX_FIFO       : natural range 1 to 2**15       := 1;
+    IO_UART1_EN_INT        : integer range 0 to 1           := 0;
+    IO_UART1_RX_FIFO       : natural range 1 to 2**15       := 1;
+    IO_UART1_TX_FIFO       : natural range 1 to 2**15       := 1;
+    IO_SPI_EN_INT          : integer range 0 to 1           := 0;
+    IO_SPI_FIFO            : natural range 1 to 2**15       := 1;
+    IO_SDI_EN_INT          : integer range 0 to 1           := 0;
+    IO_SDI_FIFO            : natural range 1 to 2**15       := 1;
+    IO_TWI_EN_INT          : integer range 0 to 1           := 0;
+    IO_TWI_FIFO            : natural range 1 to 2**15       := 1;
+    IO_TWD_EN_INT          : integer range 0 to 1           := 0;
+    IO_TWD_RX_FIFO         : natural range 1 to 2**15       := 1;
+    IO_TWD_TX_FIFO         : natural range 1 to 2**15       := 1;
+    IO_PWM_EN_INT          : integer range 0 to 1           := 0;
+    IO_PWM_NUM_CH          : natural range 1 to 16          := 1;
+    IO_WDT_EN_INT          : integer range 0 to 1           := 0;
+    IO_TRNG_EN_INT         : integer range 0 to 1           := 0;
+    IO_TRNG_FIFO           : natural range 1 to 2**15       := 1;
+    IO_CFS_EN_INT          : integer range 0 to 1           := 0;
+    IO_NEOLED_EN_INT       : integer range 0 to 1           := 0;
+    IO_NEOLED_TX_FIFO      : natural range 1 to 2**15       := 1;
+    IO_GPTMR_EN_INT        : integer range 0 to 1           := 0;
+    IO_ONEWIRE_EN_INT      : integer range 0 to 1           := 0;
+    IO_DMA_EN_INT          : integer range 0 to 1           := 0;
+    IO_DMA_DSC_FIFO        : natural range 4 to 512         := 4;
+    IO_SLINK_EN_INT        : integer range 0 to 1           := 0;
+    IO_SLINK_RX_FIFO       : natural range 1 to 2**15       := 1;
+    IO_SLINK_TX_FIFO       : natural range 1 to 2**15       := 1
   );
   port (
     -- ------------------------------------------------------------
@@ -250,65 +250,63 @@ end entity;
 architecture neorv32_libero_ip_rtl of neorv32_libero_ip is
 
   -- boolean conversions for generics --
-  constant dual_core_en_c      : boolean := (DUAL_CORE_EN_INT = 1);
-  constant ocd_en_c            : boolean := (OCD_EN_INT = 1);
-  constant ocd_hw_breakpoint_c : boolean := (OCD_HW_BREAKPOINT_INT = 1);
-  constant ocd_authentication_c: boolean := (OCD_AUTHENTICATION_INT = 1);
-  constant riscv_isa_c_c       : boolean := (RISCV_ISA_C_INT = 1);
-  constant riscv_isa_e_c       : boolean := (RISCV_ISA_E_INT = 1);
-  constant riscv_isa_m_c       : boolean := (RISCV_ISA_M_INT = 1);
-  constant riscv_isa_u_c       : boolean := (RISCV_ISA_U_INT = 1);
-  constant riscv_isa_zaamo_c   : boolean := (RISCV_ISA_Zaamo_INT = 1);
-  constant riscv_isa_zalrsc_c  : boolean := (RISCV_ISA_Zalrsc_INT = 1);
-  constant riscv_isa_zba_c     : boolean := (RISCV_ISA_Zba_INT = 1);
-  constant riscv_isa_zbb_c     : boolean := (RISCV_ISA_Zbb_INT = 1);
-  constant riscv_isa_zbkb_c    : boolean := (RISCV_ISA_Zbkb_INT = 1);
-  constant riscv_isa_zbkc_c    : boolean := (RISCV_ISA_Zbkc_INT = 1);
-  constant riscv_isa_zbkx_c    : boolean := (RISCV_ISA_Zbkx_INT = 1);
-  constant riscv_isa_zbs_c     : boolean := (RISCV_ISA_Zbs_INT = 1);
-  constant riscv_isa_zfinx_c   : boolean := (RISCV_ISA_Zfinx_INT = 1);
-  constant riscv_isa_zicntr_c  : boolean := (RISCV_ISA_Zicntr_INT = 1);
-  constant riscv_isa_zicond_c  : boolean := (RISCV_ISA_Zicond_INT = 1);
-  constant riscv_isa_zihpm_c   : boolean := (RISCV_ISA_Zihpm_INT = 1);
-  constant riscv_isa_zmmul_c   : boolean := (RISCV_ISA_Zmmul_INT = 1);
-  constant riscv_isa_zknd_c    : boolean := (RISCV_ISA_Zknd_INT = 1);
-  constant riscv_isa_zkne_c    : boolean := (RISCV_ISA_Zkne_INT = 1);
-  constant riscv_isa_zknh_c    : boolean := (RISCV_ISA_Zknh_INT = 1);
-  constant riscv_isa_zksed_c   : boolean := (RISCV_ISA_Zksed_INT = 1);
-  constant riscv_isa_zksh_c    : boolean := (RISCV_ISA_Zksh_INT = 1);
-  constant riscv_isa_zxcfu_c   : boolean := (RISCV_ISA_Zxcfu_INT = 1);
-  constant cpu_fast_mul_en_c   : boolean := (CPU_FAST_MUL_EN_INT = 1);
-  constant cpu_fast_shift_en_c : boolean := (CPU_FAST_SHIFT_EN_INT = 1);
-  constant cpu_rf_hw_rst_en_c  : boolean := (CPU_RF_HW_RST_EN_INT = 1);
-  constant pmp_tor_mode_en_c   : boolean := (PMP_TOR_MODE_EN_INT = 1);
-  constant pmp_nap_mode_en_c   : boolean := (PMP_NAP_MODE_EN_INT = 1);
-  constant imem_en_c           : boolean := (IMEM_EN_INT = 1);
-  constant imem_outreg_en_c    : boolean := (IMEM_OUTREG_EN_INT = 1);
-  constant dmem_en_c           : boolean := (DMEM_EN_INT = 1);
-  constant dmem_outreg_en_c    : boolean := (DMEM_OUTREG_EN_INT = 1);
-  constant icache_en_c         : boolean := (ICACHE_EN_INT = 1);
-  constant dcache_en_c         : boolean := (DCACHE_EN_INT = 1);
-  constant xbus_en_c           : boolean := (XBUS_EN_INT = 1);
-  constant xbus_regstage_en_c  : boolean := (XBUS_REGSTAGE_EN_INT = 1);
-  constant io_gpio_en_c        : boolean := (IO_GPIO_EN_INT = 1);
-  constant io_clint_en_c       : boolean := (IO_CLINT_EN_INT = 1);
-  constant io_uart0_en_c       : boolean := (IO_UART0_EN_INT = 1);
-  constant io_uart1_en_c       : boolean := (IO_UART1_EN_INT = 1);
-  constant io_spi_en_c         : boolean := (IO_SPI_EN_INT = 1);
-  constant io_sdi_en_c         : boolean := (IO_SDI_EN_INT = 1);
-  constant io_twi_en_c         : boolean := (IO_TWI_EN_INT = 1);
-  constant io_twd_en_c         : boolean := (IO_TWD_EN_INT = 1);
-  constant io_pwm_en_c         : boolean := (IO_PWM_EN_INT = 1);
-  constant io_wdt_en_c         : boolean := (IO_WDT_EN_INT = 1);
-  constant io_trng_en_c        : boolean := (IO_TRNG_EN_INT = 1);
-  constant io_cfs_en_c         : boolean := (IO_CFS_EN_INT = 1);
-  constant io_neoled_en_c      : boolean := (IO_NEOLED_EN_INT = 1);
-  constant io_gptmr_en_c       : boolean := (IO_GPTMR_EN_INT = 1);
-  constant io_onewire_en_c     : boolean := (IO_ONEWIRE_EN_INT = 1);
-  constant io_dma_en_c         : boolean := (IO_DMA_EN_INT = 1);
-  constant io_slink_en_c       : boolean := (IO_SLINK_EN_INT = 1);
-  constant BOOT_ADDR_CUSTOM      : std_ulogic_vector(31 downto 0) := std_ulogic_vector(to_unsigned(BOOT_ADDR_CUSTOM_UPPER * 2**16 + BOOT_ADDR_CUSTOM_LOWER, 32));
-
+  constant dual_core_en_c       : boolean := (DUAL_CORE_EN_INT = 1);
+  constant ocd_en_c             : boolean := (OCD_EN_INT = 1);
+  constant ocd_authentication_c : boolean := (OCD_AUTHENTICATION_INT = 1);
+  constant riscv_isa_c_c        : boolean := (RISCV_ISA_C_INT = 1);
+  constant riscv_isa_e_c        : boolean := (RISCV_ISA_E_INT = 1);
+  constant riscv_isa_m_c        : boolean := (RISCV_ISA_M_INT = 1);
+  constant riscv_isa_u_c        : boolean := (RISCV_ISA_U_INT = 1);
+  constant riscv_isa_zaamo_c    : boolean := (RISCV_ISA_Zaamo_INT = 1);
+  constant riscv_isa_zalrsc_c   : boolean := (RISCV_ISA_Zalrsc_INT = 1);
+  constant riscv_isa_zba_c      : boolean := (RISCV_ISA_Zba_INT = 1);
+  constant riscv_isa_zbb_c      : boolean := (RISCV_ISA_Zbb_INT = 1);
+  constant riscv_isa_zbkb_c     : boolean := (RISCV_ISA_Zbkb_INT = 1);
+  constant riscv_isa_zbkc_c     : boolean := (RISCV_ISA_Zbkc_INT = 1);
+  constant riscv_isa_zbkx_c     : boolean := (RISCV_ISA_Zbkx_INT = 1);
+  constant riscv_isa_zbs_c      : boolean := (RISCV_ISA_Zbs_INT = 1);
+  constant riscv_isa_zfinx_c    : boolean := (RISCV_ISA_Zfinx_INT = 1);
+  constant riscv_isa_zicntr_c   : boolean := (RISCV_ISA_Zicntr_INT = 1);
+  constant riscv_isa_zicond_c   : boolean := (RISCV_ISA_Zicond_INT = 1);
+  constant riscv_isa_zihpm_c    : boolean := (RISCV_ISA_Zihpm_INT = 1);
+  constant riscv_isa_zmmul_c    : boolean := (RISCV_ISA_Zmmul_INT = 1);
+  constant riscv_isa_zknd_c     : boolean := (RISCV_ISA_Zknd_INT = 1);
+  constant riscv_isa_zkne_c     : boolean := (RISCV_ISA_Zkne_INT = 1);
+  constant riscv_isa_zknh_c     : boolean := (RISCV_ISA_Zknh_INT = 1);
+  constant riscv_isa_zksed_c    : boolean := (RISCV_ISA_Zksed_INT = 1);
+  constant riscv_isa_zksh_c     : boolean := (RISCV_ISA_Zksh_INT = 1);
+  constant riscv_isa_zxcfu_c    : boolean := (RISCV_ISA_Zxcfu_INT = 1);
+  constant cpu_fast_mul_en_c    : boolean := (CPU_FAST_MUL_EN_INT = 1);
+  constant cpu_fast_shift_en_c  : boolean := (CPU_FAST_SHIFT_EN_INT = 1);
+  constant cpu_rf_hw_rst_en_c   : boolean := (CPU_RF_HW_RST_EN_INT = 1);
+  constant pmp_tor_mode_en_c    : boolean := (PMP_TOR_MODE_EN_INT = 1);
+  constant pmp_nap_mode_en_c    : boolean := (PMP_NAP_MODE_EN_INT = 1);
+  constant imem_en_c            : boolean := (IMEM_EN_INT = 1);
+  constant imem_outreg_en_c     : boolean := (IMEM_OUTREG_EN_INT = 1);
+  constant dmem_en_c            : boolean := (DMEM_EN_INT = 1);
+  constant dmem_outreg_en_c     : boolean := (DMEM_OUTREG_EN_INT = 1);
+  constant icache_en_c          : boolean := (ICACHE_EN_INT = 1);
+  constant dcache_en_c          : boolean := (DCACHE_EN_INT = 1);
+  constant xbus_en_c            : boolean := (XBUS_EN_INT = 1);
+  constant xbus_regstage_en_c   : boolean := (XBUS_REGSTAGE_EN_INT = 1);
+  constant io_gpio_en_c         : boolean := (IO_GPIO_EN_INT = 1);
+  constant io_clint_en_c        : boolean := (IO_CLINT_EN_INT = 1);
+  constant io_uart0_en_c        : boolean := (IO_UART0_EN_INT = 1);
+  constant io_uart1_en_c        : boolean := (IO_UART1_EN_INT = 1);
+  constant io_spi_en_c          : boolean := (IO_SPI_EN_INT = 1);
+  constant io_sdi_en_c          : boolean := (IO_SDI_EN_INT = 1);
+  constant io_twi_en_c          : boolean := (IO_TWI_EN_INT = 1);
+  constant io_twd_en_c          : boolean := (IO_TWD_EN_INT = 1);
+  constant io_pwm_en_c          : boolean := (IO_PWM_EN_INT = 1);
+  constant io_wdt_en_c          : boolean := (IO_WDT_EN_INT = 1);
+  constant io_trng_en_c         : boolean := (IO_TRNG_EN_INT = 1);
+  constant io_cfs_en_c          : boolean := (IO_CFS_EN_INT = 1);
+  constant io_neoled_en_c       : boolean := (IO_NEOLED_EN_INT = 1);
+  constant io_gptmr_en_c        : boolean := (IO_GPTMR_EN_INT = 1);
+  constant io_onewire_en_c      : boolean := (IO_ONEWIRE_EN_INT = 1);
+  constant io_dma_en_c          : boolean := (IO_DMA_EN_INT = 1);
+  constant io_slink_en_c        : boolean := (IO_SLINK_EN_INT = 1);
+  constant BOOT_ADDR_CUSTOM     : std_ulogic_vector(31 downto 0) := std_ulogic_vector(to_unsigned(BOOT_ADDR_CUSTOM_UPPER * 2**16 + BOOT_ADDR_CUSTOM_LOWER, 32));
 
   -- auto-configuration --
   constant num_gpio_c : natural := cond_sel_natural_f(io_gpio_en_c, max_natural_f(IO_GPIO_IN_NUM, IO_GPIO_OUT_NUM), 0);
@@ -414,7 +412,7 @@ begin
     BOOT_ADDR_CUSTOM    => BOOT_ADDR_CUSTOM,
     -- On-Chip Debugger --
     OCD_EN              => ocd_en_c,
-    OCD_HW_BREAKPOINT   => ocd_hw_breakpoint_c,
+    OCD_NUM_HW_TRIGGERS => OCD_NUM_HW_TRIGGERS,
     OCD_AUTHENTICATION  => ocd_authentication_c,
     OCD_JEDEC_ID        => std_ulogic_vector(OCD_JEDEC_ID),
     -- RISC-V CPU Extensions --

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -186,10 +186,10 @@ proc setup_ip_gui {} {
 
   set group [add_group $page {On-Chip Debugger (OCD)}]
   add_params $group {
-    { OCD_EN             {Enable OCD}          {Implement JTAG-based on-chip debugger} }
-    { OCD_HW_BREAKPOINT  {Hardware breakpoint} {Implement a single hardware-assistet breakpoint} {$OCD_EN} {$OCD_EN ? $OCD_HW_BREAKPOINT  : false} }
-    { OCD_AUTHENTICATION {OCD authentication}  {Implement debug authentication module}           {$OCD_EN} {$OCD_EN ? $OCD_AUTHENTICATION : false} }
-    { OCD_JEDEC_ID       {JEDEC ID}            {JTAG tap identification}                         {$OCD_EN}}
+    { OCD_EN              {Enable OCD}         {Implement JTAG-based on-chip debugger} }
+    { OCD_AUTHENTICATION  {OCD authentication} {Implement debug authentication module} {$OCD_EN} {$OCD_EN ? $OCD_AUTHENTICATION : false} }
+    { OCD_NUM_HW_TRIGGERS {Hardware triggers}  {Number of hardware break-/watchpoints} {$OCD_EN} {$OCD_EN ? $OCD_NUM_HW_TRIGGERS : 0} }
+    { OCD_JEDEC_ID        {JEDEC ID}           {JTAG tap identification}               {$OCD_EN}}
   }
 
 

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -34,7 +34,7 @@ entity neorv32_vivado_ip is
     BOOT_ADDR_CUSTOM      : std_ulogic_vector(31 downto 0) := x"00000000";
     -- On-Chip Debugger (OCD) --
     OCD_EN                : boolean                        := false;
-    OCD_HW_BREAKPOINT     : boolean                        := false;
+    OCD_NUM_HW_TRIGGERS   : natural range 0 to 16          := 0;
     OCD_AUTHENTICATION    : boolean                        := false;
     OCD_JEDEC_ID          : std_logic_vector(10 downto 0)  := "00000000000";
     -- RISC-V CPU Extensions --
@@ -360,7 +360,7 @@ begin
     BOOT_ADDR_CUSTOM    => BOOT_ADDR_CUSTOM,
     -- On-Chip Debugger --
     OCD_EN              => OCD_EN,
-    OCD_HW_BREAKPOINT   => OCD_HW_BREAKPOINT,
+    OCD_NUM_HW_TRIGGERS => OCD_NUM_HW_TRIGGERS,
     OCD_AUTHENTICATION  => OCD_AUTHENTICATION,
     OCD_JEDEC_ID        => std_ulogic_vector(OCD_JEDEC_ID),
     -- RISC-V CPU Extensions --

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -128,7 +128,7 @@ begin
     BOOT_ADDR_CUSTOM    => BOOT_ADDR_CUSTOM,
     -- On-Chip Debugger (OCD) --
     OCD_EN              => true,
-    OCD_HW_BREAKPOINT   => true,
+    OCD_NUM_HW_TRIGGERS => 2,
     OCD_AUTHENTICATION  => true,
     -- RISC-V CPU Extensions --
     RISCV_ISA_C         => RISCV_ISA_C,


### PR DESCRIPTION
* ⚠️ remove `OCD_HW_BREAKPOINT` top generic
* ✨ replaced by new generic to configure the number of hardware triggers:

```vhdl
OCD_NUM_HW_TRIGGERS : natural range 0 to 16 := 0; -- number of hardware break-/watchpoints
```

Tested with openOCD and GDB:

```
Info : [neorv32.cpu0] Found 4 triggers
```