### PR TITLE
🐛 fix double-trap tracking bug

### DIFF
--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -963,9 +963,9 @@ begin
         trap_ctrl.env_entered <= '1';
       end if;
       -- trap environment active (we are "inside a trap handler") --
-      if (trap_ctrl.env_exit = '1') and (debug_ctrl.run = '0') then -- exit from non-debug-mode trap handler
+      if (trap_ctrl.env_exit = '1') and (debug_ctrl.run = '0') then -- exit non-debug-mode trap
         trap_ctrl.env_running <= '0';
-      elsif (trap_ctrl.env_enter = '1') then
+      elsif (trap_ctrl.env_enter = '1') and (trap_ctrl.cause(5) = '0') then -- enter non-debug-mode trap
         trap_ctrl.env_running <= '1';
       end if;
     end if;


### PR DESCRIPTION
If the on-chip debugger is used to debug a program that triggers a trap (e.g. an environment call exception), the trap is always delivered as a "double-trap" exception due to an error in the trap monitoring logic. This PR fixes this error.