### PR TITLE
[XBUS] re-add timeout configuration generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 18.09.2025 | 1.12.2.1 | re-add `XBUS_TIMEOUT` configuration option (timeout window for processor-external bus accesses) | [#1383](https://github.com/stnolting/neorv32/pull/1383) |
 | 18.09.2025 | [**1.12.2**](https://github.com/stnolting/neorv32/releases/tag/v1.12.2) | :rocket: **New release** | |
 | 17.09.2025 | 1.12.1.9 | minor CPU logic optimizations | [#1381](https://github.com/stnolting/neorv32/pull/1381) |
 | 14.09.2025 | 1.12.1.8 | :warning: remove CFU CSRs (`cfureg[0..3]`) | [#1377](https://github.com/stnolting/neorv32/pull/1377) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -204,7 +204,7 @@ corruption of the co-processor's internal state (like FPU CSRs).
 .Multi-Cycle Execution Monitor
 [NOTE]
 The CPU control will raise an illegal instruction exception if a multi-cycle functional unit (like the <<_custom_functions_unit_cfu>>)
-does not complete processing in a bound amount of time (configured via the package's `monitor_mc_tmo_c` constant; default = 512 clock cycles).
+does not complete processing in a bound amount of time (configured via the package's `alu_cp_tmo_c` constant; default = 512 clock cycles).
 
 
 :sectnums:

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -268,6 +268,7 @@ The generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downt
 | `CACHE_BURSTS_EN`       | boolean   | true          | Enable burst transfers for cache updates.
 4+^| **<<_processor_external_bus_interface_xbus>> (Wishbone / AXI4)**
 | `XBUS_EN`               | boolean   | false         | Implement the external bus interface.
+| `XBUS_TIMEOUT`          | natural   | 2048          | Number of clock cycles after which an unacknowledged external bus access will auto-terminate (0 = disabled).
 | `XBUS_REGSTAGE_EN`      | boolean   | false         | Implement XBUS register stages to ease timing closure.
 4+^| **Peripheral/IO Modules**
 | `IO_DISABLE_SYSINFO`    | boolean   | false         | Disable <<_system_configuration_information_memory_sysinfo>> module; not recommended - for advanced users only!
@@ -526,20 +527,26 @@ constant mem_io_size_c   : natural := 32*64*1024; -- = 32 * iodev_size_c
 Besides the redirecting of bus requests the gateway also implements a **bus monitor** (aka "the bus keeper") that
 tracks all bus transactions to ensure _safe_ and _deterministic_ operations. Whenever a memory-mapped device is
 accessed the bus monitor starts an internal countdown. The accessed module has to respond ("ACK") to the bus request
-within a bound **time window**. This time window is defined by a global constant in the processor's VHDL package
-file (`rtl/core/neorv32_package.vhd`):
+within a bound time window. For **processor-internal** accesses this time windows is defined by a constant in the main
+NEORV32 package file (`neorv32_package.vhd`). For **processor-external accesses** via the
+<<_processor_external_bus_interface_xbus>> this time window is defined by the `XBUS_TIMEOUT` top configuration generic.
 
-.Global Bus Timeout Configuration
+.Internal Bus Timeout Configuration (package constant)
 [source,vhdl]
 ----
-constant bus_timeout_c : natural := 1024;
+constant int_bus_tmo_c : natural := 16;
 ----
 
-This constant defines the _maximum_ number of cycles after which a non-responding bus request (i.e. no `ACK`) will
+.External Bus Timeout Configuration (top generic)
+[source,vhdl]
+----
+XBUS_TIMEOUT : natural := 2048;
+----
+
+The according time window defines the _maximum_ number of cycles after which a non-responding bus request will
 time out raising a bus access fault exception. For example this can happen when accessing "address space holes"
 (aka _the void_) - addresses that are not mapped to any physical module. The specific bus access exception type
 corresponds to the according access type, i.e. instruction fetch bus fault, load bus fault or store bus fault.
-**Note that this timeout window is also enforced for accesses via the <<_processor_external_bus_interface_xbus>>.**
 
 
 :sectnums:

--- a/docs/datasheet/soc_sysinfo.adoc
+++ b/docs/datasheet/soc_sysinfo.adoc
@@ -62,8 +62,9 @@ to take into account a dynamic frequency scaling of the processor.
 | `7:0`   | `SYSINFO_MISC_IMEM_MBS : SYSINFO_MISC_IMEM_LSB` | _log2_(internal IMEM size in bytes), via top's `IMEM_SIZE` generic
 | `15:8`  | `SYSINFO_MISC_DMEM_MSB : SYSINFO_MISC_DMEM_LSB` | _log2_(internal DMEM size in bytes), via top's `DMEM_SIZE` generic
 | `19:16` | `SYSINFO_MISC_HART_MSB : SYSINFO_MISC_HART_LSB` | number of physical CPU cores ("harts")
-| `23:20` | `SYSINFO_MISC_BOOT_MSB : SYSINFO_MISC_BOOT_LSB` | boot mode configuration, via top's `BOOT_MODE_SELECT` generic (see <<_boot_configuration>>))
-| `31:24` | `SYSINFO_MISC_BTMO_MSB : SYSINFO_MISC_BTMO_LSB` | _log2_(bus timeout cycles), see <<_bus_monitor_and_timeout>>
+| `21:20` | `SYSINFO_MISC_BOOT_MSB : SYSINFO_MISC_BOOT_LSB` | boot mode configuration, via top's `BOOT_MODE_SELECT` generic (see <<_boot_configuration>>))
+| `26:22` | `SYSINFO_MISC_ITMO_MSB : SYSINFO_MISC_ITMO_LSB` | _log2_(internal bus timeout cycles), see <<_bus_monitor_and_timeout>>
+| `31:27` | `SYSINFO_MISC_ETMO_MSB : SYSINFO_MISC_ETMO_LSB` | _log2_(external bus timeout cycles), see <<_bus_monitor_and_timeout>>
 |=======================
 
 

--- a/docs/datasheet/soc_xbus.adoc
+++ b/docs/datasheet/soc_xbus.adoc
@@ -19,6 +19,7 @@
 |                         | `xbus_ack_i`         | acknowledge (1-bit)
 |                         | `xbus_err_i`         | bus error (1-bit)
 | Configuration generics: | `XBUS_EN`            | enable external bus interface when `true`
+|                         | `XBUS_TIMEOUT`       | number of clock cycles after which an unacknowledged external bus access will auto-terminate (0 = disabled)
 |                         | `XBUS_REGSTAGE_EN`   | implement XBUS register stages
 |                         | (`CACHE_BLOCK_SIZE`) | burst size
 |                         | (`CACHE_BURSTS_EN`)  | enable burst transfers for cache update
@@ -45,6 +46,7 @@ If any cache (<<_processor_internal_instruction_cache_icache,i-cache>> or <<_pro
 is implemented and bursts are globally enabled (by the `CACHE_BURSTS_EN` top generic) all cache block transfers are
 **always executed as burst transfers** with a burst size equal to the cache block size (`CACHE_BLOCK_SIZE` top generic).
 Burst transfers should **not** be enabled if any external module mapped to _cached_ <<_address_space>> does not support bursts.
+Note that burst transactions need to set `ACK` or `ERR` for each burst element.
 
 .Address Mapping
 [NOTE]
@@ -146,13 +148,13 @@ to maintain exclusive bus access. This transfer type is used by the CPU to perfo
 
 An accessed XBUS device does not have to respond immediately to a bus request by sending an `ACK`.
 Instead, there is a **time window** where the device has to acknowledge the transfer. This time window
-is enforced by the _bus monitors_ of the processor's central <<_bus_gateway>>: all XBUS transactions
-have to be acknowledged within this time window. Otherwise the transfer is terminated and a bus fault
-exception is raised.
+is configured by the `XBUS_TIMEOUT` generic. All XBUS transactions have to be acknowledged within this
+time window. Otherwise the transfer is terminated and a bus fault exception is raised. See section
+<<_bus_monitor_and_timeout>> for more information.
 
 Furthermore, an accesses XBUS device can signal an error condition at any time by setting the `ERR` signal
-high for one cycle. This will also terminate the current bus transaction before raising a CPU bus fault exception.
-Burst transactions need to set `ACK`/`ERR` for each burst element.
+high for one cycle. This will also terminate the current bus transaction raising a CPU bus fault exception.
+
 
 .Register Stage
 [TIP]

--- a/docs/datasheet/soc_xbus.adoc
+++ b/docs/datasheet/soc_xbus.adoc
@@ -148,9 +148,11 @@ to maintain exclusive bus access. This transfer type is used by the CPU to perfo
 
 An accessed XBUS device does not have to respond immediately to a bus request by sending an `ACK`.
 Instead, there is a **time window** where the device has to acknowledge the transfer. This time window
-is configured by the `XBUS_TIMEOUT` generic. All XBUS transactions have to be acknowledged within this
-time window. Otherwise the transfer is terminated and a bus fault exception is raised. See section
-<<_bus_monitor_and_timeout>> for more information.
+is configured by the `XBUS_TIMEOUT` generic. Note that the value provided by this generic is internally
+extended to the next power of two.
+
+All XBUS transactions have to be acknowledged within this time window. Otherwise the transfer is terminated
+and a bus fault exception is raised. See section <<_bus_monitor_and_timeout>> for more information.
 
 Furthermore, an accesses XBUS device can signal an error condition at any time by setting the `ERR` signal
 high for one cycle. This will also terminate the current bus transaction raising a CPU bus fault exception.

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -183,10 +183,7 @@ begin
       cond_sel_string_f(CPU_RF_HW_RST_EN,  "rf_hw_rst ",  "")
       severity note;
 
-    -- simulation notifier --
-    assert not is_simulation_c report "[NEORV32] Assuming this is a simulation." severity warning;
-
-  end generate; -- /hello_neorv32
+  end generate;
 
 
   -- Front-End (Instruction Fetch) ----------------------------------------------------------

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -187,7 +187,7 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
   -- misc/helpers --
   signal if_reset     : std_ulogic; -- reset instruction fetch (front-end)
   signal branch_taken : std_ulogic; -- fulfilled branch condition or unconditional jump
-  signal monitor_cnt  : std_ulogic_vector(monitor_mc_tmo_c downto 0); -- execution monitor cycle counter
+  signal monitor_cnt  : std_ulogic_vector(alu_cp_tmo_c downto 0); -- execution monitor cycle counter
   signal monitor_exc  : std_ulogic; -- execution monitor timeout exception
   signal opcode       : std_ulogic_vector(6 downto 0); -- simplified opcode (2 LSBs hardwired to "11" to indicate rv32)
   signal immediate    : std_ulogic_vector(XLEN-1 downto 0); -- instruction's immediate

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -18,19 +18,13 @@ package neorv32_package is
 -- Architecture Configuration and Constants
 -- **********************************************************************************************************
 
-  -- Architecture Configuration -------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  -- max response time for ALL bus transactions --
-  constant bus_timeout_c : natural := 1024; -- has to be a power of two
-
-  -- instruction monitor: raise exception if multi-cycle operation times out --
-  constant monitor_mc_tmo_c : natural := 9; -- = log2 of max execution cycles; default = 2^9 = 512 cycles
-
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c : std_ulogic_vector(31 downto 0) := x"01120200"; -- hardware version
-  constant archid_c     : natural := 19; -- official RISC-V architecture ID
-  constant XLEN         : natural := 32; -- native data path width
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01120201"; -- hardware version
+  constant archid_c      : natural := 19; -- official RISC-V architecture ID
+  constant XLEN          : natural := 32; -- native data path width
+  constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
+  constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 
   -- Check if we're inside the Matrix -------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -843,6 +843,7 @@ package neorv32_package is
       CACHE_BURSTS_EN       : boolean                        := true;
       -- External bus interface (XBUS) --
       XBUS_EN               : boolean                        := false;
+      XBUS_TIMEOUT          : natural                        := 2048;
       XBUS_REGSTAGE_EN      : boolean                        := false;
       -- Processor peripherals --
       IO_DISABLE_SYSINFO    : boolean                        := false;

--- a/rtl/core/neorv32_sysinfo.vhd
+++ b/rtl/core/neorv32_sysinfo.vhd
@@ -17,6 +17,8 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_sysinfo is
   generic (
+    BUS_TMO_INT       : natural; -- internal bus timeout value
+    BUS_TMO_EXT       : natural; -- internal bus timeout value
     NUM_HARTS         : natural; -- number of physical CPU cores
     CLOCK_FREQUENCY   : natural; -- clock frequency of clk_i in Hz
     BOOT_MODE_SELECT  : natural; -- boot configuration select (default = 0 = bootloader)
@@ -68,7 +70,8 @@ architecture neorv32_sysinfo_rtl of neorv32_sysinfo is
   constant int_imem_en_c    : boolean := IMEM_EN and boolean(IMEM_SIZE > 0);
   constant int_dmem_en_c    : boolean := DMEM_EN and boolean(DMEM_SIZE > 0);
   constant int_imem_rom_c   : boolean := int_imem_en_c and IMEM_ROM;
-  constant log2_btimeout_c  : natural := index_size_f(bus_timeout_c);
+  constant log2_int_tmo_c   : natural := index_size_f(BUS_TMO_INT);
+  constant log2_ext_tmo_c   : natural := index_size_f(BUS_TMO_EXT);
   constant log2_imem_size_c : natural := index_size_f(IMEM_SIZE);
   constant log2_dmem_size_c : natural := index_size_f(DMEM_SIZE);
   constant log2_ic_bnum_c   : natural := index_size_f(ICACHE_NUM_BLOCKS);
@@ -99,8 +102,9 @@ begin
   sysinfo(1)(7  downto 0)  <= std_ulogic_vector(to_unsigned(log2_imem_size_c, 8)) when int_imem_en_c else (others => '0'); -- log2(IMEM size)
   sysinfo(1)(15 downto 8)  <= std_ulogic_vector(to_unsigned(log2_dmem_size_c, 8)) when int_dmem_en_c else (others => '0'); -- log2(DMEM size)
   sysinfo(1)(19 downto 16) <= std_ulogic_vector(to_unsigned(NUM_HARTS,        4)); -- number of physical CPU cores
-  sysinfo(1)(23 downto 20) <= std_ulogic_vector(to_unsigned(BOOT_MODE_SELECT, 4)); -- boot configuration
-  sysinfo(1)(31 downto 24) <= std_ulogic_vector(to_unsigned(log2_btimeout_c,  8)); -- bus timeout
+  sysinfo(1)(21 downto 20) <= std_ulogic_vector(to_unsigned(BOOT_MODE_SELECT, 2)); -- boot configuration
+  sysinfo(1)(26 downto 22) <= std_ulogic_vector(to_unsigned(log2_int_tmo_c,   5)); -- internal bus timeout
+  sysinfo(1)(31 downto 27) <= std_ulogic_vector(to_unsigned(log2_ext_tmo_c,   5)); -- external bus timeout
 
   -- SYSINFO(2): SoC Configuration ----------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -98,6 +98,7 @@ entity neorv32_top is
 
     -- External bus interface (XBUS) --
     XBUS_EN               : boolean                        := false;       -- implement external memory bus interface
+    XBUS_TIMEOUT          : natural                        := 2048;        -- cycles after a pending bus access auto-terminates (0 = disabled)
     XBUS_REGSTAGE_EN      : boolean                        := false;       -- add XBUS register stage
 
     -- Processor peripherals --
@@ -771,7 +772,8 @@ begin
 
   neorv32_bus_gateway_inst: entity neorv32.neorv32_bus_gateway
   generic map (
-    TIMEOUT => bus_timeout_c,
+    TMO_INT => int_bus_tmo_c,
+    TMO_EXT => XBUS_TIMEOUT,
     -- port A: internal IMEM --
     A_EN    => IMEM_EN,
     A_BASE  => mem_imem_base_c,
@@ -1508,6 +1510,8 @@ begin
     if io_sysinfo_en_c generate
       neorv32_sysinfo_inst: entity neorv32.neorv32_sysinfo
       generic map (
+        BUS_TMO_INT       => int_bus_tmo_c,
+        BUS_TMO_EXT       => XBUS_TIMEOUT,
         NUM_HARTS         => num_cores_c,
         CLOCK_FREQUENCY   => CLOCK_FREQUENCY,
         BOOT_MODE_SELECT  => BOOT_MODE_SELECT,

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -384,29 +384,32 @@ begin
       "[NEORV32] Auto-adjusting invalid DMEM size configuration." severity warning;
 
     -- SYSINFO disabled --
-    assert not (not io_sysinfo_en_c) report
-      "[NEORV32] SYSINFO module disabled - some parts of the NEORV32 software framework will no longer work!" severity warning;
+    assert io_sysinfo_en_c report
+      "[NEORV32] SYSINFO module disabled - NEORV32 software framework will not function properly!" severity warning;
 
     -- Clock speed not defined --
-    assert not (CLOCK_FREQUENCY = 0) report
-      "[NEORV32] CLOCK_FREQUENCY must be configured according to the frequency of clk_i port." severity warning;
+    assert (CLOCK_FREQUENCY > 0) report
+      "[NEORV32] CLOCK_FREQUENCY must be configured according to the frequency of clk_i port!" severity warning;
 
     -- Boot configuration notifier --
-    assert not (BOOT_MODE_SELECT = 0) report "[NEORV32] BOOT_MODE_SELECT = 0: booting via bootloader" severity note;
-    assert not (BOOT_MODE_SELECT = 1) report "[NEORV32] BOOT_MODE_SELECT = 1: booting from custom address" severity note;
-    assert not (BOOT_MODE_SELECT = 2) report "[NEORV32] BOOT_MODE_SELECT = 2: booting IMEM image" severity note;
+    assert not (BOOT_MODE_SELECT = 0) report "[NEORV32] BOOT_MODE_SELECT 0 - booting via bootloader" severity note;
+    assert not (BOOT_MODE_SELECT = 1) report "[NEORV32] BOOT_MODE_SELECT 1 - booting from custom address" severity note;
+    assert not (BOOT_MODE_SELECT = 2) report "[NEORV32] BOOT_MODE_SELECT 2 - booting IMEM image" severity note;
 
     -- Boot configuration: boot from initialized IMEM requires the IMEM to be enabled --
     assert not ((BOOT_MODE_SELECT = 2) and (not IMEM_EN)) report
-      "[NEORV32] ERROR: BOOT_MODE_SELECT = 2 (boot IMEM image) requires the internal instruction memory (IMEM) to be enabled!" severity error;
+      "[NEORV32] BOOT_MODE_SELECT = 2 (boot IMEM image) requires the internal instruction memory (IMEM) to be enabled!" severity error;
 
     -- The SMP dual-core configuration requires the CLINT --
     assert not (DUAL_CORE_EN and (not IO_CLINT_EN)) report
-      "[NEORV32] ERROR: The SMP dual-core configuration requires the CLINT to be enabled!" severity error;
+      "[NEORV32] The SMP dual-core configuration requires the CLINT to be enabled!" severity error;
 
     -- XBUS interface might generate burst transfers --
     assert not (XBUS_EN and (ICACHE_EN or DCACHE_EN)) report
-      "[NEORV32] WARNING: XBUS will emit burst transfers for cached addresses!" severity warning;
+      "[NEORV32] XBUS will emit burst transfers for cached addresses!" severity warning;
+
+    -- simulation notifier --
+    assert not is_simulation_c report "[NEORV32] Assuming this is a simulation." severity warning;
 
   end generate; -- /sanity_checks
 

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -208,8 +208,9 @@ proc setup_ip_gui {} {
   set group [add_group $page {External Bus Interface (XBUS / AXI4-MM Host)}]
   add_params $group {
     { XBUS_EN          {Enable XBUS} }
-    { XBUS_REGSTAGE_EN {Add register stages} {In/out register stages; relaxes timing, but will increase latency} {$XBUS_EN} }
-    { CACHE_BURSTS_EN  {Enable AXI bursts}   {For I-/D-cache accesses only}                                      {$XBUS_EN} }
+    { XBUS_REGSTAGE_EN {Add register stages}   {In/out register stages; relaxes timing, but will increase latency} {$XBUS_EN} }
+    { CACHE_BURSTS_EN  {Enable AXI bursts}     {For I-/D-cache accesses only}                                      {$XBUS_EN} }
+    { XBUS_TIMEOUT     {Access timeout window} {Should be a power of two; timeout disabled when zero}              {$XBUS_EN} }
   }
 
   set group [add_group $page {Stream Link Interface (SLINK / AXI4-Stream Source & Sink)}]

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -92,6 +92,7 @@ entity neorv32_vivado_ip is
     CACHE_BURSTS_EN       : boolean                        := true;
     -- External Bus Interface --
     XBUS_EN               : boolean                        := false;
+    XBUS_TIMEOUT          : natural                        := 2048;
     XBUS_REGSTAGE_EN      : boolean                        := false;
     -- Processor peripherals --
     IO_GPIO_EN            : boolean                        := false;
@@ -423,6 +424,7 @@ begin
     CACHE_BURSTS_EN     => burst_en_c,
     -- External bus interface --
     XBUS_EN             => XBUS_EN,
+    XBUS_TIMEOUT        => XBUS_TIMEOUT,
     XBUS_REGSTAGE_EN    => XBUS_REGSTAGE_EN,
     -- Processor peripherals --
     IO_DISABLE_SYSINFO  => false,

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -191,6 +191,7 @@ begin
     CACHE_BURSTS_EN     => CACHE_BURSTS_EN,
     -- External bus interface --
     XBUS_EN             => true,
+    XBUS_TIMEOUT        => 2048,
     XBUS_REGSTAGE_EN    => true,
     -- Processor peripherals --
     IO_GPIO_NUM         => 32,

--- a/sw/lib/include/neorv32_sysinfo.h
+++ b/sw/lib/include/neorv32_sysinfo.h
@@ -43,10 +43,13 @@ enum NEORV32_SYSINFO_MISC_enum {
   SYSINFO_MISC_HART_MSB = 19, /**< SYSINFO_MISC (19) (r/-): number of physical CPU cores ("harts"), MSB */
 
   SYSINFO_MISC_BOOT_LSB = 20, /**< SYSINFO_MISC (20) (r/-): boot mode configuration (via BOOT_MODE_SELECT generic), LSB */
-  SYSINFO_MISC_BOOT_MSB = 23, /**< SYSINFO_MISC (23) (r/-): boot mode configuration (via BOOT_MODE_SELECT generic), MSB */
+  SYSINFO_MISC_BOOT_MSB = 21, /**< SYSINFO_MISC (21) (r/-): boot mode configuration (via BOOT_MODE_SELECT generic), MSB */
 
-  SYSINFO_MISC_BTMO_LSB = 24, /**< SYSINFO_MISC (24) (r/-): log2(bus timeout cycles), LSB */
-  SYSINFO_MISC_BTMO_MSB = 31  /**< SYSINFO_MISC (31) (r/-): log2(bus timeout cycles), MSB */
+  SYSINFO_MISC_ITMO_LSB = 22, /**< SYSINFO_MISC (22) (r/-): log2(internal bus timeout cycles), LSB */
+  SYSINFO_MISC_ITMO_MSB = 26, /**< SYSINFO_MISC (26) (r/-): log2(internal bus timeout cycles), MSB */
+
+  SYSINFO_MISC_ETMO_LSB = 27, /**< SYSINFO_MISC (27) (r/-): log2(external bus timeout cycles), LSB */
+  SYSINFO_MISC_ETMO_MSB = 31  /**< SYSINFO_MISC (31) (r/-): log2(external bus timeout cycles), MSB */
 };
 
 /** NEORV32_SYSINFO.SOC (r/-): Implemented processor devices/features */
@@ -139,15 +142,31 @@ inline uint32_t __attribute__ ((always_inline)) neorv32_sysinfo_get_dmemsize(voi
  * @return Boot configuration ID.
  **************************************************************************/
 inline uint32_t __attribute__ ((always_inline)) neorv32_sysinfo_get_bootmode(void) {
-  return (uint32_t)((NEORV32_SYSINFO->MISC >> SYSINFO_MISC_BOOT_LSB) & 0x0fu);
+  return (uint32_t)((NEORV32_SYSINFO->MISC >> SYSINFO_MISC_BOOT_LSB) & 0x03u);
 }
 
 /**********************************************************************//**
- * Get bus timeout cycles.
+ * Get internal bus timeout cycles.
  * @return Bus timeout cycles.
  **************************************************************************/
-inline uint32_t __attribute__ ((always_inline)) neorv32_sysinfo_get_bustimeout(void) {
-  return (uint32_t)(1u << ((NEORV32_SYSINFO->MISC >> SYSINFO_MISC_BTMO_LSB) & 0xffu));
+inline uint32_t __attribute__ ((always_inline)) neorv32_sysinfo_get_intbustimeout(void) {
+  uint32_t tmp = (NEORV32_SYSINFO->MISC >> SYSINFO_MISC_ITMO_LSB) & 0x1fu;
+  if (tmp) {
+    return (uint32_t)(1u << tmp);
+  }
+  return 0;
+}
+
+/**********************************************************************//**
+ * Get external bus timeout cycles.
+ * @return Bus timeout cycles.
+ **************************************************************************/
+inline uint32_t __attribute__ ((always_inline)) neorv32_sysinfo_get_extbustimeout(void) {
+  uint32_t tmp = (NEORV32_SYSINFO->MISC >> SYSINFO_MISC_ETMO_LSB) & 0x1fu;
+  if (tmp) {
+    return (uint32_t)(1u << tmp);
+  }
+  return 0;
 }
 
 /**********************************************************************//**

--- a/sw/lib/source/neorv32_aux.c
+++ b/sw/lib/source/neorv32_aux.c
@@ -440,8 +440,6 @@ void neorv32_aux_print_hw_config(void) {
     default: neorv32_uart0_printf("unknown (%u)\n", boot_config); break;
   }
 
-  neorv32_uart0_printf("Bus timeout window:  %u cycles\n", neorv32_sysinfo_get_bustimeout());
-
   // internal IMEM
   neorv32_uart0_printf("Internal IMEM:       ");
   if (NEORV32_SYSINFO->SOC & (1 << SYSINFO_SOC_IMEM)) {
@@ -519,6 +517,10 @@ void neorv32_aux_print_hw_config(void) {
   else {
     neorv32_uart0_printf("\n");
   }
+
+  // bus timeouts
+  neorv32_uart0_printf("Bus timeout (int):   %u cycles\n", neorv32_sysinfo_get_extbustimeout());
+  neorv32_uart0_printf("Bus timeout (ext):   %u cycles\n", neorv32_sysinfo_get_extbustimeout());
 
   // peripherals
   neorv32_uart0_printf("Peripherals:         ");

--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -1604,8 +1604,9 @@
             <field><name>SYSINFO_MISC_IMEM</name><bitRange>[7:0]</bitRange><description>log2(IMEM size in bytes)</description></field>
             <field><name>SYSINFO_MISC_DMEM</name><bitRange>[15:8]</bitRange><description>log2(DMEM size in bytes)</description></field>
             <field><name>SYSINFO_MISC_HART</name><bitRange>[19:16]</bitRange><description>Number of physical CPU cores</description></field>
-            <field><name>SYSINFO_MISC_BOOT</name><bitRange>[23:20]</bitRange><description>Boot mode configuration select</description></field>
-            <field><name>SYSINFO_MISC_BTMO</name><bitRange>[31:24]</bitRange><description>log2(bus timeout cycles)</description></field>
+            <field><name>SYSINFO_MISC_BOOT</name><bitRange>[21:20]</bitRange><description>Boot mode configuration select</description></field>
+            <field><name>SYSINFO_MISC_ITMO</name><bitRange>[26:22]</bitRange><description>log2(internal bus timeout cycles)</description></field>
+            <field><name>SYSINFO_MISC_ETMO</name><bitRange>[31:27]</bitRange><description>log2(external bus timeout cycles)</description></field>
           </fields>
         </register>
         <register>


### PR DESCRIPTION
Triggered in https://github.com/stnolting/neorv32/discussions/1378 by @alyxazon, this PR adds back the `XBUS_TIMEOUT` generic to configure the time window in which external bus accesses must be acknowledged before the access is terminated and a bus exception is raised.

Optionally, the timeout for external bus accesses can be disabled by setting `XBUS_TIMEOUT = 0`.

⚠️ In this PR, the layout of the `SYSINFO.MISC` register is also revised so that there is space for the values for internal and external bus timeouts.