### PR TITLE
Add GDB tracer support

### DIFF
--- a/docs/datasheet/soc_tracer.adoc
+++ b/docs/datasheet/soc_tracer.adoc
@@ -112,7 +112,7 @@ Using the tracer from GDB is briefly illustrated in the following example:
 (gdb) c <3>
 ...
 (gdb) source neorv32_tracer.gdb <4>
-(gdb) tracer_get <3>
+(gdb) tracer_get <5>
 [0] SRC: 0x3b0 -> DST: 0x2cc <TRACE_START>
 Line 128 of "main.c" starts at address 0x3b0 <main+212> and ends at 0x3b4 <main+216>.
 Line 68 of "main.c" starts at address 0x2cc <test_code> and ends at 0x2d0 <test_code+4>.

--- a/docs/datasheet/soc_tracer.adoc
+++ b/docs/datasheet/soc_tracer.adoc
@@ -55,6 +55,11 @@ time by manually writing `1` to the `TRACER_CTRL_START` control register bit. So
 in progress by reading the `TRACER_CTRL_RUN`. Tracing is _automatically stopped_ when program execution reaches
 the address in the `STOP_ADDR` register. Automatic trace stopping can be disabled by writing -1 to this register.
 
+.Halt Tracing during Debug-Mode
+[NOTE]
+Whenever the CPU enters debug mode, either by a halt request from the debugger or by a (hard-coded) breakpoint or
+watchpoint, tracing is paused until the CPU resumes normal operation.
+
 During tracing, the module writes the instruction deltas to the internal buffer. The buffer is implemented as FIFO,
 so that only the last _IO_TRACER_BUFFER_ instruction deltas are kept. At least one instruction delta is available
 in the trace buffer when `TRACER_CTRL_AVAIL` is set. A single entry ("packet") of the trace buffer data can be read
@@ -81,8 +86,43 @@ by writing `1` to the `TRACER_CTRL_IRQ_CLR` control register bit.
 
 **Evaluating Trace Data from GDB**
 
-[NOTE]
-Coming soon...
+Two simple functions for handling the tracer are implemented as GDB script. The script is located in the tracer
+example program and can be imported into GDB using the `source` command:
+
+.Importing the Tracer GDB Script
+[source, gdb]
+----
+(gdb) source path/to/neorv32/sw/example/demo_tracer/neorv32_tracer.gdb
+----
+
+After sourcing, two additional commands are available that can be executed from the GDB command line:
+
+* `tracer_get`: read-out the data from the trace buffer and print the execution history
+* `tracer_start arg`: restart the tracer; the CPU ID has to be provided as argument (`arg`, 0 or 1)
+
+Using the tracer from GDB is briefly illustrated in the following example:
+
+.Using the Tracer from GDB (GDB started in `neorv32/sw/example/demo_tracer`)
+[source, gdb]
+----
+(gdb) make clean elf <1>
+...
+(gdb) load <2>
+...
+(gdb) c <3>
+...
+(gdb) source neorv32_tracer.gdb <4>
+(gdb) tracer_get <3>
+[0] SRC: 0x3b0 -> DST: 0x2cc <TRACE_START>
+Line 128 of "main.c" starts at address 0x3b0 <main+212> and ends at 0x3b4 <main+216>.
+Line 68 of "main.c" starts at address 0x2cc <test_code> and ends at 0x2d0 <test_code+4>.
+...
+----
+<1> Compile the demo program.
+<2> Upload the compiled ELF.
+<3> Start executing. The program will stop re-entering debug-mode when reaching main's `return` statement.
+<4> Import the tracer helper functions script.
+<5> Get trace log and print.
 
 
 **Register Map**

--- a/sw/example/demo_tracer/main.c
+++ b/sw/example/demo_tracer/main.c
@@ -119,8 +119,8 @@ int main(void) {
 
   // enable tracer interrupt
   // the complete trace log will be printed in the according interrupt handler
-  // [note] disable this if you want to process the trace log via GDB
-#if 1
+  // [note] enable this if you want to use the tracer stand-alone without GDB
+#if 0
   neorv32_cpu_csr_set(CSR_MIE, 1 << TRACER_FIRQ_ENABLE);
 #endif
 

--- a/sw/example/demo_tracer/neorv32_tracer.gdb
+++ b/sw/example/demo_tracer/neorv32_tracer.gdb
@@ -1,0 +1,78 @@
+# ***********************************************
+# read out NEORV32 trace buffer and show the according code points
+# ***********************************************
+define tracer_get
+
+  set $tracer_base = 0xFFF30000
+  set $tracer_ctrl = $tracer_base + 0x0
+  set $tracer_delta_src = $tracer_base + 0x8
+  set $tracer_delta_dst = $tracer_base + 0xc
+  set $i = 0
+
+  # trace data available?
+  set $ctrl = *((unsigned int*)($tracer_ctrl))
+  set $ctrl = $ctrl & (1 << 5)
+
+  if $ctrl == 0
+    printf "No trace data available.\n"
+  else
+    while $ctrl != 0
+      printf "---------------------------\n"
+
+      # get trace data
+      set $delta_src = *((unsigned int*)($tracer_delta_src))
+      set $delta_dst = *((unsigned int*)($tracer_delta_dst))
+      set $src = $delta_src & 0xfffffffe
+      set $dst = $delta_dst & 0xfffffffe
+
+      # print branch source and destination addresses
+      printf "[%d] SRC: 0x%x -> DST: 0x%x", $i, $src , $dst
+      set $i = $i + 1
+
+      # check if branch was caused by a trap
+      if ($delta_src & 1)
+        printf " <TRAP_ENTRY>"
+      end
+      # check if this is the very first trace packet
+      if ($delta_dst & 1)
+        printf " <TRACE_START>"
+      end
+      printf "\n"
+
+      # print according source code lines
+      # this requires that debug symbols are available in the ELF
+      info line *$src
+      info line *$dst
+
+      # trace data available?
+      set $ctrl = *((unsigned int*)($tracer_ctrl))
+      set $ctrl = $ctrl & (1 << 5)
+    end
+  end
+end
+
+
+# ***********************************************
+# (re-)start the NEORV32 tracer in free-running
+# argument: CPU select (0 or 1)
+# ***********************************************
+define tracer_start
+
+  set $hart = $arg0 & 1
+
+  printf "Tracer started for CPU %d\n", $hart
+
+  set $tracer_base = 0xFFF30000
+  set $tracer_ctrl = $tracer_base + 0x0
+  set $tracer_stop = $tracer_base + 0x4
+
+  # reset tracer
+  set *((unsigned int*)($tracer_ctrl)) = 0
+
+  # not stop address
+  set *((unsigned int*)($tracer_stop)) = -1
+
+  # enable tracer and start
+  set *((unsigned int*)($tracer_ctrl)) = 0b101 + ($hart << 1)
+
+end


### PR DESCRIPTION
* add GDB helper script: `neorv32/sw/example/demo_tracer/neorv32_tracer.gdb`
  * restart tracer for CPU 0 or CPU 1
  * dump and pretty-print trace log
* updated documentation's tracer section

Using the tracer from GDB:
```
(gdb) make clean elf
...
(gdb) load
...
(gdb) c
...
(gdb) source neorv32_tracer.gdb
(gdb) tracer_get
[0] SRC: 0x3b0 -> DST: 0x2cc <TRACE_START>
Line 128 of "main.c" starts at address 0x3b0 <main+212> and ends at 0x3b4 <main+216>.
Line 68 of "main.c" starts at address 0x2cc <test_code> and ends at 0x2d0 <test_code+4>.
...
```