### PR TITLE
[tracer] write full trace log to file

### DIFF
--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -303,6 +303,7 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `IO_SLINK_TX_FIFO`      | natural   | 1             | SLINK TX FIFO depth, has to be a power of two, minimum value is 1, max 32768.
 | `IO_TRACER_EN`          | boolean   | false         | Implement the <<_execution_trace_buffer_tracer>>.
 | `IO_TRACER_BUFFER`      | natural   | 1             | Depth of the <<_execution_trace_buffer_tracer>>. Has to be a power of two, min 1, max 32768.
+| `IO_TRACER_SIMLOG_EN`   | boolean   | false         | Write full trace log to file (simulation-only).
 |=======================
 
 

--- a/docs/datasheet/soc_tracer.adoc
+++ b/docs/datasheet/soc_tracer.adoc
@@ -5,13 +5,14 @@
 [cols="<3,<3,<6"]
 [grid="none"]
 |=======================
-| Hardware source files:  | neorv32_tracer.vhd |
-| Software driver files:  | neorv32_tracer.c   | link:https://stnolting.github.io/neorv32/sw/neorv32__tracer_8c.html[Online software reference (Doxygen)]
-|                         | neorv32_tracer.h   | link:https://stnolting.github.io/neorv32/sw/neorv32__tracer_8h.html[Online software reference (Doxygen)]
-| Top entity ports:       | none               |
-| Configuration generics: | `IO_TRACER_EN`     | implement TRACER module when `true`
-|                         | `IO_TRACER_BUFFER` | trace buffer depth, has to be zero or a power of two, min 1
-| CPU interrupts:         | fast IRQ channel 5 | tracing stop-address match interrupt (see <<_processor_interrupts>>)
+| Hardware source files:  | neorv32_tracer.vhd    |
+| Software driver files:  | neorv32_tracer.c      | link:https://stnolting.github.io/neorv32/sw/neorv32__tracer_8c.html[Online software reference (Doxygen)]
+|                         | neorv32_tracer.h      | link:https://stnolting.github.io/neorv32/sw/neorv32__tracer_8h.html[Online software reference (Doxygen)]
+| Top entity ports:       | none                  |
+| Configuration generics: | `IO_TRACER_EN`        | implement TRACER module when `true`
+|                         | `IO_TRACER_BUFFER`    | trace buffer depth, has to be zero or a power of two, min 1
+|                         | `IO_TRACER_SIMLOG_EN` | write full trace log to file when `true` (simulation-only)
+| CPU interrupts:         | fast IRQ channel 5    | tracing stop-address match interrupt (see <<_processor_interrupts>>)
 |=======================
 
 
@@ -124,6 +125,52 @@ Line 68 of "main.c" starts at address 0x2cc <test_code> and ends at 0x2d0 <test_
 <4> Import the tracer helper functions script.
 <5> Get trace log and print.
 
+
+**Tracer Simulation Logging**
+
+.Simulation-Only
+[IMPORTANT]
+This feature is available in simulation only.
+
+The NEORV32 tracer module can also be used to generate a complete log of all executed instructions. Simulation
+trace logging is enabled by the `IO_TRACER_SIMLOG_EN` top generic. This also requires the tracer is implemented
+(`IO_TRACER_EN` = true). However, no specific configuration of the control register `CTRL` is required. During
+simulation, all traced instructions are written to log files in the simulator's home folder:
+
+* `neorv32.tracer0.log` for CPU 0
+* `neorv32.tracer1.log` for CPU 1 (only if the <<_dual_core_configuration>> is enabled)
+
+The trace log is structured line by line where each line describes an executed instruction.
+The start of an exemplary trace log might look like this:
+
+.Exemplary cut-out from a trace log
+[source, log]
+----
+0 31 00000000 f14020f3 M
+1 34 00000004 80002217 M
+2 36 00000008 ffb20213 M
+3 38 0000000c ff027113 M
+4 40 00000010 80000197 M
+5 42 00000014 7f018193 M
+6 44 00000018 000022b7 M
+7 46 0000001c 80028293 M
+8 61 00000020 30029073 M
+9 64 00000024 00000317 M
+----
+
+The column structure is explained here using the first line:
+
+[start=1]
+. `0`: Instruction index ("order"); a linearly increasing counter that starts at zero; printed as decimal integer
+. `31`: Time stamp; a linearly increasing counter that is set to zero by the hardware reset and increments with each clock cycle; printed as decimal integer
+. `00000000`: Instruction address (program counter); printed as hexadecimal 32-bit value
+. `f14020f3`: 32-bit instruction word; compressed 16-bit instructions are shown in their decompressed 32-bit format; printed as hexadecimal 32-bit value
+. `M`: Current operating mode / privilege level (`M` = machine-mode, `U` = user-mode, `D` = debug-mode); printed as single character
+
+.Instruction Execution Timer
+[TIP]
+The execution time of instruction _i_ (number of cycles required for retiring) can be calculated by
+subtracting the current time stamp _i_ from the next time stamp _i+1_.
 
 **Register Map**
 

