### PR TITLE
⚠️ [CPU] remove double-trap exception

### DIFF
--- a/rtl/core/neorv32_cpu_decompressor.vhd
+++ b/rtl/core/neorv32_cpu_decompressor.vhd
@@ -348,8 +348,8 @@ begin
             else -- C.EBREAK, C.JALR, C.ADD
               if (instr_i(6 downto 2) = "00000") then -- C.EBREAK, C.JALR
                 if (instr_i(11 downto 7) = "00000") then -- C.EBREAK
-                  decoded(instr_opcode_msb_c downto instr_opcode_lsb_c)   <= opcode_system_c;
-                  decoded(instr_funct12_msb_c downto instr_funct12_lsb_c) <= funct12_ebreak_c;
+                  decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_system_c;
+                  decoded(instr_imm12_msb_c downto instr_imm12_lsb_c)   <= funct12_ebreak_c;
                 else -- C.JALR
                   decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_jalr_c;
                   decoded(instr_rs1_msb_c downto instr_rs1_lsb_c)       <= instr_i(ci_rs1_5_msb_c downto ci_rs1_5_lsb_c);

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110900"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110901"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -269,8 +269,6 @@ package neorv32_package is
   constant instr_rs2_msb_c     : natural := 24; -- source register 2 address bit 4
   constant instr_funct7_lsb_c  : natural := 25; -- funct7 bit 0
   constant instr_funct7_msb_c  : natural := 31; -- funct7 bit 6
-  constant instr_funct12_lsb_c : natural := 20; -- funct12 bit 0
-  constant instr_funct12_msb_c : natural := 31; -- funct12 bit 11
   constant instr_imm12_lsb_c   : natural := 20; -- immediate12 bit 0
   constant instr_imm12_msb_c   : natural := 31; -- immediate12 bit 11
   constant instr_imm20_lsb_c   : natural := 12; -- immediate20 bit 0
@@ -531,7 +529,7 @@ package neorv32_package is
   constant csr_mhartid_c        : std_ulogic_vector(11 downto 0) := x"f14";
   constant csr_mconfigptr_c     : std_ulogic_vector(11 downto 0) := x"f15";
   -- NEORV32-specific machine registers --
---constant csr_mxctrl_c         : std_ulogic_vector(11 downto 0) := x"bc0"; -- to be implemented...
+--constant csr_mxcsr_c          : std_ulogic_vector(11 downto 0) := x"bc0"; -- to be implemented...
   constant csr_mxisa_c          : std_ulogic_vector(11 downto 0) := x"fc0";
 --constant csr_mxisah_c         : std_ulogic_vector(11 downto 0) := x"fc1"; -- to be implemented...
 
@@ -678,7 +676,6 @@ package neorv32_package is
   constant trap_sma_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00110"; -- 6: store address misaligned
   constant trap_saf_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "00111"; -- 7: store access fault
   constant trap_env_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "01000"; -- 8..11: environment call
-  constant trap_dbt_c      : std_ulogic_vector(6 downto 0) := "0" & "0" & "10000"; -- 16: double-trap
   -- RISC-V compliant asynchronous exceptions (interrupts) --
   constant trap_msi_c      : std_ulogic_vector(6 downto 0) := "1" & "0" & "00011"; -- 3:  machine software interrupt
   constant trap_mti_c      : std_ulogic_vector(6 downto 0) := "1" & "0" & "00111"; -- 7:  machine timer interrupt
@@ -718,10 +715,9 @@ package neorv32_package is
   constant exc_lalign_c   : natural :=  6; -- load address misaligned
   constant exc_saccess_c  : natural :=  7; -- store access fault
   constant exc_laccess_c  : natural :=  8; -- load access fault
