### PR TITLE
⚠️ rework TWD module

### DIFF
--- a/docs/datasheet/soc_twd.adoc
+++ b/docs/datasheet/soc_twd.adoc
@@ -22,15 +22,14 @@
 
 * Philips I²C-compatible device-side controller
 * Programmable 7-bit device address
-* Optional data FIFOs
+* Optional RX/TX data FIFOs
 * Programmable interrupt conditions
 
 
 **Overview**
 
-The NEORV32 TWD implements a I2C-compatible **device-mode** controller. Processor-external hosts can communicate
-with this module by issuing I2C transactions. The TWD is entirely passive an only reacts on those external
-transmissions.
+The NEORV32 TWD implements an I2C-compatible **device-side** interface. Processor-external I2C hosts can communicate
+with this module by issuing I2C transactions. The TWD is entirely passive an only reacts on those external transmissions.
 
 .Device-Mode Only
 [NOTE]
@@ -49,31 +48,106 @@ by software via the `TWD_CTRL_RX_*` and `TWD_CTRL_TX_*` flags.
 
 The module is globally enabled by setting the control register's `TWD_CTRL_EN` bit. Clearing this bit will disable
 and reset the entire module also clearing the internal RX and TX FIFOs. Each FIFO can also be cleared individually at
-any time by setting `TWD_CTRL_CLR_RX` or `TWD_CTRL_CLR_TX`, respectively.
+any time by setting `TWD_CTRL_CLR_RX` or `TWD_CTRL_CLR_TX` control register bits, respectively.
 
-The external two wire bus is sampled sampled and synchronized into the processor's clock domain with a sampling
-frequency of 1/8 of the processor's main clock. In order to increase the resistance to glitches the sampling
-frequency can be lowered to 1/64 of the processor clock by setting the control register's `TWD_CTRL_FSEL` bit.
+The external two wire bus is sampled and synchronized into the processor's clock domain with a sampling frequency of
+1/8 of the processor's main clock. In order to increase the resistance to glitches the sampling frequency can be lowered
+to 1/64 of the processor clock by setting the control register's `TWD_CTRL_FSEL` bit.
 
 .Current Bus State
 [TIP]
 The current state of the I2C bus lines (SCL and SDA) can be checked by software via the `TWD_CTRL_SENSE_*` control
 register bits. Note that the TWD module needs to be enabled in order to sample the bus state.
 
-The actual 7-bit device address of the TWD is programmed by the `TWD_CTRL_DEV_ADDR` bits. Note that the TWD will
-only response to a host transactions if the host issues the according address. Specific general-call or broadcast
-addresses are not supported.
+The TWD only responds to a single configurable 7bit device address that is programmed by the `TWD_CTRL_DEV_ADDR` bits.
+Specific general-call or broadcast addresses are not supported.
 
-Depending on the transaction type, data is either read from the RX FIFO and transferred to the host ("read operation")
-or data is received from the host and written to the TX FIFO ("write operation"). Hence, data sequences can be
-programmed to the TX FIFO to be fetched from the host.
+Depending on the transaction type, data is either read from the RX FIFO and transferred to the host (**read operation**)
+or data is received from the host and written to the TX FIFO (**write operation**).
 
-If the TX FIFO is empty or drained and the host keeps performing read transactions, one out of three behaviors can
-be selected:
 
-* send all-one to the bus (default)
-* send the last byte that was taken from the TX FIFO to the bus if `TWD_CTRL_TX_DUMMY_EN` is set
-* send nothing and respond with no ACK (i.e. the TWD "disappears" from the bus) if `TWD_CTRL_HIDE_READ` is set
+**Read Operation: host reads data from TWD**
+
+.TWD read operation timing (not to scale, split across two lines)
+[wavedrom, format="svg", align="center"]
+----
+{signal: [
+  {name: 'SDA', wave: '10.7..7..7..7..7..7..7..1..0..x|.', node: 'a.b.....................c..d..e', data: ['A6', 'A5', 'A4', 'A3', 'A2', 'A1', 'A0']},
+  {name: 'SCL', wave: '1.0.10.10.10.10.10.10.10.10.10.|.'},
+  {},
+  {name: 'SDA', wave: 'x|.9..9..9..9..9..9..9..9..0..0.1', node: '...........................f..gh.i', data: ['D7', 'D6', 'D5', 'D4', 'D3', 'D2', 'D1', 'D0']},
+  {name: 'SCL', wave: '0|..10.10.10.10.10.10.10.10.10.1.'}
+ ],
+   edge: [
+    'a-b START',
+    'c-d READ',
+    'd-e ACK by TWD',
+    'f-g ACK by HOST',
+    'h-i STOP'
+ ]
+}
+----
+
+For a read operation the host first generates START or REPEATED-START condition. Then, the host transmits the 7 bit device
+address (green signals `A6` to `A0`) plus the read-command bit. If the transferred address matches the one programmed to to
+`TWD_CTRL_DEV_ADDR` control register bits the TWD module will response with an ACK by pulling the SDA bus line actively
+low during the 9th SCL clock pulse. If there is no address match the TWD will not interfere with the bus and will wait for
+the next START or REPEATED-START condition.
+
+For the actual data transmission the host keeps the SDA line at high state while sending the clock pulses. The TWD will
+read a byte from the internal TX FIFO and will transmit it MSB-first to the host. During the 9th clock pulse the host has
+to acknowledged the transfer (ACK) by pulling SDA low. If no ACK is received by the TWD no data is taken from the TX FIFO
+and the same byte is transmitted in the next data phase. If the TX FIFO becomes empty while the host keeps reading data,
+all-one bytes are sent back to the host. The transaction is terminated by a STOP condition.
+
+
+**Write Operation: host writes data to TWD**
+
+.TWD write operation timing (not to scale, split across two lines)
+[wavedrom, format="svg", align="center"]
+----
+{signal: [
+  {name: 'SDA', wave: '10.7..7..7..7..7..7..7..0..0..x|.', node: 'a.b.....................c..d..e', data: ['A6', 'A5', 'A4', 'A3', 'A2', 'A1', 'A0']},
+  {name: 'SCL', wave: '1.0.10.10.10.10.10.10.10.10.10.|.'},
+  {},
+  {name: 'SDA', wave: 'x|.5..5..5..5..5..5..5..5..0..0.1', node: '...........................f..gh.i', data: ['D7', 'D6', 'D5', 'D4', 'D3', 'D2', 'D1', 'D0']},
+  {name: 'SCL', wave: '0|..10.10.10.10.10.10.10.10.10.1.'}
+ ],
+   edge: [
+    'a-b START',
+    'c-d WRITE',
+    'd-e ACK by TWD',
+    'f-g ACK by TWD',
+    'h-i STOP'
+ ]
+}
+----
+
+For a write operation the host first generates START or REPEATED-START condition. Then, the host transmits the 7 bit device
+address (green signals `A6` to `A0`) plus the write-command bit. If the transferred address matches the one programmed to to
+`TWD_CTRL_DEV_ADDR` control register bits the TWD module will response with an ACK by pulling the SDA bus line actively
+low during the 9th SCL clock pulse. If there is no address match the TWD will not interfere with the bus and will wait for
+the next START or REPEATED-START condition.
+
+For the actual data transmission the host sends the write-data MSB first together with the clock pulses. During the 9th clock
+pulse the TWD will respond with an ACK by pulling SDA low. Note that the TWD will respond with a NACK if the RX FIFO is full.
+The transaction is terminated by a STOP condition.
+
+
+**Tristate Drivers**
+
+The TWD module requires two tristate drivers (actually: open-drain drivers - signals can only be actively driven low) for
+the SDA and SCL lines, which have to be implemented by the user in the setup's top module / IO ring. A generic VHDL example
+is shown below (here, `sda_io` and `scl_io` are the actual TWD bus lines, which are of type `std_logic`).
+
+.TWD Tristate Driver Example (VHDL)
+[source,VHDL]
+----
+sda_io    <= '0' when (twd_sda_o = '0') else 'Z'; -- drive
+scl_io    <= '0' when (twd_scl_o = '0') else 'Z'; -- drive
+twd_sda_i <= std_ulogic(sda_io); -- sense
+twd_scl_i <= std_ulogic(scl_io); -- sense
+----
 
 
 **TWD Interrupt**
