### PR TITLE
minor rtl edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 05.09.2025 | 1.12.1.3 | minor rtl edits: add `ndmresetpending` & `stickyunavail` bits to DM's `dmstatus` register; fix interrupt-entry after `wfi` | [#1364](https://github.com/stnolting/neorv32/pull/1364) |
 | 04.09.2025 | 1.12.1.2 | :bug: fix debug module's `command.transfer` bit logic (ignore `aarsize` & `regno` if `transfer=0`) | [#1363](https://github.com/stnolting/neorv32/pull/1363) |
 | 03.09.2025 | 1.12.1.1 | rework bootloader; add SD card boot option; :warning: change executable image signature and checksum | [#1361](https://github.com/stnolting/neorv32/pull/1361) |
 | 29.08.2025 | [**1.12.1**](https://github.com/stnolting/neorv32/releases/tag/v1.12.1) | :rocket: **New release** | |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -670,7 +670,7 @@ defined by the NEORV32 core library (the runtime environment _RTE_) and can be u
 with the pre-defined RTE function. The <<_mcause>>, <<_mepc>>, <<_mtval>> and <<_mtinst>> columns show the value being
 written to the according CSRs when a trap is triggered:
 
-* **I-PC** - address of intercepted instruction (next instruction in program flow; instruction has _not_ been executed yet)
+* **I-PC** - address of intercepted instruction (i.e. the next instruction that has to be executed to maintain program flow; instruction has _not_ been executed yet)
 * **PC** - address of instruction that caused the trap (instruction has been executed)
 * **ADDR** - bad data memory access address that caused the trap
 * **INST** - the actual transformed/decompressed instruction word that caused the trap

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -408,7 +408,9 @@ are configured as "zero" and are read-only. Writing '1' to these bits/fields wil
 [options="header",grid="rows"]
 |=======================
 | Bit   | Name [RISC-V]     | Description
-| 31:23 | _reserved_        | reserved; zero
+| 31:25 | _reserved_        | reserved; zero
+| 24    | `ndmresetpending` | DM in reset state
+| 23    | `stickyunavail`   | `*unavail` bits reflect the current state
 | 22    | `impebreak`       | `1`: indicates an implicit `ebreak` instruction after the last program buffer entry
 | 21:20 | _reserved_        | reserved; zero
 | 19    | `allhavereset`    .2+| `1` when the selected hart is in reset state

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -958,14 +958,14 @@ begin
 
   -- any system interrupt? --
   trap_ctrl.irq_fire(0) <= '1' when
-    (exe_engine.state = EX_EXECUTE) and -- trigger system IRQ only in EX_EXECUTE state
+    ((exe_engine.state = EX_EXECUTE) or (exe_engine.state = EX_SLEEP)) and -- trigger system IRQ only in EX_EXECUTE state or in sleep mode
     (or_reduce_f(trap_ctrl.irq_buf(irq_firq_15_c downto irq_msi_irq_c)) = '1') and -- pending system IRQ
     ((csr.mstatus_mie = '1') or (csr.prv_level = priv_mode_u_c)) and -- IRQ only when in M-mode and MIE=1 OR when in U-mode
     (debug_ctrl.run = '0') and (csr.dcsr_step = '0') else '0'; -- no system IRQs when in debug-mode / during single-stepping
 
   -- debug-entry halt interrupt? --
   trap_ctrl.irq_fire(1) <= trap_ctrl.irq_buf(irq_db_halt_c) when
-    (exe_engine.state = EX_EXECUTE) or (exe_engine.state = EX_BRANCHED) else '0'; -- allow halt also after "reset" (#879)
+    (exe_engine.state = EX_EXECUTE) or (exe_engine.state = EX_SLEEP) or (exe_engine.state = EX_BRANCHED) else '0'; -- allow halt also after "reset" (#879)
 
 
   -- ****************************************************************************************************************************

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -528,10 +528,12 @@ begin
 
         -- debug module status register --
         when addr_dmstatus_c =>
-          if (not AUTHENTICATOR) or (auth.valid = '1') then -- authenticated?
-            dmi_rsp_o.data(31 downto 23) <= (others => '0'); -- reserved (r/-)
-            dmi_rsp_o.data(22)           <= '1'; -- impebreak (r/-): there is an implicit ebreak instruction after the visible program buffer
-            dmi_rsp_o.data(21 downto 20) <= (others => '0'); -- reserved (r/-)
+          if (auth.valid = '1') then -- authenticated?
+            dmi_rsp_o.data(31 downto 25) <= (others => '0');                                             -- reserved (r/-)
+            dmi_rsp_o.data(24)           <= dm_reg.dmcontrol_ndmreset;                                   -- ndmresetpending(r/-): DM in reset
+            dmi_rsp_o.data(23)           <= '0';                                                         -- stickyunavail (r/-): unavail bits reflect the current state
+            dmi_rsp_o.data(22)           <= '1';                                                         -- impebreak (r/-): implicit ebreak after visible program buffer
+            dmi_rsp_o.data(21 downto 20) <= (others => '0');                                             -- reserved (r/-)
             dmi_rsp_o.data(19)           <= or_reduce_f(dm_ctrl.hart_reset and dm_reg.hartsel_dec);      -- allhavereset (r/-): selected hart in reset
             dmi_rsp_o.data(18)           <= or_reduce_f(dm_ctrl.hart_reset and dm_reg.hartsel_dec);      -- anyhavereset (r/-): selected hart in reset
             dmi_rsp_o.data(17)           <= or_reduce_f(dm_ctrl.hart_resume_ack and dm_reg.hartsel_dec); -- allresumeack (r/-): selected hart is resuming

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -28,7 +28,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01120102"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01120103"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 

--- a/sw/example/processor_check/run_check.sh
+++ b/sw/example/processor_check/run_check.sh
@@ -3,4 +3,4 @@
 set -e
 
 echo "Starting processor check simulation..."
-make USER_FLAGS+="-DUART0_SIM_MODE -DUART1_SIM_MODE" hdl_lists clean_all all sim-check
+make USER_FLAGS+="-DUART0_SIM_MODE -DUART1_SIM_MODE" GHDL_RUN_FLAGS="--stop-time=10ms" hdl_lists clean_all all sim-check


### PR DESCRIPTION
### On-Chip-Debugger Debug Module (DM)

* add `dmstatus.ndmresetpending` flag
* add `dmstatus.stickyunavail` flag

### CPU Core - `WFI` instruction

In the current version, the instruction after `wfi` is executed before an interrupt (which woke up the CPU) can kick in. This PR fixes this behavior to comply with the RISC-V specifications:

> If an enabled interrupt is present or later becomes present while the hart is stalled, the interrupt trap will be taken on the following instruction, i.e., execution resumes in the trap handler and mepc = pc + 4.

> The following instruction takes the interrupt trap so that a simple return from the trap
handler will execute code after the WFI instruction.