### PR TITLE
Rework NEORV32 executable image generator

### DIFF
--- a/docs/datasheet/software.adoc
+++ b/docs/datasheet/software.adoc
@@ -484,22 +484,21 @@ using the <<_mscratch>> CSR.
 :sectnums:
 === Executable Image Formats
 
-The compiled and linked executable (ELF file) is further processed by the NEORV32 image generator (`sw/image_gen`) to
-generate the final executable file. The image generator can generate several types of executable file formats selected
-by a flag when calling the generator.
-**Note that all these options are managed by the makefile (see <<_makefile_targets>>).**
+The final ELF file is further processed by the NEORV32 image generator (`sw/image_gen`) to generate the final
+executable file. The image generator can generate several types of executable file formats selected by a flag
+when calling the generator. **Note that all these options are managed by the makefile (see <<_makefile_targets>>).**
 
 [cols="<2,<8"]
 [grid="none"]
 |=======================
-| `-app_bin` | Generates an executable binary file (including a bootloader header) for upload via the bootloader.
-| `-app_vhd` | Generates an executable VHDL memory initialization image for the processor-internal IMEM.
-| `-bld_vhd` | Generates an executable VHDL memory initialization image for the processor-internal BOOT ROM.
-| `-raw_hex` | Generates a raw 8x ASCII hex-char file for custom purpose.
-| `-raw_bin` | Generates a raw binary file `for custom purpose.
-| `-raw_coe` | Generates a raw COE file for FPGA memory initialization.
-| `-raw_mem` | Generates a raw MEM file for FPGA memory initialization.
-| `-raw_mif` | Generates a raw MIF file for FPGA memory initialization.
+| `app_bin` | Generates an executable binary file (including a bootloader header) for upload via the bootloader.
+| `app_vhd` | Generates an executable VHDL memory initialization image for the processor-internal IMEM.
+| `bld_vhd` | Generates an executable VHDL memory initialization image for the processor-internal BOOT ROM.
+| `raw_hex` | Generates a raw 8x ASCII hex-char file for custom purpose.
+| `raw_bin` | Generates a raw binary file for custom purpose.
+| `raw_coe` | Generates a raw COE file for FPGA memory initialization.
+| `raw_mem` | Generates a raw MEM file for FPGA memory initialization.
+| `raw_mif` | Generates a raw MIF file for FPGA memory initialization.
 |=======================
 
 .Image Generator Compilation
@@ -516,6 +515,33 @@ Based on this word the bootloader can identify a valid image file. The next word
 actual program image in bytes. A simple complement checksum of the actual program image is given by the third word.
 This provides a simple protection against data transmission or storage errors.
 **Note that this executable format cannot be used for _direct_ execution.**
+
+Optionally, the NEORV32 image generator can also be used stand-alone:
+
+[source,bash]
+----
+neorv32/sw/image_gen$ ./image_gen
+NEORV32 executable image generator
+
+Usage:    image_gen [options]
+Example:  image_gen -i main.elf -o main_exe.bin -t app_bin
+
+Options:
+  -h             Show this help text and exit
+  -i file_name   Input ELF file name, mandatory
+  -o file_name   Output file name, mandatory
+  -t type        Type of image to generate, default is 'app_bin'
+
+Image type:
+  app_bin   Application executable for bootloader upload (binary file with header)
+  app_vhd   Application memory image (IMEM VHDL package file)
+  bld_vhd   Bootloader memory image (BOOTROM VHDL package file)
+  raw_hex   ASCII hex file (raw executable)
+  raw_bin   Binary file (raw executable)
+  raw_coe   COE file (raw executable)
+  raw_mem   MEM file (raw executable)
+  raw_mif   MIF file (raw executable)
+----
 
 
 <<<

--- a/sw/common/common.mk
+++ b/sw/common/common.mk
@@ -236,7 +236,7 @@ $(BIN_MAIN): $(APP_ELF) | $(BUILD_DIR)
 $(APP_EXE): $(BIN_MAIN) $(IMAGE_GEN)
 	$(Q)$(SET) -e
 	$(ECHO) "Generating $(APP_EXE)"
-	$(Q)$(IMAGE_GEN) -app_bin $< $@ $(shell basename $(CURDIR))
+	$(Q)$(IMAGE_GEN) -t app_bin -i $< -o $@
 	$(ECHO) "Executable size in bytes:"
 	$(Q)$(WC) -c < $(APP_EXE)
 
@@ -244,37 +244,37 @@ $(APP_EXE): $(BIN_MAIN) $(IMAGE_GEN)
 $(APP_VHD): $(BIN_MAIN) $(IMAGE_GEN)
 	$(Q)$(SET) -e
 	$(ECHO) "Generating $(APP_VHD)"
-	$(Q)$(IMAGE_GEN) -app_vhd $< $@ $(shell basename $(CURDIR))
+	$(Q)$(IMAGE_GEN) -t app_vhd -i $< -o $@
 
 # Generate NEORV32 RAW executable image in plain hex format
 $(APP_HEX): $(BIN_MAIN) $(IMAGE_GEN)
 	$(Q)$(SET) -e
 	$(ECHO) "Generating $(APP_HEX)"
-	$(Q)$(IMAGE_GEN) -raw_hex $< $@ $(shell basename $(CURDIR))
+	$(Q)$(IMAGE_GEN) -t raw_hex -i $< -o $@
 
 # Generate NEORV32 RAW executable image in binary format
 $(APP_BIN): $(BIN_MAIN) $(IMAGE_GEN)
 	$(Q)$(SET) -e
 	$(ECHO) "Generating $(APP_BIN)"
-	$(Q)$(IMAGE_GEN) -raw_bin $< $@ $(shell basename $(CURDIR))
+	$(Q)$(IMAGE_GEN) -t raw_bin -i $< -o $@
 
 # Generate NEORV32 RAW executable image in COE format
 $(APP_COE): $(BIN_MAIN) $(IMAGE_GEN)
 	$(Q)$(SET) -e
 	$(ECHO) "Generating $(APP_COE)"
-	$(Q)$(IMAGE_GEN) -raw_coe $< $@ $(shell basename $(CURDIR))
+	$(Q)$(IMAGE_GEN) -t raw_coe -i $< -o $@
 
 # Generate NEORV32 RAW executable image in MIF format
 $(APP_MIF): $(BIN_MAIN) $(IMAGE_GEN)
 	$(Q)$(SET) -e
 	$(ECHO) "Generating $(APP_MIF)"
-	$(Q)$(IMAGE_GEN) -raw_mif $< $@ $(shell basename $(CURDIR))
+	$(Q)$(IMAGE_GEN) -t raw_mif -i $< -o $@
 
 # Generate NEORV32 RAW executable image in MEM format
 $(APP_MEM): $(BIN_MAIN) $(IMAGE_GEN)
 	$(Q)$(SET) -e
 	$(ECHO) "Generating $(APP_MEM)"
-	$(Q)$(IMAGE_GEN) -raw_mem $< $@ $(shell basename $(CURDIR))
+	$(Q)$(IMAGE_GEN) -t raw_mem -i $< -o $@
 
 # -----------------------------------------------------------------------------
 # BOOTROM / bootloader image targets
@@ -284,7 +284,7 @@ $(APP_MEM): $(BIN_MAIN) $(IMAGE_GEN)
 bl_image: $(BIN_MAIN) $(IMAGE_GEN)
 	$(Q)$(SET) -e
 	$(ECHO) "Generating $(BOOT_VHD)"
-	$(Q)$(IMAGE_GEN) -bld_vhd $< $(BOOT_VHD) $(shell basename $(CURDIR))
+	$(Q)$(IMAGE_GEN) -t bld_vhd -i $< -o $(BOOT_VHD)
 
 # Install BOOTROM image to VHDL source directory
 bootloader: bl_image
@@ -361,7 +361,7 @@ check: $(IMAGE_GEN)
 	$(ECHO) "---------------- $(SIZE) ----------------"
 	$(Q)$(SIZE) -V
 	$(ECHO) "---------------- NEORV32 image_gen ----------------"
-	$(Q)$(IMAGE_GEN) -help
+	$(Q)$(IMAGE_GEN) -h
 	$(ECHO) "---------------- Native GCC ----------------"
 	$(Q)$(CC_HOST) -v
 	$(ECHO) ""
@@ -375,7 +375,6 @@ info:
 	$(ECHO) "******************************************************"
 	$(ECHO) "Project / Makefile Configuration"
 	$(ECHO) "******************************************************"
-	$(ECHO) "Project folder: $(shell basename $(CURDIR))"
 	$(ECHO) "Source files: $(APP_SRC)"
 	$(ECHO) "Include folder(s): $(APP_INC)"
 	$(ECHO) "ASM include folder(s): $(ASM_INC)"


### PR DESCRIPTION
Clean up the code base, remove unnecessary elements, and improve the user interface.
The individual arguments are only mapped via explicit flags instead of their (fixed) position.

```
neorv32/sw/image_gen$ ./image_gen
NEORV32 executable image generator

Usage:    image_gen [options]
Example:  image_gen -i main.elf -o main_exe.bin -t app_bin

Options:
  -h             Show this help text and exit
  -i file_name   Input ELF file name, mandatory
  -o file_name   Output file name, mandatory
  -t type        Type of image to generate, default is 'app_bin'

Image type:
  app_bin   Application executable for bootloader upload (binary file with header)
  app_vhd   Application memory image (IMEM VHDL package file)
  bld_vhd   Bootloader memory image (BOOTROM VHDL package file)
  raw_hex   ASCII hex file (raw executable)
  raw_bin   Binary file (raw executable)
  raw_coe   COE file (raw executable)
  raw_mem   MEM file (raw executable)
  raw_mif   MIF file (raw executable)
```