### PR TITLE
Replace trace with trace_s in the top

### DIFF
--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -282,7 +282,7 @@ architecture neorv32_top_rtl of neorv32_top is
 
   -- CPU trace interface --
   type trace_t is array (0 to num_cores_c-1) of trace_port_t;
-  signal trace : trace_t;
+  signal trace_s : trace_t;
 
   -- bus: CPU core complex --
   type core_complex_req_t is array (0 to num_cores_c-1) of bus_req_t;
@@ -522,7 +522,7 @@ begin
       clk_i      => clk_i,
       rstn_i     => rstn_sys,
       -- trace port --
-      trace_o    => trace(i),
+      trace_o    => trace_s(i),
       -- interrupts --
       msi_i      => msw_irq(i),
       mei_i      => mext_irq_i,
@@ -1472,8 +1472,8 @@ begin
       port map (
         clk_i     => clk_i,
         rstn_i    => rstn_sys,
-        trace0_i  => trace(trace'left),
-        trace1_i  => trace(trace'right),
+        trace0_i  => trace_s(trace_s'left),
+        trace1_i  => trace_s(trace_s'right),
         bus_req_i => iodev_req(IODEV_TRACER),
         bus_rsp_o => iodev_rsp(IODEV_TRACER),
         irq_o     => firq(FIRQ_TRACER)


### PR DESCRIPTION
Hi Stephan!

To avoid issues with VUnit `trace` function we should change `trace` signal name in the top. I proposed to change from `trace` to `trace_s` ("s" refers to signal).

Due to `trace` elements are evaluated through "()" and in VHDL this can also refer to a function, the following error occurs:

```
Compiling into neorv32: vunit_out/preprocessed/neorv32/neorv32_application_image.vhd passed
Compiling into neorv32: vunit_out/preprocessed/neorv32/neorv32_imem.vhd              passed
Compiling into neorv32: vunit_out/preprocessed/neorv32/neorv32_top.vhd               failed
=== Command used: ===
/usr/local/bin/ghdl -a --workdir=/wrk/sim/MEM/vunit_out/ghdl/libraries/neorv32 --work=neorv32 --std=08 -P/wrk/sim/MEM/vunit_out/ghdl/libraries/vunit_lib -P/wrk/sim/MEM/vunit_out/ghdl/libraries/osvvm -P/wrk/sim/MEM/vunit_out/ghdl/libraries/MEM -P/wrk/sim/MEM/vunit_out/ghdl/libraries/neorv32 --std=08 /wrk/sim/MEM/vunit_out/preprocessed/neorv32/neorv32_top.vhd

=== Command output: ===
/wrk/sim/MEM/vunit_out/preprocessed/neorv32/neorv32_top.vhd:525:26:error: prefix is not a function name
      trace_o    => trace(i, line_num => 525, file_name => "neorv32_top.vhd"),
                         ^
/wrk/sim/MEM/vunit_out/preprocessed/neorv32/neorv32_top.vhd:1475:27:error: prefix is not a function name
        trace0_i  => trace(trace'left, line_num => 1475, file_name => "neorv32_top.vhd"),
                          ^
/wrk/sim/MEM/vunit_out/preprocessed/neorv32/neorv32_top.vhd:1476:27:error: prefix is not a function name
        trace1_i  => trace(trace'right, line_num => 1476, file_name => "neorv32_top.vhd"),
                          ^
```

This PR solves this problem.


---

Info about VUnit trace function:

https://vunit.github.io/logging/user_guide.html#log-levels

Cheers!