@@ -90,101 +164,6 @@ The interrupt remains active until all enabled interrupt-causing conditions are 
 The interrupt can only trigger if the module is actually enabled (`TWD_CTRL_EN` is set).
 
 
-**TWD Transmissions**
-
-Two standard I2C-compatible transaction types are supported: **read** operations and **write** operations. These
-two operation types are illustrated in the following figure (note that the transactions are split across two lines
-to improve readability).
-
-.TWD single-byte read and write transaction timing (not to scale)
-[wavedrom, format="svg", align="center"]
-----
-{signal: [
-   [
-     "write byte",
-     {name: 'SDA', wave: '10.7..7..7..7..7..7..7..0..0..x|.', node: 'a.b.....................c..d..e', data: ['A6', 'A5', 'A4', 'A3', 'A2', 'A1', 'A0']},
-     {name: 'SCL', wave: '1.0.10.10.10.10.10.10.10.10.10.|.'},
-   {},
-     {name: 'SDA', wave: 'x|.5..5..5..5..5..5..5..5..0..0.1', node: '...........................f..gh.i', data: ['D7', 'D6', 'D5', 'D4', 'D3', 'D2', 'D1', 'D0']},
-     {name: 'SCL', wave: '0|..10.10.10.10.10.10.10.10.10.1.'}
-   ],
-   {},
-   {},
-   [
-     "read byte",
-     {name: 'SDA', wave: '10.7..7..7..7..7..7..7..1..0..x|.', node: 'j.k.....................l..m..n', data: ['A6', 'A5', 'A4', 'A3', 'A2', 'A1', 'A0']},
-     {name: 'SCL', wave: '1.0.10.10.10.10.10.10.10.10.10.|.'},
-   {},
-     {name: 'SDA', wave: 'x|.9..9..9..9..9..9..9..9..0..0.1', node: '...........................o..pq.r', data: ['D7', 'D6', 'D5', 'D4', 'D3', 'D2', 'D1', 'D0']},
-     {name: 'SCL', wave: '0|..10.10.10.10.10.10.10.10.10.1.'}
-   ]
- ],
-   edge: [
-    'a-b START',
-    'c-d WRITE',
-    'd-e ACK by TWD',
-    'f-g ACK by TWD',
-    'h-i STOP',
-
-    'j-k START',
-    'l-m READ',
-    'm-n ACK by TWD',
-    'o-p ACK by HOST',
-    'q-r STOP'
- ]
-}
-----
-
-Any new transaction starts with a **START** condition. Then, the host transmits the 7 bit device address MSB-first
-(green signals `A6` to `A0`) plus a command bit. The command bit can be either **write** (pulling the SDA line low)
-or **read** (leaving the SDA line high). If the transferred address matches the one programmed to to `TWD_CTRL_DEV_ADDR`
-control register bits the TWD module will response with an **ACK** (acknowledge) by pulling the SDA bus line actively
-low during the 9th SCL clock pulse. If there is no address match the TWD will not interfere with the bus and move back
-to idle state.
-
-For a **write transaction** (upper timing diagram) the host can now transfer an arbitrary number of bytes (blue signals
-`D7` to `D0`, MSB-first) to the TWD module. Each byte is acknowledged by the TWD by pulling SDA low during the 9th SCL
-clock pules (**ACK**), if moved into the FIFO. When the FIFO is full, the transfer gets not acknowledged (**NACK**).
-Each received data byte is pushed to the internal RX FIFO. Data will be lost if the FIFO overflows.
-The transaction is terminated when the host issues a **STOP** condition after the TWD has acknowledged the last data
-transfer.
-
-For a **read transaction** (lower timing diagram) the host keeps the SDA line at high state while sending the clock
-pulse. The TWD will read a byte from the internal TX FIFO and will transmit it MSB-first to the host (blue signals `D7`
-to `D0)`. During the 9th clock pulse the host has to acknowledged the transfer (**ACK**) by pulling SDA low. If no ACK
-is received by the TWD no data is taken from the TX FIFO and the same byte can be transmitted in the next data phase.
-If the TX FIFO becomes empty while the host keeps reading data, all-one bytes are transmitted (if `TWD_CTRL_TX_DUMMY_EN = 0`)
-or the last value taken from the TX FIFO (before it got empty is sent again (`TWD_CTRL_TX_DUMMY_EN = 1`). To terminate the
-transmission the host hast so send a **NACK** after receiving the last data byte by keeping SDA high. After that, the
-host has to issue a **STOP** condition. If the `TWD_CTRL_HIDE_READ` bit is set, the access will not get acknowledged
-at all if the TX FIFO is empty.
-
-A **repeated-START** condition can be issued at any time (but after the complete transaction of a data byte and there
-according ACK/NACK) bringing the TWD back to the start of the address/command transmission phase. The control register's
-`TWD_CTRL_BUSY` flag remains high while a bus transaction is in progress.
-
-.Abort / Termination
-[TIP]
-An active or even stuck transmission can be terminated at any time by disabling the TWD module.
-This will also clear the RX/TX FIFOs.
-
-
-**Tristate Drivers**
-
-The TWD module requires two tristate drivers (actually: open-drain drivers - signals can only be actively driven low) for
-the SDA and SCL lines, which have to be implemented by the user in the setup's top module / IO ring. A generic VHDL example
-is shown below (here, `sda_io` and `scl_io` are the actual TWD bus lines, which are of type `std_logic`).
-
-.TWD VHDL Tristate Driver Example
-[source,VHDL]
-----
-sda_io    <= '0' when (twd_sda_o = '0') else 'Z'; -- drive
-scl_io    <= '0' when (twd_scl_o = '0') else 'Z'; -- drive
-twd_sda_i <= std_ulogic(sda_io); -- sense
-twd_scl_i <= std_ulogic(scl_io); -- sense
-----
-
-
 **Register Map**
 
 .TWD register map (`struct NEORV32_TWD`)
@@ -192,7 +171,7 @@ twd_scl_i <= std_ulogic(scl_io); -- sense
 [options="header",grid="all"]
 |=======================
 | Address | Name [C] | Bit(s), Name [C] | R/W | Function
-.20+<| `0xffea0000` .20+<| `CTRL` <|`0`     `TWD_CTRL_EN`                                   ^| r/w <| TWD enable, reset if cleared
+.19+<| `0xffea0000` .19+<| `CTRL` <|`0`     `TWD_CTRL_EN`                                   ^| r/w <| TWD enable, reset if cleared
                                   <|`1`     `TWD_CTRL_CLR_RX`                               ^| -/w <| Clear RX FIFO, flag auto-clears
                                   <|`2`     `TWD_CTRL_CLR_TX`                               ^| -/w <| Clear TX FIFO, flag auto-clears
                                   <|`3`     `TWD_CTRL_FSEL`                                 ^| r/w <| Bus sample clock / filter select
@@ -200,8 +179,7 @@ twd_scl_i <= std_ulogic(scl_io); -- sense
                                   <|`11`    `TWD_CTRL_IRQ_RX_AVAIL`                         ^| r/w <| IRQ if RX FIFO data available
                                   <|`12`    `TWD_CTRL_IRQ_RX_FULL`                          ^| r/w <| IRQ if RX FIFO full
                                   <|`13`    `TWD_CTRL_IRQ_TX_EMPTY`                         ^| r/w <| IRQ if TX FIFO empty
-                                  <|`14`    `TWD_CTRL_TX_DUMMY_EN`                          ^| r/w <| enable sending tx_dummy (last sent byte) when FIFO is empty
-                                  <|`15`    `TWD_CTRL_HIDE_READ`                            ^| r/w <| Generate NACK on READ-access when TX FIFO is empty
+                                  <|`15:14` -                                               ^| r/w <|_reserved_, read as zero
                                   <|`19:16` `TWD_CTRL_RX_FIFO_MSB : TWD_CTRL_RX_FIFO_LSB`   ^| r/- <| FIFO depth; log2(`IO_TWD_RX_FIFO`)
                                   <|`23:20` `TWD_CTRL_TX_FIFO_MSB : TWD_CTRL_TX_FIFO_LSB`   ^| r/- <| FIFO depth; log2(`IO_TWD_TX_FIFO`)
                                   <|`24`    -                                               ^| r/- <| _reserved_, read as zero

--- a/docs/datasheet/soc_twi.adoc
+++ b/docs/datasheet/soc_twi.adoc
@@ -29,8 +29,8 @@
 
 **Overview**
 
-The NEORV32 TWI implements a I²C-compatible host controller to communicate with arbitrary I2C-devices.
-Note that peripheral-mode (controller acts as a device) and multi-controller mode are not supported yet.
+The NEORV32 TWI implements an I2C-compatible host controller to communicate with arbitrary I2C-devices.
+Note that multi-controller mode and bus arbitration are not supported.
 
 .Host-Mode Only
 [NOTE]
@@ -38,24 +38,19 @@ The NEORV32 TWI controller only supports **host mode**. Transmission are initiat
 and not by an external I²C module. If you are looking for a _device-mode_ module (transactions
 initiated by an external host) check out the <<_two_wire_serial_device_controller_twd>>.
 
-The TWI controller provides two memory-mapped registers that are used for configuring the module and
-for triggering operations: the control and status register `CTRL` and the command and data register `DCMD`.
+The TWI controller provides two memory-mapped registers that are used for configuration & status check (`CTRL`) and
+for accessing transmission data (`DATA`). The `DATA` register is transparently buffered by separate RX and TX FIFOs.
+The size of those FIFOs can be configured by the `IO_TWI_RX_FIFO` and `IO_TWI_TX_FIFO` generics. Software can determine
+the FIFO size via the control register's `TWI_CTRL_FIFO_*` bits. The current status of the RX and TX FIFO can be polled
+by software via the `TWD_CTRL_RX_*` and `TWI_CTRL_TX_*` flags.
 
+The module is globally enabled by setting the control register's `TWI_CTRL_EN` bit. Clearing this bit will disable
+and reset the entire module also clearing the internal RX and TX FIFOs.
 
-**Tristate Drivers**
-
-The TWI module requires two tristate drivers (actually: open-drain drivers - signals can only be actively driven low) for
-the SDA and SCL lines, which have to be implemented by the user in the setup's top module / IO ring. A generic VHDL example
-is shown below (here, `sda_io` and `scl_io` are the actual I²C bus lines, which are of type `std_logic`).
-
-.TWI VHDL Tristate Driver Example
-[source,VHDL]
-----
-sda_io    <= '0' when (twi_sda_o = '0') else 'Z'; -- drive
-scl_io    <= '0' when (twi_scl_o = '0') else 'Z'; -- drive
-twi_sda_i <= std_ulogic(sda_io); -- sense
-twi_scl_i <= std_ulogic(scl_io); -- sense
-----
+.Current Bus State
+[TIP]
+The current state of the I2C bus lines (SCL and SDA) can be checked by software via the `TWI_CTRL_SENSE_*` control
+register bits. Note that the TWI module needs to be enabled in order to sample the bus state.
 
 
 **TWI Clock Speed**
@@ -89,37 +84,40 @@ SCL line low). The controller will halt operation in this case. Clock stretching
 
 **TWI Transfers**
 
-The TWI is enabled via the `TWI_CTRL_EN` bit in the `CTRL` control register. All TWI operations are controlled by
-the `DCMD` register. The actual operation is selected by a 2-bit value that is written to the register's `TWI_DCMD_CMD_*`
-bit-field:
+All TWI operations are controlled by the `DCMD` register, which is buffered by a FIFO. This command/data FIFO is internally
+split into a TX FIFO and a RX FIFO. Writing to `DCMD` will write to the TX FIFO while reading from `DCMD` will read from the
+RX FIFO. Thus, complete TWI sequences can be programmed and executed without further CPU intervention. The actual operation
+is selected by a 2-bit value that is written to the register's `TWI_DCMD_CMD_*` bit-field:
 
-* `00`: NOP (no-operation); all further bit-fields in `DCMD` are ignored
-* `01`: Generate a (repeated) START conditions; all further bit-fields in `DCMD` are ignored
-* `10`: Generate a STOP conditions; all further bit-fields in `DCMD` are ignored
-* `11`: Trigger a data transmission; the data to be send has to be written to the register's `TWI_DCMD_MSB : TWI_DCMD_LSB`
-bit-field; if `TWI_DCMD_ACK` is set the controller will send a host-ACK in the ACK/NACK time slot; after the transmission
-is completed `TWI_DCMD_MSB : TWI_DCMD_LSB` contains the RX data and `TWI_DCMD_ACK` the device's response if no host-ACK was
-configured (`0` = ACK, `1` = ACK)
+* `00`: NOP (no-operation); all further bit-fields in `DCMD` are ignored; no bus operation is executed
+* `01`: Generate a (repeated) START condition; all further bit-fields in `DCMD` are ignored
+* `10`: Generate a STOP condition; all further bit-fields in `DCMD` are ignored
+* `11`: Trigger a data transmission; see below
 
-All operations/data written to the `DCMD` register are buffered by a configurable data/command FIFO. The depth of the FIFO is
-configured by the `IO_TWI_FIFO` top generic. Software can retrieve this size by reading the control register's `TWI_CTRL_FIFO` bits.
+For any transmission the data to be send has to be written to the register's `TWI_DCMD_MSB : TWI_DCMD_LSB` bit-field.
+If `TWI_DCMD_ACK` is set the controller will generate an ACK by it's own. If `TWI_DCMD_ACK` is cleared the controller will
+sample ACK/NACK from the accessed device. Vice versa, the device's data response can be read from `TWI_DCMD_MSB : TWI_DCMD_LSB`
+bit-field. The ACK/NACK generated by the device can be read from the `TWI_DCMD_ACK` bit.
 
-The command/data FIFO is internally split into a TX FIFO and a RX FIFO. Writing to `DCMD` will write to the TX FIFO while reading from
-`DCMD` will read from the RX FIFO. The TX FIFO is full when the `TWI_CTRL_TX_FULL` flag is set. Accordingly, the RX FIFO contains valid
-data when the `TWI_CTRL_RX_AVAIL` flag is set.
+The control register's busy flag `TWI_CTRL_BUSY` is set as long as the TX FIFO contains data (i.e. programmed TWI operations
+that have not been executed yet) or if the TWI bus engine is still processing an operation. An active transmission can be
+terminated at any time by disabling the TWI module. This will also clear the data/command FIFO.
 
