### PR TITLE
Rework bus access error logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 16.08.2025 | 1.11.9.5 | rework bus access error logic; add per-word cache status bits; :warning: remove top's `XBUS_TIMEOUT` generic; extend _global_ bus timeout to 1024 cycles | [#1339](https://github.com/stnolting/neorv32/pull/1339) |
 | 15.08.2025 | 1.11.9.4 | :lock: add new CPU tuning option: constant-time branches | [#1338](https://github.com/stnolting/neorv32/pull/1338) |
 | 12.08.2025 | 1.11.9.3 | add NEORV32-specific "machine control and status register" `mxcsr`; :warning: move tuning options flags from `mxisa` to `mxcsr` | [#1355](https://github.com/stnolting/neorv32/pull/1335) |
 | 09.08.2025 | 1.11.9.2 | minor fixes and optimizations | [#1333](https://github.com/stnolting/neorv32/pull/1333) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -539,7 +539,7 @@ This constant defines the _maximum_ number of cycles after which a non-respondin
 time out raising a bus access fault exception. For example this can happen when accessing "address space holes"
 (aka _the void_) - addresses that are not mapped to any physical module. The specific bus access exception type
 corresponds to the according access type, i.e. instruction fetch bus fault, load bus fault or store bus fault.
-Note that this time window is also enforced for accesses via the <<_processor_external_bus_interface_xbus>>.
+**Note that this timeout window is also enforced for accesses via the <<_processor_external_bus_interface_xbus>>.**
 
 
 :sectnums:

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -521,22 +521,25 @@ constant mem_io_base_c   : std_ulogic_vector(31 downto 0) := x"ffe00000";
 constant mem_io_size_c   : natural := 32*64*1024; -- = 32 * iodev_size_c
 ----
 
-Besides the redirecting of bus requests the gateway also implements a bus monitor (aka "the bus keeper") that tracks all
-active bus transactions to ensure _safe_ and _deterministic_ operations. Whenever a memory-mapped device is accessed (a
-real memory, a memory-mapped IO or some processor-external module) the bus monitor starts an internal countdown. The
-accessed module has to respond ("ACK") to the bus request within a bound **time window**. This time window is defined
-by a global constant in the processor's VHDL package file (`rtl/core/neorv323_package.vhd`).
+===== Bus Monitor and Timeout
 
-.Internal Bus Timeout Configuration
+Besides the redirecting of bus requests the gateway also implements a **bus monitor** (aka "the bus keeper") that
+tracks all bus transactions to ensure _safe_ and _deterministic_ operations. Whenever a memory-mapped device is
+accessed the bus monitor starts an internal countdown. The accessed module has to respond ("ACK") to the bus request
+within a bound **time window**. This time window is defined by a global constant in the processor's VHDL package
+file (`rtl/core/neorv323_package.vhd`):
+
+.Global Bus Timeout Configuration
 [source,vhdl]
 ----
-constant bus_timeout_c : natural := 16;
+constant bus_timeout_c : natural := 1024;
 ----
 
-This constant defines the _maximum_ number of cycles after which a non-responding bus request (i.e. no `ack`
-and no `err` signal) will time out raising a bus access fault exception. For example this can happen when accessing
-"address space holes" - addresses that are not mapped to any physical module. The resulting exception type corresponds
-to the according access type, i.e. instruction fetch access exception, load access exception or store access exception.
+This constant defines the _maximum_ number of cycles after which a non-responding bus request (i.e. no `ACK`) will
+time out raising a bus access fault exception. For example this can happen when accessing "address space holes"
+(aka _the void_) - addresses that are not mapped to any physical module. The specific bus access exception type
+corresponds to the according access type, i.e. instruction fetch bus fault, load bus fault or store bus fault.
+Note that this time window is also enforced for accesses via the <<_processor_external_bus_interface_xbus>>.
 
 
 :sectnums:

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -268,7 +268,6 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `CACHE_BURSTS_EN`       | boolean   | true          | Enable burst transfers for cache updates.
 4+^| **<<_processor_external_bus_interface_xbus>> (Wishbone / AXI4)**
 | `XBUS_EN`               | boolean   | false         | Implement the external bus interface.
-| `XBUS_TIMEOUT`          | natural   | 255           | Clock cycles after which a pending external bus access will auto-terminate and raise a bus fault exception.
 | `XBUS_REGSTAGE_EN`      | boolean   | false         | Implement XBUS register stages to ease timing closure.
 4+^| **Peripheral/IO Modules**
 | `IO_DISABLE_SYSINFO`    | boolean   | false         | Disable <<_system_configuration_information_memory_sysinfo>> module; not recommended - for advanced users only!
@@ -538,11 +537,6 @@ This constant defines the _maximum_ number of cycles after which a non-respondin
 and no `err` signal) will time out raising a bus access fault exception. For example this can happen when accessing
 "address space holes" - addresses that are not mapped to any physical module. The resulting exception type corresponds
 to the according access type, i.e. instruction fetch access exception, load access exception or store access exception.
-
-.External Bus Interface Timeout
-[NOTE]
-Accesses that are delegated to the external bus interface have a different maximum timeout value that is defined by an
-explicit specific processor generic. See section <<_processor_external_bus_interface_xbus>> for more information.
 
 
 :sectnums:

--- a/docs/datasheet/soc_dcache.adoc
+++ b/docs/datasheet/soc_dcache.adoc
@@ -48,11 +48,11 @@ the atomic memory operations of the <<_zaamo_isa_extension>> will always **bypas
 By executing the `fence` instruction the data cache is flushed, cleared and reloaded.
 See section <<_memory_coherence>> for more information.
 
-.Cache Block Update Fault Handling
+.Cache Block Update Bus Error Handling
 [NOTE]
-If the cache encounters a bus error when uploading a modified block to main memory or when
-downloading a new block from main memory, the entire block is invalidated and a bus access
-error exception is raised.
+If the cache encounters a bus error while downloading a new block from main memory, only the according
+data word is marked as faulty (instead of invalidating the entire cache block). A bus access fault exception
+is only raised if the CPU accesses a cached word that has actually been marked as faulty.
 
 .Retrieve Cache Configuration from Software
 [TIP]

--- a/docs/datasheet/soc_icache.adoc
+++ b/docs/datasheet/soc_icache.adoc
@@ -48,10 +48,11 @@ the atomic memory operations of the <<_zaamo_isa_extension>> will always **bypas
 By executing the `fence.i` instruction the instruction cache is cleared and reloaded.
 See section <<_memory_coherence>> for more information.
 
-.Cache Block Update Fault Handling
+.Cache Block Update Bus Error Handling
 [NOTE]
-If the cache encounters a bus error when downloading a new block from main memory, the
-entire block is invalidated and a bus access error exception is raised.
+If the cache encounters a bus error while downloading a new block from main memory, only the according
+data word is marked as faulty (instead of invalidating the entire cache block). A bus access fault exception
+is only raised if the CPU accesses a cached word that has actually been marked as faulty.
 
 .Retrieve Cache Configuration from Software
 [TIP]

--- a/docs/datasheet/soc_xbus.adoc
+++ b/docs/datasheet/soc_xbus.adoc
@@ -19,7 +19,6 @@
 |                         | `xbus_ack_i`         | acknowledge (1-bit)
 |                         | `xbus_err_i`         | bus error (1-bit)
 | Configuration generics: | `XBUS_EN`            | enable external bus interface when `true`
-|                         | `XBUS_TIMEOUT`       | number of clock cycles after which an unacknowledged external bus access will auto-terminate (0 = disabled)
 |                         | `XBUS_REGSTAGE_EN`   | implement XBUS register stages
 |                         | (`CACHE_BLOCK_SIZE`) | burst size
 |                         | (`CACHE_BURSTS_EN`)  | enable burst transfers for cache update
@@ -140,10 +139,9 @@ to maintain exclusive bus access. This transfer type is used by the CPU to perfo
 
 An accessed XBUS device does not have to respond immediately to a bus request by sending an `ACK`.
 Instead, there is a **time window** where the device has to acknowledge the transfer. This time window
-is configured by the `XBUS_TIMEOUT` generic and it defines the maximum time (in clock cycles) a bus access can
-be pending before it is automatically terminated raising an bus fault exception. If `XBUS_TIMEOUT` is set to zero,
-the timeout is disabled and a bus access can take an arbitrary number of cycles to complete. Note that this is not
-recommended as a missing ACK will permanently stall the entire processor!
+is enforced by the _bus monitors_ of the processor's central <<_bus_gateway>>: all XBUS transactions
+have to be acknowledged within this time window. Otherwise the transfer is terminated and a bus fault
+exception is raised.
 
 Furthermore, an accesses XBUS device can signal an error condition at any time by setting the `ERR` signal
 high for one cycle. This will also terminate the current bus transaction before raising a CPU bus fault exception.

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,9 +20,8 @@ package neorv32_package is
 
   -- Architecture Configuration -------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  -- max response time for processor-internal bus transactions --
-  -- cycles after which an unacknowledged internal bus access will timeout raising a bus fault exception
-  constant bus_timeout_c : natural := 16; -- has to be a power of two
+  -- max response time for ALL bus transactions --
+  constant bus_timeout_c : natural := 1024; -- has to be a power of two
 
   -- instruction monitor: raise exception if multi-cycle operation times out --
   constant monitor_mc_tmo_c : natural := 9; -- = log2 of max execution cycles; default = 2^9 = 512 cycles

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -29,7 +29,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110904"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110905"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -858,7 +858,6 @@ package neorv32_package is
       CACHE_BURSTS_EN       : boolean                        := true;
       -- External bus interface (XBUS) --
       XBUS_EN               : boolean                        := false;
-      XBUS_TIMEOUT          : natural                        := 255;
       XBUS_REGSTAGE_EN      : boolean                        := false;
       -- Processor peripherals --
       IO_DISABLE_SYSINFO    : boolean                        := false;

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -98,7 +98,6 @@ entity neorv32_top is
 
     -- External bus interface (XBUS) --
     XBUS_EN               : boolean                        := false;       -- implement external memory bus interface
-    XBUS_TIMEOUT          : natural                        := 255;         -- cycles after a pending bus access auto-terminates (0 = disabled)
     XBUS_REGSTAGE_EN      : boolean                        := false;       -- add XBUS register stage
 
     -- Processor peripherals --
@@ -865,7 +864,6 @@ begin
     if XBUS_EN generate
       neorv32_xbus_inst: entity neorv32.neorv32_xbus
       generic map (
-        TIMEOUT_VAL => XBUS_TIMEOUT,
         REGSTAGE_EN => XBUS_REGSTAGE_EN
       )
       port map (

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -297,6 +297,7 @@ architecture neorv32_top_rtl of neorv32_top is
   -- bus: system --
   signal sys1_req, sys2_req, dma_req, amo_req, sys3_req, imem_req, dmem_req, io_req, xbus_req : bus_req_t;
   signal sys1_rsp, sys2_rsp, dma_rsp, amo_rsp, sys3_rsp, imem_rsp, dmem_rsp, io_rsp, xbus_rsp : bus_rsp_t;
+  signal xbus_terminate : std_ulogic;
 
   -- bus: IO devices --
   type io_devices_enum_t is (
@@ -769,26 +770,27 @@ begin
 
   neorv32_bus_gateway_inst: entity neorv32.neorv32_bus_gateway
   generic map (
-    TIMEOUT  => bus_timeout_c,
+    TIMEOUT => bus_timeout_c,
     -- port A: internal IMEM --
-    A_EN   => IMEM_EN,
-    A_BASE => mem_imem_base_c,
-    A_SIZE => imem_size_c,
+    A_EN    => IMEM_EN,
+    A_BASE  => mem_imem_base_c,
+    A_SIZE  => imem_size_c,
     -- port B: internal DMEM --
-    B_EN   => DMEM_EN,
-    B_BASE => mem_dmem_base_c,
-    B_SIZE => dmem_size_c,
+    B_EN    => DMEM_EN,
+    B_BASE  => mem_dmem_base_c,
+    B_SIZE  => dmem_size_c,
     -- port C: IO --
-    C_EN   => true, -- always enabled (but will be trimmed if no IO devices are implemented)
-    C_BASE => mem_io_base_c,
-    C_SIZE => mem_io_size_c,
+    C_EN    => true, -- always enabled (but will be trimmed if no IO devices are implemented)
+    C_BASE  => mem_io_base_c,
+    C_SIZE  => mem_io_size_c,
     -- port X (the void): XBUS --
-    X_EN   => XBUS_EN
+    X_EN    => XBUS_EN
   )
   port map (
     -- global control --
     clk_i   => clk_i,
     rstn_i  => rstn_sys,
+    term_o  => xbus_terminate,
     -- host port --
     req_i   => sys3_req,
     rsp_o   => sys3_rsp,
@@ -869,6 +871,7 @@ begin
       port map (
         clk_i      => clk_i,
         rstn_i     => rstn_sys,
+        bus_term_i => xbus_terminate,
         bus_req_i  => xbus_req,
         bus_rsp_o  => xbus_rsp,
         xbus_adr_o => xbus_adr_o,

--- a/rtl/system_integration/neorv32_libero_ip.vhd
+++ b/rtl/system_integration/neorv32_libero_ip.vhd
@@ -470,7 +470,6 @@ begin
     CACHE_BLOCK_SIZE    => CACHE_BLOCK_SIZE,
     -- External bus interface --
     XBUS_EN             => xbus_en_c,
-    XBUS_TIMEOUT        => 0, -- AXI does not allow any timeouts
     XBUS_REGSTAGE_EN    => xbus_regstage_en_c,
     -- Processor peripherals --
     IO_DISABLE_SYSINFO  => false,

--- a/rtl/system_integration/neorv32_litex_core_complex.vhd
+++ b/rtl/system_integration/neorv32_litex_core_complex.vhd
@@ -143,7 +143,6 @@ begin
     HPM_CNT_WIDTH         => 64,                             -- total size of HPM counters (0..64)
     -- External bus interface (XBUS) --
     XBUS_EN               => true,                           -- implement external memory bus interface?
-    XBUS_TIMEOUT          => 1024,                           -- cycles after a pending bus access auto-terminates (0 = disabled)
     XBUS_REGSTAGE_EN      => false,                          -- add XBUS register stage
     -- Processor peripherals --
     IO_CLINT_EN           => configs_c.clint(CONFIG)         -- implement core local interruptor (CLINT)?

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -423,7 +423,6 @@ begin
     CACHE_BURSTS_EN     => burst_en_c,
     -- External bus interface --
     XBUS_EN             => XBUS_EN,
-    XBUS_TIMEOUT        => 0, -- AXI does not allow any timeouts
     XBUS_REGSTAGE_EN    => XBUS_REGSTAGE_EN,
     -- Processor peripherals --
     IO_DISABLE_SYSINFO  => false,

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -189,7 +189,6 @@ begin
     CACHE_BURSTS_EN     => CACHE_BURSTS_EN,
     -- External bus interface --
     XBUS_EN             => true,
-    XBUS_TIMEOUT        => 64,
     XBUS_REGSTAGE_EN    => true,
     -- Processor peripherals --
     IO_GPIO_NUM         => 32,
@@ -413,12 +412,10 @@ begin
     -- device address size in bytes and base address --
     DEV_0_EN => EXT_MEM_A_EN, DEV_0_SIZE => EXT_MEM_A_SIZE, DEV_0_BASE => EXT_MEM_A_BASE,
     DEV_1_EN => EXT_MEM_B_EN, DEV_1_SIZE => EXT_MEM_B_SIZE, DEV_1_BASE => EXT_MEM_B_BASE,
-    DEV_2_EN => true,         DEV_2_SIZE =>             64, DEV_2_BASE => x"F0000000",
+    DEV_2_EN => true,         DEV_2_SIZE =>              8, DEV_2_BASE => x"A0000000",
     DEV_3_EN => true,         DEV_3_SIZE =>              4, DEV_3_BASE => x"FF000000"
   )
   port map (
-    clk_i       => clk_gen,
-    rstn_i      => rst_gen,
     -- host port --
     host_req_i  => xbus_core_req,
     host_rsp_o  => xbus_core_rsp,
@@ -478,7 +475,7 @@ begin
   end generate;
 
 
-  -- XBUS: External Memory-Mapped IO --------------------------------------------------------
+  -- XBUS: External Memory-Mapped IO (cached) -----------------------------------------------
   -- -------------------------------------------------------------------------------------------
   xbus_mmio: entity work.xbus_memory
   generic map (

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -30,7 +30,7 @@
 //** Unreachable word-aligned cached address */
 #define ADDR_UNREACHABLE (0x70000000U)
 //** External memory base address */
-#define EXT_MEM_BASE     (0xF0000000U)
+#define EXT_MEM_BASE     (0xA0000000U)
 //** External IRQ trigger base address */
 #define SIM_TRIG_BASE    (0xFF000000U)
 /**@}*/
@@ -111,6 +111,11 @@ void __attribute__((constructor)) neorv32_constructor() {
   constr_res = 0;
   for (i=0; i<16; i++) {
     constr_res = (31 * constr_res) + tmp[i];
+  }
+
+  // clear top of stack (to make sure variables on the stack are initialized)
+  for (i=0; i<64; i++) {
+    neorv32_cpu_store_unsigned_word((NEORV32_RAM_BASE + (NEORV32_RAM_SIZE-4)) - 4*i, 0);
   }
 }
 


### PR DESCRIPTION
* ⚠️ remove top's `XBUS_TIMEOUT` generic
* the number of cycles after which a bus access times out is now entirely defined by the `bus_timeout_c` package constant (1024 by default)
* rework bus monitor: if a burst transfer causes an error the bus monitor will issue the missing data ACKs if the accessed device does not provide them
* rework caches: the cache now stores a status-bit for each cache word (absorbed into the BRAM's parity bit):
  * if a single access within a cache block transfer causes a bus error only that specific word is marked as invalid instead of the entire cache block; this also allows to cache memories that are smaller than a single cache line