### PR TITLE
minor fixes and optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 09.08.2025 | 1.11.9.2 | minor fixes and optimizations | [#1333](https://github.com/stnolting/neorv32/pull/1333) |
 | 08.08.2025 | 1.11.9.1 | :warning: remove double-trap exception | [#1332](https://github.com/stnolting/neorv32/pull/1332) |
 | 03.08.2025 | [**1.11.9**](https://github.com/stnolting/neorv32/releases/tag/v1.11.9) | :rocket: **New release** | |
 | 03.08.2025 | 1.11.8.9 | minor rtl edits and cleanups | [#1331](https://github.com/stnolting/neorv32/pull/1331) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -656,48 +656,49 @@ defined by the NEORV32 core library (the runtime environment _RTE_) and can be u
 with the pre-defined RTE function. The <<_mcause>>, <<_mepc>>, <<_mtval>> and <<_mtinst>> columns show the value being
 written to the according CSRs when a trap is triggered:
 
-* **I-PC** - address of intercepted instruction (instruction has _not_ been executed yet)
+* **I-PC** - address of intercepted instruction (next instruction in program flow; instruction has _not_ been executed yet)
 * **PC** - address of instruction that caused the trap (instruction has been executed)
-* **ADR** - bad data memory access address that caused the trap
-* **INS** - the transformed/decompressed instruction word that caused the trap
+* **ADDR** - bad data memory access address that caused the trap
+* **INST** - the actual transformed/decompressed instruction word that caused the trap
+* **LAST** - the last transformed/decompressed instruction word that was executed before the trap
 * **0** - zero
 
 .NEORV32 Trap Listing
 [cols="1,4,8,10,2,2,2"]
 [options="header",grid="rows"]
 |=======================
-| Prio. | `mcause`     | RTE Trap ID              | Cause                                | `mepc` | `mtval` | `mtinst`
+| Prio. | `mcause`     | RTE Trap ID              | Cause                             | `mepc` | `mtval` | `mtinst`
 8+^| **Exceptions** (_synchronous_ to instruction execution)
-| 1     | `0x00000001` | `TRAP_CODE_I_ACCESS`     | instruction access fault             | I-PC   | 0       | INS
-| 2     | `0x00000002` | `TRAP_CODE_I_ILLEGAL`    | illegal instruction                  | PC     | 0       | INS
-| 3     | `0x00000000` | `TRAP_CODE_I_MISALIGNED` | instruction address misaligned       | PC     | 0       | INS
-| 4     | `0x0000000b` | `TRAP_CODE_MENV_CALL`    | environment call from M-mode         | PC     | 0       | INS
-| 5     | `0x00000008` | `TRAP_CODE_UENV_CALL`    | environment call from U-mode         | PC     | 0       | INS
-| 6     | `0x00000003` | `TRAP_CODE_BREAKPOINT`   | software breakpoint / trigger firing | PC     | 0       | INS
-| 7     | `0x00000006` | `TRAP_CODE_S_MISALIGNED` | store address misaligned             | PC     | ADR     | INS
-| 8     | `0x00000004` | `TRAP_CODE_L_MISALIGNED` | load address misaligned              | PC     | ADR     | INS
-| 9     | `0x00000007` | `TRAP_CODE_S_ACCESS`     | store access fault                   | PC     | ADR     | INS
-| 10    | `0x00000005` | `TRAP_CODE_L_ACCESS`     | load access fault                    | PC     | ADR     | INS
+| 1     | `0x00000001` | `TRAP_CODE_I_ACCESS`     | instruction access fault          | I-PC   | 0       | _undefined_
+| 2     | `0x00000002` | `TRAP_CODE_I_ILLEGAL`    | illegal instruction               | PC     | 0       | INST
+| 3     | `0x00000000` | `TRAP_CODE_I_MISALIGNED` | instruction address misaligned    | PC     | 0       | INST
+| 4     | `0x0000000b` | `TRAP_CODE_MENV_CALL`    | environment call from M-mode      | PC     | 0       | INST
+| 5     | `0x00000008` | `TRAP_CODE_UENV_CALL`    | environment call from U-mode      | PC     | 0       | INST
+| 6     | `0x00000003` | `TRAP_CODE_BREAKPOINT`   | software breakpoint / HW trigger  | PC     | 0       | INST
+| 7     | `0x00000006` | `TRAP_CODE_S_MISALIGNED` | store address misaligned          | PC     | ADDR    | INST
+| 8     | `0x00000004` | `TRAP_CODE_L_MISALIGNED` | load address misaligned           | PC     | ADDR    | INST
+| 9     | `0x00000007` | `TRAP_CODE_S_ACCESS`     | store access fault                | PC     | ADDR    | INST
+| 10    | `0x00000005` | `TRAP_CODE_L_ACCESS`     | load access fault                 | PC     | ADDR    | INST
 8+^| **Interrupts** (_asynchronous_ to instruction execution)
-| 11    | `0x80000010` | `TRAP_CODE_FIRQ_0`       | fast interrupt request channel 0     | I-PC   | 0       | 0
-| 12    | `0x80000011` | `TRAP_CODE_FIRQ_1`       | fast interrupt request channel 1     | I-PC   | 0       | 0
-| 13    | `0x80000012` | `TRAP_CODE_FIRQ_2`       | fast interrupt request channel 2     | I-PC   | 0       | 0
-| 14    | `0x80000013` | `TRAP_CODE_FIRQ_3`       | fast interrupt request channel 3     | I-PC   | 0       | 0
-| 15    | `0x80000014` | `TRAP_CODE_FIRQ_4`       | fast interrupt request channel 4     | I-PC   | 0       | 0
-| 16    | `0x80000015` | `TRAP_CODE_FIRQ_5`       | fast interrupt request channel 5     | I-PC   | 0       | 0
-| 17    | `0x80000016` | `TRAP_CODE_FIRQ_6`       | fast interrupt request channel 6     | I-PC   | 0       | 0
-| 18    | `0x80000017` | `TRAP_CODE_FIRQ_7`       | fast interrupt request channel 7     | I-PC   | 0       | 0
-| 19    | `0x80000018` | `TRAP_CODE_FIRQ_8`       | fast interrupt request channel 8     | I-PC   | 0       | 0
-| 20    | `0x80000019` | `TRAP_CODE_FIRQ_9`       | fast interrupt request channel 9     | I-PC   | 0       | 0
-| 21    | `0x8000001a` | `TRAP_CODE_FIRQ_10`      | fast interrupt request channel 10    | I-PC   | 0       | 0
-| 22    | `0x8000001b` | `TRAP_CODE_FIRQ_11`      | fast interrupt request channel 11    | I-PC   | 0       | 0
-| 23    | `0x8000001c` | `TRAP_CODE_FIRQ_12`      | fast interrupt request channel 12    | I-PC   | 0       | 0
-| 24    | `0x8000001d` | `TRAP_CODE_FIRQ_13`      | fast interrupt request channel 13    | I-PC   | 0       | 0
-| 25    | `0x8000001e` | `TRAP_CODE_FIRQ_14`      | fast interrupt request channel 14    | I-PC   | 0       | 0
-| 26    | `0x8000001f` | `TRAP_CODE_FIRQ_15`      | fast interrupt request channel 15    | I-PC   | 0       | 0
-| 27    | `0x8000000b` | `TRAP_CODE_MEI`          | machine external interrupt (MEI)     | I-PC   | 0       | 0
-| 28    | `0x80000003` | `TRAP_CODE_MSI`          | machine software interrupt (MSI)     | I-PC   | 0       | 0
-| 29    | `0x80000007` | `TRAP_CODE_MTI`          | machine timer interrupt (MTI)        | I-PC   | 0       | 0
+| 11    | `0x80000010` | `TRAP_CODE_FIRQ_0`       | fast interrupt request channel 0  | I-PC   | 0       | LAST
+| 12    | `0x80000011` | `TRAP_CODE_FIRQ_1`       | fast interrupt request channel 1  | I-PC   | 0       | LAST
+| 13    | `0x80000012` | `TRAP_CODE_FIRQ_2`       | fast interrupt request channel 2  | I-PC   | 0       | LAST
+| 14    | `0x80000013` | `TRAP_CODE_FIRQ_3`       | fast interrupt request channel 3  | I-PC   | 0       | LAST
+| 15    | `0x80000014` | `TRAP_CODE_FIRQ_4`       | fast interrupt request channel 4  | I-PC   | 0       | LAST
+| 16    | `0x80000015` | `TRAP_CODE_FIRQ_5`       | fast interrupt request channel 5  | I-PC   | 0       | LAST
+| 17    | `0x80000016` | `TRAP_CODE_FIRQ_6`       | fast interrupt request channel 6  | I-PC   | 0       | LAST
+| 18    | `0x80000017` | `TRAP_CODE_FIRQ_7`       | fast interrupt request channel 7  | I-PC   | 0       | LAST
+| 19    | `0x80000018` | `TRAP_CODE_FIRQ_8`       | fast interrupt request channel 8  | I-PC   | 0       | LAST
+| 20    | `0x80000019` | `TRAP_CODE_FIRQ_9`       | fast interrupt request channel 9  | I-PC   | 0       | LAST
+| 21    | `0x8000001a` | `TRAP_CODE_FIRQ_10`      | fast interrupt request channel 10 | I-PC   | 0       | LAST
+| 22    | `0x8000001b` | `TRAP_CODE_FIRQ_11`      | fast interrupt request channel 11 | I-PC   | 0       | LAST
+| 23    | `0x8000001c` | `TRAP_CODE_FIRQ_12`      | fast interrupt request channel 12 | I-PC   | 0       | LAST
+| 24    | `0x8000001d` | `TRAP_CODE_FIRQ_13`      | fast interrupt request channel 13 | I-PC   | 0       | LAST
+| 25    | `0x8000001e` | `TRAP_CODE_FIRQ_14`      | fast interrupt request channel 14 | I-PC   | 0       | LAST
+| 26    | `0x8000001f` | `TRAP_CODE_FIRQ_15`      | fast interrupt request channel 15 | I-PC   | 0       | LAST
+| 27    | `0x8000000b` | `TRAP_CODE_MEI`          | machine external interrupt (MEI)  | I-PC   | 0       | LAST
+| 28    | `0x80000003` | `TRAP_CODE_MSI`          | machine software interrupt (MSI)  | I-PC   | 0       | LAST
+| 29    | `0x80000007` | `TRAP_CODE_MTI`          | machine timer interrupt (MTI)     | I-PC   | 0       | LAST
 |=======================
 
 .NEORV32 Trap Description

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1239,22 +1239,6 @@ begin
         case csr.addr is
 
           -- --------------------------------------------------------------------
-          -- floating-point unit
-          -- --------------------------------------------------------------------
-          when csr_fflags_c | csr_frm_c | csr_fcsr_c =>
-            if RISCV_ISA_Zfinx then
-              csr.rdata <= xcsr_rdata_i; -- implemented externally
-            end if;
-
-          -- --------------------------------------------------------------------
-          -- custom functions unit (NEORV32-specific)
-          -- --------------------------------------------------------------------
-          when csr_cfureg0_c | csr_cfureg1_c | csr_cfureg2_c | csr_cfureg3_c =>
-            if RISCV_ISA_Zxcfu then
-              csr.rdata <= xcsr_rdata_i; -- implemented externally
-            end if;
-
-          -- --------------------------------------------------------------------
           -- machine trap setup
           -- --------------------------------------------------------------------
           when csr_mstatus_c => -- machine status register, low word
@@ -1263,8 +1247,6 @@ begin
             csr.rdata(12 downto 11) <= (others => csr.mstatus_mpp);
             csr.rdata(17) <= csr.mstatus_mprv;
             csr.rdata(21) <= csr.mstatus_tw and bool_to_ulogic_f(RISCV_ISA_U);
-
---        when csr_mstatush_c => csr.rdata <= (others => '0'); -- machine status register, high word - hardwired to zero
 
           when csr_misa_c => -- ISA and extensions
             csr.rdata(0)  <= bool_to_ulogic_f(RISCV_ISA_A);
@@ -1293,12 +1275,6 @@ begin
             end if;
 
           -- --------------------------------------------------------------------
-          -- machine configuration
-          -- --------------------------------------------------------------------
---        when csr_menvcfg_c  => csr.rdata <= (others => '0'); -- hardwired to zero
---        when csr_menvcfgh_c => csr.rdata <= (others => '0'); -- hardwired to zero
-
-          -- --------------------------------------------------------------------
           -- machine trap handling
           -- --------------------------------------------------------------------
           when csr_mscratch_c => -- machine scratch register
@@ -1324,18 +1300,6 @@ begin
             csr.rdata <= csr.mtinst;
 
           -- --------------------------------------------------------------------
-          -- physical memory protection
-          -- --------------------------------------------------------------------
-          when csr_pmpcfg0_c   | csr_pmpcfg1_c   | csr_pmpcfg2_c   | csr_pmpcfg3_c   |
-               csr_pmpaddr0_c  | csr_pmpaddr1_c  | csr_pmpaddr2_c  | csr_pmpaddr3_c  |
-               csr_pmpaddr4_c  | csr_pmpaddr5_c  | csr_pmpaddr6_c  | csr_pmpaddr7_c  |
-               csr_pmpaddr8_c  | csr_pmpaddr9_c  | csr_pmpaddr10_c | csr_pmpaddr11_c |
-               csr_pmpaddr12_c | csr_pmpaddr13_c | csr_pmpaddr14_c | csr_pmpaddr15_c =>
-            if RISCV_ISA_Smpmp then
-              csr.rdata <= xcsr_rdata_i; -- implemented externally
-            end if;
-
-          -- --------------------------------------------------------------------
           -- machine counter setup
           -- --------------------------------------------------------------------
           when csr_mcountinhibit_c => -- machine counter-inhibit register
@@ -1347,52 +1311,12 @@ begin
               csr.rdata(15 downto 3) <= csr.mcountinhibit(15 downto 3); -- [m]hpmcounter*[h]
             end if;
 
-          -- HPM event configuration --
-          when csr_mhpmevent3_c  | csr_mhpmevent4_c  | csr_mhpmevent5_c  | csr_mhpmevent6_c  |
-               csr_mhpmevent7_c  | csr_mhpmevent8_c  | csr_mhpmevent9_c  | csr_mhpmevent10_c |
-               csr_mhpmevent11_c | csr_mhpmevent12_c | csr_mhpmevent13_c | csr_mhpmevent14_c |
-               csr_mhpmevent15_c =>
-            if RISCV_ISA_Zihpm then
-              csr.rdata <= xcsr_rdata_i; -- implemented externally
-            end if;
-
-          -- --------------------------------------------------------------------
-          -- counters and timers
-          -- --------------------------------------------------------------------
-          -- base counters --
-          when csr_cycle_c   | csr_cycleh_c   | csr_mcycle_c   | csr_mcycleh_c   |
-               csr_time_c    | csr_timeh_c    | csr_mtime_c    | csr_mtimeh_c    |
-               csr_instret_c | csr_instreth_c | csr_minstret_c | csr_minstreth_c =>
-            if RISCV_ISA_Zicntr then
-              csr.rdata <= xcsr_rdata_i; -- implemented externally
-            end if;
-
-          -- hardware performance monitors --
-          when csr_hpmcounter3_c  | csr_hpmcounter3h_c  | csr_mhpmcounter3_c  | csr_mhpmcounter3h_c  |
-               csr_hpmcounter4_c  | csr_hpmcounter4h_c  | csr_mhpmcounter4_c  | csr_mhpmcounter4h_c  |
-               csr_hpmcounter5_c  | csr_hpmcounter5h_c  | csr_mhpmcounter5_c  | csr_mhpmcounter5h_c  |
-               csr_hpmcounter6_c  | csr_hpmcounter6h_c  | csr_mhpmcounter6_c  | csr_mhpmcounter6h_c  |
-               csr_hpmcounter7_c  | csr_hpmcounter7h_c  | csr_mhpmcounter7_c  | csr_mhpmcounter7h_c  |
-               csr_hpmcounter8_c  | csr_hpmcounter8h_c  | csr_mhpmcounter8_c  | csr_mhpmcounter8h_c  |
-               csr_hpmcounter9_c  | csr_hpmcounter9h_c  | csr_mhpmcounter9_c  | csr_mhpmcounter9h_c  |
-               csr_hpmcounter10_c | csr_hpmcounter10h_c | csr_mhpmcounter10_c | csr_mhpmcounter10h_c |
-               csr_hpmcounter11_c | csr_hpmcounter11h_c | csr_mhpmcounter11_c | csr_mhpmcounter11h_c |
-               csr_hpmcounter12_c | csr_hpmcounter12h_c | csr_mhpmcounter12_c | csr_mhpmcounter12h_c |
-               csr_hpmcounter13_c | csr_hpmcounter13h_c | csr_mhpmcounter13_c | csr_mhpmcounter13h_c |
-               csr_hpmcounter14_c | csr_hpmcounter14h_c | csr_mhpmcounter14_c | csr_mhpmcounter14h_c |
-               csr_hpmcounter15_c | csr_hpmcounter15h_c | csr_mhpmcounter15_c | csr_mhpmcounter15h_c =>
-            if RISCV_ISA_Zihpm then
-              csr.rdata <= xcsr_rdata_i; -- implemented externally
-            end if;
-
           -- --------------------------------------------------------------------
           -- machine information
           -- --------------------------------------------------------------------
---        when csr_mvendorid_c  => csr.rdata <= (others => '0'); -- vendor's JEDEC ID
-          when csr_marchid_c    => csr.rdata(4 downto 0) <= "10011"; -- architecture ID - official RISC-V open-source arch ID
-          when csr_mimpid_c     => csr.rdata <= hw_version_c; -- implementation ID -- NEORV32 hardware version
-          when csr_mhartid_c    => csr.rdata(9 downto 0) <= std_ulogic_vector(to_unsigned(HART_ID, 10)); -- hardware thread ID
---        when csr_mconfigptr_c => csr.rdata <= (others => '0'); -- machine configuration pointer register - hardwired to zero
+          when csr_marchid_c => csr.rdata(4 downto 0) <= "10011"; -- architecture ID - official RISC-V open-source arch ID
+          when csr_mimpid_c  => csr.rdata <= hw_version_c; -- implementation ID -- NEORV32 hardware version
+          when csr_mhartid_c => csr.rdata(9 downto 0) <= std_ulogic_vector(to_unsigned(HART_ID, 10)); -- hardware thread ID
 
           -- --------------------------------------------------------------------
           -- debug-mode
@@ -1400,14 +1324,6 @@ begin
           when csr_dcsr_c      => if RISCV_ISA_Sdext then csr.rdata <= csr.dcsr_rd;   end if; -- debug mode control and status
           when csr_dpc_c       => if RISCV_ISA_Sdext then csr.rdata <= csr.dpc;       end if; -- debug mode program counter
           when csr_dscratch0_c => if RISCV_ISA_Sdext then csr.rdata <= csr.dscratch0; end if; -- debug mode scratch register 0
-
-          -- --------------------------------------------------------------------
-          -- trigger module
-          -- --------------------------------------------------------------------
-          when csr_tselect_c | csr_tdata1_c | csr_tdata2_c | csr_tinfo_c =>
-            if RISCV_ISA_Sdtrig then
-              csr.rdata <= xcsr_rdata_i; -- implemented externally
-            end if;
 
           -- --------------------------------------------------------------------
           -- NEORV32-specific
@@ -1451,9 +1367,10 @@ begin
             csr.rdata(31) <= bool_to_ulogic_f(is_simulation_c);   -- is this a simulation?
 
           -- --------------------------------------------------------------------
-          -- undefined/unavailable
+          -- undefined/unavailable or implemented externally
           -- --------------------------------------------------------------------
-          when others => NULL; -- use default: read as zero
+          when others => -- FPU, CFU, PMP, HPM, base counters, trigger module
+            csr.rdata <= xcsr_rdata_i; -- return zero if accessing invalid external CSR
 
         end case;
       end if;

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1142,13 +1142,9 @@ begin
             csr.mtval <= (others => '0');
           end if;
           -- trap instruction --
-          if (trap_ctrl.cause(6) = '0') then -- exception
-            csr.mtinst <= exe_engine.ir;
-            if (exe_engine.ci = '1') and RISCV_ISA_C then
-              csr.mtinst(1) <= '0'; -- RISC-V priv. spec: clear bit 1 if compressed instruction
-            end if;
-          else -- interrupt
-            csr.mtinst <= (others => '0');
+          csr.mtinst <= exe_engine.ir;
+          if (exe_engine.ci = '1') and RISCV_ISA_C then
+            csr.mtinst(1) <= '0'; -- RISC-V priv. spec: clear bit 1 if compressed instruction
           end if;
           -- update privilege level and interrupt-enable stack --
           csr.prv_level    <= priv_mode_m_c; -- execute trap in machine mode

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110901"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110902"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -698,10 +698,10 @@ package neorv32_package is
   constant trap_firq14_c   : std_ulogic_vector(6 downto 0) := "1" & "0" & "11110"; -- 30: fast interrupt 14
   constant trap_firq15_c   : std_ulogic_vector(6 downto 0) := "1" & "0" & "11111"; -- 31: fast interrupt 15
   -- debug-mode-entry exceptions --
-  constant trap_db_break_c : std_ulogic_vector(6 downto 0) := "0" & "1" & "00001"; -- 1: break instruction (sync)
-  constant trap_db_trig_c  : std_ulogic_vector(6 downto 0) := "1" & "1" & "00010"; -- 2: hardware trigger (async)
-  constant trap_db_halt_c  : std_ulogic_vector(6 downto 0) := "1" & "1" & "00011"; -- 3: external halt request (async)
-  constant trap_db_step_c  : std_ulogic_vector(6 downto 0) := "1" & "1" & "00100"; -- 4: single-stepping (async)
+  constant trap_db_break_c : std_ulogic_vector(6 downto 0) := "0" & "1" & "00001"; -- 1: break instruction
+  constant trap_db_trig_c  : std_ulogic_vector(6 downto 0) := "1" & "1" & "00010"; -- 2: hardware trigger
+  constant trap_db_halt_c  : std_ulogic_vector(6 downto 0) := "1" & "1" & "00011"; -- 3: external halt request
+  constant trap_db_step_c  : std_ulogic_vector(6 downto 0) := "1" & "1" & "00100"; -- 4: single-stepping
 
   -- Trap System ----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -715,9 +715,10 @@ package neorv32_package is
   constant exc_lalign_c   : natural :=  6; -- load address misaligned
   constant exc_saccess_c  : natural :=  7; -- store access fault
   constant exc_laccess_c  : natural :=  8; -- load access fault
-  constant exc_db_break_c : natural :=  9; -- enter debug mode via ebreak instruction
-  constant exc_db_hw_c    : natural := 10; -- enter debug mode via hw trigger
-  constant exc_width_c    : natural := 11; -- length of this list in bits
+  constant exc_db_break_c : natural :=  9; -- enter debug mode via break instruction
+  constant exc_db_trig_c  : natural := 10; -- enter debug mode via hardware trigger
+  constant exc_db_step_c  : natural := 11; -- enter debug mode via single-stepping
+  constant exc_width_c    : natural := 12; -- length of this list in bits
   -- interrupt source list --
   constant irq_msi_irq_c  : natural :=  0; -- machine software interrupt
   constant irq_mti_irq_c  : natural :=  1; -- machine timer interrupt
@@ -739,8 +740,7 @@ package neorv32_package is
   constant irq_firq_14_c  : natural := 17; -- fast interrupt channel 14
   constant irq_firq_15_c  : natural := 18; -- fast interrupt channel 15
   constant irq_db_halt_c  : natural := 19; -- enter debug mode via external halt request
-  constant irq_db_step_c  : natural := 20; -- enter debug mode via single-stepping
-  constant irq_width_c    : natural := 21; -- length of this list in bits
+  constant irq_width_c    : natural := 20; -- length of this list in bits
 
   -- Privilege Modes ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------


### PR DESCRIPTION
* Runtime environment (RTE): Adjust the return address (`mepc`) _after_ calling the handler. This allows the trap handler to check/use the original `mepc` value.
* Hardware trigger module (`Sdtrig` ISA extensions): Correct trigger logic. Now the instruction address trigger is triggered precisely even when it is set to an instruction that raises an exception (such as the environment call command `ecall`).
* Single-stepping: Rework single-step trap trigger (turn it into an actual _synchronous_ exception).
* `mtinst` CSR: Do not write zero to the CSR in case of an interrupt. `mtinst` now also shows the last executed instruction word when encountering an interrupt.
* CSR write logic: Code cleanup; use a single `case` statement instead of several `if` statements.
* Code cleanups and logic optimizations.