-The control register's busy flag `TWI_CTRL_BUSY` is set as long as the TX FIFO contains valid data (i.e. programmed TWI operations
-that have not been executed yet) or of the TWI bus engine is still processing an operation.
 
-[TIP]
-An active transmission can be terminated at any time by disabling the TWI module. This will also clear the data/command FIFO.
+**Tristate Drivers**
 
-[TIP]
-The current state of the I²C bus lines (SCL and SDA) can be checked by software via the `TWI_CTRL_SENSE_*` control register bits.
+The TWI module requires two tristate drivers (actually: open-drain drivers - signals can only be actively driven low) for
+the SDA and SCL lines, which have to be implemented by the user in the setup's top module / IO ring. A generic VHDL example
+is shown below (here, `sda_io` and `scl_io` are the actual I²C bus lines, which are of type `std_logic`).
 
-[NOTE]
-When reading data from a device, an all-one byte (`0xFF`) has to be written to TWI data register `NEORV32_TWI.DATA`
-so the accessed device can actively pull-down SDA when required.
+.TWI VHDL Tristate Driver Example
+[source,VHDL]
+----
+sda_io    <= '0' when (twi_sda_o = '0') else 'Z'; -- drive
+scl_io    <= '0' when (twi_scl_o = '0') else 'Z'; -- drive
+twi_sda_i <= std_ulogic(sda_io); -- sense
+twi_scl_i <= std_ulogic(scl_io); -- sense
+----
 
 
 **TWI Interrupt**
