### PR TITLE
Cleanup UART simulation logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,11 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 14.07.2025 | 1.11.8.3 | cleanup UART simulation logging | [#1314](https://github.com/stnolting/neorv32/pull/1314) |
 | 12.07.2025 | 1.11.8.2 | :sparkles: add new module: execution trace buffer (TRACER) | [#1313](https://github.com/stnolting/neorv32/pull/1313) |
 | 11.07.2025 | 1.11.8.1 | :bug: fix bug in double-trap monitoring logic | [#1312](https://github.com/stnolting/neorv32/pull/1312) |
 | 10.07.2025 | [**1.11.8**](https://github.com/stnolting/neorv32/releases/tag/v1.11.8) | :rocket: **New release** | |
-| 09.07.2025 | 1.11.7.9 | :bug: fix minimal cache block size (has to be at least 8 bytes / 2 words) | [#](https://github.com/stnolting/neorv32/pull/1310) |
+| 09.07.2025 | 1.11.7.9 | :bug: fix minimal cache block size (has to be at least 8 bytes / 2 words) | [#1310](https://github.com/stnolting/neorv32/pull/1310) |
 | 08.07.2025 | 1.11.7.8 | :warning: remove top `HART_BASE` generic | [#1308](https://github.com/stnolting/neorv32/pull/1308) |
 | 07.07.2025 | 1.11.7.7 | minor rtl edits and cleanups | [#1307](https://github.com/stnolting/neorv32/pull/1307) |
 | 06.07.2025 | 1.11.7.6 | :sparkles: add configurable number of HW triggers (break-/watchpoints) | [#1304](https://github.com/stnolting/neorv32/pull/1304) |

--- a/docs/datasheet/soc_uart.adoc
+++ b/docs/datasheet/soc_uart.adoc
@@ -105,7 +105,7 @@ unconnected. If the CTS handshake is not required it has to be tied to zero.
 The UART provides a _simulation-only_ mode to dump console data as well as raw data directly to a file. When the simulation
 mode is enabled (by setting the `UART_CTRL_SIM_MODE` bit) there will be **no** physical transaction on the `uart0_txd_o` signal.
 Instead, all data written to the `DATA` register is immediately dumped to a file. Data written to `DATA[7:0]` will be dumped as
-ASCII chars to a file named `neorv32.uart0_sim_mode.out`. Additionally, the ASCII data is printed to the simulator console.
+ASCII chars to a file named `neorv32.uart0_sim_mode.log`. Additionally, the ASCII data is printed to the simulator console.
 
 Both file are created in the simulation's home folder.
 
@@ -179,7 +179,7 @@ as for the primary UART. The RX and TX interrupts of UART1 are mapped to differe
 **Simulation Mode**
 
 The secondary UART (UART1) provides the same simulation options as the primary UART (UART0). However, output data is
-written to UART1-specific file `neorv32.uart1_sim_mode.out`. This data is also printed to the simulator console.
+written to UART1-specific file `neorv32.uart1_sim_mode.log`. This data is also printed to the simulator console.
 
 
 **Register Map**

--- a/docs/userguide/simulating_the_processor.adoc
+++ b/docs/userguide/simulating_the_processor.adoc
@@ -38,8 +38,8 @@ Basically, these configuration generics represent most of the processor's **top 
 .UART output during simulation
 [IMPORTANT]
 Data written to the NEORV32 UART0 / UART1 transmitter is send to a virtual UART receiver implemented as part of the default
-testbench. The received chars are send to the simulator console and are also stored to a log file (`neorv32_tb.uart0_rx.out`
-for UART0, `neorv32_tb.uart1_rx.out` for UART1) inside the simulator's home folder. **Please note that printing via the
+testbench. The received chars are send to the simulator console and are also stored to a log file (`tb.uart0_rx.log`
+for UART0, `tb.uart1_rx.log` for UART1) inside the simulator's home folder. **Please note that printing via the
 native UART receiver takes a lot of time.** For faster simulation console output see section <<_faster_simulation_console_output>>.
 
 
@@ -53,8 +53,8 @@ section https://stnolting.github.io/neorv32/#_primary_universal_asynchronous_rec
 ASCII data sent to UART0 / UART1 will be immediately printed to the simulator console and logged to files in the
 simulator's home directory.
 
-* `neorv32.uart0_sim_mode.out`: ASCII data send via UART0
-* `neorv32.uart1_sim_mode.out`: ASCII data send via UART1
+* `neorv32.uart0_sim_mode.log`: ASCII data send via UART0
+* `neorv32.uart1_sim_mode.log`: ASCII data send via UART1
 
 .Automatic Simulation Mode
 [TIP]

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110802"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110803"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -1137,8 +1137,8 @@ begin
     if IO_UART0_EN generate
       neorv32_uart0_inst: entity neorv32.neorv32_uart
       generic map (
-        SIM_MODE_EN  => true,
-        SIM_LOG_FILE => "neorv32.uart0_sim_mode.out",
+        SIM_MODE_EN  => is_simulation_c,
+        SIM_LOG_FILE => "neorv32.uart0_sim_mode.log",
         UART_RX_FIFO => IO_UART0_RX_FIFO,
         UART_TX_FIFO => IO_UART0_TX_FIFO
       )
@@ -1171,8 +1171,8 @@ begin
     if IO_UART1_EN generate
       neorv32_uart1_inst: entity neorv32.neorv32_uart
       generic map (
-        SIM_MODE_EN  => true,
-        SIM_LOG_FILE => "neorv32.uart1_sim_mode.out",
+        SIM_MODE_EN  => is_simulation_c,
+        SIM_LOG_FILE => "neorv32.uart1_sim_mode.log",
         UART_RX_FIFO => IO_UART1_RX_FIFO,
         UART_TX_FIFO => IO_UART1_TX_FIFO
       )

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -44,9 +44,6 @@ end neorv32_uart;
 
 architecture neorv32_uart_rtl of neorv32_uart is
 
-  -- simulation mode? --
-  constant sim_mode_en_c : boolean := SIM_MODE_EN and is_simulation_c;
-
   -- control register bits --
   constant ctrl_en_c            : natural :=  0; -- r/w: UART enable
   constant ctrl_sim_en_c        : natural :=  1; -- r/w: simulation-mode enable
@@ -176,7 +173,7 @@ begin
         if (bus_req_i.rw = '1') then -- write access
           if (bus_req_i.addr(2) = '0') then -- control register
             ctrl.enable        <= bus_req_i.data(ctrl_en_c);
-            ctrl.sim_mode      <= bus_req_i.data(ctrl_sim_en_c) and bool_to_ulogic_f(sim_mode_en_c);
+            ctrl.sim_mode      <= bus_req_i.data(ctrl_sim_en_c) and bool_to_ulogic_f(SIM_MODE_EN);
             ctrl.hwfc_en       <= bus_req_i.data(ctrl_hwfc_en_c);
             ctrl.prsc          <= bus_req_i.data(ctrl_prsc2_c downto ctrl_prsc0_c);
             ctrl.baud          <= bus_req_i.data(ctrl_baud9_c downto ctrl_baud0_c);
@@ -192,7 +189,7 @@ begin
         else -- read access
           if (bus_req_i.addr(2) = '0') then -- control register
             bus_rsp_o.data(ctrl_en_c)                        <= ctrl.enable;
-            bus_rsp_o.data(ctrl_sim_en_c)                    <= ctrl.sim_mode and bool_to_ulogic_f(sim_mode_en_c);
+            bus_rsp_o.data(ctrl_sim_en_c)                    <= ctrl.sim_mode and bool_to_ulogic_f(SIM_MODE_EN);
             bus_rsp_o.data(ctrl_hwfc_en_c)                   <= ctrl.hwfc_en;
             bus_rsp_o.data(ctrl_prsc2_c downto ctrl_prsc0_c) <= ctrl.prsc;
             bus_rsp_o.data(ctrl_baud9_c downto ctrl_baud0_c) <= ctrl.baud;
@@ -478,7 +475,7 @@ begin
 -- pragma translate_off
 -- RTL_SYNTHESIS OFF
   simulation_transmitter:
-  if sim_mode_en_c generate -- for simulation only!
+  if SIM_MODE_EN generate -- for simulation only!
     sim_tx: process(clk_i)
       file file_out          : text open write_mode is SIM_LOG_FILE;
       variable char_v        : integer;

--- a/sim/ghdl.sh
+++ b/sim/ghdl.sh
@@ -5,14 +5,6 @@ set -e
 cd $(dirname "$0")
 GHDL="${GHDL:-ghdl}"
 
-# Prepare UART SIM_MODE output files
-touch neorv32.uart0_sim_mode.out neorv32.uart1_sim_mode.out
-chmod 777 neorv32.uart0_sim_mode.out neorv32.uart1_sim_mode.out
-
-# Prepare testbench UART log files
-touch neorv32_tb.uart0_rx.out neorv32_tb.uart1_rx.out
-chmod 777 neorv32_tb.uart0_rx.out neorv32_tb.uart1_rx.out
-
 # GHDL build directory
 mkdir -p build
 

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -377,7 +377,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   sim_rx_uart0: entity work.sim_uart_rx
   generic map (
-    NAME => "uart0",
+    NAME => "tb.uart0",
     FCLK => real(CLOCK_FREQUENCY),
     BAUD => real(19200)
   )
@@ -388,7 +388,7 @@ begin
 
   sim_rx_uart1: entity work.sim_uart_rx
   generic map (
-    NAME => "uart1",
+    NAME => "tb.uart1",
     FCLK => real(CLOCK_FREQUENCY),
     BAUD => real(19200)
   )

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -377,7 +377,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   sim_rx_uart0: entity work.sim_uart_rx
   generic map (
-    NAME => "tb.uart0",
+    NAME => "tb.uart0_rx",
     FCLK => real(CLOCK_FREQUENCY),
     BAUD => real(19200)
   )
@@ -388,7 +388,7 @@ begin
 
   sim_rx_uart1: entity work.sim_uart_rx
   generic map (
-    NAME => "tb.uart1",
+    NAME => "tb.uart1_rx",
     FCLK => real(CLOCK_FREQUENCY),
     BAUD => real(19200)
   )

--- a/sim/sim_uart_rx.vhd
+++ b/sim/sim_uart_rx.vhd
@@ -1,9 +1,9 @@
 -- ================================================================================ --
--- NEORV32 - Simulation UART Receiver (print to simulator console)                  --
+-- NEORV32 - Simulation UART Receiver (print to simulator console and log to file)  --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2024 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -16,7 +16,7 @@ use std.textio.all;
 
 entity sim_uart_rx is
   generic (
-    NAME : string; -- receiver name (for log file)
+    NAME : string; -- receiver name
     FCLK : real; -- clock speed of clk_i in Hz
     BAUD : real -- baud rate
   );
@@ -32,9 +32,9 @@ architecture sim_uart_rx_rtl of sim_uart_rx is
   signal busy : std_ulogic := '0';
   signal sreg : std_ulogic_vector(8 downto 0) := (others => '0');
   signal baudcnt : real;
-  signal bitcnt  : natural;
+  signal bitcnt : integer;
   constant baud_val_c : real := FCLK / BAUD;
-  file file_out : text open write_mode is "neorv32_tb." & NAME & "_rx.out";
+  file file_out : text open write_mode is NAME & "_rx.log";
 
 begin
 

--- a/sim/sim_uart_rx.vhd
+++ b/sim/sim_uart_rx.vhd
@@ -12,7 +12,12 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 use ieee.math_real.all;
+
+-- pragma translate_off
+-- RTL_SYNTHESIS OFF
 use std.textio.all;
+-- RTL_SYNTHESIS ON
+-- pragma translate_on
 
 entity sim_uart_rx is
   generic (
@@ -34,13 +39,15 @@ architecture sim_uart_rx_rtl of sim_uart_rx is
   signal baudcnt : real;
   signal bitcnt : integer;
   constant baud_val_c : real := FCLK / BAUD;
-  file file_out : text open write_mode is NAME & "_rx.log";
 
 begin
 
+-- pragma translate_off
+-- RTL_SYNTHESIS OFF
   sim_receiver: process(clk)
-    variable c : integer;
-    variable l : line;
+    file file_out   : text open write_mode is NAME & ".log";
+    variable char_v : integer;
+    variable line_v : line;
   begin
     if rising_edge(clk) then
       -- synchronizer --
@@ -64,18 +71,18 @@ begin
 
           if (bitcnt = 0) then
             busy <= '0'; -- done
-            c := to_integer(unsigned(sreg(8 downto 1)));
+            char_v := to_integer(unsigned(sreg(8 downto 1)));
 
-            if (c < 32) or (c > 32+95) then -- non-printable character?
-              report NAME & ".rx: (" & integer'image(c) & ")";
+            if (char_v < 32) or (char_v > 32+95) then -- non-printable character?
+              report NAME & ": (" & integer'image(char_v) & ")";
             else
-              report NAME & ".rx: " & character'val(c);
+              report NAME & ": " & character'val(char_v);
             end if;
 
-            if (c = 10) then -- LF line break
+            if (char_v = 10) then -- LF line break
               writeline(file_out, l);
-            elsif (c /= 13) then -- no additional CR
-              write(l, character'val(c));
+            elsif (char_v /= 13) then -- no additional CR
+              write(line_v, character'val(char_v));
             end if;
 
           else
@@ -89,5 +96,7 @@ begin
       end if;
     end if;
   end process sim_receiver;
+-- RTL_SYNTHESIS ON
+-- pragma translate_on
 
 end architecture sim_uart_rx_rtl;

--- a/sw/example/demo_semihosting/makefile
+++ b/sw/example/demo_semihosting/makefile
@@ -26,6 +26,3 @@ NEORV32_HOME ?= ../../..
 
 # Include the main NEORV32 makefile
 include $(NEORV32_HOME)/sw/common/common.mk
-
-sim-check: sim
-	cat $(NEORV32_HOME)/sim/neorv32.uart0_sim_mode.out | grep "Hello world! :)"

--- a/sw/example/hello_world/makefile
+++ b/sw/example/hello_world/makefile
@@ -33,4 +33,4 @@ NEORV32_HOME ?= ../../..
 include $(NEORV32_HOME)/sw/common/common.mk
 
 sim-check: sim
-	cat $(NEORV32_HOME)/sim/neorv32.uart0_sim_mode.out | grep "Hello world! :)"
+	cat $(NEORV32_HOME)/sim/neorv32.uart0_sim_mode.log | grep "Hello world! :)"

--- a/sw/example/processor_check/makefile
+++ b/sw/example/processor_check/makefile
@@ -32,4 +32,4 @@ include $(NEORV32_HOME)/sw/common/common.mk
 
 # Add test-specific makefile target
 sim-check: sim
-	cat $(NEORV32_HOME)/sim/neorv32.uart0_sim_mode.out | grep "PROCESSOR TEST COMPLETED SUCCESSFULLY!"
+	cat $(NEORV32_HOME)/sim/neorv32.uart0_sim_mode.log | grep "PROCESSOR TEST COMPLETED SUCCESSFULLY!"


### PR DESCRIPTION
Rename UART log files.

#### UART0 & UART1 Modules

* `neorv32.uart0_sim_mode.out` -> `neorv32.uart0_sim_mode.log`
* `neorv32.uart1_sim_mode.out` -> `neorv32.uart1_sim_mode.log`

#### Testbench

* `neorv32_tb.uart0_rx.out` -> `tb.uart0_rx.log`
* `neorv32_tb.uart1_rx.out` -> `tb.uart1_rx.log`