### PR TITLE
⚠️ remove CFU CSRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
-| 14.09.2025 | 1.12.1.7 | :bug: fix unaligned instruction fetch bus error; do not trigger co-processors if pending instruction-related exception | [#1367](https://github.com/stnolting/neorv32/pull/1376) |
+| 14.09.2025 | 1.12.1.8 | :warning: remove CFU CSRs (`cfureg[0..3]`) | [#1377](https://github.com/stnolting/neorv32/pull/1377) |
+| 13.09.2025 | 1.12.1.7 | :bug: fix unaligned instruction fetch bus error; do not trigger co-processors if pending instruction-related exception | [#1367](https://github.com/stnolting/neorv32/pull/1376) |
 | 13.09.2025 | 1.12.1.6 | minor RTL edits; add `Zca` ISA extension flag to `mxisa` CSR | [#1375](https://github.com/stnolting/neorv32/pull/1375) |
 | 09.09.2025 | 1.12.1.5 | TRACER: rework instruction decoding logic and add all remaining ISA extensions | [#1368](https://github.com/stnolting/neorv32/pull/1368) |
 | 05.09.2025 | 1.12.1.4 | improve TRACER's simulation-mode instruction decoding | [#1366](https://github.com/stnolting/neorv32/pull/1366) |

--- a/docs/datasheet/cpu_cfu.adoc
+++ b/docs/datasheet/cpu_cfu.adoc
@@ -10,14 +10,14 @@ program memory requirements when implemented entirely in software. Some potentia
 use-cases might include:
 
 * **AI:** sub-word / vertical vector/SIMD operations like processing all four sub-bytes of a 32-bit data word individually
-* **Cryptographic:** bit substitution and permutation
+* **Cryptography:** bit substitution and permutation
 * **Communication:** data conversions like binary to gray-code
 * **Arithmetic:** BCD (binary-coded decimal) operations; multiply-add operations; shift-and-add algorithms like CORDIC or BKM
 * **Image processing:** look-up-tables for color space transformations
 * implementing instructions from **other RISC-V ISA extensions** that are not yet supported by NEORV32
 
-The NEORV32 CFU supports two different instruction formats (R3-type and R4-type; see <<_cfu_instruction_formats>>) and also
-allows to implement up to 4 CFU-internal custom control and status registers (see <<_cfu_control_and_status_registers_cfu_csrs>>).
+The NEORV32 CFU supports two different instruction formats: RISC-V R3-type (up to two source operands) and RISC-V R4-type
+(up to three source operands) instructions. See <<_cfu_instruction_formats>> for more information.
 
 .CFU Complexity
 [NOTE]
@@ -30,7 +30,7 @@ https://stnolting.github.io/neorv32/ug/#_adding_custom_hardware_modules[Adding C
 .Default CFU Hardware Example
 [TIP]
 The default CFU module (`rtl/core/neorv32_cpu_cp_cfu.vhd`) implements the _Extended Tiny Encryption Algorithm (XTEA)_
-as "real world" application example.
+as application example.
 
 
 :sectnums:
@@ -45,8 +45,8 @@ The NEORV32 CFU utilizes these two opcodes to support user-defined **R3-type** i
 1 destination register) and **R4-type** instructions (3 source registers, 1 destination register). Both instruction
 formats are compliant to the RISC-V specification.
 
-* `custom-0`: `0001011` RISC-V standard, used for NEORV32 <<_cfu_r3_type_instructions>> (3x register addresses)
-* `custom-1`: `0101011` RISC-V standard, used for NEORV32 <<_cfu_r4_type_instructions>> (4x register addresses)
+* `custom-0`: `0001011` RISC-V standard, used for NEORV32 <<_cfu_r3_type_instructions>> (3 register addresses)
+* `custom-1`: `0101011` RISC-V standard, used for NEORV32 <<_cfu_r4_type_instructions>> (4 register addresses)
 
 [TIP]
 The provided instructions formats are _predefined_ to allow an easy integration framework.
@@ -182,34 +182,6 @@ neorv32_cfu_r3_instr(0b0100100, 0b001, tmp, foo); // discard result
 [TIP]
 There is an example program for the CFU, which shows how to use the _default_ CFU hardware module.
 This example program is located in `sw/example/demo_cfu`.
-
-
-:sectnums:
-==== CFU Control and Status Registers (CFU-CSRs)
-
-The CPU provides up to four control and status registers (<<_cfureg, `cfureg*`>>) to be used within the CFU.
-These CSRs are mapped to the "custom user-mode read/write" CSR address space, which is explicitly reserved for
-platform-specific application by the RISC-V spec. For example, these CSRs can be used to pass additional operands
-to the CFU, to obtain additional results, to check processing status or to configure operation modes.
-
-.CFU CSR Access Example
-[source,c]
-----
-neorv32_cpu_csr_write(CSR_CFUREG0, 0xabcdabcd); // write data to CFU CSR 0
-uint32_t tmp = neorv32_cpu_csr_read(CSR_CFUREG3); // read data from CFU CSR 3
-----
-
-.Additional CFU-internal CSRs
-[TIP]
-If more than four CFU-internal CSRs are required the designer can implement an "indirect access mechanism" based
-on just two of the default CSRs: one CSR is used to configure the index while the other is used as alias to exchange
-data with the indexed CFU-internal CSR - this concept is similar to the RISC-V Indirect CSR Access Extension
-Specification (`Smcsrind`).
-
-.Security Considerations
-[NOTE]
-The CFU CSRs are mapped to the user-mode CSR space so software running at _any privilege level_ can access these
-CSRs.
 
 
 :sectnums:

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -81,7 +81,6 @@ In the following table these CSRs are highlighted with "⚠️".
 | 0xf14 | <<_mhartid>>    | `CSR_MHARTID`    | MRO | Machine hardware thread ID
 | 0xf15 | <<_mconfigptr>> | `CSR_MCONFIGPTR` | MRO | Machine configuration pointer register
 5+^| **<<_neorv32_specific_csrs>>**
-| 0x800 .. 0x803 | <<_cfureg, `cfureg0`>> .. <<_cfureg, `cfureg3`>> | `CSR_CFUCREG0` .. `CSR_CFUCREG3` | URW | Custom CFU registers 0 to 3
 | 0xbc0 | <<_mxcsr>> | `CSR_MXCSR` | MRW | Machine status and control register
 | 0xfc0 | <<_mxisa>> | `CSR_MXISA` | MRO | Extended machine CPU ISA and extensions
 |=======================
@@ -921,24 +920,6 @@ ID of each core is unique and starts at 0 and is incremented continuously.
 All NEORV32-specific CSRs are mapped to addresses that are explicitly reserved for custom/implementation-specific use.
 
 
-[discrete]
-===== **`cfureg`**
-
-[cols="<1,<8"]
-[grid="none"]
-|=======================
-| Name        | Custom (user-defined) CFU CSRs
-| Address     | `0x800` (`cfureg0`)
-|             | `0x801` (`cfureg1`)
-|             | `0x802` (`cfureg2`)
-|             | `0x803` (`cfureg3`)
-| Reset value | `0x00000000`
-| ISA         | `Zicsr` & `Zxcfu`
-| Description | User-defined CSRs to be used within the <<_custom_functions_unit_cfu>>.
-|=======================
-
-
-{empty} +
 [discrete]
 ===== **`mxcsr`**
 

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -652,10 +652,6 @@ begin
     -- ------------------------------------------------------------
     case csr_addr_v is
 
-      -- NEORV32-specific user-mode CFU CSRs --
-      when csr_cfureg0_c | csr_cfureg1_c | csr_cfureg2_c | csr_cfureg3_c =>
-        csr_valid(2) <= bool_to_ulogic_f(RISCV_ISA_Zxcfu); -- available if CFU implemented
-
       -- floating-point-unit CSRs --
       when csr_fflags_c | csr_frm_c | csr_fcsr_c =>
         csr_valid(2) <= bool_to_ulogic_f(RISCV_ISA_Zfinx); -- available if FPU implemented

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -28,7 +28,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01120107"; -- hardware version
+  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01120108"; -- hardware version
   constant archid_c     : natural := 19; -- official RISC-V architecture ID
   constant XLEN         : natural := 32; -- native data path width
 
@@ -445,11 +445,6 @@ package neorv32_package is
   constant csr_dcsr_c           : std_ulogic_vector(11 downto 0) := x"7b0";
   constant csr_dpc_c            : std_ulogic_vector(11 downto 0) := x"7b1";
   constant csr_dscratch0_c      : std_ulogic_vector(11 downto 0) := x"7b2";
-  -- NEORV32-specific read/write user registers --
-  constant csr_cfureg0_c        : std_ulogic_vector(11 downto 0) := x"800";
-  constant csr_cfureg1_c        : std_ulogic_vector(11 downto 0) := x"801";
-  constant csr_cfureg2_c        : std_ulogic_vector(11 downto 0) := x"802";
-  constant csr_cfureg3_c        : std_ulogic_vector(11 downto 0) := x"803";
   -- machine counters/timers --
   constant csr_mcycle_c         : std_ulogic_vector(11 downto 0) := x"b00";
   constant csr_mtime_c          : std_ulogic_vector(11 downto 0) := x"b01";

--- a/rtl/core/neorv32_tracer.vhd
+++ b/rtl/core/neorv32_tracer.vhd
@@ -616,11 +616,6 @@ architecture neorv32_tracer_simlog_rtl of neorv32_tracer_simlog is
       when csr_dcsr_c           => return "dcsr";
       when csr_dpc_c            => return "dpc";
       when csr_dscratch0_c      => return "dscratch0";
-      -- NEORV32-specific read/write user registers --
-      when csr_cfureg0_c        => return "cfureg0";
-      when csr_cfureg1_c        => return "cfureg1";
-      when csr_cfureg2_c        => return "cfureg2";
-      when csr_cfureg3_c        => return "cfureg3";
       -- machine counters/timers --
       when csr_mcycle_c         => return "mcycle";
       when csr_mtime_c          => return "mtime";

--- a/sw/example/demo_cfu/main.c
+++ b/sw/example/demo_cfu/main.c
@@ -34,6 +34,8 @@
  * @name Define macros for easy CFU instruction wrapping
  **************************************************************************/
 /**@{*/
+#define xtea_key_write(i, data)     neorv32_cfu_r4_instr(0b100 | i, data, 0, 0)
+#define xtea_key_read(i)            neorv32_cfu_r4_instr(0b000 | i, 0,    0, 0)
 #define xtea_hw_init(sum)           neorv32_cfu_r3_instr(0b0000000, 0b100, sum, 0 )
 #define xtea_hw_enc_v0_step(v0, v1) neorv32_cfu_r3_instr(0b0000000, 0b000, v0,  v1)
 #define xtea_hw_enc_v1_step(v0, v1) neorv32_cfu_r3_instr(0b0000000, 0b001, v0,  v1)
@@ -191,17 +193,17 @@ int main() {
   // ----------------------------------------------------------
 
   // set XTEA-CFU key storage (via CFU CSRs)
-  neorv32_cpu_csr_write(CSR_CFUREG0, key[0]);
-  neorv32_cpu_csr_write(CSR_CFUREG1, key[1]);
-  neorv32_cpu_csr_write(CSR_CFUREG2, key[2]);
-  neorv32_cpu_csr_write(CSR_CFUREG3, key[3]);
+  xtea_key_write(0, key[0]);
+  xtea_key_write(1, key[1]);
+  xtea_key_write(2, key[2]);
+  xtea_key_write(3, key[3]);
 
   // read-back CSRs and print key
   neorv32_uart0_printf("XTEA key: 0x%x%x%x%x\n\n",
-                       neorv32_cpu_csr_read(CSR_CFUREG0),
-                       neorv32_cpu_csr_read(CSR_CFUREG1),
-                       neorv32_cpu_csr_read(CSR_CFUREG2),
-                       neorv32_cpu_csr_read(CSR_CFUREG3));
+                       xtea_key_read(0),
+                       xtea_key_read(1),
+                       xtea_key_read(2),
+                       xtea_key_read(3));
 
   // generate "random" data for the plain text
   for (i=0; i<DATA_NUM; i++) {
@@ -312,7 +314,6 @@ int main() {
   neorv32_uart0_printf("ENC HW = %u cycles\n", time_enc_hw);
   neorv32_uart0_printf("DEC SW = %u cycles\n", time_dec_sw);
   neorv32_uart0_printf("DEC HW = %u cycles\n", time_dec_hw);
-  neorv32_uart0_printf("Average speedup: ~%ux\n", (time_enc_sw + time_dec_sw) / (time_enc_hw + time_dec_hw));
 
 
   // ----------------------------------------------------------

--- a/sw/lib/include/neorv32_cpu_csr.h
+++ b/sw/lib/include/neorv32_cpu_csr.h
@@ -96,12 +96,6 @@ enum NEORV32_CSR_enum {
   CSR_DPC            = 0x7b1, /**< 0x7b1 - dpc:       Debug program counter */
   CSR_DSCRATCH0      = 0x7b2, /**< 0x7b2 - dscratch0: Debug scratch register */
 
-  /* custom functions unit (CFU) */
-  CSR_CFUREG0        = 0x800, /**< 0x800 - cfureg0: custom CFU CSR 0 */
-  CSR_CFUREG1        = 0x801, /**< 0x801 - cfureg1: custom CFU CSR 1 */
-  CSR_CFUREG2        = 0x802, /**< 0x802 - cfureg2: custom CFU CSR 2 */
-  CSR_CFUREG3        = 0x803, /**< 0x803 - cfureg3: custom CFU CSR 3 */
-
   /* machine counters and timers */
   CSR_MCYCLE         = 0xb00, /**< 0xb00 - mcycle:        Machine cycle counter low word */
   CSR_MINSTRET       = 0xb02, /**< 0xb02 - minstret:      Machine instructions-retired counter low word */

--- a/sw/openocd/target.cfg
+++ b/sw/openocd/target.cfg
@@ -34,10 +34,6 @@ proc target_setup { {NUM_CORES 1} } {
   ##gdb report_register_access_error enable
 
   # expose NEORV32-specific CSRs
-  riscv expose_csrs 2048=cfureg0
-  riscv expose_csrs 2049=cfureg1
-  riscv expose_csrs 2050=cfureg2
-  riscv expose_csrs 2051=cfureg3
   riscv expose_csrs 3008=mxcsr
   riscv expose_csrs 4032=mxisa
 


### PR DESCRIPTION
Remove the `cfureg*` CSRs used by the CFU (custom instructions wrapper). CFU-internal state should be accessible only via the according custom instructions.

I am planning to replace the NEORV32 CFU by the RISC-V **Composable Custom Extensions Specification** and this is the first step in the migration. This ISA extension is still in the "planning" phase (https://riscv.atlassian.net/browse/RVS-2611). However, a first draft is already available: https://github.com/grayresearch/CX