@@ -147,7 +145,8 @@ TWI module is enabled (`TWI_CTRL_EN` = `1`) and the TX FIFO is empty and the TWI
                                   <|`29`    `TWI_CTRL_TX_FULL`                      ^| r/- <| set if the TWI bus is claimed by any controller
                                   <|`30`    `TWI_CTRL_RX_AVAIL`                     ^| r/- <| RX FIFO data available
                                   <|`31`    `TWI_CTRL_BUSY`                         ^| r/- <| TWI bus engine busy or TX FIFO not empty
-.3+<| `0xfff90004` .3+<| `DCMD`   <|`7:0`   `TWI_DCMD_MSB : TWI_DCMD_LSB`           ^| r/w <| RX/TX data byte
-                                  <|`8`     `TWI_DCMD_ACK`                          ^| r/w <| write: ACK bit sent by controller; read: `1` = device NACK, `0` = device ACK
-                                  <|`10:9`  `TWI_DCMD_CMD_HI : TWI_DCMD_CMD_LO`     ^| r/w <| TWI operation (`00` = NOP, `01` = START conditions, `10` = STOP condition, `11` = data transmission)
+.4+<| `0xfff90004` .4+<| `DCMD`   <|`7:0`   `TWI_DCMD_MSB : TWI_DCMD_LSB`           ^| r/w <| write: TX data byte; read: RX data byte
+                                  <|`8`     `TWI_DCMD_ACK`                          ^| r/w <| write: ACK issued by controller; read: `1` = device NACK, `0` = device ACK
+                                  <|`10:9`  `TWI_DCMD_CMD_HI : TWI_DCMD_CMD_LO`     ^| -/w <| TWI operation (`00` = NOP, `01` = START conditions, `10` = STOP condition, `11` = data transmission)
+                                  <|`31:11`  -                                      ^| r/- <| _reserved_, read as zero
 |=======================

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -28,7 +28,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01120008"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01120009"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/rtl/core/neorv32_twi.vhd
+++ b/rtl/core/neorv32_twi.vhd
@@ -17,7 +17,7 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_twi is
   generic (
-    IO_TWI_FIFO : natural range 1 to 2**15 -- TWI RTX fifo depth, has to be a power of two, min 1
+    IO_TWI_FIFO : natural range 1 to 2**15 -- TWI RTX FIFO depth, has to be a power of two, min 1
   );
   port (
     clk_i     : in  std_ulogic; -- global clock line
@@ -26,9 +26,9 @@ entity neorv32_twi is
     bus_rsp_o : out bus_rsp_t;  -- bus response
     clkgen_i  : in  std_ulogic_vector(7 downto 0);
     twi_sda_i : in  std_ulogic; -- serial data line input
-    twi_sda_o : out std_ulogic; -- serial data line output
+    twi_sda_o : out std_ulogic; -- serial data line output (0=GND, 1=high-Z)
     twi_scl_i : in  std_ulogic; -- serial clock line input
-    twi_scl_o : out std_ulogic; -- serial clock line output
+    twi_scl_o : out std_ulogic; -- serial clock line output (0=GND, 1=high-Z)
     irq_o     : out std_ulogic  -- interrupt
   );
 end neorv32_twi;
@@ -36,21 +36,21 @@ end neorv32_twi;
 architecture neorv32_twi_rtl of neorv32_twi is
 
   -- control register --
-  constant ctrl_en_c         : natural :=  0; -- r/w: module enable (reset when zero)
-  constant ctrl_prsc0_c      : natural :=  1; -- r/w: clock prescaler bit 0
-  constant ctrl_prsc2_c      : natural :=  3; -- r/w: clock prescaler bit 2
-  constant ctrl_cdiv0_c      : natural :=  4; -- r/w: clock divider bit 0
-  constant ctrl_cdiv3_c      : natural :=  7; -- r/w: clock divider bit 3
-  constant ctrl_clkstr_en_c  : natural :=  8; -- r/w: enable clock stretching
+  constant ctrl_en_c        : natural :=  0; -- r/w: module enable (reset when zero)
+  constant ctrl_prsc0_c     : natural :=  1; -- r/w: clock prescaler bit 0
+  constant ctrl_prsc2_c     : natural :=  3; -- r/w: clock prescaler bit 2
+  constant ctrl_cdiv0_c     : natural :=  4; -- r/w: clock divider bit 0
+  constant ctrl_cdiv3_c     : natural :=  7; -- r/w: clock divider bit 3
+  constant ctrl_clkstr_en_c : natural :=  8; -- r/w: enable clock stretching
   --
