### PR TITLE
Make cache/AXI bursts optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 25.07.2025 | 1.11.8.7 | make cache burst support optional | [#1324](https://github.com/stnolting/neorv32/pull/1324) |
 | 20.07.2025 | 1.11.8.6 | extend tracer simulation log; refine semihosting file (write) access; minor rtl edits | [#1322](https://github.com/stnolting/neorv32/pull/1322) |
 | 18.07.2025 | 1.11.8.5 | :sparkles: add support for the RISC-V `Zcb` ISA extension (further code size reduction instructions; "add-on" for the `C` ISA extension) | [#1320](https://github.com/stnolting/neorv32/pull/1320) |
 | 18.07.2025 | 1.11.8.4 | :sparkles: TRACER: write full trace log to file (simulation-only) | [#1318](https://github.com/stnolting/neorv32/pull/1318) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -542,6 +542,11 @@ request the remaining burst strobes ("k").
 . The burst is completed when all required `stb` pulses are sent and when all corresponding `ack` have been received ("n").
 `burst` is cleared. `lock` is cleared and has to be low for at least one cycle to release the bus lock.
 
+.Burst Generators
+[NOTE]
+Only the caches (<<_processor_internal_instruction_cache_icache,i-cache>> / <<_processor_internal_data_cache_dcache, d-cache>>)
+can generate burst transfers (and only if explicitly enabled via `CACHE_BURSTS_EN`).
+
 .Fast Burst Response
 [TIP]
 The accessed device/memory can return all data words of the burst already after receiving the first strobe of

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -264,6 +264,7 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `DCACHE_EN`             | boolean   | false         | Implement the data cache (D$)
 | `DCACHE_NUM_BLOCKS`     | natural   | 4             | Number of blocks ("lines"). Has to be a power of two.
 | `CACHE_BLOCK_SIZE`      | natural   | 64            | Size in bytes of each block (I$ and D$). Has to be a power of two, min 8.
+| `CACHE_BURSTS_EN`       | boolean   | true          | Enable burst transfers for cache updates.
 4+^| **<<_processor_external_bus_interface_xbus>> (Wishbone / AXI4)**
 | `XBUS_EN`               | boolean   | false         | Implement the external bus interface.
 | `XBUS_TIMEOUT`          | natural   | 255           | Clock cycles after which a pending external bus access will auto-terminate and raise a bus fault exception.

--- a/docs/datasheet/soc_dcache.adoc
+++ b/docs/datasheet/soc_dcache.adoc
@@ -12,7 +12,8 @@
 | Configuration generics: | `DCACHE_EN`         | implement processor-internal, CPU-exclusive data cache (D$) when `true`
 |                         | `DCACHE_NUM_BLOCKS` | number of cache blocks ("cache lines"); has to be a power of two
 |                         | `CACHE_BLOCK_SIZE`  | size of a cache block in bytes; has to be a power of two (global configuration for I$ and D$), min 8
-| CPU interrupts:         | none |
+|                         | `CACHE_BURSTS_EN`   | enable burst transfers for cache update
+| CPU interrupts:         | none                |
 |=======================
 
 
@@ -29,9 +30,11 @@ and `CACHE_BLOCK_SIZE` defines the block size in bytes; note that this configura
 
 .Burst Transfers
 [IMPORTANT]
-If the cache is activated, this also means that cache block transfers are **always executed as burst transfers**.
-There is no possibility to execute the cache block transfers as single bus transactions. Therefore, all devices,
-memories and endpoints that can be accessed by the cache must also be able to process bursts.
+Cache update operations (e.g. to resolve a cache miss) can use <<_locked_bus_accesses_and_bursts,burst transfers>> to
+increase performance. Burst operations are enabled (for all caches) by the `CACHE_BURSTS_EN` top generic. Note that
+when bursts are enabled all cache block transfers are **always executed as burst transfers**. Hence, all devices,
+memories and endpoints that can be accessed by the cache must also be able to process bursts
+(including the <<_processor_external_bus_interface_xbus>>).
 
 .Uncached Accesses
 [NOTE]

--- a/docs/datasheet/soc_icache.adoc
+++ b/docs/datasheet/soc_icache.adoc
@@ -12,7 +12,8 @@
 | Configuration generics: | `ICACHE_EN`         | implement processor-internal, CPU-exclusive instruction cache (I$) when `true`
 |                         | `ICACHE_NUM_BLOCKS` | number of cache blocks ("cache lines"); has to be a power of two
 |                         | `CACHE_BLOCK_SIZE`  | size of a cache block in bytes; has to be a power of two (global configuration for I$ and D$), min 8
-| CPU interrupts:         | none |
+|                         | `CACHE_BURSTS_EN`   | enable burst transfers for cache update
+| CPU interrupts:         | none                |
 |=======================
 
 
@@ -29,9 +30,11 @@ and `CACHE_BLOCK_SIZE` defines the block size in bytes; note that this configura
 
 .Burst Transfers
 [IMPORTANT]
-If the cache is activated, this also means that cache block transfers are **always executed as burst transfers**.
-There is no possibility to execute the cache block transfers as single bus transactions. Therefore, all devices,
-memories and endpoints that can be accessed by the cache must also be able to process bursts.
+Cache update operations (e.g. to resolve a cache miss) can use <<_locked_bus_accesses_and_bursts,burst transfers>> to
+increase performance. Burst operations are enabled (for all caches) by the `CACHE_BURSTS_EN` top generic. Note that
+when bursts are enabled all cache block transfers are **always executed as burst transfers**. Hence, all devices,
+memories and endpoints that can be accessed by the cache must also be able to process bursts
+(including the <<_processor_external_bus_interface_xbus>>).
 
 .Uncached Accesses
 [NOTE]

--- a/docs/datasheet/soc_sysinfo.adoc
+++ b/docs/datasheet/soc_sysinfo.adoc
@@ -123,8 +123,8 @@ The SYSINFO cache register provides information about the configuration of the p
 | `7:4`   | `SYSINFO_CACHE_INST_NUM_BLOCKS_3 : SYSINFO_CACHE_INST_NUM_BLOCKS_0` | _log2_(i-cache number of cache blocks), via top's `ICACHE_NUM_BLOCKS` generic
 | `11:8`  | `SYSINFO_CACHE_DATA_BLOCK_SIZE_3 : SYSINFO_CACHE_DATA_BLOCK_SIZE_0` | _log2_(d-cache block size in bytes), via top's `DCACHE_BLOCK_SIZE` generic
 | `15:12` | `SYSINFO_CACHE_DATA_NUM_BLOCKS_3 : SYSINFO_CACHE_DATA_NUM_BLOCKS_0` | _log2_(d-cache number of cache blocks), via top's `DCACHE_NUM_BLOCKS` generic
-| `19:16` | `0000`                                                              | _reserved_
-| `23:20` | `0000`                                                              | _reserved_
-| `27:24` | `0000`                                                              | _reserved_
-| `31:28` | `0000`                                                              | _reserved_
+| `16`    | `SYSINFO_CACHE_INST_BURSTS_EN`                                      | i-cache burst transfers enabled, via top's `CACHE_BURSTS_EN` generic
+| `23:17` | `0000000`                                                           | _reserved_
+| `24`    | `SYSINFO_CACHE_DATA_BURSTS_EN`                                      | d-cache burst transfers enabled, via top's `CACHE_BURSTS_EN` generic
+| `31:25` | `0000000`                                                           | _reserved_
 |=======================

--- a/docs/datasheet/soc_xbus.adoc
+++ b/docs/datasheet/soc_xbus.adoc
@@ -5,23 +5,25 @@
 [cols="<3,<3,<4"]
 [grid="none"]
 |=======================
-| Hardware source files:  | neorv32_xbus.vhd   | External bus gateway
-| Software driver files:  | none               |
-| Top entity ports:       | `xbus_adr_o`       | address output (32-bit)
-|                         | `xbus_dat_i`       | data input (32-bit)
-|                         | `xbus_dat_o`       | data output (32-bit)
-|                         | `xbus_cti_o`       | cycle type (3-bit)
-|                         | `xbus_tag_o`       | access tag (3-bit)
-|                         | `xbus_we_o`        | write enable (1-bit)
-|                         | `xbus_sel_o`       | byte enable (4-bit)
-|                         | `xbus_stb_o`       | bus strobe (1-bit)
-|                         | `xbus_cyc_o`       | valid cycle (1-bit)
-|                         | `xbus_ack_i`       | acknowledge (1-bit)
-|                         | `xbus_err_i`       | bus error (1-bit)
-| Configuration generics: | `XBUS_EN`          | enable external bus interface when `true`
-|                         | `XBUS_TIMEOUT`     | number of clock cycles after which an unacknowledged external bus access will auto-terminate (0 = disabled)
-|                         | `XBUS_REGSTAGE_EN` | implement XBUS register stages
-| CPU interrupts:         | none               |
+| Hardware source files:  | neorv32_xbus.vhd     | External bus gateway
+| Software driver files:  | none                 |
+| Top entity ports:       | `xbus_adr_o`         | address output (32-bit)
+|                         | `xbus_dat_i`         | data input (32-bit)
+|                         | `xbus_dat_o`         | data output (32-bit)
+|                         | `xbus_cti_o`         | cycle type (3-bit)
+|                         | `xbus_tag_o`         | access tag (3-bit)
+|                         | `xbus_we_o`          | write enable (1-bit)
+|                         | `xbus_sel_o`         | byte enable (4-bit)
+|                         | `xbus_stb_o`         | bus strobe (1-bit)
+|                         | `xbus_cyc_o`         | valid cycle (1-bit)
+|                         | `xbus_ack_i`         | acknowledge (1-bit)
+|                         | `xbus_err_i`         | bus error (1-bit)
+| Configuration generics: | `XBUS_EN`            | enable external bus interface when `true`
+|                         | `XBUS_TIMEOUT`       | number of clock cycles after which an unacknowledged external bus access will auto-terminate (0 = disabled)
+|                         | `XBUS_REGSTAGE_EN`   | implement XBUS register stages
+|                         | (`CACHE_BLOCK_SIZE`) | burst size
+|                         | (`CACHE_BURSTS_EN`)  | enable burst transfers for cache update
+| CPU interrupts:         | none                 |
 |=======================
 
 
@@ -33,10 +35,10 @@ peripheral devices.
 
 .Burst Transfers
 [IMPORTANT]
-If any cache (<<_processor_internal_instruction_cache_icache>>, <<_processor_internal_data_cache_dcache>>) is
-enabled, this also means that cache block transfers are **always executed as burst transfers**. There is no
-possibility to execute the cache block transfers as single bus transactions. Therefore, all devices,
-memories and endpoints that can be accessed by the cache must also be able to process bursts.
+If any cache (<<_processor_internal_instruction_cache_icache,i-cache>> or <<_processor_internal_data_cache_dcache, d-cache>>)
+is implemented and bursts are globally enabled (by the `CACHE_BURSTS_EN` top generic) all cache block transfers are
+**always executed as burst transfers** with a burst size equal to the cache block size (`CACHE_BLOCK_SIZE` top generic).
+Burst transfers should **not** be enabled if any external module mapped to _cached_ <<_address_space>> does not support bursts.
 
 .Address Mapping
 [NOTE]

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110806"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110807"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -859,6 +859,7 @@ package neorv32_package is
       DCACHE_EN             : boolean                        := false;
       DCACHE_NUM_BLOCKS     : natural range 1 to 4096        := 4;
       CACHE_BLOCK_SIZE      : natural range 8 to 1024        := 64;
+      CACHE_BURSTS_EN       : boolean                        := true;
       -- External bus interface (XBUS) --
       XBUS_EN               : boolean                        := false;
       XBUS_TIMEOUT          : natural                        := 255;

--- a/rtl/core/neorv32_sysinfo.vhd
+++ b/rtl/core/neorv32_sysinfo.vhd
@@ -31,6 +31,7 @@ entity neorv32_sysinfo is
     DCACHE_EN         : boolean; -- implement data cache
     DCACHE_NUM_BLOCKS : natural; -- d-cache: number of blocks (min 2), has to be a power of 2
     CACHE_BLOCK_SIZE  : natural; -- i-cache/d-cache: block size in bytes (min 4), has to be a power of 2
+    CACHE_BURSTS_EN   : boolean; -- i-cache/d-cache: enable issuing of burst transfer for cache update
     XBUS_EN           : boolean; -- implement external memory bus interface
     OCD_EN            : boolean; -- implement OCD
     OCD_AUTH          : boolean; -- implement OCD authenticator
@@ -146,7 +147,11 @@ begin
   sysinfo(3)(11 downto 8)  <= std_ulogic_vector(to_unsigned(log2_c_bsize_c, 4)) when DCACHE_EN else (others => '0'); -- d-cache: log2(block_size)
   sysinfo(3)(15 downto 12) <= std_ulogic_vector(to_unsigned(log2_dc_bnum_c, 4)) when DCACHE_EN else (others => '0'); -- d-cache: log2(num_blocks)
   --
-  sysinfo(3)(31 downto 16) <= (others => '0'); -- reserved
+  sysinfo(3)(16) <= '1' when (ICACHE_EN and CACHE_BURSTS_EN) else '0'; -- i-cache: enable burst transfers
+  sysinfo(3)(23 downto 17) <= (others => '0'); -- reserved
+  --
+  sysinfo(3)(24) <= '1' when (DCACHE_EN and CACHE_BURSTS_EN) else '0'; -- d-cache: enable burst transfers
+  sysinfo(3)(31 downto 25) <= (others => '0'); -- reserved
 
   -- Bus Response ---------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -93,6 +93,7 @@ entity neorv32_top is
     DCACHE_EN             : boolean                        := false;       -- implement data cache (d-cache)
     DCACHE_NUM_BLOCKS     : natural range 1 to 4096        := 4;           -- d-cache: number of blocks (min 1), has to be a power of 2
     CACHE_BLOCK_SIZE      : natural range 8 to 1024        := 64;          -- i-cache/d-cache: block size in bytes (min 8), has to be a power of 2
+    CACHE_BURSTS_EN       : boolean                        := true;        -- i-cache/d-cache: enable issuing of burst transfer for cache update
 
     -- External bus interface (XBUS) --
     XBUS_EN               : boolean                        := false;       -- implement external memory bus interface
@@ -552,7 +553,8 @@ begin
         NUM_BLOCKS => ICACHE_NUM_BLOCKS,
         BLOCK_SIZE => CACHE_BLOCK_SIZE,
         UC_BEGIN   => mem_uncached_begin_c(31 downto 28),
-        READ_ONLY  => true
+        READ_ONLY  => true,
+        BURSTS_EN  => CACHE_BURSTS_EN
       )
       port map (
         clk_i      => clk_i,
@@ -580,7 +582,8 @@ begin
         NUM_BLOCKS => DCACHE_NUM_BLOCKS,
         BLOCK_SIZE => CACHE_BLOCK_SIZE,
         UC_BEGIN   => mem_uncached_begin_c(31 downto 28),
-        READ_ONLY  => false
+        READ_ONLY  => false,
+        BURSTS_EN  => CACHE_BURSTS_EN
       )
       port map (
         clk_i      => clk_i,
@@ -1515,6 +1518,7 @@ begin
         DCACHE_EN         => DCACHE_EN,
         DCACHE_NUM_BLOCKS => DCACHE_NUM_BLOCKS,
         CACHE_BLOCK_SIZE  => CACHE_BLOCK_SIZE,
+        CACHE_BURSTS_EN   => CACHE_BURSTS_EN,
         XBUS_EN           => XBUS_EN,
         OCD_EN            => OCD_EN,
         OCD_AUTH          => ocd_auth_en_c,

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -208,6 +208,7 @@ proc setup_ip_gui {} {
   add_params $group {
     { XBUS_EN          {Enable XBUS} }
     { XBUS_REGSTAGE_EN {Add register stages} {In/out register stages; relaxes timing, but will increase latency} {$XBUS_EN} }
+    { CACHE_BURSTS_EN  {Enable AXI bursts}   {For I-/D-cache accesses only}                                      {$XBUS_EN} }
   }
 
   set group [add_group $page {Stream Link Interface (SLINK / AXI4-Stream Source & Sink)}]

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -88,6 +88,7 @@ entity neorv32_vivado_ip is
     DCACHE_EN             : boolean                        := false;
     DCACHE_NUM_BLOCKS     : natural range 1 to 4096        := 4;
     CACHE_BLOCK_SIZE      : natural range 8 to 1024        := 64;
+    CACHE_BURSTS_EN       : boolean                        := true;
     -- External Bus Interface --
     XBUS_EN               : boolean                        := false;
     XBUS_REGSTAGE_EN      : boolean                        := false;
@@ -262,7 +263,7 @@ architecture neorv32_vivado_ip_rtl of neorv32_vivado_ip is
   -- auto-configuration --
   constant num_gpio_c : natural := cond_sel_natural_f(IO_GPIO_EN, max_natural_f(IO_GPIO_IN_NUM, IO_GPIO_OUT_NUM), 0);
   constant num_pwm_c  : natural := cond_sel_natural_f(IO_PWM_EN, IO_PWM_NUM_CH, 0);
-  constant burst_en_c : boolean := ICACHE_EN or DCACHE_EN; -- any cache bursts?
+  constant burst_en_c : boolean := CACHE_BURSTS_EN and (ICACHE_EN or DCACHE_EN); -- any cache bursts?
 
   -- AXI4 bridge --
   component xbus2axi4_bridge
@@ -417,6 +418,7 @@ begin
     DCACHE_EN           => DCACHE_EN,
     DCACHE_NUM_BLOCKS   => DCACHE_NUM_BLOCKS,
     CACHE_BLOCK_SIZE    => CACHE_BLOCK_SIZE,
+    CACHE_BURSTS_EN     => burst_en_c,
     -- External bus interface --
     XBUS_EN             => XBUS_EN,
     XBUS_TIMEOUT        => 0, -- AXI does not allow any timeouts

--- a/rtl/system_integration/xbus2axi4_bridge.vhd
+++ b/rtl/system_integration/xbus2axi4_bridge.vhd
@@ -106,13 +106,17 @@ begin
 
         when S_BURST_RUN => -- burst read transfer in progress
         -- ------------------------------------------------------------
-          if (m_axi_rlast = '1') then -- burst completed by device
+          if not BURST_EN then -- burst not supported
+            state <= S_IDLE;
+          elsif (m_axi_rlast = '1') then -- burst completed by device
             state <= S_BURST_END;
           end if;
 
         when S_BURST_END => -- end of burst
         -- ------------------------------------------------------------
-          if (xbus_cti_i = "000") then -- burst completed by host
+          if not BURST_EN then -- burst not supported
+            state <= S_IDLE;
+          elsif (xbus_cti_i = "000") then -- burst completed by host
             state <= S_IDLE;
           end if;
 

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -59,6 +59,7 @@ entity neorv32_tb is
     DCACHE_EN           : boolean                        := true;        -- implement data cache
     DCACHE_NUM_BLOCKS   : natural range 1 to 4096        := 32;          -- d-cache: number of blocks (min 1), has to be a power of 2
     CACHE_BLOCK_SIZE    : natural range 8 to 1024        := 32;          -- i-cache/d-cache: block size in bytes (min 8), has to be a power of 2
+    CACHE_BURSTS_EN     : boolean                        := true;        -- enable issuing of burst transfer for cache update
     TRACE_LOG_EN        : boolean                        := true;        -- write full trace log to file
     -- external memory A --
     EXT_MEM_A_EN        : boolean                        := false;       -- enable memory
@@ -183,6 +184,7 @@ begin
     DCACHE_EN           => DCACHE_EN,
     DCACHE_NUM_BLOCKS   => DCACHE_NUM_BLOCKS,
     CACHE_BLOCK_SIZE    => CACHE_BLOCK_SIZE,
+    CACHE_BURSTS_EN     => CACHE_BURSTS_EN,
     -- External bus interface --
     XBUS_EN             => true,
     XBUS_TIMEOUT        => 64,

--- a/sw/lib/include/neorv32_sysinfo.h
+++ b/sw/lib/include/neorv32_sysinfo.h
@@ -77,15 +77,18 @@ enum NEORV32_SYSINFO_SOC_enum {
 
 /** NEORV32_SYSINFO.CACHE (r/-): Cache configuration */
  enum NEORV32_SYSINFO_CACHE_enum {
-  SYSINFO_CACHE_INST_BLOCK_SIZE_0 =  0, /**< SYSINFO_CACHE  (0) (r/-): i-cache: log2(Block size in bytes), bit 0 (via ICACHE_BLOCK_SIZE generic) */
-  SYSINFO_CACHE_INST_BLOCK_SIZE_3 =  3, /**< SYSINFO_CACHE  (3) (r/-): i-cache: log2(Block size in bytes), bit 3 (via ICACHE_BLOCK_SIZE generic) */
+  SYSINFO_CACHE_INST_BLOCK_SIZE_0 =  0, /**< SYSINFO_CACHE  (0) (r/-): i-cache: log2(Block size in bytes), bit 0 (via CACHE_BLOCK_SIZE generic) */
+  SYSINFO_CACHE_INST_BLOCK_SIZE_3 =  3, /**< SYSINFO_CACHE  (3) (r/-): i-cache: log2(Block size in bytes), bit 3 (via CACHE_BLOCK_SIZE generic) */
   SYSINFO_CACHE_INST_NUM_BLOCKS_0 =  4, /**< SYSINFO_CACHE  (4) (r/-): i-cache: log2(Number of cache blocks), bit 0 (via ICACHE_NUM_BLOCKS generic) */
   SYSINFO_CACHE_INST_NUM_BLOCKS_3 =  7, /**< SYSINFO_CACHE  (7) (r/-): i-cache: log2(Number of cache blocks), bit 3 (via ICACHE_NUM_BLOCKS generic) */
 
-  SYSINFO_CACHE_DATA_BLOCK_SIZE_0 =  8, /**< SYSINFO_CACHE  (8) (r/-): d-cache: log2(Block size in bytes), bit 0 (via DCACHE_BLOCK_SIZE generic) */
-  SYSINFO_CACHE_DATA_BLOCK_SIZE_3 = 11, /**< SYSINFO_CACHE (11) (r/-): d-cache: log2(Block size in bytes), bit 3 (via DCACHE_BLOCK_SIZE generic) */
+  SYSINFO_CACHE_DATA_BLOCK_SIZE_0 =  8, /**< SYSINFO_CACHE  (8) (r/-): d-cache: log2(Block size in bytes), bit 0 (via CACHE_BLOCK_SIZE generic) */
+  SYSINFO_CACHE_DATA_BLOCK_SIZE_3 = 11, /**< SYSINFO_CACHE (11) (r/-): d-cache: log2(Block size in bytes), bit 3 (via CACHE_BLOCK_SIZE generic) */
   SYSINFO_CACHE_DATA_NUM_BLOCKS_0 = 12, /**< SYSINFO_CACHE (12) (r/-): d-cache: log2(Number of cache blocks), bit 0 (via DCACHE_NUM_BLOCKS generic) */
-  SYSINFO_CACHE_DATA_NUM_BLOCKS_3 = 15  /**< SYSINFO_CACHE (15) (r/-): d-cache: log2(Number of cache blocks), bit 3 (via DCACHE_NUM_BLOCKS generic) */
+  SYSINFO_CACHE_DATA_NUM_BLOCKS_3 = 15, /**< SYSINFO_CACHE (15) (r/-): d-cache: log2(Number of cache blocks), bit 3 (via DCACHE_NUM_BLOCKS generic) */
+
+  SYSINFO_CACHE_INST_BURSTS_EN    = 16, /**< SYSINFO_CACHE (16) (r/-): i-cache: issue burst transfers or cache update (via CACHE_BURSTS_EN generic) */
+  SYSINFO_CACHE_DATA_BURSTS_EN    = 24  /**< SYSINFO_CACHE (14) (r/-): d-cache: issue burst transfers or cache update (via CACHE_BURSTS_EN generic) */
 };
 /**@}*/
 

--- a/sw/lib/source/neorv32_aux.c
+++ b/sw/lib/source/neorv32_aux.c
@@ -332,7 +332,7 @@ void neorv32_aux_print_hw_config(void) {
   neorv32_aux_print_hw_version(neorv32_cpu_csr_read(CSR_MIMPID));
   neorv32_uart0_printf(")\n");
 
-  // CPU architecture and endianness
+  // CPU architecture and Endianness
   neorv32_uart0_printf("Architecture:        ");
   tmp = neorv32_cpu_csr_read(CSR_MISA);
   tmp = (tmp >> 30) & 0x03;
@@ -464,10 +464,16 @@ void neorv32_aux_print_hw_config(void) {
     uint32_t ic_num_blocks = (NEORV32_SYSINFO->CACHE >> SYSINFO_CACHE_INST_NUM_BLOCKS_0) & 0x0F;
     ic_num_blocks = 1 << ic_num_blocks;
 
-    neorv32_uart0_printf("%u bytes (%ux%u)\n", ic_num_blocks*ic_block_size, ic_num_blocks, ic_block_size);
+    neorv32_uart0_printf("%u bytes (%ux%u)", ic_num_blocks*ic_block_size, ic_num_blocks, ic_block_size);
   }
   else {
-    neorv32_uart0_printf("none\n");
+    neorv32_uart0_printf("none");
+  }
+  if (NEORV32_SYSINFO->CACHE & (1 << SYSINFO_CACHE_INST_BURSTS_EN)) {
+    neorv32_uart0_printf(", bursts enabled\n");
+  }
+  else {
+    neorv32_uart0_printf("\n");
   }
 
   // CPU d-cache
@@ -480,20 +486,32 @@ void neorv32_aux_print_hw_config(void) {
     uint32_t dc_num_blocks = (NEORV32_SYSINFO->CACHE >> SYSINFO_CACHE_DATA_NUM_BLOCKS_0) & 0x0F;
     dc_num_blocks = 1 << dc_num_blocks;
 
-    neorv32_uart0_printf("%u bytes (%ux%u)\n", dc_num_blocks*dc_block_size, dc_num_blocks, dc_block_size);
+    neorv32_uart0_printf("%u bytes (%ux%u)", dc_num_blocks*dc_block_size, dc_num_blocks, dc_block_size);
   }
   else {
-    neorv32_uart0_printf("none\n");
+    neorv32_uart0_printf("none");
+  }
+  if (NEORV32_SYSINFO->CACHE & (1 << SYSINFO_CACHE_DATA_BURSTS_EN)) {
+    neorv32_uart0_printf(", bursts enabled\n");
+  }
+  else {
+    neorv32_uart0_printf("\n");
   }
 
   // external bus interface
   neorv32_uart0_printf("Ext. bus interface:  ");
   tmp = NEORV32_SYSINFO->SOC;
   if (tmp & (1 << SYSINFO_SOC_XBUS)) {
-    neorv32_uart0_printf("enabled\n");
+    neorv32_uart0_printf("enabled");
   }
   else {
-    neorv32_uart0_printf("none\n");
+    neorv32_uart0_printf("none");
+  }
+  if (NEORV32_SYSINFO->CACHE & ((1 << SYSINFO_CACHE_INST_BURSTS_EN) | (1 << SYSINFO_CACHE_DATA_BURSTS_EN))) {
+    neorv32_uart0_printf(", bursts enabled\n");
+  }
+  else {
+    neorv32_uart0_printf("\n");
   }
 
   // peripherals

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -1784,6 +1784,8 @@
             <field><name>SYSINFO_CACHE_INST_NUM_BLOCKS</name><bitRange>[7:4]</bitRange><description>i-cache: log2(Number of cache blocks)</description></field>
             <field><name>SYSINFO_CACHE_DATA_BLOCK_SIZE</name><bitRange>[11:8]</bitRange><description>d-cache: log2(Block size in bytes)</description></field>
             <field><name>SYSINFO_CACHE_DATA_NUM_BLOCKS</name><bitRange>[15:12]</bitRange><description>d-cache: log2(Number of cache blocks)</description></field>
+            <field><name>SYSINFO_CACHE_INST_BURSTS_EN</name><bitRange>[16:16]</bitRange><description>i-cache: burst transfers enabled</description></field>
+            <field><name>SYSINFO_CACHE_DATA_BURSTS_EN</name><bitRange>[24:24]</bitRange><description>d-cache: burst transfers enabled</description></field>
           </fields>
         </register>
       </registers>


### PR DESCRIPTION
New configuration option that allows you to set whether the caches use burst transfers or only single accesses for cache block update operations:

```vhdl
CACHE_BURSTS_EN : boolean := true; -- i-cache/d-cache: enable issuing of burst transfer for cache update
```

Bursts should only be disabled if modules connected to the external bus interface (AXI) do not support burst transfers. By default bursts are always enabled. Hence, the changes from the PR are fully backwards-compatible.