### PR TITLE
fix minor RISC-V incompatibilities

### DIFF
--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -177,7 +177,7 @@ In the following table these CSRs are highlighted with "⚠️".
 |=======================
 | Name        | Machine status register - low word
 | Address     | `0x300`
-| Reset value | `0x00001800`
+| Reset value | `0x00000000`
 | ISA         | `Zicsr`
 | Description | The `mstatus` CSR is used to configure general machine environment parameters.
 |=======================

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1002,7 +1002,7 @@ begin
       csr.prv_level      <= priv_mode_m_c;
       csr.mstatus_mie    <= '0';
       csr.mstatus_mpie   <= '0';
-      csr.mstatus_mpp    <= priv_mode_m_c;
+      csr.mstatus_mpp    <= '0';
       csr.mstatus_mprv   <= '0';
       csr.mstatus_tw     <= '0';
       csr.mie_msi        <= '0';

--- a/sw/lib/include/neorv32_cpu.h
+++ b/sw/lib/include/neorv32_cpu.h
@@ -310,4 +310,265 @@ inline uint32_t __attribute__ ((always_inline)) neorv32_cpu_amosc(uint32_t addr,
 }
 
 
+/**********************************************************************//**
+ * Atomic memory access: atomic SWAP.
+ *
+ * @note The address has to be word-aligned - otherwise an alignment exception will be raised.
+ * @warning This function requires the A/Zaamo ISA extension.
+ *
+ * @param[in] addr Address (32-bit).
+ * @param[in] wdata Operand data for read-modify-write operation (32-bit).
+ * @return Status: Pre-operation memory content
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) neorv32_cpu_amoswap(uint32_t addr, uint32_t wdata) {
+
+#if defined __riscv_atomic
+  uint32_t amo_addr  = addr;
+  uint32_t amo_wdata = wdata;
+  uint32_t amo_rdata;
+
+  asm volatile ("amoswap.w %[dst], %[src], (%[addr])" : [dst] "=r" (amo_rdata) : [src] "r" (amo_wdata), [addr] "r" (amo_addr));
+
+  return amo_rdata;
+#else
+  (void)addr;
+  (void)wdata;
+
+  return 0;
+#endif
+}
+
+
+/**********************************************************************//**
+ * Atomic memory access: atomic ADD.
+ *
+ * @note The address has to be word-aligned - otherwise an alignment exception will be raised.
+ * @warning This function requires the A/Zaamo ISA extension.
+ *
+ * @param[in] addr Address (32-bit).
+ * @param[in] wdata Operand data for read-modify-write operation (32-bit).
+ * @return Status: Pre-operation memory content
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) neorv32_cpu_amoadd(uint32_t addr, uint32_t wdata) {
+
+#if defined __riscv_atomic
+  uint32_t amo_addr  = addr;
+  uint32_t amo_wdata = wdata;
+  uint32_t amo_rdata;
+
+  asm volatile ("amoadd.w %[dst], %[src], (%[addr])" : [dst] "=r" (amo_rdata) : [src] "r" (amo_wdata), [addr] "r" (amo_addr));
+
+  return amo_rdata;
+#else
+  (void)addr;
+  (void)wdata;
+
+  return 0;
+#endif
+}
+
+
+/**********************************************************************//**
+ * Atomic memory access: atomic XOR.
+ *
+ * @note The address has to be word-aligned - otherwise an alignment exception will be raised.
+ * @warning This function requires the A/Zaamo ISA extension.
+ *
+ * @param[in] addr Address (32-bit).
+ * @param[in] wdata Operand data for read-modify-write operation (32-bit).
+ * @return Status: Pre-operation memory content
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) neorv32_cpu_amoxor(uint32_t addr, uint32_t wdata) {
+
+#if defined __riscv_atomic
+  uint32_t amo_addr  = addr;
+  uint32_t amo_wdata = wdata;
+  uint32_t amo_rdata;
+
+  asm volatile ("amoxor.w %[dst], %[src], (%[addr])" : [dst] "=r" (amo_rdata) : [src] "r" (amo_wdata), [addr] "r" (amo_addr));
+
+  return amo_rdata;
+#else
+  (void)addr;
+  (void)wdata;
+
+  return 0;
+#endif
+}
+
+
+/**********************************************************************//**
+ * Atomic memory access: atomic AND.
+ *
+ * @note The address has to be word-aligned - otherwise an alignment exception will be raised.
+ * @warning This function requires the A/Zaamo ISA extension.
+ *
+ * @param[in] addr Address (32-bit).
+ * @param[in] wdata Operand data for read-modify-write operation (32-bit).
+ * @return Status: Pre-operation memory content
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) neorv32_cpu_amoand(uint32_t addr, uint32_t wdata) {
+
+#if defined __riscv_atomic
+  uint32_t amo_addr  = addr;
+  uint32_t amo_wdata = wdata;
+  uint32_t amo_rdata;
+
+  asm volatile ("amoand.w %[dst], %[src], (%[addr])" : [dst] "=r" (amo_rdata) : [src] "r" (amo_wdata), [addr] "r" (amo_addr));
+
+  return amo_rdata;
+#else
+  (void)addr;
+  (void)wdata;
+
+  return 0;
+#endif
+}
+
+
+/**********************************************************************//**
+ * Atomic memory access: atomic OR.
+ *
+ * @note The address has to be word-aligned - otherwise an alignment exception will be raised.
+ * @warning This function requires the A/Zaamo ISA extension.
+ *
+ * @param[in] addr Address (32-bit).
+ * @param[in] wdata Operand data for read-modify-write operation (32-bit).
+ * @return Status: Pre-operation memory content
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) neorv32_cpu_amoor(uint32_t addr, uint32_t wdata) {
+
+#if defined __riscv_atomic
+  uint32_t amo_addr  = addr;
+  uint32_t amo_wdata = wdata;
+  uint32_t amo_rdata;
+
+  asm volatile ("amoor.w %[dst], %[src], (%[addr])" : [dst] "=r" (amo_rdata) : [src] "r" (amo_wdata), [addr] "r" (amo_addr));
+
+  return amo_rdata;
+#else
+  (void)addr;
+  (void)wdata;
+
+  return 0;
+#endif
+}
+
+
+/**********************************************************************//**
+ * Atomic memory access: atomic MIN.
+ *
+ * @note The address has to be word-aligned - otherwise an alignment exception will be raised.
+ * @warning This function requires the A/Zaamo ISA extension.
+ *
+ * @param[in] addr Address (32-bit).
+ * @param[in] wdata Operand data for read-modify-write operation (32-bit).
+ * @return Status: Pre-operation memory content
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) neorv32_cpu_amomin(uint32_t addr, uint32_t wdata) {
+
+#if defined __riscv_atomic
+  uint32_t amo_addr  = addr;
+  uint32_t amo_wdata = wdata;
+  uint32_t amo_rdata;
+
+  asm volatile ("amomin.w %[dst], %[src], (%[addr])" : [dst] "=r" (amo_rdata) : [src] "r" (amo_wdata), [addr] "r" (amo_addr));
+
+  return amo_rdata;
+#else
+  (void)addr;
+  (void)wdata;
+
+  return 0;
+#endif
+}
+
+
+/**********************************************************************//**
+ * Atomic memory access: atomic MAX.
+ *
+ * @note The address has to be word-aligned - otherwise an alignment exception will be raised.
+ * @warning This function requires the A/Zaamo ISA extension.
+ *
+ * @param[in] addr Address (32-bit).
+ * @param[in] wdata Operand data for read-modify-write operation (32-bit).
+ * @return Status: Pre-operation memory content
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) neorv32_cpu_amomax(uint32_t addr, uint32_t wdata) {
+
+#if defined __riscv_atomic
+  uint32_t amo_addr  = addr;
+  uint32_t amo_wdata = wdata;
+  uint32_t amo_rdata;
+
+  asm volatile ("amomax.w %[dst], %[src], (%[addr])" : [dst] "=r" (amo_rdata) : [src] "r" (amo_wdata), [addr] "r" (amo_addr));
+
+  return amo_rdata;
+#else
+  (void)addr;
+  (void)wdata;
+
+  return 0;
+#endif
+}
+
+
+/**********************************************************************//**
+ * Atomic memory access: atomic MINU.
+ *
+ * @note The address has to be word-aligned - otherwise an alignment exception will be raised.
+ * @warning This function requires the A/Zaamo ISA extension.
+ *
+ * @param[in] addr Address (32-bit).
+ * @param[in] wdata Operand data for read-modify-write operation (32-bit).
+ * @return Status: Pre-operation memory content
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) neorv32_cpu_amominu(uint32_t addr, uint32_t wdata) {
+
+#if defined __riscv_atomic
+  uint32_t amo_addr  = addr;
+  uint32_t amo_wdata = wdata;
+  uint32_t amo_rdata;
+
+  asm volatile ("amominu.w %[dst], %[src], (%[addr])" : [dst] "=r" (amo_rdata) : [src] "r" (amo_wdata), [addr] "r" (amo_addr));
+
+  return amo_rdata;
+#else
+  (void)addr;
+  (void)wdata;
+
+  return 0;
+#endif
+}
+
+
+/**********************************************************************//**
+ * Atomic memory access: atomic MAXU.
+ *
+ * @note The address has to be word-aligned - otherwise an alignment exception will be raised.
+ * @warning This function requires the A/Zaamo ISA extension.
+ *
+ * @param[in] addr Address (32-bit).
+ * @param[in] wdata Operand data for read-modify-write operation (32-bit).
+ * @return Status: Pre-operation memory content
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) neorv32_cpu_amomaxu(uint32_t addr, uint32_t wdata) {
+
+#if defined __riscv_atomic
+  uint32_t amo_addr  = addr;
+  uint32_t amo_wdata = wdata;
+  uint32_t amo_rdata;
+
+  asm volatile ("amomaxu.w %[dst], %[src], (%[addr])" : [dst] "=r" (amo_rdata) : [src] "r" (amo_wdata), [addr] "r" (amo_addr));
+
+  return amo_rdata;
+#else
+  (void)addr;
+  (void)wdata;
+
+  return 0;
+#endif
+}
+
+
 #endif // NEORV32_CPU_H


### PR DESCRIPTION
* reset `mstatus.mpp` to all-zero (previous privilege mode = user-mode
* AMO memory exceptions must raise store/AMO exceptions (and not load exceptions)