-  constant ctrl_fifo_size0_c : natural := 15; -- r/-: log2(FIFO size), bit 0 (LSB)
-  constant ctrl_fifo_size3_c : natural := 18; -- r/-: log2(FIFO size), bit 3 (MSB)
+  constant ctrl_fifo0_c     : natural := 15; -- r/-: log2(FIFO size), bit 0 (LSB)
+  constant ctrl_fifo3_c     : natural := 18; -- r/-: log2(FIFO size), bit 3 (MSB)
   --
-  constant ctrl_sense_scl_c  : natural := 27; -- r/-: current state of the SCL bus line
-  constant ctrl_sense_sda_c  : natural := 28; -- r/-: current state of the SDA bus line
-  constant ctrl_tx_full_c    : natural := 29; -- r/-: TX FIFO full
-  constant ctrl_rx_avail_c   : natural := 30; -- r/-: RX FIFO data available
-  constant ctrl_busy_c       : natural := 31; -- r/-: Set if TWI unit is busy
+  constant ctrl_sense_scl_c : natural := 27; -- r/-: current state of the SCL bus line
+  constant ctrl_sense_sda_c : natural := 28; -- r/-: current state of the SDA bus line
+  constant ctrl_tx_full_c   : natural := 29; -- r/-: TX FIFO full
+  constant ctrl_rx_avail_c  : natural := 30; -- r/-: RX FIFO data available
+  constant ctrl_busy_c      : natural := 31; -- r/-: Set if TWI unit is busy
 
   -- data/command register --
   constant dcmd_lsb_c    : natural :=  0; -- r/w: data byte LSB
@@ -73,7 +73,7 @@ architecture neorv32_twi_rtl of neorv32_twi is
 
   -- FIFO interface --
   type fifo_t is record
-    clear              : std_ulogic; -- sync reset, high-active
+    rx_clear, tx_clear : std_ulogic; -- sync reset, high-active
     rx_we,    tx_we    : std_ulogic; -- write enable
     rx_re,    tx_re    : std_ulogic; -- read enable
     rx_wdata, rx_rdata : std_ulogic_vector(8 downto 0); -- RX read/write data
@@ -98,19 +98,16 @@ architecture neorv32_twi_rtl of neorv32_twi is
   type engine_t is record
     state  : std_ulogic_vector(2 downto 0); -- FSM state
     bitcnt : std_ulogic_vector(3 downto 0); -- bit counter
-    sreg   : std_ulogic_vector(8 downto 0); -- main rx/tx shift reg
-    done   : std_ulogic; -- data transmission done
+    sreg   : std_ulogic_vector(8 downto 0); -- shift register
+    tx_re  : std_ulogic; -- pop from TX FIFO
+    rx_we  : std_ulogic; -- push to RX FIFO
     busy   : std_ulogic; -- bus operation in progress
   end record;
   signal engine : engine_t;
 
-  -- tristate I/O control --
-  type io_con_t is record
-    sda_in_ff, scl_in_ff : std_ulogic_vector(1 downto 0); -- input sync
-    sda_in,    scl_in    : std_ulogic;
-    sda_out,   scl_out   : std_ulogic;
-  end record;
-  signal io_con : io_con_t;
+  -- I/O control --
+  signal sda_sync, scl_sync : std_ulogic_vector(1 downto 0); -- input synchronizer
+  signal sda_out,  scl_out  : std_ulogic;
 
 begin
 
@@ -123,6 +120,7 @@ begin
       ctrl.enable <= '0';
       ctrl.prsc   <= (others => '0');
       ctrl.cdiv   <= (others => '0');
+      ctrl.clkstr <= '0';
     elsif rising_edge(clk_i) then
       -- bus handshake defaults --
       bus_rsp_o.ack  <= bus_req_i.stb;
@@ -143,15 +141,13 @@ begin
             bus_rsp_o.data(ctrl_prsc2_c downto ctrl_prsc0_c) <= ctrl.prsc;
             bus_rsp_o.data(ctrl_cdiv3_c downto ctrl_cdiv0_c) <= ctrl.cdiv;
             bus_rsp_o.data(ctrl_clkstr_en_c)                 <= ctrl.clkstr;
-            --
-            bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
-            --
-            bus_rsp_o.data(ctrl_sense_scl_c) <= io_con.scl_in_ff(1);
-            bus_rsp_o.data(ctrl_sense_sda_c) <= io_con.sda_in_ff(1);
-            bus_rsp_o.data(ctrl_tx_full_c)   <= not fifo.tx_free;
-            bus_rsp_o.data(ctrl_rx_avail_c)  <= fifo.rx_avail;
-            bus_rsp_o.data(ctrl_busy_c)      <= engine.busy or fifo.tx_avail; -- bus engine busy or TX FIFO not empty
-          else -- RX FIFO
+            bus_rsp_o.data(ctrl_fifo3_c downto ctrl_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
+            bus_rsp_o.data(ctrl_sense_scl_c)                 <= scl_sync(1);
+            bus_rsp_o.data(ctrl_sense_sda_c)                 <= sda_sync(1);
+            bus_rsp_o.data(ctrl_tx_full_c)                   <= not fifo.tx_free;
+            bus_rsp_o.data(ctrl_rx_avail_c)                  <= fifo.rx_avail;
+            bus_rsp_o.data(ctrl_busy_c)                      <= engine.busy or fifo.tx_avail;
+          else -- RX data
             bus_rsp_o.data(8 downto 0) <= fifo.rx_rdata; -- ACK + data
           end if;
         end if;
@@ -160,25 +156,21 @@ begin
   end process bus_access;
 
 
-  -- Data FIFO ("Ring Buffer") --------------------------------------------------------------
+  -- Data FIFOs ("Ring Buffer") -------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-
-  -- global FIFO clear --
-  fifo.clear <= not ctrl.enable;
-
 
   -- TX FIFO --
   tx_fifo_inst: entity neorv32.neorv32_prim_fifo
   generic map (
     AWIDTH  => log2_fifo_size_c,
-    DWIDTH  => 11, -- command, MACK, data
+    DWIDTH  => 11, -- command, host-ACK, data
     OUTGATE => false
   )
   port map (
     -- global control --
     clk_i   => clk_i,
     rstn_i  => rstn_i,
-    clear_i => fifo.clear,
+    clear_i => fifo.tx_clear,
     -- write port --
     wdata_i => fifo.tx_wdata,
     we_i    => fifo.tx_we,
@@ -189,9 +181,10 @@ begin
     avail_o => fifo.tx_avail
   );
 
-  fifo.tx_we    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '1') else '0';
+  fifo.tx_clear <= not ctrl.enable;
   fifo.tx_wdata <= bus_req_i.data(dcmd_cmd_hi_c downto dcmd_lsb_c);
-  fifo.tx_re    <= '1' when (engine.busy = '0') and (fifo.tx_avail = '1') and (clk_gen.tick = '1') else '0';
+  fifo.tx_we    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '1') else '0';
+  fifo.tx_re    <= engine.tx_re;
 
 
   -- RX FIFO --
@@ -205,7 +198,7 @@ begin
     -- global control --
     clk_i   => clk_i,
     rstn_i  => rstn_i,
-    clear_i => fifo.clear,
+    clear_i => fifo.rx_clear,
     -- write port --
     wdata_i => fifo.rx_wdata,
     we_i    => fifo.rx_we,
@@ -216,8 +209,9 @@ begin
     avail_o => fifo.rx_avail
   );
 