-  constant exc_doublet_c  : natural :=  9; -- double-trap
-  constant exc_db_break_c : natural := 10; -- enter debug mode via ebreak instruction
-  constant exc_db_hw_c    : natural := 11; -- enter debug mode via hw trigger
-  constant exc_width_c    : natural := 12; -- length of this list in bits
+  constant exc_db_break_c : natural :=  9; -- enter debug mode via ebreak instruction
+  constant exc_db_hw_c    : natural := 10; -- enter debug mode via hw trigger
+  constant exc_width_c    : natural := 11; -- length of this list in bits
   -- interrupt source list --
   constant irq_msi_irq_c  : natural :=  0; -- machine software interrupt
   constant irq_mti_irq_c  : natural :=  1; -- machine timer interrupt

--- a/sw/lib/include/neorv32_cpu_csr.h
+++ b/sw/lib/include/neorv32_cpu_csr.h
@@ -96,7 +96,7 @@ enum NEORV32_CSR_enum {
   CSR_DPC            = 0x7b1, /**< 0x7b1 - dpc:       Debug program counter */
   CSR_DSCRATCH0      = 0x7b2, /**< 0x7b2 - dscratch0: Debug scratch register */
 
-  /* custom functions unit (CFU) registers */
+  /* custom functions unit (CFU) */
   CSR_CFUREG0        = 0x800, /**< 0x800 - cfureg0: custom CFU CSR 0 */
   CSR_CFUREG1        = 0x801, /**< 0x801 - cfureg1: custom CFU CSR 1 */
   CSR_CFUREG2        = 0x802, /**< 0x802 - cfureg2: custom CFU CSR 2 */
@@ -142,13 +142,15 @@ enum NEORV32_CSR_enum {
   CSR_CYCLEH         = 0xc80, /**< 0xc80 - cycleh:        User cycle counter high word */
   CSR_INSTRETH       = 0xc82, /**< 0xc82 - instreth:      User instructions-retired counter high word */
 
-  /* machine information registers */
+  /* machine information */
   CSR_MVENDORID      = 0xf11, /**< 0xf11 - mvendorid:  Machine vendor ID */
   CSR_MARCHID        = 0xf12, /**< 0xf12 - marchid:    Machine architecture ID */
   CSR_MIMPID         = 0xf13, /**< 0xf13 - mimpid:     Machine implementation ID */
   CSR_MHARTID        = 0xf14, /**< 0xf14 - mhartid:    Machine hardware thread ID */
   CSR_MCONFIGPTR     = 0xf15, /**< 0xf15 - mconfigptr: Machine configuration pointer register */
-  CSR_MXISA          = 0xfc0  /**< 0xfc0 - mxisa:      Machine extended ISA and extensions (#NEORV32_CSR_MXISA_enum) */
+
+  /* NEORV32-specific */
+  CSR_MXISA          = 0xfc0  /**< 0xfc0 - mxisa: Machine extended ISA and extensions (#NEORV32_CSR_MXISA_enum) */
 };
 
 
@@ -396,7 +398,6 @@ enum NEORV32_EXCEPTION_CODES_enum {
   TRAP_CODE_S_ACCESS     = 0x00000007U, /**< 0.7:  Store (bus) access fault */
   TRAP_CODE_UENV_CALL    = 0x00000008U, /**< 0.8:  Environment call from user mode (ECALL instruction) */
   TRAP_CODE_MENV_CALL    = 0x0000000bU, /**< 0.11: Environment call from machine mode (ECALL instruction) */
-  TRAP_CODE_DOUBLE_TRAP  = 0x00000010U, /**< 0.16: Double-trap */
   TRAP_CODE_MSI          = 0x80000003U, /**< 1.3:  Machine software interrupt */
   TRAP_CODE_MTI          = 0x80000007U, /**< 1.7:  Machine timer interrupt */
   TRAP_CODE_MEI          = 0x8000000bU, /**< 1.11: Machine external interrupt */


### PR DESCRIPTION
Removing the double-trap trap (introduced in #1294):
* it is not RISC-V-compatible (`Smdbltrp` would be)
* it is not possible to determine the cause of the double-trap
* the impact on the trap logic is way too high

However, a double-trap detection mechanism similat to th eone found in Ibex might be added in the future (https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html#double-fault-detect).