### PR TITLE
🐛 [dtm] fix bypass register; further code optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 04.10.2025 | 1.12.2.8 | :bug: fix broken DTM bypass register; further DTM logic optimization | [#1393](https://github.com/stnolting/neorv32/pull/1393) |
 | 03.10.2025 | 1.12.2.7 | :bug: FPU: code cleanups and minor bug fix in "float to int" conversion (incorrect sign for if negative overflow) | [#1392](https://github.com/stnolting/neorv32/pull/1392) |
 | 03.10.2025 | 1.12.2.6 | add generic multiplier primitive (used by `M` and `Zicsr` ALU co-processors) | [#1391](https://github.com/stnolting/neorv32/pull/1391) |
 | 03.10.2025 | 1.12.2.5 | :warning: rename and rework openOCD scripts ; optimize debug transfer module (DTM) | [#1390](https://github.com/stnolting/neorv32/pull/1390) |

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -266,7 +266,7 @@ shows all available data registers and their addresses:
 | 16     | `dmireset`     | r/w | setting this bit will clear the sticky error state; this bit auto-clears
 | 15     | -              | r/- | _reserved_, hardwired to zero
 | 14:12  | `idle`         | r/- | recommended idle states (= 0, no idle states required)
-| 11:10  | `dmistat`      | r/- | read-only alias of `DMI.op`
+| 11:10  | `dmistat`      | r/- | read-only alias of `DMI.op`; hardwired to `00` (NOP)
 | 9:4    | `abits`        | r/- | number of address bits in `DMI` register (= 6)
 | 3:0    | `version`      | r/- | `0001` = DTM is compatible to RISC-V debug spec. versions v0.13 and v1.0
 |=======================

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -260,12 +260,13 @@ shows all available data registers and their addresses:
 [options="header",grid="rows"]
 |=======================
 | Bit(s) | Name           | R/W | Description
-| 31:18  | -              | r/- | _reserved_, hardwired to zero
+| 31:21  | -              | r/- | _reserved_, hardwired to zero
+| 20:18  | `errinfo`      | r/- | not implemented; hardwired to zero
 | 17     | `dmihardreset` | r/w | setting this bit will reset the debug module interface; this bit auto-clears
 | 16     | `dmireset`     | r/w | setting this bit will clear the sticky error state; this bit auto-clears
 | 15     | -              | r/- | _reserved_, hardwired to zero
 | 14:12  | `idle`         | r/- | recommended idle states (= 0, no idle states required)
-| 11:10  | `dmistat`      | r/- | DMI status: `00` = no error, `01` = reserved, `10` = operation failed, `11` = failed operation during pending DMI operation
+| 11:10  | `dmistat`      | r/- | read-only alias of `DMI.op`
 | 9:4    | `abits`        | r/- | number of address bits in `DMI` register (= 6)
 | 3:0    | `version`      | r/- | `0001` = DTM is compatible to RISC-V debug spec. versions v0.13 and v1.0
 |=======================
@@ -274,10 +275,10 @@ shows all available data registers and their addresses:
 [cols="^2,^3,^1,<8"]
 [options="header",grid="rows"]
 |=======================
-| Bit(s) | Name           | R/W | Description
-| 40:34  | `address`      | r/w | 7-bit address, see <<_dm_registers>>
-| 33:2   | `data`         | r/w | 32-bit to write/read to/from the addresses DM register
-| 1:0    | `command`      | r/w | 2-bit operation (`00` = NOP; `10` = write; `01` = read)
+| Bit(s) | Name   | R/W | Description
+| 40:34  | `addr` | r/w | 7-bit address, see <<_dm_registers>>
+| 33:2   | `data` | r/w | 32-bit data to write/read to/from the addresses DM register
+| 1:0    | `op`   | r/w | 2-bit operation (`00` = NOP; `10` = write; `01` = read)
 |=======================
 
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -158,7 +158,7 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   -- request --
   type dmi_req_t is record
-    op   : std_ulogic_vector(1 downto 0);
+    op   : std_ulogic_vector(1 downto 0); -- single-shot
     addr : std_ulogic_vector(6 downto 0);
     data : std_ulogic_vector(31 downto 0);
   end record;
@@ -178,7 +178,7 @@ package neorv32_package is
   -- response --
   type dmi_rsp_t is record
     data : std_ulogic_vector(31 downto 0);
-    ack  : std_ulogic;
+    ack  : std_ulogic; -- single-shot
   end record;
 
   -- endpoint (response) termination --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01120207"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01120208"; -- hardware version
   constant archid_c      : natural := 19; -- official RISC-V architecture ID
   constant XLEN          : natural := 32; -- native data path width
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two


### PR DESCRIPTION
* 🐛 fix JTAG bypass register (pass-through was broken; bug introduced in v1.12.2.5 / #1390)
* further logic optimization / simplifcation: replace individual `dtmcs`, `dmi`, `idcode` and `bypass` registers by a single shift register