--- a/docs/datasheet/soc_uart.adoc
+++ b/docs/datasheet/soc_uart.adoc
@@ -105,7 +105,7 @@ unconnected. If the CTS handshake is not required it has to be tied to zero.
 The UART provides a _simulation-only_ mode to dump console data as well as raw data directly to a file. When the simulation
 mode is enabled (by setting the `UART_CTRL_SIM_MODE` bit) there will be **no** physical transaction on the `uart0_txd_o` signal.
 Instead, all data written to the `DATA` register is immediately dumped to a file. Data written to `DATA[7:0]` will be dumped as
-ASCII chars to a file named `neorv32.uart0_sim_mode.log`. Additionally, the ASCII data is printed to the simulator console.
+ASCII chars to a file named `neorv32.uart0.log`. Additionally, the ASCII data is printed to the simulator console.
 
 Both file are created in the simulation's home folder.
 
@@ -179,7 +179,7 @@ as for the primary UART. The RX and TX interrupts of UART1 are mapped to differe
 **Simulation Mode**
 
 The secondary UART (UART1) provides the same simulation options as the primary UART (UART0). However, output data is
-written to UART1-specific file `neorv32.uart1_sim_mode.log`. This data is also printed to the simulator console.
+written to UART1-specific file `neorv32.uart1.log`. This data is also printed to the simulator console.
 
 
 **Register Map**

--- a/docs/userguide/simulating_the_processor.adoc
+++ b/docs/userguide/simulating_the_processor.adoc
@@ -53,8 +53,8 @@ section https://stnolting.github.io/neorv32/#_primary_universal_asynchronous_rec
 ASCII data sent to UART0 / UART1 will be immediately printed to the simulator console and logged to files in the
 simulator's home directory.
 
-* `neorv32.uart0_sim_mode.log`: ASCII data send via UART0
-* `neorv32.uart1_sim_mode.log`: ASCII data send via UART1
+* `neorv32.uart0.log`: ASCII data send via UART0
+* `neorv32.uart1.log`: ASCII data send via UART1
 
 .Automatic Simulation Mode
 [TIP]

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110803"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110804"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -897,7 +897,8 @@ package neorv32_package is
       IO_SLINK_RX_FIFO      : natural range 1 to 2**15       := 1;
       IO_SLINK_TX_FIFO      : natural range 1 to 2**15       := 1;
       IO_TRACER_EN          : boolean                        := false;
