### PR TITLE
[semihosting] add option to redirect UART data

### DIFF
--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -183,9 +183,14 @@ USER_FLAGS += -DSTDIO_SEMIHOSTING
 When `STDIO_SEMIHOSTING` is defined _all_ file accesses provided by `stdio.h` (via Newlib) will be redirected to the host
 computer via semihosting services.
 
+.Redirecting all UART data via Semihosting
+[TIP]
+You can redirect **all** physical UART data via semihosting by defining `UART_SEMIHOSTING`
+(e.g. `"USER_FLAGS+=-DSTDIO_SEMIHOSTING -DUART_SEMIHOSTING"`).
+
 .Semihosting Services Without a Host
 [NOTE]
-If any semihosting request is issued without a host being connected, a breakpoint exception is raised.
+If any semihosting request is issued without a host being connected, an environment breakpoint exception is raised.
 
 Further references:
 

--- a/sw/example/demo_semihosting/main.c
+++ b/sw/example/demo_semihosting/main.c
@@ -54,7 +54,13 @@ int main() {
   // semihosting enabled at all?
 #ifndef STDIO_SEMIHOSTING
   neorv32_uart0_printf("[WARNING] stdio semihosting not enabled!\n");
-  neorv32_uart0_printf("Recompile with 'USER_FLAGS+=-DSTDIO_SEMIHOSTING'\n");
+  neorv32_uart0_printf("Recompile with USER_FLAGS+=-DSTDIO_SEMIHOSTING\n\n");
+#endif
+
+  // hint
+#ifndef UART_SEMIHOSTING
+  neorv32_uart0_puts("[NOTE] You can redirect ALL UART data via semihosting\n");
+  neorv32_uart0_puts("Recompile with USER_FLAGS+\"=-DSTDIO_SEMIHOSTING -DUART_SEMIHOSTING\"\n\n");
 #endif
 
 
@@ -62,6 +68,15 @@ int main() {
   // Print string to host's STDOUT
   // ------------------------------------------------------
   neorv32_semihosting_puts("Hello semihosting!\r\n");
+
+
+  // ------------------------------------------------------
+  // Print a RTE panic message via UART redirection
+  // ------------------------------------------------------
+#ifdef UART_SEMIHOSTING
+  neorv32_uart0_printf("NEORV32-RTE panic warning:\r\n");
+  asm volatile ("ecall");
+#endif
 
 
   // ------------------------------------------------------


### PR DESCRIPTION
When compiling with `make clean USER_FLAGS+="-DSTDIO_SEMIHOSTING -DUART_SEMIHOSTING" elf` **all** UART data is sent to the host console via semihosting:

```c
neorv32_uart0_puts("This is also sent to the host instead of being sent via the physical UART");
```