### PR TITLE
[ci] update xpack riscv gcc

### DIFF
--- a/.github/workflows/Processor.yml
+++ b/.github/workflows/Processor.yml
@@ -34,10 +34,10 @@ jobs:
 
     - name: '📦 Install xPack RISC-V GCC'
       run: |
-        wget -q https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v14.2.0-2/xpack-riscv-none-elf-gcc-14.2.0-2-linux-x64.tar.gz
+        wget -q https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v15.2.0-1/xpack-riscv-none-elf-gcc-15.2.0-1-linux-x64.tar.gz
         mkdir $GITHUB_WORKSPACE/riscv-gcc
-        tar -xzf xpack-riscv-none-elf-gcc-14.2.0-2-linux-x64.tar.gz -C $GITHUB_WORKSPACE/riscv-gcc
-        echo $GITHUB_WORKSPACE/riscv-gcc/xpack-riscv-none-elf-gcc-14.2.0-2/bin >> $GITHUB_PATH
+        tar -xzf xpack-riscv-none-elf-gcc-15.2.0-1-linux-x64.tar.gz -C $GITHUB_WORKSPACE/riscv-gcc
+        echo $GITHUB_WORKSPACE/riscv-gcc/xpack-riscv-none-elf-gcc-15.2.0-1/bin >> $GITHUB_PATH
 
     - name: '📦 Install GHDL'
       uses: ghdl/setup-ghdl@v1


### PR DESCRIPTION
Update RISC-V GCC to version v15.2.0:

https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v15.2.0-1