### PR TITLE
rtl code cleanups and optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 19.08.2025 | 1.11.9.8 | simplify CPU front-end's IPB; code cleanups and logic optimization | [#1345](https://github.com/stnolting/neorv32/pull/1345) |
 | 17.08.2025 | 1.11.9.7 | replace IMEM and DMEM RTL modules by a generic memory component | [#1344](https://github.com/stnolting/neorv32/pull/1344) |
 | 16.08.2025 | 1.11.9.6 | :warning: rework layout of `SYSINFO.MISC` information register | [#1342](https://github.com/stnolting/neorv32/pull/1342) |
 | 16.08.2025 | 1.11.9.5 | rework bus access error logic; add per-word cache status bits; :warning: remove top's `XBUS_TIMEOUT` generic; extend _global_ bus timeout to 1024 cycles | [#1339](https://github.com/stnolting/neorv32/pull/1339) |

--- a/rtl/core/neorv32_cpu_regfile.vhd
+++ b/rtl/core/neorv32_cpu_regfile.vhd
@@ -39,56 +39,77 @@ entity neorv32_cpu_regfile is
     rstn_i : in  std_ulogic; -- global reset, low-active, async
     ctrl_i : in  ctrl_bus_t; -- main control bus
     -- operands --
-    rd_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- destination operand rd
-    rs1_o  : out std_ulogic_vector(XLEN-1 downto 0); -- source operand rs1
-    rs2_o  : out std_ulogic_vector(XLEN-1 downto 0); -- source operand rs2
-    rs3_o  : out std_ulogic_vector(XLEN-1 downto 0)  -- source operand rs3
+    rd_i   : in  std_ulogic_vector(XLEN-1 downto 0); -- destination data rd
+    rs1_o  : out std_ulogic_vector(XLEN-1 downto 0); -- source data rs1
+    rs2_o  : out std_ulogic_vector(XLEN-1 downto 0); -- source data rs2
+    rs3_o  : out std_ulogic_vector(XLEN-1 downto 0)  -- source data rs3
   );
 end neorv32_cpu_regfile;
 
 architecture neorv32_cpu_regfile_rtl of neorv32_cpu_regfile is
 
   -- auto-configuration --
-  constant addr_bits_c : natural := cond_sel_natural_f(RVE_EN, 4, 5); -- address width
+  constant awidth_c : natural := cond_sel_natural_f(RVE_EN, 4, 5); -- address width
 
   -- register file --
-  type   reg_file_t is array ((2**addr_bits_c)-1 downto 0) of std_ulogic_vector(XLEN-1 downto 0);
+  type   reg_file_t is array (0 to (2**awidth_c)-1) of std_ulogic_vector(XLEN-1 downto 0);
   signal reg_file : reg_file_t;
 
-  -- access --
-  signal rf_we    : std_ulogic; -- write enable
-  signal rd_zero  : std_ulogic; -- writing to x0?
-  signal opa_addr : std_ulogic_vector(4 downto 0); -- rs1/rd address
-  signal rs3_addr : std_ulogic_vector(4 downto 0); -- rs3 address
+  -- access logic --
+  signal rf_we, rd_zero : std_ulogic;
+  signal opa_addr : std_ulogic_vector(4 downto 0);
 
 begin
+
+  -- FPGA-Style Register File Access Logic --------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+
+  -- Register zero (x0) is a "normal" physical register that is set to zero by the CPU control
+  -- hardware. The register file uses synchronous read accesses and a *single* multiplexed
+  -- address port for writing and reading rd/rs1 and a single read-only port for reading rs2.
+  -- Therefore, the whole register file can be mapped to a single true-dual-port block RAM.
+
+  rd_zero  <= '1' when (ctrl_i.rf_rd = "00000") else '0';
+  rf_we    <= (ctrl_i.rf_wb_en and (not rd_zero)) or ctrl_i.rf_zero_we; -- never write to x0 unless forced
+  opa_addr <= "00000" when (ctrl_i.rf_zero_we = '1') else -- force rd = zero
+              ctrl_i.rf_rd when (ctrl_i.rf_wb_en = '1') else -- rd
+              ctrl_i.rf_rs1; -- rs1
+
 
   -- FPGA-Style Register File (BlockRAM, no hardware reset at all) --------------------------
   -- -------------------------------------------------------------------------------------------
   register_file_fpga:
   if not RST_EN generate
 
-    -- Register zero (x0) is a "normal" physical register that is set to zero by the CPU control
-    -- hardware. The register file uses synchronous read accesses and a *single* multiplexed
-    -- address port for writing and reading rd/rs1 and a single read-only port for reading rs2.
-    -- Therefore, the whole register file can be mapped to a single true-dual-port block RAM.
-
-    rd_zero  <= '1' when (ctrl_i.rf_rd = "00000") else '0';
-    rf_we    <= (ctrl_i.rf_wb_en and (not rd_zero)) or ctrl_i.rf_zero_we; -- never write to x0 unless explicitly forced
-    opa_addr <= "00000" when (ctrl_i.rf_zero_we = '1') else -- force rd = zero
-                ctrl_i.rf_rd when (ctrl_i.rf_wb_en = '1') else -- rd
-                ctrl_i.rf_rs1; -- rs1
-
+    -- simple dual-port RAM --
     register_file: process(clk_i)
     begin
       if rising_edge(clk_i) then
         if (rf_we = '1') then
-          reg_file(to_integer(unsigned(opa_addr(addr_bits_c-1 downto 0)))) <= rd_i;
+          reg_file(to_integer(unsigned(opa_addr(awidth_c-1 downto 0)))) <= rd_i;
+        else
+          rs1_o <= reg_file(to_integer(unsigned(opa_addr(awidth_c-1 downto 0))));
         end if;
-        rs1_o <= reg_file(to_integer(unsigned(opa_addr(addr_bits_c-1 downto 0))));
-        rs2_o <= reg_file(to_integer(unsigned(ctrl_i.rf_rs2(addr_bits_c-1 downto 0))));
+        rs2_o <= reg_file(to_integer(unsigned(ctrl_i.rf_rs2(awidth_c-1 downto 0))));
       end if;
     end process register_file;
+
+    -- third read operand --
+    rs3_enabled:
+    if RS3_EN generate
+      register_file_rs3: process(clk_i)
+      begin
+        if rising_edge(clk_i) then
+          rs3_o <= reg_file(to_integer(unsigned(ctrl_i.ir_funct12((7+awidth_c)-1 downto 7))));
+        end if;
+      end process register_file_rs3;
+    end generate;
+
+    -- no third read operand --
+    rs3_disabled:
+    if not RS3_EN generate
+      rs3_o <= (others => '0');
+    end generate;
 
   end generate; -- /register_file_fpga
 
@@ -98,23 +119,23 @@ begin
   register_file_asic:
   if RST_EN generate
 
+    -- x0 is hardwired to zero --
+    reg_file(0) <= (others => '0');
+
     -- individual registers --
     reg_gen:
-    for i in 1 to (2**addr_bits_c)-1 generate
+    for i in 1 to (2**awidth_c)-1 generate
       register_file: process(rstn_i, clk_i)
       begin
         if (rstn_i = '0') then
           reg_file(i) <= (others => '0'); -- full hardware reset
         elsif rising_edge(clk_i) then
-          if (unsigned(ctrl_i.rf_rd(addr_bits_c-1 downto 0)) = to_unsigned(i, addr_bits_c)) and (ctrl_i.rf_wb_en = '1') then
+          if (unsigned(ctrl_i.rf_rd(awidth_c-1 downto 0)) = to_unsigned(i, awidth_c)) and (ctrl_i.rf_wb_en = '1') then
             reg_file(i) <= rd_i;
           end if;
         end if;
       end process register_file;
     end generate;
-
-    -- x0 is hardwired to zero --
-    reg_file(0) <= (others => '0');
 
     -- synchronous read --
     rf_read: process(rstn_i, clk_i)
@@ -123,33 +144,31 @@ begin
         rs1_o <= (others => '0');
         rs2_o <= (others => '0');
       elsif rising_edge(clk_i) then
-        rs1_o <= reg_file(to_integer(unsigned(ctrl_i.rf_rs1(addr_bits_c-1 downto 0))));
-        rs2_o <= reg_file(to_integer(unsigned(ctrl_i.rf_rs2(addr_bits_c-1 downto 0))));
+        rs1_o <= reg_file(to_integer(unsigned(ctrl_i.rf_rs1(awidth_c-1 downto 0))));
+        rs2_o <= reg_file(to_integer(unsigned(ctrl_i.rf_rs2(awidth_c-1 downto 0))));
       end if;
     end process rf_read;
 
+    -- third read operand --
+    rs3_enabled:
+    if RS3_EN generate
+      rs3_read: process(rstn_i, clk_i)
+      begin
+        if (rstn_i = '0') then
+          rs3_o <= (others => '0');
+        elsif rising_edge(clk_i) then
+          rs3_o <= reg_file(to_integer(unsigned(ctrl_i.ir_funct12((7+awidth_c)-1 downto 7))));
+        end if;
+      end process rs3_read;
+    end generate;
+
+    -- no third read operand --
+    rs3_disabled:
+    if not RS3_EN generate
+      rs3_o <= (others => '0');
+    end generate;
+
   end generate; -- /register_file_asic
-
-
-  -- Optional Third Read Port (rs3) ---------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  rs3_enabled:
-  if RS3_EN generate
-    rs3_read: process(clk_i)
-    begin
-      if rising_edge(clk_i) then
-        rs3_o <= reg_file(to_integer(unsigned(rs3_addr(addr_bits_c-1 downto 0))));
-      end if;
-    end process rs3_read;
-  end generate;
-
-  rs3_disabled:
-  if not RS3_EN generate
-    rs3_o <= (others => '0');
-  end generate;
-
-  -- RISC-V rs3 operand --
-  rs3_addr <= ctrl_i.ir_funct12(11 downto 7);
 
 
 end neorv32_cpu_regfile_rtl;

--- a/rtl/core/neorv32_dma.vhd
+++ b/rtl/core/neorv32_dma.vhd
@@ -150,9 +150,7 @@ begin
   generic map (
     FIFO_DEPTH => fifo_size_c,
     FIFO_WIDTH => 32,
-    FIFO_RSYNC => false,
     FIFO_SAFE  => true,
-    FULL_RESET => false,
     OUT_GATE   => false
   )
   port map (
@@ -161,7 +159,6 @@ begin
     rstn_i  => rstn_i,
     clear_i => fifo.clr,
     half_o  => open,
-    level_o => open,
     -- write port --
     wdata_i => bus_req_i.data,
     we_i    => fifo.we,

--- a/rtl/core/neorv32_fifo.vhd
+++ b/rtl/core/neorv32_fifo.vhd
@@ -19,9 +19,7 @@ entity neorv32_fifo is
   generic (
     FIFO_DEPTH : natural := 4;     -- number of FIFO entries; has to be a power of two; min 1
     FIFO_WIDTH : natural := 32;    -- size of data elements in FIFO
-    FIFO_RSYNC : boolean := false; -- true = sync read; false = async read
     FIFO_SAFE  : boolean := false; -- true = allow read/write only if data/space available
-    FULL_RESET : boolean := false; -- true = reset all memory cells
     OUT_GATE   : boolean := false  -- true = output zero if no data is available
   );
   port (
@@ -30,7 +28,6 @@ entity neorv32_fifo is
     rstn_i  : in  std_ulogic; -- async reset, low-active
     clear_i : in  std_ulogic; -- sync reset, high-active
     half_o  : out std_ulogic; -- FIFO is at least half full
-    level_o : out std_ulogic_vector(31 downto 0); -- fill level, zero-extended, 0 to FIFO_DEPTH
     -- write port --
     wdata_i : in  std_ulogic_vector(FIFO_WIDTH-1 downto 0); -- write data
     we_i    : in  std_ulogic; -- write enable
@@ -46,28 +43,22 @@ architecture neorv32_fifo_rtl of neorv32_fifo is
 
   -- make sure FIFO depth is a power of two --
   constant fifo_depth_c : natural := cond_sel_natural_f(is_power_of_two_f(FIFO_DEPTH), FIFO_DEPTH, 2**index_size_f(FIFO_DEPTH));
+  constant awidth_c     : natural := index_size_f(fifo_depth_c); -- address width
 
   -- memory core --
   type fifo_mem_t is array (0 to fifo_depth_c-1) of std_ulogic_vector(FIFO_WIDTH-1 downto 0);
-  signal fifo_mem : fifo_mem_t; -- for fifo_depth_c > 1
-  signal fifo_reg : std_ulogic_vector(FIFO_WIDTH-1 downto 0); -- for fifo_depth_c = 1
+  signal fifo_mem : fifo_mem_t;
 
   -- direct output data --
   signal rdata : std_ulogic_vector(FIFO_WIDTH-1 downto 0);
 
   -- control and status --
-  signal we, re, match, empty, full, half, half_ff, free, free_ff, avail, avail_ff : std_ulogic;
+  signal we, re, match, full, empty, half, half_ff, free_ff, avail_ff : std_ulogic;
 
   -- write/read pointers --
-  signal w_pnt, w_nxt, r_pnt, r_nxt, r_pnt_ff, level : std_ulogic_vector(index_size_f(fifo_depth_c) downto 0);
+  signal w_pnt, w_nxt, r_pnt, r_nxt, level : std_ulogic_vector(awidth_c downto 0);
 
 begin
-
-  -- Access Control -------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  re <= re_i when (FIFO_SAFE = false) else (re_i and avail); -- SAFE = read only if data available
-  we <= we_i when (FIFO_SAFE = false) else (we_i and free);  -- SAFE = write only if free space left
-
 
   -- Pointers -------------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -86,16 +77,19 @@ begin
   w_nxt <= (others => '0') when (clear_i = '1') else std_ulogic_vector(unsigned(w_pnt) + 1) when (we = '1') else w_pnt;
   r_nxt <= (others => '0') when (clear_i = '1') else std_ulogic_vector(unsigned(r_pnt) + 1) when (re = '1') else r_pnt;
 
+  -- access control --
+  re <= re_i when (FIFO_SAFE = false) else (re_i and (not empty)); -- SAFE = read only if data available
+  we <= we_i when (FIFO_SAFE = false) else (we_i and (not full));  -- SAFE = write only if free space left
+
 
   -- Status ---------------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-
   -- more than 1 FIFO entry --
   check_large:
   if (fifo_depth_c > 1) generate
-    match <= '1' when (r_pnt(r_pnt'left-1 downto 0) = w_pnt(w_pnt'left-1 downto 0)) else '0';
-    full  <= '1' when (r_pnt(r_pnt'left) /= w_pnt(w_pnt'left)) and (match = '1') else '0';
-    empty <= '1' when (r_pnt(r_pnt'left)  = w_pnt(w_pnt'left)) and (match = '1') else '0';
+    match <= '1' when (r_pnt(awidth_c-1 downto 0) = w_pnt(awidth_c-1 downto 0)) else '0';
+    full  <= '1' when (r_pnt(awidth_c) /= w_pnt(awidth_c)) and (match = '1') else '0';
+    empty <= '1' when (r_pnt(awidth_c)  = w_pnt(awidth_c)) and (match = '1') else '0';
     level <= std_ulogic_vector(unsigned(w_pnt) - unsigned(r_pnt));
     half  <= level(level'left-1) or full;
   end generate;
@@ -110,187 +104,56 @@ begin
     half  <= full;
   end generate;
 
-  -- aliases --
-  free  <= not full;
-  avail <= not empty;
-
-  -- fill level, zero-extended --
-  level_extend: process(level)
+  -- synchronous status --
+  status_reg: process(rstn_i, clk_i)
   begin
-    level_o <= (others => '0');
-    level_o(level'left downto 0) <= level(level'left downto 0);
-  end process level_extend;
+    if (rstn_i = '0') then
+      free_ff  <= '0';
+      avail_ff <= '0';
+      half_ff  <= '0';
+    elsif rising_edge(clk_i) then
+      free_ff  <= not full;
+      avail_ff <= not empty;
+      half_ff  <= half;
+    end if;
+  end process status_reg;
+  free_o  <= free_ff;
+  avail_o <= avail_ff;
+  half_o  <= half_ff;
 
 
-  -- Write Access (with Reset) --------------------------------------------------------------
+  -- Memory Access -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  memory_full_reset: -- cannot be mapped to memory primitives
-  if FULL_RESET generate
-
-    -- just 1 FIFO entry --
-    fifo_write_reset_small:
-    if (fifo_depth_c = 1) generate
-      write_reset_small: process(rstn_i, clk_i)
-      begin
-        if (rstn_i = '0') then
-          fifo_reg <= (others => '0');
-        elsif rising_edge(clk_i) then
-          if (we = '1') then
-            fifo_reg <= wdata_i;
-          end if;
-        end if;
-      end process write_reset_small;
-      fifo_mem <= (others => (others => '0')); -- unused
-    end generate;
-
-    -- more than 1 FIFO entry --
-    fifo_write_reset_large:
-    if (fifo_depth_c > 1) generate
-      write_reset_large: process(rstn_i, clk_i)
-      begin
-        if (rstn_i = '0') then
-          fifo_mem <= (others => (others => '0'));
-        elsif rising_edge(clk_i) then
-          if (we = '1') then
-            fifo_mem(to_integer(unsigned(w_pnt(w_pnt'left-1 downto 0)))) <= wdata_i;
-          end if;
-        end if;
-      end process write_reset_large;
-      fifo_reg <= (others => '0'); -- unused
-    end generate;
-
-  end generate;
-
-
-  -- Write Access (without Reset) -----------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  memory_no_reset: -- no reset to infer memory primitives
-  if not FULL_RESET generate
-
-    -- just 1 FIFO entry --
-    fifo_write_noreset_small:
-    if (fifo_depth_c = 1) generate
-      write_small: process(clk_i)
-      begin
-        if rising_edge(clk_i) then
-          if (we = '1') then
-            fifo_reg <= wdata_i;
-          end if;
-        end if;
-      end process write_small;
-      fifo_mem <= (others => (others => '0')); -- unused
-    end generate;
-
-    -- more than 1 FIFO entry --
-    fifo_write_noreset_large:
-    if (fifo_depth_c > 1) generate
-      write_large: process(clk_i)
-      begin
-        if rising_edge(clk_i) then
-          if (we = '1') then
-            fifo_mem(to_integer(unsigned(w_pnt(w_pnt'left-1 downto 0)))) <= wdata_i;
-          end if;
-        end if;
-      end process write_large;
-      fifo_reg <= (others => '0'); -- unused
-    end generate;
-
-  end generate;
-
-
-  -- Asynchronous Read Access ---------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  fifo_read_async:
-  if not FIFO_RSYNC generate
-
-    -- just 1 FIFO entry --
-    fifo_read_async_small:
-    if (fifo_depth_c = 1) generate
-      rdata    <= fifo_reg;
-      r_pnt_ff <= (others => '0'); -- unused
-    end generate;
-
-    -- more than 1 FIFO entry --
-    fifo_read_async_large:
-    if (fifo_depth_c > 1) generate
-      async_r_pnt_reg: process(clk_i)
-      begin
-        if rising_edge(clk_i) then
-          r_pnt_ff <= r_nxt; -- individual read address register; allows mapping "async" FIFOs to memory primitives
-        end if;
-      end process async_r_pnt_reg;
-      rdata <= fifo_mem(to_integer(unsigned(r_pnt_ff(r_pnt_ff'left-1 downto 0))));
-    end generate;
-
-    -- status --
-    free_ff  <= free;
-    avail_ff <= avail;
-    half_ff  <= half;
-    free_o   <= free_ff;
-    avail_o  <= avail_ff;
-    half_o   <= half_ff;
-
-  end generate;
-
-
-  -- Synchronous Read Access ----------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  fifo_read_sync:
-  if FIFO_RSYNC generate
-
-    -- just 1 FIFO entry --
-    fifo_read_sync_small:
-    if (fifo_depth_c = 1) generate
-      rdata <= fifo_reg;
-    end generate;
-
-    -- more than 1 FIFO entry --
-    fifo_read_sync_large:
-    if (fifo_depth_c > 1) generate
-      sync_read_large: process(clk_i)
-      begin
-        if rising_edge(clk_i) then
-          rdata <= fifo_mem(to_integer(unsigned(r_pnt(r_pnt'left-1 downto 0))));
-        end if;
-      end process sync_read_large;
-    end generate;
-
-    -- registered status --
-    sync_status: process(rstn_i, clk_i)
+  -- more than 1 FIFO entry --
+  fifo_write_large:
+  if (fifo_depth_c > 1) generate
+    memory_core: process(clk_i)
     begin
-      if (rstn_i = '0') then
-        free_ff  <= '0';
-        avail_ff <= '0';
-        half_ff  <= '0';
-      elsif rising_edge(clk_i) then
-        free_ff  <= free;
-        avail_ff <= avail;
-        half_ff  <= half;
+      if rising_edge(clk_i) then
+        if (we = '1') then
+          fifo_mem(to_integer(unsigned(w_pnt(awidth_c-1 downto 0)))) <= wdata_i;
+        end if;
+        rdata <= fifo_mem(to_integer(unsigned(r_pnt(awidth_c-1 downto 0))));
       end if;
-    end process sync_status;
-
-    free_o  <= free_ff;
-    avail_o <= avail_ff;
-    half_o  <= half_ff;
-
-    -- unused --
-    r_pnt_ff <= (others => '0');
-
+    end process memory_core;
   end generate;
 
-
-  -- Output Gate (output zero if no data available) -----------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  out_gate_enabled:
-  if OUT_GATE generate
-    rdata_o <= rdata when (avail_ff = '1') else (others => '0');
+  -- just 1 FIFO entry --
+  fifo_write_small:
+  if (fifo_depth_c = 1) generate
+    memory_core: process(clk_i)
+    begin
+      if rising_edge(clk_i) then
+        if (we = '1') then
+          fifo_mem(0) <= wdata_i;
+        end if;
+      end if;
+    end process memory_core;
+    rdata <= fifo_mem(0); -- "async" read; not additional output register required
   end generate;
 
-  -- direct output --
-  out_gate_disabled:
-  if not OUT_GATE generate
-    rdata_o <= rdata;
-  end generate;
+  -- output gate (output zero if no data available) --
+  rdata_o <= rdata when (avail_ff = '1') or (OUT_GATE = false) else (others => '0');
 
 
 end neorv32_fifo_rtl;

--- a/rtl/core/neorv32_neoled.vhd
+++ b/rtl/core/neorv32_neoled.vhd
@@ -162,9 +162,7 @@ begin
   generic map (
     FIFO_DEPTH => FIFO_DEPTH, -- number of FIFO entries; has to be a power of two; min 1
     FIFO_WIDTH => 32+2,       -- size of data elements in FIFO
-    FIFO_RSYNC => true,       -- sync read
     FIFO_SAFE  => true,       -- safe access
-    FULL_RESET => false,      -- no HW reset, try to infer BRAM
     OUT_GATE   => false       -- no output-gating required
   )
   port map (
@@ -173,7 +171,6 @@ begin
     rstn_i  => rstn_i,        -- async reset, low-active
     clear_i => tx_fifo.clear, -- sync reset, high-active
     half_o  => tx_fifo.half,  -- FIFO is at least half full
-    level_o => open,          -- fill level, zero-extended
     -- write port --
     wdata_i => tx_fifo.wdata, -- write data
     we_i    => tx_fifo.we,    -- write enable

--- a/rtl/core/neorv32_onewire.vhd
+++ b/rtl/core/neorv32_onewire.vhd
@@ -174,9 +174,7 @@ begin
   generic map (
     FIFO_DEPTH => ONEWIRE_FIFO,
     FIFO_WIDTH => 10, -- 2-bit command + 8-bit data
-    FIFO_RSYNC => true,
     FIFO_SAFE  => true,
-    FULL_RESET => false,
     OUT_GATE   => false
   )
   port map (
@@ -185,7 +183,6 @@ begin
     rstn_i  => rstn_i,
     clear_i => fifo.tx_clr,
     half_o  => open,
-    level_o => open,
     -- write port --
     wdata_i => fifo.tx_wdata,
     we_i    => fifo.tx_we,
@@ -207,9 +204,7 @@ begin
   generic map (
     FIFO_DEPTH => ONEWIRE_FIFO,
     FIFO_WIDTH => 9, -- 1-bit presence status + 8-bit data
-    FIFO_RSYNC => true,
     FIFO_SAFE  => true,
-    FULL_RESET => false,
     OUT_GATE   => false
   )
   port map (
@@ -218,7 +213,6 @@ begin
     rstn_i  => rstn_i,
     clear_i => fifo.rx_clr,
     half_o  => open,
-    level_o => open,
     -- write port --
     wdata_i => fifo.rx_wdata,
     we_i    => fifo.rx_we,

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -28,7 +28,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110907"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01110908"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_sdi.vhd
+++ b/rtl/core/neorv32_sdi.vhd
@@ -175,9 +175,7 @@ begin
   generic map (
     FIFO_DEPTH => RTX_FIFO, -- number of FIFO entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,        -- size of data elements in FIFO (32-bit only for simulation)
-    FIFO_RSYNC => true,     -- sync read
     FIFO_SAFE  => true,     -- safe access
-    FULL_RESET => false,    -- no HW reset, try to infer BRAM
     OUT_GATE   => true      -- output zero if no data available
   )
   port map (
@@ -186,7 +184,6 @@ begin
     rstn_i  => rstn_i,        -- async reset, low-active
     clear_i => tx_fifo.clear, -- sync reset, high-active
     half_o  => tx_fifo.half,  -- FIFO at least half-full
-    level_o => open,          -- fill level, zero-extended
     -- write port --
     wdata_i => tx_fifo.wdata, -- write data
     we_i    => tx_fifo.we,    -- write enable
@@ -211,9 +208,7 @@ begin
   generic map (
     FIFO_DEPTH => RTX_FIFO, -- number of FIFO entries; has to be a power of two; min 1
     FIFO_WIDTH => 8,        -- size of data elements in FIFO (32-bit only for simulation)
-    FIFO_RSYNC => true,     -- sync read
     FIFO_SAFE  => true,     -- safe access
-    FULL_RESET => false,    -- no HW reset, try to infer BRAM
     OUT_GATE   => false     -- no output gate required
   )
   port map (
@@ -222,7 +217,6 @@ begin
     rstn_i  => rstn_i,        -- async reset, low-active
     clear_i => rx_fifo.clear, -- sync reset, high-active
     half_o  => rx_fifo.half,  -- FIFO at least half-full
-    level_o => open,          -- fill level, zero-extended
     -- write port --
     wdata_i => rx_fifo.wdata, -- write data
     we_i    => rx_fifo.we,    -- write enable

--- a/rtl/core/neorv32_slink.vhd
+++ b/rtl/core/neorv32_slink.vhd
@@ -200,9 +200,7 @@ begin
   generic map (
     FIFO_DEPTH => SLINK_RX_FIFO,
     FIFO_WIDTH => 1+4+32, -- last + routing + data
-    FIFO_RSYNC => false,  -- "async" read - update FIFO status RIGHT after write access (for slink_rx_ready_o)
     FIFO_SAFE  => true,   -- safe access
-    FULL_RESET => false,  -- no HW reset, try to infer BRAM
     OUT_GATE   => false   -- no output gate required
   )
   port map (
@@ -211,7 +209,6 @@ begin
     rstn_i  => rstn_i,
     clear_i => rx_fifo.clear,
     half_o  => rx_fifo.half,
-    level_o => open,
     -- write port --
     wdata_i => rx_fifo.wdata,
     we_i    => rx_fifo.we,
@@ -253,9 +250,7 @@ begin
   generic map (
     FIFO_DEPTH => SLINK_TX_FIFO,
     FIFO_WIDTH => 1+4+32, -- last + routing + data
-    FIFO_RSYNC => false,  -- "async" read - update FIFO status RIGHT after read access (for slink_tx_valid_o)
     FIFO_SAFE  => true,   -- safe access
-    FULL_RESET => false,  -- no HW reset, try to infer BRAM
     OUT_GATE   => false   -- no output gate required
   )
   port map (
@@ -264,7 +259,6 @@ begin
     rstn_i  => rstn_i,
     clear_i => tx_fifo.clear,
     half_o  => tx_fifo.half,
-    level_o => open,
     -- write port --
     wdata_i => tx_fifo.wdata,
     we_i    => tx_fifo.we,

--- a/rtl/core/neorv32_spi.vhd
+++ b/rtl/core/neorv32_spi.vhd
@@ -186,9 +186,7 @@ begin
   generic map (
     FIFO_DEPTH => IO_SPI_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 9,           -- size of data elements in fifo (cmd/data select + cmd/data byte)
-    FIFO_RSYNC => true,        -- sync read
     FIFO_SAFE  => true,        -- safe access
-    FULL_RESET => false,       -- no HW reset, try to infer BRAM
     OUT_GATE   => false        -- no output gate required
   )
   port map (
@@ -197,7 +195,6 @@ begin
     rstn_i  => rstn_i,        -- async reset, low-active
     clear_i => tx_fifo.clear, -- sync reset, high-active
     half_o  => tx_fifo.half,  -- FIFO at least half-full
-    level_o => open,          -- fill level, zero-extended
     -- write port --
     wdata_i => tx_fifo.wdata, -- write data
     we_i    => tx_fifo.we,    -- write enable
@@ -219,9 +216,7 @@ begin
   generic map (
     FIFO_DEPTH => IO_SPI_FIFO, -- number of fifo entries; has to be a power of two; min 1
     FIFO_WIDTH => 9,           -- size of data elements in fifo (data byte + dummy bit)
-    FIFO_RSYNC => true,        -- sync read
     FIFO_SAFE  => true,        -- safe access
-    FULL_RESET => false,       -- no HW reset, try to infer BRAM
     OUT_GATE   => false        -- no output gate required
   )
   port map (
@@ -230,7 +225,6 @@ begin
     rstn_i  => rstn_i,        -- async reset, low-active
     clear_i => rx_fifo.clear, -- sync reset, high-active
     half_o  => rx_fifo.half,  -- FIFO at least half-full
-    level_o => open,          -- fill level, zero-extended
     -- write port --
     wdata_i => rx_fifo.wdata, -- write data
     we_i    => rx_fifo.we,    -- write enable

--- a/rtl/core/neorv32_tracer.vhd
+++ b/rtl/core/neorv32_tracer.vhd
@@ -256,9 +256,7 @@ begin
   generic map (
     FIFO_DEPTH => TRACE_DEPTH,
     FIFO_WIDTH => 2*32,
-    FIFO_RSYNC => true,
     FIFO_SAFE  => true,
-    FULL_RESET => false,
     OUT_GATE   => false
   )
   port map (
@@ -267,7 +265,6 @@ begin
     rstn_i  => rstn_i,
     clear_i => fifo.clear,
     half_o  => open,
-    level_o => open,
     -- write port --
     wdata_i => fifo.wdata,
     we_i    => fifo.we,

--- a/rtl/core/neorv32_trng.vhd
+++ b/rtl/core/neorv32_trng.vhd
@@ -138,9 +138,7 @@ begin
   generic map (
     FIFO_DEPTH => TRNG_FIFO,
     FIFO_WIDTH => 8,
-    FIFO_RSYNC => true,
     FIFO_SAFE  => true,
-    FULL_RESET => false,
     OUT_GATE   => true -- output zero if no data available
   )
   port map (
@@ -149,7 +147,6 @@ begin
     rstn_i  => rstn_i,
     clear_i => fifo.clear,
     half_o  => fifo.half,
-    level_o => open,
     -- write port --
     wdata_i => fifo.wdata,
     we_i    => fifo.we,

--- a/rtl/core/neorv32_twd.vhd
+++ b/rtl/core/neorv32_twd.vhd
@@ -202,9 +202,7 @@ begin
   generic map (
     FIFO_DEPTH => TWD_TX_FIFO,
     FIFO_WIDTH => 8,
-    FIFO_RSYNC => true,
     FIFO_SAFE  => true,
-    FULL_RESET => false,
     OUT_GATE   => false
   )
   port map (
@@ -213,7 +211,6 @@ begin
     rstn_i  => rstn_i,
     clear_i => tx_fifo.clr,
     half_o  => open,
-    level_o => open,
     -- write port --
     wdata_i => tx_fifo.wdata,
     we_i    => tx_fifo.we,
@@ -254,9 +251,7 @@ begin
   generic map (
     FIFO_DEPTH => TWD_RX_FIFO,
     FIFO_WIDTH => 8,
-    FIFO_RSYNC => true,
     FIFO_SAFE  => true,
-    FULL_RESET => false,
     OUT_GATE   => false
   )
   port map (
@@ -265,7 +260,6 @@ begin
     rstn_i  => rstn_i,
     clear_i => rx_fifo.clr,
     half_o  => open,
-    level_o => open,
     -- write port --
     wdata_i => rx_fifo.wdata,
     we_i    => rx_fifo.we,

--- a/rtl/core/neorv32_twi.vhd
+++ b/rtl/core/neorv32_twi.vhd
@@ -172,9 +172,7 @@ begin
   generic map (
     FIFO_DEPTH => IO_TWI_FIFO,
     FIFO_WIDTH => 11, -- command, MACK, data
-    FIFO_RSYNC => true,
     FIFO_SAFE  => true,
-    FULL_RESET => false,
     OUT_GATE   => false
   )
   port map (
@@ -183,7 +181,6 @@ begin
     rstn_i  => rstn_i,
     clear_i => fifo.clear,
     half_o  => open,
-    level_o => open,
     -- write port --
     wdata_i => fifo.tx_wdata,
     we_i    => fifo.tx_we,
@@ -204,9 +201,7 @@ begin
   generic map (
     FIFO_DEPTH => IO_TWI_FIFO,
     FIFO_WIDTH => 9, -- ACK + data
-    FIFO_RSYNC => true,
     FIFO_SAFE  => true,
-    FULL_RESET => false,
     OUT_GATE   => false
   )
   port map (
@@ -215,7 +210,6 @@ begin
     rstn_i  => rstn_i,
     clear_i => fifo.clear,
     half_o  => open,
-    level_o => open,
     -- write port --
     wdata_i => fifo.rx_wdata,
     we_i    => fifo.rx_we,

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -227,9 +227,7 @@ begin
   generic map (
     FIFO_DEPTH => UART_TX_FIFO,
     FIFO_WIDTH => 8,
-    FIFO_RSYNC => true,
     FIFO_SAFE  => true,
-    FULL_RESET => false,
     OUT_GATE   => false
   )
   port map (
@@ -238,7 +236,6 @@ begin
     rstn_i  => rstn_i,
     clear_i => tx_fifo.clear,
     half_o  => tx_fifo.half,
-    level_o => open,
     -- write port --
     wdata_i => tx_fifo.wdata,
     we_i    => tx_fifo.we,
@@ -261,9 +258,7 @@ begin
   generic map (
     FIFO_DEPTH => UART_RX_FIFO,
     FIFO_WIDTH => 8,
-    FIFO_RSYNC => true,
     FIFO_SAFE  => true,
-    FULL_RESET => false,
     OUT_GATE   => false
   )
   port map (
@@ -272,7 +267,6 @@ begin
     rstn_i  => rstn_i,
     clear_i => rx_fifo.clear,
     half_o  => rx_fifo.half,
-    level_o => open,
     -- write port --
     wdata_i => rx_fifo.wdata,
     we_i    => rx_fifo.we,

--- a/rtl/file_list_cpu.f
+++ b/rtl/file_list_cpu.f
@@ -1,5 +1,4 @@
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_package.vhd
-NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_fifo.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_decompressor.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_frontend.vhd
 NEORV32_RTL_PATH_PLACEHOLDER/core/neorv32_cpu_control.vhd

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -353,9 +353,7 @@ begin
   generic map (
     FIFO_DEPTH => 4,
     FIFO_WIDTH => 32+4+1,
-    FIFO_RSYNC => false,
     FIFO_SAFE  => true,
-    FULL_RESET => true,
     OUT_GATE   => false
   )
   port map (
@@ -364,7 +362,6 @@ begin
     rstn_i                => rst_gen,
     clear_i               => '0',
     half_o                => open,
-    level_o               => open,
     -- write port --
     wdata_i(31 downto  0) => slink_tx.data,
     wdata_i(35 downto 32) => slink_tx.addr,


### PR DESCRIPTION
* optimize instruction prefetch buffer (CPU front-end): use a specialized module instead of the generic FIFO module
* rework CPU register file logic
* cleanup and otimize FIFO component:
  * remove memory-reset option
  * remove asynchronous reset option; read access are always synchronous
  * remove level output (was unused anyway)