### PR TITLE
[docs] use Doxygen only for documenting the API

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -42,7 +42,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "NEORV32 Software Framework Documentation"
+PROJECT_NAME           = "NEORV32 API Reference"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -933,12 +933,9 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = $(PWD)/../README.md \
-                         $(PWD)/doxygen_main.md \
+INPUT                  = $(PWD)/doxygen_main.md \
                          $(PWD)/../sw/lib/source \
-                         $(PWD)/../sw/lib/include \
-                         $(PWD)/../sw/bootloader \
-                         $(PWD)/../sw/example
+                         $(PWD)/../sw/lib/include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1010,8 +1007,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = ~* \
-                         */example/coremark/*
+EXCLUDE_PATTERNS       =
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/docs/doxygen_main.md
+++ b/docs/doxygen_main.md
@@ -1,4 +1,1 @@
-### NEORV32 Doxygen Reference
-
-Click on [**Files**](https://stnolting.github.io/neorv32/sw/files.html) to see the documentation
-of the software framework.
+Click on [**Files/File List**](https://stnolting.github.io/neorv32/sw/files.html) to see the documentation of the API / software framework.


### PR DESCRIPTION
Example programs and the bootloader sources will no longer be listed in the Doxygen-based SW documentation.

I think this will make the documentation clearer. Clicking on the [_files_](https://stnolting.github.io/neorv32/sw/files.html) link takes you directly to sw/lib files.

## Current Doxygen "Files" Page

<img width="832" height="878" alt="grafik" src="https://github.com/user-attachments/assets/6cfd5ee7-c23f-43f5-80d9-997938efc097" />


## Proposed Doxygen "Files" Page

<img width="904" height="901" alt="grafik" src="https://github.com/user-attachments/assets/95cde80b-ebbe-4b61-b3e6-0d4244fc6c66" />