-      IO_TRACER_BUFFER      : natural range 1 to 2**15       := 1
+      IO_TRACER_BUFFER      : natural range 1 to 2**15       := 1;
+      IO_TRACER_SIMLOG_EN   : boolean                        := false
     );
     port (
       -- Global control --

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -1138,7 +1138,7 @@ begin
       neorv32_uart0_inst: entity neorv32.neorv32_uart
       generic map (
         SIM_MODE_EN  => is_simulation_c,
-        SIM_LOG_FILE => "neorv32.uart0_sim_mode.log",
+        SIM_LOG_FILE => "neorv32.uart0.log",
         UART_RX_FIFO => IO_UART0_RX_FIFO,
         UART_TX_FIFO => IO_UART0_TX_FIFO
       )
@@ -1172,7 +1172,7 @@ begin
       neorv32_uart1_inst: entity neorv32.neorv32_uart
       generic map (
         SIM_MODE_EN  => is_simulation_c,
-        SIM_LOG_FILE => "neorv32.uart1_sim_mode.log",
+        SIM_LOG_FILE => "neorv32.uart1.log",
         UART_RX_FIFO => IO_UART1_RX_FIFO,
         UART_TX_FIFO => IO_UART1_TX_FIFO
       )

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -133,7 +133,8 @@ entity neorv32_top is
     IO_SLINK_RX_FIFO      : natural range 1 to 2**15       := 1;           -- RX FIFO depth, has to be a power of two, min 1
     IO_SLINK_TX_FIFO      : natural range 1 to 2**15       := 1;           -- TX FIFO depth, has to be a power of two, min 1
     IO_TRACER_EN          : boolean                        := false;       -- implement instruction tracer
-    IO_TRACER_BUFFER      : natural range 1 to 2**15       := 1            -- trace buffer depth, has to be a power of two, min 1
+    IO_TRACER_BUFFER      : natural range 1 to 2**15       := 1;           -- trace buffer depth, has to be a power of two, min 1
+    IO_TRACER_SIMLOG_EN   : boolean                        := false        -- write full trace log to file (simulation-only)
   );
   port (
     -- Global control --
@@ -261,6 +262,7 @@ architecture neorv32_top_rtl of neorv32_top is
   constant io_sysinfo_en_c : boolean := not IO_DISABLE_SYSINFO;
   constant ocd_auth_en_c   : boolean := OCD_EN and OCD_AUTHENTICATION;
   constant cpu_sdtrig_en_c : boolean := OCD_EN and boolean(OCD_NUM_HW_TRIGGERS > 0);
+  constant tracer_log_en_c : boolean := IO_TRACER_SIMLOG_EN and is_simulation_c;
 
   -- make sure physical memory sizes are a power of two --
   constant imem_size_c : natural := cond_sel_natural_f(is_power_of_two_f(IMEM_SIZE), IMEM_SIZE, 2**index_size_f(IMEM_SIZE));
@@ -1466,8 +1468,11 @@ begin
     if IO_TRACER_EN generate
       neorv32_tracer_inst: entity neorv32.neorv32_tracer
       generic map (
-        TRACE_DEPTH  => IO_TRACER_BUFFER,
-        DUAL_CORE_EN => DUAL_CORE_EN
+        TRACE_DEPTH   => IO_TRACER_BUFFER,
+        DUAL_CORE_EN  => DUAL_CORE_EN,
+        SIM_LOG_EN    => tracer_log_en_c,
+        SIM_LOG_FILE0 => "neorv32.tracer0.log",
+        SIM_LOG_FILE1 => "neorv32.tracer1.log"
       )
       port map (
         clk_i     => clk_i,

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -474,6 +474,11 @@ begin
   -- -------------------------------------------------------------------------------------------
 -- pragma translate_off
 -- RTL_SYNTHESIS OFF
+
+  -- notification --
+  assert false report "[NEORV32] UART logging enabled: " & SIM_LOG_FILE severity note;
+
+  -- write to simulator console and to log file --
   simulation_transmitter:
   if SIM_MODE_EN generate -- for simulation only!
     sim_tx: process(clk_i)
@@ -501,6 +506,7 @@ begin
       end if;
     end process sim_tx;
   end generate;
+
 -- RTL_SYNTHESIS ON
 -- pragma translate_on
 

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -58,6 +58,7 @@ entity neorv32_tb is
     DCACHE_EN           : boolean                        := true;        -- implement data cache
     DCACHE_NUM_BLOCKS   : natural range 1 to 4096        := 32;          -- d-cache: number of blocks (min 1), has to be a power of 2
     CACHE_BLOCK_SIZE    : natural range 8 to 1024        := 32;          -- i-cache/d-cache: block size in bytes (min 8), has to be a power of 2
+    TRACE_LOG_EN        : boolean                        := true;        -- write full trace log to file
     -- external memory A --
     EXT_MEM_A_EN        : boolean                        := false;       -- enable memory
     EXT_MEM_A_BASE      : std_ulogic_vector(31 downto 0) := x"00000000"; -- base address, has to be word-aligned
@@ -218,7 +219,8 @@ begin
     IO_SLINK_RX_FIFO    => 4,
     IO_SLINK_TX_FIFO    => 4,
     IO_TRACER_EN        => true,
-    IO_TRACER_BUFFER    => 32
+    IO_TRACER_BUFFER    => 32,
+    IO_TRACER_SIMLOG_EN => TRACE_LOG_EN
   )
   port map (
     -- Global control --

--- a/sw/example/hello_world/makefile
+++ b/sw/example/hello_world/makefile
@@ -33,4 +33,4 @@ NEORV32_HOME ?= ../../..
 include $(NEORV32_HOME)/sw/common/common.mk
 
 sim-check: sim
-	cat $(NEORV32_HOME)/sim/neorv32.uart0_sim_mode.log | grep "Hello world! :)"
+	cat $(NEORV32_HOME)/sim/neorv32.uart0.log | grep "Hello world! :)"

--- a/sw/example/processor_check/makefile
+++ b/sw/example/processor_check/makefile
@@ -32,4 +32,4 @@ include $(NEORV32_HOME)/sw/common/common.mk
 
 # Add test-specific makefile target
 sim-check: sim
-	cat $(NEORV32_HOME)/sim/neorv32.uart0_sim_mode.log | grep "PROCESSOR TEST COMPLETED SUCCESSFULLY!"
+	cat $(NEORV32_HOME)/sim/neorv32.uart0.log | grep "PROCESSOR TEST COMPLETED SUCCESSFULLY!"


### PR DESCRIPTION
This PR enabled the tracer to write a full trace log file (simulation-only).

### TRACER

* add new top generic to enabled tracer's simulation logging:

```vhdl
IO_TRACER_SIMLOG_EN : boolean := false -- write full trace log to file (simulation-only)
```

* tracer log files (generated in simulator's home folder):
  * `neorv32.tracer0.log`: trace log for CPU 0
  * `neorv32.tracer1.log`: trace log for CPU 1 (if the dual-core configuration is enabled)

For now, the trace log provides
* instruction index (order)
* time stamp
* instruction address (PC)
* instruction word (32-bit)
* privilege / operation mode (machine, user, debug)

Example cut-out:

```
0 31 00000000 f14020f3 M
1 34 00000004 80002217 M
2 36 00000008 ffb20213 M
3 38 0000000c ff027113 M
4 40 00000010 80000197 M
5 42 00000014 7f018193 M
6 44 00000018 000022b7 M
7 46 0000001c 80028293 M
8 61 00000020 30029073 M
9 64 00000024 00000317 M
```

### UART

* ⚠️ rename UART simulation-mode log files
  * `neorv32.uart0_sim_mode.log` -> `neorv32.uart0.log`
  * `neorv32.uart1_sim_mode.log` -> `neorv32.uart1.log`