+  fifo.rx_clear <= not ctrl.enable;
   fifo.rx_wdata <= engine.sreg(0) & engine.sreg(8 downto 1); -- ACK + data
-  fifo.rx_we    <= engine.done;
+  fifo.rx_we    <= engine.rx_we;
   fifo.rx_re    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(2) = '1') else '0';
 
 
@@ -266,22 +260,22 @@ begin
     elsif rising_edge(clk_i) then
       clk_gen.phase_gen_ff <= clk_gen.phase_gen;
       if (ctrl.enable = '0') or (engine.busy = '0') then -- disabled or idle
-        clk_gen.phase_gen <= "0001"; -- make sure to start with a new phase beginning
+        clk_gen.phase_gen <= "0001"; -- start with a new phase
       elsif (clk_gen.tick = '1') and (clk_gen.halt = '0') then -- clock tick and no clock stretching
         clk_gen.phase_gen <= clk_gen.phase_gen(2 downto 0) & clk_gen.phase_gen(3); -- rotate left
       end if;
     end if;
   end process phase_generator;
 
-  -- TWI bus signals are set/sampled using 4 clock phases --
+  -- TWI bus signals are set/sampled using 4 clock phase ticks --
   clk_gen.phase(0) <= clk_gen.phase_gen_ff(0) and (not clk_gen.phase_gen(0)); -- first step
   clk_gen.phase(1) <= clk_gen.phase_gen_ff(1) and (not clk_gen.phase_gen(1));
   clk_gen.phase(2) <= clk_gen.phase_gen_ff(2) and (not clk_gen.phase_gen(2));
   clk_gen.phase(3) <= clk_gen.phase_gen_ff(3) and (not clk_gen.phase_gen(3)); -- last step
 
-  -- Clock Stretching Detector --
+  -- clock stretching detector --
   -- controller wants to drive SCL high, but SCL is still pulled low by peripheral --
-  clk_gen.halt <= '1' when (io_con.scl_out = '1') and (io_con.scl_in_ff(1) = '0') and (ctrl.clkstr = '1') else '0';
+  clk_gen.halt <= '1' when (scl_out = '1') and (scl_sync(1) = '0') and (ctrl.clkstr = '1') else '0';
 
 
   -- TWI Bus Engine -------------------------------------------------------------------------
@@ -289,23 +283,16 @@ begin
   twi_engine: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      io_con.sda_in_ff <= (others => '0');
-      io_con.scl_in_ff <= (others => '0');
-      io_con.sda_out   <= '1';
-      io_con.scl_out   <= '1';
-      engine.state     <= (others => '0');
-      engine.bitcnt    <= (others => '0');
-      engine.sreg      <= (others => '0');
-      engine.done      <= '0';
+      engine.state  <= (others => '0');
+      engine.bitcnt <= (others => '0');
+      engine.sreg   <= (others => '0');
+      engine.tx_re  <= '0';
+      engine.rx_we  <= '0';
+      sda_out       <= '1';
+      scl_out       <= '1';
     elsif rising_edge(clk_i) then
-      -- input synchronizer --
-      io_con.sda_in_ff <= io_con.sda_in_ff(0) & io_con.sda_in;
-      io_con.scl_in_ff <= io_con.scl_in_ff(0) & io_con.scl_in;
-
-      -- defaults --
-      engine.done <= '0';
-
-      -- serial engine --
+      engine.tx_re    <= '0';
+      engine.rx_we    <= '0';
       engine.state(2) <= ctrl.enable; -- module enabled?
       case engine.state is
 
@@ -314,56 +301,55 @@ begin
           engine.bitcnt <= (others => '0');
           engine.sreg   <= fifo.tx_rdata(dcmd_msb_c downto dcmd_lsb_c) & (not fifo.tx_rdata(dcmd_ack_c)); -- data + HOST ACK
           if (fifo.tx_avail = '1') and (clk_gen.tick = '1') then -- trigger new operation on next TWI clock pulse
+            engine.tx_re             <= '1'; -- pop from TX FIFO
             engine.state(1 downto 0) <= fifo.tx_rdata(dcmd_cmd_hi_c downto dcmd_cmd_lo_c);
           end if;
 
         when "101" => -- START: generate (repeated) START condition
         -- ------------------------------------------------------------
           if (clk_gen.phase(0) = '1') then
-            io_con.sda_out <= '1';
+            sda_out <= '1';
           elsif (clk_gen.phase(2) = '1') then
-            io_con.sda_out <= '0';
+            sda_out <= '0';
           end if;
-          --
           if (clk_gen.phase(0) = '1') then
-            io_con.scl_out <= '1';
+            scl_out <= '1';
           elsif (clk_gen.phase(3) = '1') then
-            io_con.scl_out <= '0';
+            scl_out <= '0';
             engine.state(1 downto 0) <= "00"; -- go back to IDLE
           end if;
 
         when "110" => -- STOP: generate STOP condition
         -- ------------------------------------------------------------
           if (clk_gen.phase(0) = '1') then
-            io_con.sda_out <= '0';
+            sda_out <= '0';
           elsif (clk_gen.phase(3) = '1') then
-            io_con.sda_out <= '1';
+            sda_out                  <= '1';
             engine.state(1 downto 0) <= "00"; -- go back to IDLE
           end if;
-          --
           if (clk_gen.phase(0) = '1') then
-            io_con.scl_out <= '0';
+            scl_out <= '0';
           elsif (clk_gen.phase(1) = '1') then
-            io_con.scl_out <= '1';
+            scl_out <= '1';
           end if;
 
         when "111" => -- TRANSMISSION: send/receive byte + ACK/NACK/MACK
         -- ------------------------------------------------------------
           -- SCL clocking --
           if (clk_gen.phase(0) = '1') or (clk_gen.phase(3) = '1') then
-            io_con.scl_out <= '0'; -- set SCL low after transmission to keep bus claimed
+            scl_out <= '0'; -- set SCL low after transmission to keep bus claimed
           elsif (clk_gen.phase(1) = '1') then -- first half + second half of valid data strobe
-            io_con.scl_out <= '1';
+            scl_out <= '1';
           end if;
           -- SDA output --
           if (engine.bitcnt = "1001") and (clk_gen.phase(0) = '1') then
-            io_con.sda_out <= '0'; -- set SDA low after transmission to keep bus claimed
+            sda_out <= '0'; -- set SDA low after transmission to keep bus claimed
           elsif (clk_gen.phase(0) = '1') then
-            io_con.sda_out <= engine.sreg(8); -- MSB first
+            sda_out <= engine.sreg(8); -- MSB first
           end if;
           -- SDA input --
           if (clk_gen.phase(2) = '1') then
-            engine.sreg <= engine.sreg(7 downto 0) & io_con.sda_in_ff(1); -- sample SDA input and shift left
+            engine.sreg <= engine.sreg(7 downto 0) & sda_sync(1); -- sample SDA input and shift left
           end if;
           -- bit counter --
           if (clk_gen.phase(3) = '1') then
@@ -371,14 +357,14 @@ begin
           end if;
           -- transmission done --
           if (engine.bitcnt = "1001") and (clk_gen.phase(0) = '1') then
