### PR TITLE
Add description to TOPCMP in svd

### DIFF
--- a/sw/svd/neorv32.svd
+++ b/sw/svd/neorv32.svd
@@ -462,6 +462,7 @@
           <description>Channel configuration register</description>
           <register>
             <name>TOPCMP</name>
+            <description>Channel counter full word access alias</description>
             <addressOffset>0x0</addressOffset>
             <fields>
               <field>


### PR DESCRIPTION
This PR just adds a description for the TOPCMP register in the svd file mainly to silence a warning [svd2rust](https://docs.rs/svd2rust/latest/svd2rust/) generates for missing register descriptions (and prevents a minor issue in generated Rust code). Just went with the description from the datasheet.

If this warrants an entry in the CHANGELOG, let me know and I'll gladly add one.