### PR TITLE
[rtl] add multiplier primitive

### DIFF
--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01120205"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01120206"; -- hardware version
   constant archid_c      : natural := 19; -- official RISC-V architecture ID
   constant XLEN          : natural := 32; -- native data path width
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two


### PR DESCRIPTION
Add a generic signed/unsigned 2-cycle multiplier primitive (`neorv32_prim.vhd`) that is used in:

* CPU multiplier (`M` ISA extension)
* FPU (`Zicsr` ISA extension)