-            engine.done              <= '1';
+            engine.rx_we             <= '1';
             engine.state(1 downto 0) <= "00"; -- go back to IDLE
           end if;
 
         when others => -- "0--" OFFLINE: TWI deactivated, bus unclaimed
         -- ------------------------------------------------------------
-          io_con.scl_out           <= '1'; -- SCL driven by pull-up resistor
-          io_con.sda_out           <= '1'; -- SDA driven by pull-up resistor
+          scl_out                  <= '1';  -- bus idle, SCL driven by pull-up resistor
+          sda_out                  <= '1';  -- bus idle, SDA driven by pull-up resistor
           engine.state(1 downto 0) <= "00"; -- stay here, go to IDLE when activated
 
       end case;
@@ -389,12 +375,22 @@ begin
   engine.busy <= '1' when (engine.state(2) = '1') and (engine.state(1 downto 0) /= "00") else '0';
 
 
-  -- Tristate Driver Interface --------------------------------------------------------------
+  -- IO Control -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  twi_sda_o     <= io_con.sda_out; -- NOTE: signal lines can only be actively driven low
-  twi_scl_o     <= io_con.scl_out;
-  io_con.sda_in <= to_stdulogic(to_bit(twi_sda_i)); -- "to_bit" to avoid hardware-vs-simulation mismatch
-  io_con.scl_in <= to_stdulogic(to_bit(twi_scl_i)); -- "to_bit" to avoid hardware-vs-simulation mismatch
+  input_synchronizer: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      sda_sync <= (others => '0');
+      scl_sync <= (others => '0');
+    elsif rising_edge(clk_i) then
+      sda_sync <= sda_sync(0) & to_stdulogic(to_bit(twi_sda_i)); -- "to_bit" to avoid HW-vs-sim mismatch
+      scl_sync <= scl_sync(0) & to_stdulogic(to_bit(twi_scl_i));
+    end if;
+  end process input_synchronizer;
+
+  -- tri-state control: 0 = drive GND, 1 = tri-state / driven by pull-up --
+  twi_sda_o <= sda_out;
+  twi_scl_o <= scl_out;
 
 
 end neorv32_twi_rtl;

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1075,7 +1075,7 @@ int main() {
     cnt_test++;
 
     // configure TWD and enable RX-available interrupt
-    neorv32_twd_setup(0b1101001, 0, 1, 0, 0, 0, 0);
+    neorv32_twd_setup(0b1101001, 0, 1 << TWD_CTRL_IRQ_RX_AVAIL);
 
     // configure TWI with third-fastest clock, no clock stretching
     neorv32_twi_setup(CLK_PRSC_8, 1, 0);
@@ -1329,7 +1329,7 @@ int main() {
     neorv32_twi_setup(CLK_PRSC_8, 1, 0);
 
     // configure TWD, no interrupts
-    neorv32_twd_setup(0b0010110, 0, 0, 0, 0, 0, 0);
+    neorv32_twd_setup(0b0010110, 0, 0);
     neorv32_twd_put(0x8e);
 
     // program sequence: read data via TWI

--- a/sw/lib/include/neorv32_twd.h
+++ b/sw/lib/include/neorv32_twd.h
@@ -41,8 +41,7 @@ enum NEORV32_TWD_CTRL_enum {
   TWD_CTRL_IRQ_RX_AVAIL = 11, /**< TWD control register(11) (r/w): IRQ if RX FIFO data available */
   TWD_CTRL_IRQ_RX_FULL  = 12, /**< TWD control register(12) (r/w): IRQ if RX FIFO full */
   TWD_CTRL_IRQ_TX_EMPTY = 13, /**< TWD control register(13) (r/w): IRQ if TX FIFO empty */
-  TWD_CTRL_TX_DUMMY_EN  = 14, /**< TWD control register(14) (r/w): enable sending tx_dummy (last sent byte) when FIFO is empty */
-  TWD_CTRL_HIDE_READ    = 15, /**< TWD control register(15) (r/w): Generate NACK on READ-access when TX FIFO is empty */
+  
   TWD_CTRL_RX_FIFO_LSB  = 16, /**< TWD control register(16) (r/-): log2(RX_FIFO size), LSB */
   TWD_CTRL_RX_FIFO_MSB  = 19, /**< TWD control register(19) (r/-): log2(RX_FIFO size), MSB */
   TWD_CTRL_TX_FIFO_LSB  = 20, /**< TWD control register(20) (r/-): log2(TX_FIFO size), LSB */
@@ -70,13 +69,11 @@ enum NEORV32_TWD_DATA_enum {
  **************************************************************************/
 /**@{*/
 int     neorv32_twd_available(void);
-void    neorv32_twd_setup(int device_addr, int fsel, int irq_rx_avail, int irq_rx_full, int irq_tx_empty, int tx_dummy_en, int hide_read);
+void    neorv32_twd_setup(int device_addr, int fsel, uint32_t irq_mask);
 int     neorv32_twd_get_rx_fifo_depth(void);
 int     neorv32_twd_get_tx_fifo_depth(void);
 void    neorv32_twd_disable(void);
 void    neorv32_twd_enable(void);
-void    neorv32_twd_disable_tx_dummy(void);
-void    neorv32_twd_enable_tx_dummy(void);
 void    neorv32_twd_clear_rx(void);
 void    neorv32_twd_clear_tx(void);
 int     neorv32_twd_sense_scl(void);

--- a/sw/lib/include/neorv32_twi.h
+++ b/sw/lib/include/neorv32_twi.h
@@ -24,7 +24,7 @@
 /** TWI module prototype */
 typedef volatile struct __attribute__((packed,aligned(4))) {
   uint32_t CTRL; /**< offset 0: control register (#NEORV32_TWI_CTRL_enum) */
-  uint32_t DCMD; /**< offset 4: data/cmd register (#NEORV32_TWI_DCMD_enum) */
+  uint32_t DCMD; /**< offset 4: data/command register (#NEORV32_TWI_DCMD_enum) */
 } neorv32_twi_t;
 
 /** TWI module hardware handle (#neorv32_twi_t) */
@@ -42,8 +42,8 @@ enum NEORV32_TWI_CTRL_enum {
   TWI_CTRL_CDIV3     =  7, /**< TWI control register(7)  (r/w): Clock divider bit 3 */
   TWI_CTRL_CLKSTR    =  8, /**< TWI control register(8)  (r/w): Enable/allow clock stretching */
 
-  TWI_CTRL_FIFO_LSB  = 15, /**< TWI control register(15) (r/-): log2(FIFO size), lsb */
-  TWI_CTRL_FIFO_MSB  = 18, /**< TWI control register(18) (r/-): log2(FIFO size), msb */
+  TWI_CTRL_FIFO_LSB  = 15, /**< TWI control register(15) (r/-): log2(FIFO size), LSB */
+  TWI_CTRL_FIFO_MSB  = 18, /**< TWI control register(18) (r/-): log2(FIFO size), MSB */
 
   TWI_CTRL_SENSE_SCL = 27, /**< TWI control register(27) (r/-): current state of the SCL bus line */
   TWI_CTRL_SENSE_SDA = 28, /**< TWI control register(28) (r/-): current state of the SDA bus line */
@@ -54,11 +54,11 @@ enum NEORV32_TWI_CTRL_enum {
 
 /** TWI command/data register bits */
 enum NEORV32_TWI_DCMD_enum {
-  TWI_DCMD_LSB    =  0, /**< TWI data register(0)  (r/w): Receive/transmit data (8-bit) LSB */
-  TWI_DCMD_MSB    =  7, /**< TWI data register(7)  (r/w): Receive/transmit data (8-bit) MSB */
+  TWI_DCMD_LSB    =  0, /**< TWI data register(0)  (r/w): Receive/transmit data (8-bit), LSB */
+  TWI_DCMD_MSB    =  7, /**< TWI data register(7)  (r/w): Receive/transmit data (8-bit), MSB */
   TWI_DCMD_ACK    =  8, /**< TWI data register(8)  (r/w): RX = ACK/NACK, TX = MACK */
-  TWI_DCMD_CMD_LO =  9, /**< TWI data register(9)  (r/w): CMD lsb */
-  TWI_DCMD_CMD_HI = 10  /**< TWI data register(10) (r/w): CMD msb */
+  TWI_DCMD_CMD_LO =  9, /**< TWI data register(9)  (r/w): Operation command (#NEORV32_TWI_DCMD_CMD_enum), LSB */
+  TWI_DCMD_CMD_HI = 10  /**< TWI data register(10) (r/w): Operation command (#NEORV32_TWI_DCMD_CMD_enum), MSB */
 };
 /**@}*/
 
@@ -67,10 +67,12 @@ enum NEORV32_TWI_DCMD_enum {
  * @name TWI commands
  **************************************************************************/
 /**@{*/
-#define TWI_CMD_NOP   (0b00) // no operation
-#define TWI_CMD_START (0b01) // generate start condition
-#define TWI_CMD_STOP  (0b10) // generate stop condition
-#define TWI_CMD_RTX   (0b11) // transmit+receive data byte
+enum NEORV32_TWI_DCMD_CMD_enum {
+  TWI_CMD_NOP   = 0b00, /**< 0b00: no operation */
+  TWI_CMD_START = 0b01, /**< 0b01: generate start condition */
+  TWI_CMD_STOP  = 0b10, /**< 0b10: generate stop condition */
+  TWI_CMD_RTX   = 0b11  /**< 0b11: transmit+receive data byte */
+};
 /**@}*/
 
 

--- a/sw/lib/source/neorv32_twd.c
+++ b/sw/lib/source/neorv32_twd.c
@@ -30,25 +30,20 @@ int neorv32_twd_available(void) {
  *
  * @param[in] device_addr 7-bit device address.
  * @param[in] fsel Bus sample clock / filter select.
- * @param[in] irq_rx_avail IRQ if RX FIFO data available.
- * @param[in] irq_rx_full IRQ if RX FIFO full.
- * @param[in] irq_tx_empty IRQ if TX FIFO empty.
- * @param[in] tx_dummy_en enable sending tx_dummy (last sent byte) when fifo is empty
- * @param[in] hide_read generate NACK ony READ-access when TX FIFO is empty
+ * @param[in] irq_mask Interrupt configuration bit mask (CTRL's irq_* bits).
  **************************************************************************/
-void neorv32_twd_setup(int device_addr, int fsel, int irq_rx_avail, int irq_rx_full, int irq_tx_empty, int tx_dummy_en, int hide_read) {
+void neorv32_twd_setup(int device_addr, int fsel, uint32_t irq_mask) {
 
   NEORV32_TWD->CTRL = 0; // reset
 
-  uint32_t ctrl = 0;
+  const uint32_t mask = (1 << TWD_CTRL_IRQ_RX_AVAIL) |
+                        (1 << TWD_CTRL_IRQ_RX_FULL)  |
+                        (1 << TWD_CTRL_IRQ_TX_EMPTY);
+
+  uint32_t ctrl = irq_mask & mask;
   ctrl |= ((uint32_t)(               0x01) << TWD_CTRL_EN);
   ctrl |= ((uint32_t)(device_addr  & 0x7f) << TWD_CTRL_DEV_ADDR0);
   ctrl |= ((uint32_t)(fsel         & 0x01) << TWD_CTRL_FSEL);
-  ctrl |= ((uint32_t)(irq_rx_avail & 0x01) << TWD_CTRL_IRQ_RX_AVAIL);
-  ctrl |= ((uint32_t)(irq_rx_full  & 0x01) << TWD_CTRL_IRQ_RX_FULL);
-  ctrl |= ((uint32_t)(irq_tx_empty & 0x01) << TWD_CTRL_IRQ_TX_EMPTY);
-  ctrl |= ((uint32_t)(tx_dummy_en  & 0x01) << TWD_CTRL_TX_DUMMY_EN);
-  ctrl |= ((uint32_t)(hide_read    & 0x01) << TWD_CTRL_HIDE_READ);
   NEORV32_TWD->CTRL = ctrl;
 }
 
@@ -92,24 +87,6 @@ void neorv32_twd_disable(void) {
 void neorv32_twd_enable(void) {
 
   NEORV32_TWD->CTRL |= (uint32_t)(1 << TWD_CTRL_EN);
-}
-
-
-/**********************************************************************//**
- * Disable TWD tx_dummy byte.
- **************************************************************************/
-void neorv32_twd_disable_tx_dummy(void) {
-
-  NEORV32_TWD->CTRL &= ~((uint32_t)(1 << TWD_CTRL_TX_DUMMY_EN));
-}
-
-
-/**********************************************************************//**
- * Enable TWD tx_dummy byte.
- **************************************************************************/
-void neorv32_twd_enable_tx_dummy(void) {
-
-  NEORV32_TWD->CTRL |= (uint32_t)(1 << TWD_CTRL_TX_DUMMY_EN);
 }
 
 

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -1146,16 +1146,6 @@
               <description>IRQ if TX FIFO empty</description>
             </field>
             <field>
-              <name>TWD_CTRL_TX_DUMMY_EN</name>
-              <bitRange>[14:14]</bitRange>
-              <description>Repeat sending last sent byte if TY FIFO is empty</description>
-            </field>
-            <field>
-              <name>TWD_CTRL_HIDE_READ</name>
-              <bitRange>[15:15]</bitRange>
-              <description>Send no ACK on READ access if TX FIFO is empty</description>
-            </field>
-            <field>
               <name>TWD_CTRL_RX_FIFO</name>
               <bitRange>[19:16]</bitRange>
               <access>read-only</access>


### PR DESCRIPTION
After extensive testing, during which many minor (and major) errors were found, I decided to completely rewrite the TWD module. :warning: The only change that is not backward compatible is the removal of the "dummy byte" function.

### I²C Read Operations (host reads from TWD)

* host sends read address
* TWD responds with an ACK if there is an address matchs; TWD returns to idle state if there is not address match
* data is retrieved from the TX FIFO and sent to the host; if the TX FIFO is empty, `0xFF` is sent to the host
* the host has to acknowledge each read byte with an ACK; if no ACK is received, the same data byte is read during the next data transfer (nothing is popped from the TX FIFO)

### I²C Write Operation (host writes to TWD)

* host sends read address
* TWD responds with an ACK if there is an address matchs; TWD returns to idle state if there is not address match
* data is sent by the host and pushed to the RX FIFO
* TWD responds with an ACK for each data byte; if the RX FIFO is full, the TWD responds with a NACK