### PR TITLE
[lsu] add unaligned support

### DIFF
--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -42,6 +42,7 @@ entity neorv32_cpu is
     RISCV_ISA_Zcb       : boolean;                        -- additional code size reduction instructions
     RISCV_ISA_Zfinx     : boolean;                        -- 32-bit floating-point extension
     RISCV_ISA_Zibi      : boolean;                        -- branch with immediate
+    RISCV_ISA_Zicclsm   : boolean;                        -- misaligned loads/stores to main memory
     RISCV_ISA_Zicntr    : boolean;                        -- base counters
     RISCV_ISA_Zicond    : boolean;                        -- integer conditional operations
     RISCV_ISA_Zihpm     : boolean;                        -- hardware performance monitors
@@ -166,6 +167,7 @@ begin
       sel_string_f(riscv_zcb_c,         "_zcb",       "" ) &
       sel_string_f(RISCV_ISA_Zfinx,     "_zfinx",     "" ) &
       sel_string_f(RISCV_ISA_Zibi,      "_zibi",      "" ) &
+      sel_string_f(RISCV_ISA_Zicclsm,   "_zicclsm",   "" ) &
       sel_string_f(RISCV_ISA_Zicntr,    "_zicntr",    "" ) &
       sel_string_f(RISCV_ISA_Zicond,    "_zicond",    "" ) &
       sel_string_f(true,                "_zicsr",     "" ) & -- always enabled
@@ -445,8 +447,9 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_lsu_inst: entity neorv32.neorv32_cpu_lsu
   generic map (
-    HART_ID => HART_ID,  -- hardware thread ID
-    AMO_EN  => any_amo_c -- enable atomic memory accesses
+    HART_ID      => HART_ID,          -- hardware thread ID
+    AMO_EN       => any_amo_c,        -- enable atomic memory accesses
+    UNALIGNED_EN => RISCV_ISA_Zicclsm -- enable misaligned load/store support
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -44,6 +44,7 @@ entity neorv32_cpu is
     RISCV_ISA_Zcmop     : boolean                        := false;       -- compressed may-be-operations
     RISCV_ISA_Zfinx     : boolean                        := false;       -- 32-bit floating-point extension
     RISCV_ISA_Zibi      : boolean                        := false;       -- branch with immediate
+    RISCV_ISA_Zicclsm   : boolean                        := false;       -- misaligned loads/stores to main memory
     RISCV_ISA_Zicntr    : boolean                        := false;       -- base counters
     RISCV_ISA_Zicond    : boolean                        := false;       -- integer conditional operations
     RISCV_ISA_Zihpm     : boolean                        := false;       -- hardware performance monitors
@@ -174,6 +175,7 @@ begin
       sel_string_f(riscv_zcmop_c,       "_zcmop",     "" ) &
       sel_string_f(RISCV_ISA_Zfinx,     "_zfinx",     "" ) &
       sel_string_f(RISCV_ISA_Zibi,      "_zibi",      "" ) &
+      sel_string_f(RISCV_ISA_Zicclsm,   "_zicclsm",   "" ) &
       sel_string_f(RISCV_ISA_Zicntr,    "_zicntr",    "" ) &
       sel_string_f(RISCV_ISA_Zicond,    "_zicond",    "" ) &
       sel_string_f(true,                "_zicsr",     "" ) & -- always enabled
@@ -465,8 +467,9 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_lsu_inst: entity neorv32.neorv32_cpu_lsu
   generic map (
-    HART_ID => HART_ID,  -- hardware thread ID
-    AMO_EN  => any_amo_c -- enable atomic memory accesses
+    HART_ID      => HART_ID,          -- hardware thread ID
+    AMO_EN       => any_amo_c,        -- enable atomic memory accesses
+    UNALIGNED_EN => RISCV_ISA_Zicclsm -- enable misaligned load/store support
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_cpu_lsu.vhd
+++ b/rtl/core/neorv32_cpu_lsu.vhd
@@ -17,8 +17,9 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_lsu is
   generic (
-    HART_ID : natural; -- hardware thread ID
-    AMO_EN  : boolean  -- enable atomic memory accesses
+    HART_ID      : natural; -- hardware thread ID
+    AMO_EN       : boolean; -- enable atomic memory accesses
+    UNALIGNED_EN : boolean  -- enable hardware-supported unaligned loads/stores (Zicclsm)
   );
   port (
     -- global control --
@@ -43,6 +44,23 @@ architecture neorv32_cpu_lsu_rtl of neorv32_cpu_lsu is
 
   signal req : bus_req_t;
   signal misalign : std_ulogic;
+
+  -- unaligned split-transaction support --
+  -- Set by mem_do_reg on lsu_mo_en; held stable until next transaction.
+  type state_t is (
+    S_INACTIVE, S_UNALIGNED_W, S_UNALIGNED_HW
+  );
+  signal state            : state_t;
+  signal req2_needed      : boolean;                        -- access straddles a word boundary and requires a 2nd bus transaction
+  signal req2_wdata       : std_ulogic_vector(31 downto 0); -- 2nd sub-access write data
+
+  -- Set/cleared by unaligned_fsm.
+  type phase_t is (
+    REQ1, REQ2
+  );
+  signal req_phase   : phase_t; -- REQ1=waiting for 1st ack, REQ2=waiting for 2nd ack
+  signal req_phase_d : phase_t; -- registered delay of req_phase (for one-cycle stb pulse)
+  signal req1_data   : std_ulogic_vector(31 downto 0); -- captured 1st response word
 
 begin
 
@@ -95,41 +113,96 @@ begin
 
   -- Request --------------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
+  -- This process captures address, data, byte-enables and misalignment for each transaction.
+  -- When UNALIGNED_EN is true and a non-AMO misaligned access is detected, the address is
+  -- aligned down, byte-enables and data are adjusted for the first sub-access, and split
+  -- parameters for the second sub-access are registered.
   mem_do_reg: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      req.meta <= (others => '0');
-      req.addr <= (others => '0');
-      req.data <= (others => '0');
-      req.ben  <= (others => '0');
-      req.rw   <= '0';
-      misalign <= '0';
+      req.meta           <= (others => '0');
+      req.addr           <= (others => '0');
+      req.data           <= (others => '0');
+      req.ben            <= (others => '0');
+      req.rw             <= '0';
+      misalign           <= '0';
+      state              <= S_INACTIVE;
+      req2_wdata         <= (others => '0');
     elsif rising_edge(clk_i) then
       if (ctrl_i.lsu_mo_en = '1') then
         req.meta <= std_ulogic_vector(to_unsigned(HART_ID, 2)) & ctrl_i.cpu_debug & ctrl_i.lsu_priv & '0';
-        req.addr <= addr_i; -- memory address register
-        case ctrl_i.ir_funct3(1 downto 0) is -- alignment + byte-enable
-          when "00" => -- byte
-            req.data   <= wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0);
-            req.ben(0) <= (not addr_i(1)) and (not addr_i(0));
-            req.ben(1) <= (not addr_i(1)) and (    addr_i(0));
-            req.ben(2) <= (    addr_i(1)) and (not addr_i(0));
-            req.ben(3) <= (    addr_i(1)) and (    addr_i(0));
-            misalign   <= '0';
-          when "01" => -- half-word
-            req.data <= wdata_i(15 downto 0) & wdata_i(15 downto 0);
-            req.ben  <= addr_i(1) & addr_i(1) & (not addr_i(1)) & (not addr_i(1));
-            misalign <= addr_i(0);
-          when others => -- word
-            req.data <= wdata_i;
-            req.ben  <= (others => '1');
-            misalign <= addr_i(1) or addr_i(0);
-        end case;
         if AMO_EN and (ctrl_i.ir_opcode(2) = '1') and (ctrl_i.ir_funct12(8) = '0') then
           req.rw <= '0'; -- atomic read-modify-write operations are modified load requests
         else
           req.rw <= ctrl_i.lsu_wr;
         end if;
+        case ctrl_i.ir_funct3(1 downto 0) is
+          when "00" => -- byte (always aligned)
+            req.addr           <= addr_i;
+            req.data           <= wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0);
+            req.ben(0)         <= (not addr_i(1)) and (not addr_i(0));
+            req.ben(1)         <= (not addr_i(1)) and (    addr_i(0));
+            req.ben(2)         <= (    addr_i(1)) and (not addr_i(0));
+            req.ben(3)         <= (    addr_i(1)) and (    addr_i(0));
+            misalign           <= '0';
+            state              <= S_INACTIVE;
+
+          when "01" => -- half-word
+            if UNALIGNED_EN and (addr_i(0) = '1') and (ctrl_i.ir_opcode(2) = '0') then
+              -- UNALIGNED_EN: handle misaligned half-word
+              misalign         <= '0';
+              state            <= S_UNALIGNED_HW;
+              req.addr         <= addr_i;
+              if (addr_i(1) = '0') then
+                -- offset "01": bytes 1-2 both within the same aligned word, no straddle
+                -- lane1=bits[15:8]=wdata[7:0], lane2=bits[23:16]=wdata[15:8]
+                req.ben        <= "0110";
+                req.data       <= x"00" & wdata_i(15 downto 0) & x"00";
+              else
+                -- offset "11": byte 3 of word1, byte 0 of word2 - straddles boundary
+                req.ben        <= "1000";
+                req.data       <= wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0);
+                req2_wdata     <= wdata_i(15 downto 8) & wdata_i(15 downto 8) & wdata_i(15 downto 8) & wdata_i(15 downto 8);
+              end if;
+            else
+              -- aligned half-word or AMO
+              req.addr         <= addr_i;
+              req.data         <= wdata_i(15 downto 0) & wdata_i(15 downto 0);
+              req.ben          <= addr_i(1) & addr_i(1) & (not addr_i(1)) & (not addr_i(1));
+              misalign         <= addr_i(0);
+              state            <= S_INACTIVE;
+            end if;
+
+          when others => -- word
+            if UNALIGNED_EN and ((addr_i(1) or addr_i(0)) = '1') and (ctrl_i.ir_opcode(2) = '0') then
+              -- handle misaligned word (all non-zero offsets straddle a word boundary)
+              misalign         <= '0';
+              state            <= S_UNALIGNED_W;
+              req.addr         <= addr_i;
+              case addr_i(1 downto 0) is
+                when "01" => -- 3 bytes in word1 (lanes 1,2,3), 1 byte in word2 (lane 0)
+                  req.ben    <= "1110";
+                  req.data   <= wdata_i(23 downto 0) & x"00";
+                  req2_wdata <= wdata_i(31 downto 24) & wdata_i(31 downto 24) & wdata_i(31 downto 24) & wdata_i(31 downto 24);
+                when "10" => -- 2 bytes in word1 (lanes 2,3), 2 bytes in word2 (lanes 0,1)
+                  req.ben    <= "1100";
+                  req.data   <= wdata_i(15 downto 0) & x"0000";
+                  req2_wdata <= wdata_i(31 downto 16) & wdata_i(31 downto 16);
+                when others => -- "11": 1 byte in word1 (lane 3), 3 bytes in word2 (lanes 0,1,2)
+                  req.ben    <= "1000";
+                  req.data   <= wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0);
+                  req2_wdata <= x"00" & wdata_i(31 downto 8);
+              end case;
+            else
+              -- aligned word or AMO
+              req.addr       <= addr_i;
+              req.data       <= wdata_i;
+              req.ben        <= (others => '1');
+              misalign       <= addr_i(1) or addr_i(0);
+              state          <= S_INACTIVE;
+            end if;
+
+        end case;
       end if;
     end if;
   end process mem_do_reg;
@@ -138,14 +211,108 @@ begin
   req.burst <= '0'; -- only non-burst/single-accesses
   req.fence <= ctrl_i.lsu_fence;
 
-  -- access request (all source signals are driven by registers) --
-  req.stb <= ctrl_i.lsu_req and (not misalign) and (not pmp_fault_i);
+  -- req2_needed: true when the access straddles a word boundary (all word misalignments; HW only at offset "11")
+  req2_needed <= (state = S_UNALIGNED_W) or (state = S_UNALIGNED_HW and req.addr(1) = '1');
 
-  -- output bus request --
-  dbus_req_o <= req;
+  -- Unaligned Split-Transaction FSM -----------------------------------------------------------
+  -- Manages req_phase (which sub-access is in flight) and captures first response word.
+  -- -------------------------------------------------------------------------------------------
+  unaligned_fsm: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      req_phase   <= REQ1;
+      req_phase_d <= REQ1;
+      req1_data     <= (others => '0');
+    elsif rising_edge(clk_i) then
+      req_phase_d <= req_phase; -- one-cycle delay for rising-edge detection
+      if UNALIGNED_EN then
+        if (ctrl_i.cpu_trap = '1') then
+          -- exception: abort any in-progress split
+          req_phase <= REQ1;
+        elsif (state /= S_INACTIVE) and (req2_needed) then
+          if (req_phase = REQ1) and (dbus_rsp_i.ack = '1') then
+            -- first sub-access complete: save word1, move to phase 1
+            req_phase <= REQ2;
+            req1_data   <= dbus_rsp_i.data;
+          elsif (req_phase = REQ2) and (dbus_rsp_i.ack = '1') then
+            -- second sub-access complete: transaction done
+            req_phase <= REQ1;
+          end if;
+        end if;
+      end if;
+    end if;
+  end process unaligned_fsm;
 
-  -- address feedback for MTVAL CSR --
-  mar_o <= req.addr;
+
+  -- Bus Output Mux ----------------------------------------------------------------------------
+  -- Generate a second transaction if the unaligned accesses are allowed and the request requires it
+  -- -------------------------------------------------------------------------------------------
+  unaligned_output:
+  if UNALIGNED_EN generate
+    req.stb <= '0'; -- stb is not used in this path; dbus_req_o.stb is driven by the process below
+    mar_o   <= req.addr; -- unaligned address reported to MTVAL CSR on fault
+
+    bus_output: process(req, req2_wdata, req2_needed,
+                        req_phase, req_phase_d, misalign, pmp_fault_i,
+                        state, ctrl_i, dbus_rsp_i)
+    begin
+      -- defaults: first sub-access / aligned access
+      -- req.addr holds the original unaligned address; mask it for the bus
+      dbus_req_o      <= req;
+      dbus_req_o.addr <= req.addr(31 downto 2) & "00";
+      dbus_req_o.stb  <= ctrl_i.lsu_req and (not misalign) and (not pmp_fault_i);
+
+      if req2_needed then
+        if req_phase = REQ2 then
+          -- second sub-access: switch to second word address/data/ben
+          -- ben bits 2:0 = number of bytes in the second word;
+          dbus_req_o.addr <= std_ulogic_vector(unsigned(req.addr(31 downto 2) & "00") + 4);
+          dbus_req_o.data <= req2_wdata;
+          if (state = S_UNALIGNED_W) then
+            dbus_req_o.ben(3) <= '0';
+            dbus_req_o.ben(2) <= req.addr(1) and req.addr(0);
+            dbus_req_o.ben(1) <= req.addr(1);
+            dbus_req_o.ben(0) <= '1';
+          else
+            dbus_req_o.ben <= "0001";
+          end if;
+          -- one-cycle strobe pulse on the rising edge of req_phase
+          if (req_phase_d = REQ1) then
+            dbus_req_o.stb <= not pmp_fault_i;
+          else
+            dbus_req_o.stb <= '0';
+          end if;
+        end if;
+
+        -- hold CPU in S_MEM_RSP until the final ack
+        if (req_phase = REQ1) then
+          wait_o <= '1';
+        elsif dbus_rsp_i.ack = '1' then
+          wait_o <= '0';
+        else
+          wait_o <= not dbus_rsp_i.ack;
+        end if;
+      else
+        wait_o <= not dbus_rsp_i.ack;
+      end if;
+    end process bus_output;
+  end generate;
+
+  no_unaligned_output:
+  if not UNALIGNED_EN generate
+    -- access request (all source signals are driven by registers) --
+    req.stb    <= ctrl_i.lsu_req and (not misalign) and (not pmp_fault_i);
+    -- output bus request --
+    dbus_req_o <= req;
+    -- address feedback for MTVAL CSR --
+    mar_o      <= req.addr;
+    -- wait for bus response --
+    wait_o     <= not dbus_rsp_i.ack;
+    -- req_phase/req_phase_d/req1_data are driven by unaligned_fsm (always present);
+    -- when UNALIGNED_EN=false they stay at reset ('0')
+    -- unaligned_active/straddle/is_hw and split_* registers are driven by mem_do_reg reset
+    -- and never updated when UNALIGNED_EN=false, so no extra assignments needed here.
+  end generate;
 
 
   -- Response -------------------------------------------------------------------------------
@@ -157,33 +324,58 @@ begin
     elsif rising_edge(clk_i) then
       rdata_o <= (others => '0'); -- output zero if there is no pending memory request
       if (ctrl_i.lsu_mi_en = '1') then
-        case ctrl_i.ir_funct3(1 downto 0) is
-          when "00" => -- byte
-            case req.addr(1 downto 0) is
-              when "00"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(7),  24) & dbus_rsp_i.data(7 downto 0);
-              when "01"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(15), 24) & dbus_rsp_i.data(15 downto 8);
-              when "10"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(23), 24) & dbus_rsp_i.data(23 downto 16);
-              when others => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(31), 24) & dbus_rsp_i.data(31 downto 24);
-            end case;
-          when "01" => -- half-word
+        if UNALIGNED_EN and (state /= S_INACTIVE) then
+          if (state = S_UNALIGNED_HW) then
             if (req.addr(1) = '0') then
-              rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(15), 16) & dbus_rsp_i.data(15 downto 0);
-            else
-              rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(31), 16) & dbus_rsp_i.data(31 downto 16);
+              -- Half-word at offset "01": bytes 1-2 within the single aligned word
+              -- Extract bits[23:8]; sign-extend if LH (funct3(2)='0')
+              rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(23), 16) & dbus_rsp_i.data(23 downto 8);
+            elsif (req_phase = REQ2) then
+              -- half-word at offset "11": byte3/word1 + byte0/word2
+              rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(7), 16) & dbus_rsp_i.data(7 downto 0) & req1_data(31 downto 24);
             end if;
-          when others => -- word
-            rdata_o <= dbus_rsp_i.data;
-        end case;
+          elsif (req_phase = REQ2) then
+            -- Straddling access: combine req1_data (first word) with current response (second word)
+            if (req.addr(1 downto 0) = "01") then -- word at offset "01": bytes 1-3 from word1, byte 0 from word2
+              rdata_o <= dbus_rsp_i.data(7 downto 0) & req1_data(31 downto 8);
+            elsif (req.addr(1 downto 0) = "10") then -- word at offset "10": bytes 2-3 from word1, bytes 0-1 from word2
+              rdata_o <= dbus_rsp_i.data(15 downto 0) & req1_data(31 downto 16);
+            else -- word at offset "11": byte 3 from word1, bytes 0-2 from word2
+              rdata_o <= dbus_rsp_i.data(23 downto 0) & req1_data(31 downto 24);
+            end if;
+          end if;
+          -- else: straddle phase 0 (first ack received but second not yet started):
+          -- rdata_o is set to zero (default above); CPU is still in S_MEM_RSP (wait_o='1')
+          -- and will not read rdata_o until the second ack clears wait_o.
+        else
+          -- standard aligned response path
+          case ctrl_i.ir_funct3(1 downto 0) is
+            when "00" => -- byte
+              case req.addr(1 downto 0) is
+                when "00"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(7),  24) & dbus_rsp_i.data(7 downto 0);
+                when "01"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(15), 24) & dbus_rsp_i.data(15 downto 8);
+                when "10"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(23), 24) & dbus_rsp_i.data(23 downto 16);
+                when others => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(31), 24) & dbus_rsp_i.data(31 downto 24);
+              end case;
+            when "01" => -- half-word
+              if (req.addr(1) = '0') then
+                rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(15), 16) & dbus_rsp_i.data(15 downto 0);
+              else
+                rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(31), 16) & dbus_rsp_i.data(31 downto 16);
+              end if;
+            when others => -- word
+              rdata_o <= dbus_rsp_i.data;
+          end case;
+        end if;
       end if;
     end if;
   end process mem_di_reg;
 
-  -- wait for bus response --
-  wait_o <= not dbus_rsp_i.ack;
-
   -- access/alignment errors --
   -- [NOTE] AMOs will report load AND store exceptions. However, only the store exception will be reported due to its higher priority.
   -- [NOTE] ACK is ignored for the error response to shorten the bus system's critical path.
+  -- [NOTE] For UNALIGNED_EN, misalign is forced to '0' for non-AMO accesses in mem_do_reg,
+  --        so misaligned regular loads/stores will not raise exceptions here.
   err_o(0) <= ctrl_i.lsu_mi_en and ctrl_i.lsu_rd and misalign; -- misaligned load
   err_o(1) <= ctrl_i.lsu_mi_en and ctrl_i.lsu_rd and (dbus_rsp_i.err or pmp_fault_i); -- load access error
   err_o(2) <= ctrl_i.lsu_mi_en and ctrl_i.lsu_wr and misalign; -- misaligned store

--- a/rtl/core/neorv32_cpu_lsu.vhd
+++ b/rtl/core/neorv32_cpu_lsu.vhd
@@ -17,8 +17,9 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_lsu is
   generic (
-    HART_ID : natural range 0 to 1; -- hardware thread ID
-    AMO_EN  : boolean  -- enable atomic memory accesses
+    HART_ID      : natural range 0 to 1; -- hardware thread ID
+    AMO_EN       : boolean; -- enable atomic memory accesses
+    UNALIGNED_EN : boolean  -- enable hardware-supported unaligned loads/stores (Zicclsm)
   );
   port (
     -- global control --
@@ -41,8 +42,9 @@ end entity;
 
 architecture neorv32_cpu_lsu_rtl of neorv32_cpu_lsu is
 
-  signal req : bus_req_t;
+  signal req      : bus_req_t;
   signal misalign : std_ulogic;
+  signal bus_rsp  : bus_rsp_t;
 
 begin
 
@@ -119,11 +121,19 @@ begin
           when "01" => -- half-word
             req.data <= wdata_i(15 downto 0) & wdata_i(15 downto 0);
             req.ben  <= addr_i(1) & addr_i(1) & (not addr_i(1)) & (not addr_i(1));
-            misalign <= addr_i(0);
+            if UNALIGNED_EN and (ctrl_i.ir_opcode(2) = '0') then
+              misalign <= '0'; -- handled by the unaligned access handler
+            else
+              misalign <= addr_i(0);
+            end if;
           when others => -- word
             req.data <= wdata_i;
             req.ben  <= (others => '1');
-            misalign <= addr_i(1) or addr_i(0);
+            if UNALIGNED_EN and (ctrl_i.ir_opcode(2) = '0') then
+              misalign <= '0'; -- handled by the unaligned access handler
+            else
+              misalign <= addr_i(1) or addr_i(0);
+            end if;
         end case;
         if AMO_EN and (ctrl_i.ir_opcode(2) = '1') and (ctrl_i.ir_funct12(8) = '0') then
           req.rw <= '0'; -- atomic read-modify-write operations are modified load requests
@@ -134,13 +144,43 @@ begin
     end if;
   end process;
 
-  req.burst  <= '0'; -- only non-burst/single-accesses
-  req.stb    <= ctrl_i.lsu_req and (not misalign) and (not pmp_fault_i); -- access request (all source signals are driven by registers)
-  dbus_req_o <= req; -- output bus request
-  mar_o      <= req.addr; -- address feedback for MTVAL CSR
+  req.burst <= '0'; -- only non-burst/single-accesses
+  req.stb   <= ctrl_i.lsu_req and (not misalign) and (not pmp_fault_i); -- access request (all source signals are driven by registers)
+  mar_o     <= req.addr; -- address feedback for MTVAL CSR
 
 
-  -- Response -------------------------------------------------------------------------------
+  -- Unaligned Memory Access Handler ---------------------------------------------------------
+  -- If enabled, misaligned non AMO requests are translated into one or two aligned
+  -- bus transactions. The responses are merged and returned as a single word.
+  -- -----------------------------------------------------------------------------------------
+  unaligned_enabled:
+  if UNALIGNED_EN generate
+    lsu_unaligned_inst: entity neorv32.neorv32_cpu_lsu_unaligned
+    port map (
+      clk_i       => clk_i,
+      rstn_i      => rstn_i,
+      ctrl_i      => ctrl_i,
+      pmp_fault_i => pmp_fault_i,
+      addr_i      => addr_i,
+      wdata_i     => wdata_i,
+      req_i       => req,
+      rsp_o       => bus_rsp,
+      req_o       => dbus_req_o,
+      rsp_i       => dbus_rsp_i
+    );
+  end generate;
+
+  -- direct bus connection --
+  unaligned_disabled:
+  if not UNALIGNED_EN generate
+    dbus_req_o <= req;
+    bus_rsp    <= dbus_rsp_i;
+  end generate;
+
+
+  -- Response ----------------------------------------------------------------------------------
+  -- When UNALIGNED_EN the unaligned handler has already reconstructed the read data,
+  -- so it is just registered here. otherwise the aligned byte/half/word extraction is applied.
   -- -------------------------------------------------------------------------------------------
   mem_di_reg: process(rstn_i, clk_i)
   begin
@@ -149,37 +189,41 @@ begin
     elsif rising_edge(clk_i) then
       rdata_o <= (others => '0'); -- output zero if there is no pending memory request
       if (ctrl_i.lsu_mi_en = '1') then
-        case ctrl_i.ir_funct3(1 downto 0) is
-          when "00" => -- byte
-            case req.addr(1 downto 0) is
-              when "00"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(7),  24) & dbus_rsp_i.data(7 downto 0);
-              when "01"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(15), 24) & dbus_rsp_i.data(15 downto 8);
-              when "10"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(23), 24) & dbus_rsp_i.data(23 downto 16);
-              when "11"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(31), 24) & dbus_rsp_i.data(31 downto 24);
-              when others => rdata_o <= (others => 'X');
-            end case;
-          when "01" => -- half-word
-            if (req.addr(1) = '0') then
-              rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(15), 16) & dbus_rsp_i.data(15 downto 0);
-            else
-              rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and dbus_rsp_i.data(31), 16) & dbus_rsp_i.data(31 downto 16);
-            end if;
-          when others => -- word
-            rdata_o <= dbus_rsp_i.data;
-        end case;
+        if UNALIGNED_EN then
+          rdata_o <= bus_rsp.data; -- already correctly (re-)aligned
+        else
+          case ctrl_i.ir_funct3(1 downto 0) is
+            when "00" => -- byte
+              case req.addr(1 downto 0) is
+                when "00"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and bus_rsp.data(7),  24) & bus_rsp.data(7 downto 0);
+                when "01"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and bus_rsp.data(15), 24) & bus_rsp.data(15 downto 8);
+                when "10"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and bus_rsp.data(23), 24) & bus_rsp.data(23 downto 16);
+                when "11"   => rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and bus_rsp.data(31), 24) & bus_rsp.data(31 downto 24);
+                when others => rdata_o <= (others => 'X');
+              end case;
+            when "01" => -- half-word
+              if (req.addr(1) = '0') then
+                rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and bus_rsp.data(15), 16) & bus_rsp.data(15 downto 0);
+              else
+                rdata_o <= replicate_f((not ctrl_i.ir_funct3(2)) and bus_rsp.data(31), 16) & bus_rsp.data(31 downto 16);
+              end if;
+            when others => -- word
+              rdata_o <= bus_rsp.data;
+          end case;
+        end if;
       end if;
     end if;
   end process;
 
   -- wait for bus response --
-  wait_o <= not dbus_rsp_i.ack;
+  wait_o <= not bus_rsp.ack;
 
   -- access/alignment errors --
   -- [NOTE] AMOs will report load AND store exceptions. However, only the store exception will be reported due to its higher priority.
   -- [NOTE] ACK is ignored for the error response to shorten the bus system's critical path.
   err_o(0) <= ctrl_i.lsu_mi_en and ctrl_i.lsu_rd and misalign; -- misaligned load
-  err_o(1) <= ctrl_i.lsu_mi_en and ctrl_i.lsu_rd and (dbus_rsp_i.err or pmp_fault_i); -- load access error
+  err_o(1) <= ctrl_i.lsu_mi_en and ctrl_i.lsu_rd and (bus_rsp.err or pmp_fault_i); -- load access error
   err_o(2) <= ctrl_i.lsu_mi_en and ctrl_i.lsu_wr and misalign; -- misaligned store
-  err_o(3) <= ctrl_i.lsu_mi_en and ctrl_i.lsu_wr and (dbus_rsp_i.err or pmp_fault_i); -- store access error
+  err_o(3) <= ctrl_i.lsu_mi_en and ctrl_i.lsu_wr and (bus_rsp.err or pmp_fault_i); -- store access error
 
 end architecture;

--- a/rtl/core/neorv32_cpu_lsu_unaligned.vhd
+++ b/rtl/core/neorv32_cpu_lsu_unaligned.vhd
@@ -1,0 +1,249 @@
+-- ================================================================================ --
+-- NEORV32 CPU - Load/Store Unit: Unaligned Memory Access Handler                   --
+-- -------------------------------------------------------------------------------- --
+-- Sits between the LSU and the data bus. Translates a potentially-misaligned       --
+-- bus_req_t into one or two word-aligned sub-transactions, then reassembles the    --
+-- responses. Aligned and AMO accesses are passed through as a single transaction.  --
+-- -------------------------------------------------------------------------------- --
+-- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
+-- Copyright (c) NEORV32 contributors.                                              --
+-- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
+-- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
+-- SPDX-License-Identifier: BSD-3-Clause                                            --
+-- ================================================================================ --
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library neorv32;
+use neorv32.neorv32_package.all;
+
+entity neorv32_cpu_lsu_unaligned is
+  port (
+    -- global control --
+    clk_i       : in  std_ulogic; -- global clock, rising edge
+    rstn_i      : in  std_ulogic; -- global reset, low-active, async
+    -- CPU control bus --
+    ctrl_i      : in  ctrl_bus_t;
+    -- PMP access fault --
+    pmp_fault_i : in  std_ulogic;
+    -- raw access operands (combinational, valid when ctrl_i.lsu_mo_en = '1') --
+    addr_i      : in  std_ulogic_vector(31 downto 0); -- access address
+    wdata_i     : in  std_ulogic_vector(31 downto 0); -- write data
+    -- LSU interface --
+    req_i       : in  bus_req_t; -- request (possibly unaligned)
+    rsp_o       : out bus_rsp_t; -- response
+    -- BUS interface --
+    req_o       : out bus_req_t; -- request (aligned)
+    rsp_i       : in  bus_rsp_t  -- response
+  );
+end neorv32_cpu_lsu_unaligned;
+
+architecture neorv32_cpu_lsu_unaligned_rtl of neorv32_cpu_lsu_unaligned is
+
+  -- registered access parameters --
+  signal acc_addr   : std_ulogic_vector(31 downto 0); -- original (possibly unaligned) address
+  signal acc_funct3 : std_ulogic_vector(2 downto 0);  -- access type and sign control
+
+  -- sub-access parameters --
+  signal r1_stb  : std_ulogic;
+  signal r1_addr : std_ulogic_vector(31 downto 0);
+  signal r1_data : std_ulogic_vector(31 downto 0);
+  signal r1_ben  : std_ulogic_vector(3 downto 0);
+  signal r2_stb  : std_ulogic;
+  signal r2_data : std_ulogic_vector(31 downto 0);
+  signal r2_ben  : std_ulogic_vector(3 downto 0);
+
+  -- access classification --
+  type state_t is (S_IDLE, S_UNALIGNED_W, S_UNALIGNED_HW);
+  signal state      : state_t;
+  signal req2_split : boolean; -- true when access straddles a word boundary
+
+  -- split-transaction phase --
+  type phase_t is (REQ1, REQ2);
+  signal req_phase : phase_t;
+  signal rsp1_data : std_ulogic_vector(31 downto 0); -- captured first sub-access response
+
+begin
+
+  -- Split Parameter Computation -------------------------------------------------------------
+  -- Computes word-aligned sub-access parameters from the raw (possibly unaligned) address and write data.
+  -- Aligned and AMO accesses fall into S_IDLE (single transaction).
+  -- Misaligned non-AMO half-words and words use S_UNALIGNED_HW and S_UNALIGNED_W respectively.
+  -- -----------------------------------------------------------------------------------------
+  param_reg: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      acc_addr   <= (others => '0');
+      acc_funct3 <= (others => '0');
+      r1_addr    <= (others => '0');
+      r1_data    <= (others => '0');
+      r1_ben     <= (others => '0');
+      r2_data    <= (others => '0');
+      r2_ben     <= (others => '0');
+      state      <= S_IDLE;
+    elsif rising_edge(clk_i) then
+      if (ctrl_i.lsu_mo_en = '1') then
+        acc_addr   <= addr_i;
+        acc_funct3 <= ctrl_i.ir_funct3;
+        r1_addr    <= addr_i(31 downto 2) & "00"; -- align down to word boundary
+        r2_data    <= (others => '0');
+        r2_ben     <= (others => '0');
+
+        case ctrl_i.ir_funct3(1 downto 0) is
+          when "00" => -- byte: always naturally aligned, single transaction
+            state      <= S_IDLE;
+            r1_data    <= wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0);
+            r1_ben(0)  <= (not addr_i(1)) and (not addr_i(0));
+            r1_ben(1)  <= (not addr_i(1)) and (    addr_i(0));
+            r1_ben(2)  <= (    addr_i(1)) and (not addr_i(0));
+            r1_ben(3)  <= (    addr_i(1)) and (    addr_i(0));
+
+          when "01" => -- half-word
+            if (addr_i(0) = '1') and (ctrl_i.ir_opcode(2) = '0') then -- misaligned, non-AMO
+              state <= S_UNALIGNED_HW;
+              if (addr_i(1) = '0') then
+                -- offset "01": both bytes lie within the same aligned word
+                r1_ben  <= "0110";
+                r1_data <= x"00" & wdata_i(15 downto 0) & x"00";
+                -- no second access
+              else
+                -- offset "11": straddles word boundary
+                r1_ben  <= "1000";
+                r1_data <= wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0);
+                r2_ben  <= "0001";
+                r2_data <= wdata_i(15 downto 8) & wdata_i(15 downto 8) & wdata_i(15 downto 8) & wdata_i(15 downto 8);
+              end if;
+            else -- aligned half-word or AMO: single transaction
+              state   <= S_IDLE;
+              r1_ben  <= addr_i(1) & addr_i(1) & (not addr_i(1)) & (not addr_i(1));
+              r1_data <= wdata_i(15 downto 0) & wdata_i(15 downto 0);
+            end if;
+
+          when others => -- word
+            if ((addr_i(1) or addr_i(0)) = '1') and (ctrl_i.ir_opcode(2) = '0') then -- misaligned, non-AMO
+              state <= S_UNALIGNED_W;
+              case addr_i(1 downto 0) is
+                when "01" => -- 3 bytes in word1 (lanes 1,2,3), 1 byte in word2 (lane 0)
+                  r1_ben  <= "1110"; r1_data <= wdata_i(23 downto 0) & x"00";
+                  r2_ben  <= "0001"; r2_data <= wdata_i(31 downto 24) & wdata_i(31 downto 24) & wdata_i(31 downto 24) & wdata_i(31 downto 24);
+                when "10" => -- 2 bytes in word1 (lanes 2,3), 2 bytes in word2 (lanes 0,1)
+                  r1_ben  <= "1100"; r1_data <= wdata_i(15 downto 0) & x"0000";
+                  r2_ben  <= "0011"; r2_data <= wdata_i(31 downto 16) & wdata_i(31 downto 16);
+                when others => -- "11": 1 byte in word1 (lane 3), 3 bytes in word2 (lanes 0,1,2)
+                  r1_ben  <= "1000"; r1_data <= wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0) & wdata_i(7 downto 0);
+                  r2_ben  <= "0111"; r2_data <= x"00" & wdata_i(31 downto 8);
+              end case;
+            else -- aligned word or AMO: single transaction
+              state   <= S_IDLE;
+              r1_ben  <= (others => '1');
+              r1_data <= wdata_i;
+            end if;
+
+        end case;
+      end if;
+    end if;
+  end process param_reg;
+
+  -- forward request unless it's a misaligned AMO transaction
+  r1_stb <= ctrl_i.lsu_req and (not (req_i.amo and (acc_addr(1) or acc_addr(0))));
+  -- second word required when the access straddles a word boundary --
+  req2_split <= (state = S_UNALIGNED_W) or (state = S_UNALIGNED_HW and acc_addr(1) = '1');
+
+  unaligned_fsm: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      r2_stb    <= '0';
+      req_phase <= REQ1;
+      rsp1_data <= (others => '0');
+    elsif rising_edge(clk_i) then
+      r2_stb <= '0';
+      if (ctrl_i.cpu_trap = '1') then
+        req_phase <= REQ1; -- abort any in-progress split on exception
+      elsif req2_split then
+        -- only issue the second request if there is no error
+        if (req_phase = REQ1) and (rsp_i.ack = '1') and (rsp_i.err = '0') then
+          req_phase <= REQ2;
+          rsp1_data <= rsp_i.data; -- capture first word response
+          r2_stb <= '1';
+        elsif (req_phase = REQ2) and (rsp_i.ack = '1') then
+          req_phase <= REQ1; -- split complete
+        end if;
+      end if;
+    end if;
+  end process unaligned_fsm;
+
+
+  -- Bus Output and Response Mux -----------------------------------------------------------
+  -- -----------------------------------------------------------------------------------------
+  bus_output: process(req_i, r1_stb, r1_addr, r1_data, r1_ben, r2_stb, r2_data, r2_ben,
+                      acc_addr, acc_funct3, state, req2_split,
+                      req_phase, rsp1_data, pmp_fault_i, rsp_i)
+  begin
+    req_o       <= req_i;
+    req_o.addr  <= r1_addr;
+    req_o.data  <= r1_data;
+    req_o.ben   <= r1_ben;
+    req_o.stb   <= r1_stb and (not pmp_fault_i);
+    req_o.burst <= '0';
+
+    rsp_o <= rsp_i; -- Default or first sub access
+
+    -- Second sub-access
+    if req2_split then
+      if (req_phase = REQ2) then
+        req_o.addr <= std_ulogic_vector(unsigned(r1_addr) + 4);
+        req_o.data <= r2_data;
+        req_o.ben  <= r2_ben;
+        req_o.stb  <= r2_stb and (not pmp_fault_i);
+      end if;
+      -- Wait for second ack
+      if (req_phase = REQ1) then
+        rsp_o.ack <= '0';
+      else
+        rsp_o.ack <= rsp_i.ack;
+      end if;
+    end if;
+
+    -- Read data reconstruction
+    if (req_i.rw = '0') then
+      if (state = S_IDLE) then
+        -- aligned response: extract bytes and sign-extend
+        case acc_funct3(1 downto 0) is
+          when "00" => -- byte
+            case acc_addr(1 downto 0) is
+              when "00"   => rsp_o.data <= replicate_f((not acc_funct3(2)) and rsp_i.data(7),  24) & rsp_i.data(7  downto 0);
+              when "01"   => rsp_o.data <= replicate_f((not acc_funct3(2)) and rsp_i.data(15), 24) & rsp_i.data(15 downto 8);
+              when "10"   => rsp_o.data <= replicate_f((not acc_funct3(2)) and rsp_i.data(23), 24) & rsp_i.data(23 downto 16);
+              when others => rsp_o.data <= replicate_f((not acc_funct3(2)) and rsp_i.data(31), 24) & rsp_i.data(31 downto 24);
+            end case;
+          when "01" => -- half-word (aligned)
+            if (acc_addr(1) = '0') then
+              rsp_o.data <= replicate_f((not acc_funct3(2)) and rsp_i.data(15), 16) & rsp_i.data(15 downto 0);
+            else
+              rsp_o.data <= replicate_f((not acc_funct3(2)) and rsp_i.data(31), 16) & rsp_i.data(31 downto 16);
+            end if;
+          when others => -- word
+            rsp_o.data <= rsp_i.data;
+        end case;
+      elsif (state = S_UNALIGNED_HW) then
+        if (acc_addr(1) = '0') then
+          -- offset "01": bytes 1-2 within a single aligned word
+          rsp_o.data <= replicate_f((not acc_funct3(2)) and rsp_i.data(23), 16) & rsp_i.data(23 downto 8);
+        elsif (req_phase = REQ2) then
+          -- offset "11": byte3/word1 (captured) + byte0/word2 (current)
+          rsp_o.data <= replicate_f((not acc_funct3(2)) and rsp_i.data(7), 16) & rsp_i.data(7 downto 0) & rsp1_data(31 downto 24);
+        end if;
+      elsif (req_phase = REQ2) then -- S_UNALIGNED_W
+        -- reassemble 32-bit word from the two sub-access responses
+        case acc_addr(1 downto 0) is
+          when "01"   => rsp_o.data <= rsp_i.data(7  downto 0) & rsp1_data(31 downto 8);
+          when "10"   => rsp_o.data <= rsp_i.data(15 downto 0) & rsp1_data(31 downto 16);
+          when others => rsp_o.data <= rsp_i.data(23 downto 0) & rsp1_data(31 downto 24);
+        end case;
+      end if;
+    end if;
+  end process bus_output;
+
+end neorv32_cpu_lsu_unaligned_rtl;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -843,6 +843,7 @@ package neorv32_package is
       RISCV_ISA_Zcb       : boolean                        := false;
       RISCV_ISA_Zfinx     : boolean                        := false;
       RISCV_ISA_Zibi      : boolean                        := false;
+      RISCV_ISA_Zicclsm   : boolean                        := false;
       RISCV_ISA_Zicntr    : boolean                        := false;
       RISCV_ISA_Zicond    : boolean                        := false;
       RISCV_ISA_Zihpm     : boolean                        := false;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -926,6 +926,7 @@ package neorv32_package is
       RISCV_ISA_Zcmop     : boolean                        := false;
       RISCV_ISA_Zfinx     : boolean                        := false;
       RISCV_ISA_Zibi      : boolean                        := false;
+      RISCV_ISA_Zicclsm   : boolean                        := false;
       RISCV_ISA_Zicntr    : boolean                        := false;
       RISCV_ISA_Zicond    : boolean                        := false;
       RISCV_ISA_Zihpm     : boolean                        := false;

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -51,6 +51,7 @@ entity neorv32_top is
     RISCV_ISA_Zcb       : boolean                        := false;         -- additional code size reduction instructions
     RISCV_ISA_Zfinx     : boolean                        := false;         -- 32-bit floating-point extension
     RISCV_ISA_Zibi      : boolean                        := false;         -- branch with immediate
+    RISCV_ISA_Zicclsm   : boolean                        := false;         -- misaligned loads/stores to main memory
     RISCV_ISA_Zicntr    : boolean                        := false;         -- base counters
     RISCV_ISA_Zicond    : boolean                        := false;         -- integer conditional operations
     RISCV_ISA_Zihpm     : boolean                        := false;         -- hardware performance monitors
@@ -537,6 +538,7 @@ begin
       RISCV_ISA_Zcb       => RISCV_ISA_Zcb,
       RISCV_ISA_Zfinx     => RISCV_ISA_Zfinx,
       RISCV_ISA_Zibi      => RISCV_ISA_Zibi,
+      RISCV_ISA_Zicclsm   => RISCV_ISA_Zicclsm,
       RISCV_ISA_Zicntr    => RISCV_ISA_Zicntr,
       RISCV_ISA_Zicond    => RISCV_ISA_Zicond,
       RISCV_ISA_Zihpm     => RISCV_ISA_Zihpm,

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -53,6 +53,7 @@ entity neorv32_top is
     RISCV_ISA_Zcmop     : boolean                        := false;         -- compressed may-be-operations
     RISCV_ISA_Zfinx     : boolean                        := false;         -- 32-bit floating-point extension
     RISCV_ISA_Zibi      : boolean                        := false;         -- branch with immediate
+    RISCV_ISA_Zicclsm   : boolean                        := false;         -- misaligned loads/stores to main memory
     RISCV_ISA_Zicntr    : boolean                        := false;         -- base counters
     RISCV_ISA_Zicond    : boolean                        := false;         -- integer conditional operations
     RISCV_ISA_Zihpm     : boolean                        := false;         -- hardware performance monitors
@@ -569,6 +570,7 @@ begin
       RISCV_ISA_Zcmop     => RISCV_ISA_Zcmop,
       RISCV_ISA_Zfinx     => RISCV_ISA_Zfinx,
       RISCV_ISA_Zibi      => RISCV_ISA_Zibi,
+      RISCV_ISA_Zicclsm   => RISCV_ISA_Zicclsm,
       RISCV_ISA_Zicntr    => RISCV_ISA_Zicntr,
       RISCV_ISA_Zicond    => RISCV_ISA_Zicond,
       RISCV_ISA_Zihpm     => RISCV_ISA_Zihpm,

--- a/rtl/file_list_cpu.f
+++ b/rtl/file_list_cpu.f
@@ -14,6 +14,7 @@ $NEORV32_HOME/rtl/core/neorv32_cpu_alu_cfu.vhd
 $NEORV32_HOME/rtl/core/neorv32_cpu_alu_cond.vhd
 $NEORV32_HOME/rtl/core/neorv32_cpu_alu_crypto.vhd
 $NEORV32_HOME/rtl/core/neorv32_cpu_alu.vhd
+$NEORV32_HOME/rtl/core/neorv32_cpu_lsu_unaligned.vhd
 $NEORV32_HOME/rtl/core/neorv32_cpu_lsu.vhd
 $NEORV32_HOME/rtl/core/neorv32_cpu_pmp.vhd
 $NEORV32_HOME/rtl/core/neorv32_cpu_trace.vhd

--- a/rtl/file_list_soc.f
+++ b/rtl/file_list_soc.f
@@ -15,6 +15,7 @@ $NEORV32_HOME/rtl/core/neorv32_cpu_alu_cfu.vhd
 $NEORV32_HOME/rtl/core/neorv32_cpu_alu_cond.vhd
 $NEORV32_HOME/rtl/core/neorv32_cpu_alu_crypto.vhd
 $NEORV32_HOME/rtl/core/neorv32_cpu_alu.vhd
+$NEORV32_HOME/rtl/core/neorv32_cpu_lsu_unaligned.vhd
 $NEORV32_HOME/rtl/core/neorv32_cpu_lsu.vhd
 $NEORV32_HOME/rtl/core/neorv32_cpu_pmp.vhd
 $NEORV32_HOME/rtl/core/neorv32_cpu_trace.vhd

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -52,6 +52,7 @@ entity neorv32_vivado_ip is
     RISCV_ISA_Zcb         : boolean                        := false;
     RISCV_ISA_Zfinx       : boolean                        := false;
     RISCV_ISA_Zibi        : boolean                        := false;
+    RISCV_ISA_Zicclsm     : boolean                        := false;
     RISCV_ISA_Zicntr      : boolean                        := false;
     RISCV_ISA_Zicond      : boolean                        := false;
     RISCV_ISA_Zihpm       : boolean                        := false;
@@ -408,6 +409,7 @@ begin
     RISCV_ISA_Zcb       => RISCV_ISA_Zcb,
     RISCV_ISA_Zfinx     => RISCV_ISA_Zfinx,
     RISCV_ISA_Zibi      => RISCV_ISA_Zibi,
+    RISCV_ISA_Zicclsm   => RISCV_ISA_Zicclsm,
     RISCV_ISA_Zicntr    => RISCV_ISA_Zicntr,
     RISCV_ISA_Zicond    => RISCV_ISA_Zicond,
     RISCV_ISA_Zihpm     => RISCV_ISA_Zihpm,

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -54,6 +54,7 @@ entity neorv32_vivado_ip is
     RISCV_ISA_Zcmop       : boolean                        := false;
     RISCV_ISA_Zfinx       : boolean                        := false;
     RISCV_ISA_Zibi        : boolean                        := false;
+    RISCV_ISA_Zicclsm     : boolean                        := false;
     RISCV_ISA_Zicntr      : boolean                        := false;
     RISCV_ISA_Zicond      : boolean                        := false;
     RISCV_ISA_Zihpm       : boolean                        := false;
@@ -426,6 +427,7 @@ begin
     RISCV_ISA_Zcmop     => RISCV_ISA_Zcmop,
     RISCV_ISA_Zfinx     => RISCV_ISA_Zfinx,
     RISCV_ISA_Zibi      => RISCV_ISA_Zibi,
+    RISCV_ISA_Zicclsm   => RISCV_ISA_Zicclsm,
     RISCV_ISA_Zicntr    => RISCV_ISA_Zicntr,
     RISCV_ISA_Zicond    => RISCV_ISA_Zicond,
     RISCV_ISA_Zihpm     => RISCV_ISA_Zihpm,

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -38,6 +38,7 @@ entity neorv32_tb is
     RISCV_ISA_Zbs     : boolean                        := true;        -- single-bit bit-manipulation extension
     RISCV_ISA_Zfinx   : boolean                        := true;        -- 32-bit floating-point extension
     RISCV_ISA_Zibi    : boolean                        := true;        -- branch with immediate
+    RISCV_ISA_Zicclsm : boolean                        := true;        -- misaligned loads/stores to main memory
     RISCV_ISA_Zicntr  : boolean                        := true;        -- base counters
     RISCV_ISA_Zicond  : boolean                        := true;        -- integer conditional operations
     RISCV_ISA_Zihpm   : boolean                        := true;        -- hardware performance monitors
@@ -157,6 +158,7 @@ begin
     RISCV_ISA_Zbs       => RISCV_ISA_Zbs,
     RISCV_ISA_Zfinx     => RISCV_ISA_Zfinx,
     RISCV_ISA_Zibi      => RISCV_ISA_Zibi,
+    RISCV_ISA_Zicclsm   => RISCV_ISA_Zicclsm,
     RISCV_ISA_Zicntr    => RISCV_ISA_Zicntr,
     RISCV_ISA_Zicond    => RISCV_ISA_Zicond,
     RISCV_ISA_Zihpm     => RISCV_ISA_Zihpm,

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -45,6 +45,7 @@ entity neorv32_tb is
     RISCV_ISA_Zcmop   : boolean                        := true;        -- compressed may-be-operations
     RISCV_ISA_Zfinx   : boolean                        := true;        -- 32-bit floating-point extension
     RISCV_ISA_Zibi    : boolean                        := true;        -- branch with immediate
+    RISCV_ISA_Zicclsm : boolean                        := true;        -- misaligned loads/stores to main memory
     RISCV_ISA_Zicntr  : boolean                        := true;        -- base counters
     RISCV_ISA_Zicond  : boolean                        := true;        -- integer conditional operations
     RISCV_ISA_Zihpm   : boolean                        := true;        -- hardware performance monitors
@@ -283,6 +284,7 @@ begin
     RISCV_ISA_Zcmop     => RISCV_ISA_Zcmop,
     RISCV_ISA_Zfinx     => RISCV_ISA_Zfinx,
     RISCV_ISA_Zibi      => RISCV_ISA_Zibi,
+    RISCV_ISA_Zicclsm   => RISCV_ISA_Zicclsm,
     RISCV_ISA_Zicntr    => RISCV_ISA_Zicntr,
     RISCV_ISA_Zicond    => RISCV_ISA_Zicond,
     RISCV_ISA_Zihpm     => RISCV_ISA_Zihpm,

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -45,6 +45,7 @@
 #define TERM_HL_RESET      "\033[0m"
 /**@}*/
 
+#define ZICCLSM_EN 1
 
 /**********************************************************************//**
  * @name UART print macros
@@ -893,24 +894,39 @@ int main() {
 
 
   // ----------------------------------------------------------
-  // Unaligned load address
+  // Unaligned word load - all three misaligned offsets
+  // With ZICCLSM_EN: load must succeed and return correct data.
+  // Without: must raise L_MISALIGNED exception, dest reg unchanged.
   // ----------------------------------------------------------
-  PRINT("[%i] LD align EXC ", cnt_test);
-  trap_cause = trap_never_c;
-  cnt_test++;
-
-  // load from unaligned address
-  asm volatile ("li %[da], 0xcafe1230 \n" // initialize destination register with known value
-                "lw %[da], 0(%[ad])   \n" // must not update destination register to to exception
-                : [da] "=&r" (tmp_b) : [ad] "r" (ADDR_UNALIGNED_1));
-
-  if ((trap_cause == TRAP_CODE_L_MISALIGNED) &&
-      (neorv32_cpu_csr_read(CSR_MTVAL) == ADDR_UNALIGNED_1) &&
-      (tmp_b == 0xcafe1230)) { // make sure dest. reg is not updated
-    test_ok();
-  }
-  else {
-    test_fail();
+  {
+    volatile uint32_t lw_buf[2] = {0x44332211U, 0x88776655U};
+    // expected LW result for offsets 1, 2, 3 (little-endian byte assembly)
+    const uint32_t lw_expected[4] = {0, 0x55443322U, 0x66554433U, 0x77665544U};
+    int lw_off;
+    for (lw_off = 1; lw_off <= 3; lw_off++) {
+      uint32_t lw_addr = (uint32_t)lw_buf + lw_off;
+      PRINT("[%i] LW align+%i ", cnt_test, lw_off);
+      trap_cause = trap_never_c;
+      cnt_test++;
+      asm volatile ("li %[da], 0xcafe1230 \n"
+                    "lw %[da], 0(%[ad])   \n"
+                    : [da] "=&r" (tmp_b) : [ad] "r" (lw_addr));
+#ifdef ZICCLSM_EN
+      if ((trap_cause == trap_never_c) && (tmp_b == lw_expected[lw_off])) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+#else
+      if ((trap_cause == TRAP_CODE_L_MISALIGNED) &&
+          (neorv32_cpu_csr_read(CSR_MTVAL) == lw_addr) &&
+          (tmp_b == 0xcafe1230U)) { // dest reg must not be updated on exception
+        test_ok();
+      } else {
+        test_fail();
+      }
+#endif
+    }
   }
 
 
@@ -937,29 +953,41 @@ int main() {
 
 
   // ----------------------------------------------------------
-  // Unaligned store address
+  // Unaligned word store - all three misaligned offsets
+  // With ZICCLSM_EN: store must succeed and write correct bytes.
+  // Without: must raise S_MISALIGNED exception, memory unchanged.
   // ----------------------------------------------------------
-  PRINT("[%i] ST align EXC ", cnt_test);
-  trap_cause = trap_never_c;
-  cnt_test++;
-
-  // initialize test variable
-  store_access_addr[0] = 0x11223344;
-  store_access_addr[1] = 0x55667788;
-  tmp_a = (uint32_t)(&store_access_addr[0]);
-  tmp_a += 2; // make word-unaligned
-
-  // store to unaligned address
-  neorv32_cpu_store_unsigned_word(tmp_a, 0);
-
-  if ((trap_cause == TRAP_CODE_S_MISALIGNED) &&
-      (neorv32_cpu_csr_read(CSR_MTVAL) == tmp_a) &&
-      (store_access_addr[0] == 0x11223344) &&
-      (store_access_addr[1] == 0x55667788)) { // make sure memory was not altered
-    test_ok();
-  }
-  else {
-    test_fail();
+  {
+    // expected buf[0]/buf[1] after SW 0x11223344 at each offset (little-endian)
+    const uint32_t sw_exp0[4] = {0, 0x22334400U, 0x33440000U, 0x44000000U};
+    const uint32_t sw_exp1[4] = {0, 0x00000011U, 0x00001122U, 0x00112233U};
+    int sw_off;
+    for (sw_off = 1; sw_off <= 3; sw_off++) {
+      volatile uint32_t sw_buf[2] = {0x00000000U, 0x00000000U};
+      uint32_t sw_addr = (uint32_t)sw_buf + sw_off;
+      PRINT("[%i] SW align+%i ", cnt_test, sw_off);
+      trap_cause = trap_never_c;
+      cnt_test++;
+      asm volatile ("sw %[s], 0(%[a])" : : [s] "r" (0x11223344U), [a] "r" (sw_addr));
+#ifdef ZICCLSM_EN
+      if ((trap_cause == trap_never_c) &&
+          (sw_buf[0] == sw_exp0[sw_off]) &&
+          (sw_buf[1] == sw_exp1[sw_off])) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+#else
+      if ((trap_cause == TRAP_CODE_S_MISALIGNED) &&
+          (neorv32_cpu_csr_read(CSR_MTVAL) == sw_addr) &&
+          (sw_buf[0] == 0x00000000U) && // memory must not be altered
+          (sw_buf[1] == 0x00000000U)) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+#endif
+    }
   }
 
 
@@ -980,6 +1008,154 @@ int main() {
   else {
     test_fail();
   }
+
+
+  // ----------------------------------------------------------
+  // Misaligned half-word load - only odd offset (+1, +3) is misaligned
+  // With ZICCLSM_EN: load must succeed and return correct data.
+  // Without: must raise L_MISALIGNED, dest reg unchanged.
+  // ----------------------------------------------------------
+  {
+    // LH expected results (sign-extended int16): offset 1=0x3322, offset 3=0x5544
+    const int16_t lh_expected[4] = {0, (int16_t)0x3322, 0, (int16_t)0x5544};
+    int lh_off;
+    for (lh_off = 1; lh_off <= 3; lh_off += 2) { // only offsets 1 and 3 are misaligned for HW
+      volatile uint32_t lh_buf[2] = {0x44332211U, 0x88776655U};
+      uint32_t lh_addr = (uint32_t)lh_buf + lh_off;
+      PRINT("[%i] LH align+%i ", cnt_test, lh_off);
+      trap_cause = trap_never_c;
+      cnt_test++;
+      int16_t lh_res;
+      asm volatile ("li %[da], 0xcafe \n"
+                    "lh %[da], 0(%[ad]) \n"
+                    : [da] "=&r" (lh_res) : [ad] "r" (lh_addr));
+#ifdef ZICCLSM_EN
+      if ((trap_cause == trap_never_c) && (lh_res == lh_expected[lh_off])) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+#else
+      if ((trap_cause == TRAP_CODE_L_MISALIGNED) &&
+          (neorv32_cpu_csr_read(CSR_MTVAL) == lh_addr) &&
+          ((uint16_t)lh_res == (uint16_t)0xcafe)) { // dest reg must not be updated on exception
+        test_ok();
+      } else {
+        test_fail();
+      }
+#endif
+    }
+  }
+
+
+  // ----------------------------------------------------------
+  // Misaligned half-word store - only odd offset (+1, +3) is misaligned
+  // With ZICCLSM_EN: store must succeed and write correct bytes.
+  // Without: must raise S_MISALIGNED, memory unchanged.
+  // SH 0xABCD: LE stores byte[0]=0xCD at addr+0, byte[1]=0xAB at addr+1
+  // ----------------------------------------------------------
+  {
+    // expected buf[0] and buf[1] after SH 0xABCD at each odd offset
+    const uint32_t sh_exp0[4] = {0, 0x00ABCD00U, 0, 0xCD000000U};
+    const uint32_t sh_exp1[4] = {0, 0x00000000U, 0, 0x000000ABU};
+    int sh_off;
+    for (sh_off = 1; sh_off <= 3; sh_off += 2) {
+      volatile uint32_t sh_buf[2] = {0x00000000U, 0x00000000U};
+      uint32_t sh_addr = (uint32_t)sh_buf + sh_off;
+      PRINT("[%i] SH align+%i ", cnt_test, sh_off);
+      trap_cause = trap_never_c;
+      cnt_test++;
+      asm volatile ("sh %[s], 0(%[a])" : : [s] "r" (0x0000ABCDU), [a] "r" (sh_addr));
+#ifdef ZICCLSM_EN
+      if ((trap_cause == trap_never_c) &&
+          (sh_buf[0] == sh_exp0[sh_off]) &&
+          (sh_buf[1] == sh_exp1[sh_off])) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+#else
+      if ((trap_cause == TRAP_CODE_S_MISALIGNED) &&
+          (neorv32_cpu_csr_read(CSR_MTVAL) == sh_addr) &&
+          (sh_buf[0] == 0x00000000U) && // memory must not be altered
+          (sh_buf[1] == 0x00000000U)) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+#endif
+    }
+  }
+
+
+  // ----------------------------------------------------------
+  // Zicclsm + PMP: access fault on first or second sub-access
+  // Only meaningful when hardware decomposes misaligned accesses (ZICCLSM_EN).
+  // Uses the TOR-protected pmp_access region already set up earlier:
+  //   - pmp_access[0..6]: R-only in U-mode  (TOR range)
+  //   - pmp_access[7]   : no R/W in U-mode  (outside TOR, X-only region 2)
+  //   - pmp_access[-1]  : no R/W in U-mode  (before TOR base, X-only region 2)
+  // For store fault tests, region 1 is temporarily extended with W permission.
+  // ----------------------------------------------------------
+#ifdef ZICCLSM_EN
+  if (pmp_num_regions >= 3) {
+
+    uint32_t pmp_bound = (uint32_t)(&pmp_access[0]) + sizeof(pmp_access) - 4;
+
+    // Two cases per access type: fault on 1st sub-access, fault on 2nd sub-access.
+    const int32_t offsets[2] = {
+      -3,                                        // 1st sub-access expected to fault (before allowed range)
+      sizeof(pmp_access) - sizeof(uint32_t) + 1, // 2nd sub-access expected to fault (after allowed range)
+    };
+
+    int i;
+    for (i = 0; i < 2; i++) {
+      int32_t offset = offsets[i];
+      uint32_t addr = (uint32_t)pmp_access + offset;
+      uint32_t res;
+
+      PRINT("[%i] LW align %d PMP EXC ", cnt_test, offset);
+      trap_cause = trap_never_c;
+      cnt_test++;
+      goto_user_mode();
+      asm volatile ("lw %[d], 0(%[a])" : [d] "=r" (res) : [a] "r" (addr));
+      if (trap_cause == TRAP_CODE_L_ACCESS) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+    }
+
+    // Temporarily add W permission to region 1 for store fault tests
+    neorv32_cpu_pmp_configure_region(1, pmp_bound >> 2,
+      (PMP_TOR << PMPCFG_A_LSB) | (1 << PMPCFG_R) | (1 << PMPCFG_W));
+
+    for (i = 0; i < 2; i++) {
+      int32_t offset = offsets[i];
+      uint32_t addr = (uint32_t)pmp_access + offset;
+
+      PRINT("[%i] SW align %d PMP EXC ", cnt_test, offset);
+      trap_cause = trap_never_c;
+      cnt_test++;
+      goto_user_mode();
+      {
+        asm volatile ("sw %[s], 0(%[a])" : : [s] "r" (0xdeadbeefU), [a] "r" (addr));
+      }
+      if (trap_cause == TRAP_CODE_S_ACCESS) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+    }
+
+    // Restore region 1 to read-only
+    neorv32_cpu_pmp_configure_region(1, pmp_bound >> 2,
+      (PMP_TOR << PMPCFG_A_LSB) | (1 << PMPCFG_R));
+
+  } else {
+    PRINT("[n.a.] Zicclsm PMP access fault tests (no PMP)\n");
+  }
+#endif
 
 
   // ----------------------------------------------------------

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -45,6 +45,7 @@
 #define TERM_HL_RESET      "\033[0m"
 /**@}*/
 
+#define ZICCLSM_EN 1
 
 /**********************************************************************//**
  * @name UART print macros
@@ -887,24 +888,39 @@ int main() {
 
 
   // ----------------------------------------------------------
-  // Unaligned load address
+  // Unaligned word load - all three misaligned offsets
+  // With ZICCLSM_EN: load must succeed and return correct data.
+  // Without: must raise L_MISALIGNED exception, dest reg unchanged.
   // ----------------------------------------------------------
-  PRINT("[%i] LD align EXC ", cnt_test);
-  neorv32_cpu_csr_write(CSR_MCAUSE, trap_never_c);
-  cnt_test++;
-
-  // load from unaligned address
-  asm volatile ("li %[da], 0xcafe1230 \n" // initialize destination register with known value
-                "lw %[da], 0(%[ad])   \n" // must not update destination register to to exception
-                : [da] "=&r" (tmp_b) : [ad] "r" (ADDR_UNALIGNED_1));
-
-  if ((neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_L_MISALIGNED) &&
-      (neorv32_cpu_csr_read(CSR_MTVAL) == ADDR_UNALIGNED_1) &&
-      (tmp_b == 0xcafe1230)) { // make sure dest. reg is not updated
-    test_ok();
-  }
-  else {
-    test_fail();
+  {
+    volatile uint32_t lw_buf[2] = {0x44332211U, 0x88776655U};
+    // expected LW result for offsets 1, 2, 3 (little-endian byte assembly)
+    const uint32_t lw_expected[4] = {0, 0x55443322U, 0x66554433U, 0x77665544U};
+    int lw_off;
+    for (lw_off = 1; lw_off <= 3; lw_off++) {
+      uint32_t lw_addr = (uint32_t)lw_buf + lw_off;
+      PRINT("[%i] LW align+%i ", cnt_test, lw_off);
+      neorv32_cpu_csr_write(CSR_MCAUSE, trap_never_c);
+      cnt_test++;
+      asm volatile ("li %[da], 0xcafe1230 \n"
+                    "lw %[da], 0(%[ad])   \n"
+                    : [da] "=&r" (tmp_b) : [ad] "r" (lw_addr));
+#ifdef ZICCLSM_EN
+      if ((neorv32_cpu_csr_read(CSR_MCAUSE) == trap_never_c) && (tmp_b == lw_expected[lw_off])) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+#else
+      if ((neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_L_MISALIGNED) &&
+          (neorv32_cpu_csr_read(CSR_MTVAL) == lw_addr) &&
+          (tmp_b == 0xcafe1230U)) { // dest reg must not be updated on exception
+        test_ok();
+      } else {
+        test_fail();
+      }
+#endif
+    }
   }
 
 
@@ -931,29 +947,41 @@ int main() {
 
 
   // ----------------------------------------------------------
-  // Unaligned store address
+  // Unaligned word store - all three misaligned offsets
+  // With ZICCLSM_EN: store must succeed and write correct bytes.
+  // Without: must raise S_MISALIGNED exception, memory unchanged.
   // ----------------------------------------------------------
-  PRINT("[%i] ST align EXC ", cnt_test);
-  neorv32_cpu_csr_write(CSR_MCAUSE, trap_never_c);
-  cnt_test++;
-
-  // initialize test variable
-  store_access_addr[0] = 0x11223344;
-  store_access_addr[1] = 0x55667788;
-  tmp_a = (uint32_t)(&store_access_addr[0]);
-  tmp_a += 2; // make word-unaligned
-
-  // store to unaligned address
-  neorv32_cpu_store_unsigned_word(tmp_a, 0);
-
-  if ((neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_S_MISALIGNED) &&
-      (neorv32_cpu_csr_read(CSR_MTVAL) == tmp_a) &&
-      (store_access_addr[0] == 0x11223344) &&
-      (store_access_addr[1] == 0x55667788)) { // make sure memory was not altered
-    test_ok();
-  }
-  else {
-    test_fail();
+  {
+    // expected buf[0]/buf[1] after SW 0x11223344 at each offset (little-endian)
+    const uint32_t sw_exp0[4] = {0, 0x22334400U, 0x33440000U, 0x44000000U};
+    const uint32_t sw_exp1[4] = {0, 0x00000011U, 0x00001122U, 0x00112233U};
+    int sw_off;
+    for (sw_off = 1; sw_off <= 3; sw_off++) {
+      volatile uint32_t sw_buf[2] = {0x00000000U, 0x00000000U};
+      uint32_t sw_addr = (uint32_t)sw_buf + sw_off;
+      PRINT("[%i] SW align+%i ", cnt_test, sw_off);
+      neorv32_cpu_csr_write(CSR_MCAUSE, trap_never_c);
+      cnt_test++;
+      asm volatile ("sw %[s], 0(%[a])" : : [s] "r" (0x11223344U), [a] "r" (sw_addr));
+#ifdef ZICCLSM_EN
+      if ((neorv32_cpu_csr_read(CSR_MCAUSE) == trap_never_c) &&
+          (sw_buf[0] == sw_exp0[sw_off]) &&
+          (sw_buf[1] == sw_exp1[sw_off])) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+#else
+      if ((neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_S_MISALIGNED) &&
+          (neorv32_cpu_csr_read(CSR_MTVAL) == sw_addr) &&
+          (sw_buf[0] == 0x00000000U) && // memory must not be altered
+          (sw_buf[1] == 0x00000000U)) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+#endif
+    }
   }
 
 
@@ -973,6 +1001,84 @@ int main() {
   }
   else {
     test_fail();
+  }
+
+
+  // ----------------------------------------------------------
+  // Misaligned half-word load - only odd offset (+1, +3) is misaligned
+  // With ZICCLSM_EN: load must succeed and return correct data.
+  // Without: must raise L_MISALIGNED, dest reg unchanged.
+  // ----------------------------------------------------------
+  {
+    // LH expected results (sign-extended int16): offset 1=0x3322, offset 3=0x5544
+    const int16_t lh_expected[4] = {0, (int16_t)0x3322, 0, (int16_t)0x5544};
+    int lh_off;
+    for (lh_off = 1; lh_off <= 3; lh_off += 2) { // only offsets 1 and 3 are misaligned for HW
+      volatile uint32_t lh_buf[2] = {0x44332211U, 0x88776655U};
+      uint32_t lh_addr = (uint32_t)lh_buf + lh_off;
+      PRINT("[%i] LH align+%i ", cnt_test, lh_off);
+      neorv32_cpu_csr_write(CSR_MCAUSE, trap_never_c);
+      cnt_test++;
+      int16_t lh_res;
+      asm volatile ("li %[da], 0xcafe \n"
+                    "lh %[da], 0(%[ad]) \n"
+                    : [da] "=&r" (lh_res) : [ad] "r" (lh_addr));
+#ifdef ZICCLSM_EN
+      if ((neorv32_cpu_csr_read(CSR_MCAUSE) == trap_never_c) && (lh_res == lh_expected[lh_off])) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+#else
+      if ((neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_L_MISALIGNED) &&
+          (neorv32_cpu_csr_read(CSR_MTVAL) == lh_addr) &&
+          ((uint16_t)lh_res == (uint16_t)0xcafe)) { // dest reg must not be updated on exception
+        test_ok();
+      } else {
+        test_fail();
+      }
+#endif
+    }
+  }
+
+
+  // ----------------------------------------------------------
+  // Misaligned half-word store - only odd offset (+1, +3) is misaligned
+  // With ZICCLSM_EN: store must succeed and write correct bytes.
+  // Without: must raise S_MISALIGNED, memory unchanged.
+  // SH 0xABCD: LE stores byte[0]=0xCD at addr+0, byte[1]=0xAB at addr+1
+  // ----------------------------------------------------------
+  {
+    // expected buf[0] and buf[1] after SH 0xABCD at each odd offset
+    const uint32_t sh_exp0[4] = {0, 0x00ABCD00U, 0, 0xCD000000U};
+    const uint32_t sh_exp1[4] = {0, 0x00000000U, 0, 0x000000ABU};
+    int sh_off;
+    for (sh_off = 1; sh_off <= 3; sh_off += 2) {
+      volatile uint32_t sh_buf[2] = {0x00000000U, 0x00000000U};
+      uint32_t sh_addr = (uint32_t)sh_buf + sh_off;
+      PRINT("[%i] SH align+%i ", cnt_test, sh_off);
+      neorv32_cpu_csr_write(CSR_MCAUSE, trap_never_c);
+      cnt_test++;
+      asm volatile ("sh %[s], 0(%[a])" : : [s] "r" (0x0000ABCDU), [a] "r" (sh_addr));
+#ifdef ZICCLSM_EN
+      if ((neorv32_cpu_csr_read(CSR_MCAUSE) == trap_never_c) &&
+          (sh_buf[0] == sh_exp0[sh_off]) &&
+          (sh_buf[1] == sh_exp1[sh_off])) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+#else
+      if ((neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_S_MISALIGNED) &&
+          (neorv32_cpu_csr_read(CSR_MTVAL) == sh_addr) &&
+          (sh_buf[0] == 0x00000000U) && // memory must not be altered
+          (sh_buf[1] == 0x00000000U)) {
+        test_ok();
+      } else {
+        test_fail();
+      }
+#endif
+    }
   }
 
 
@@ -2383,6 +2489,81 @@ int main() {
     else {
       test_fail();
     }
+
+
+    // Zicclsm + PMP: both sub-accesses of a hardware-split misaligned access
+    // must be PMP-checked. Region 1 (TOR) permits pmp_access[0..6]; pmp_access[7]
+    // lies outside it (region 2 is X-only -> no data R/W in U-mode).
+    //   +29: the accessed word itself is in the denied region -> the fault is
+    //        visible from the original address.
+    //   +25: first sub-access (pmp_access[6]) is permitted, second sub-access
+    //        (pmp_access[7]) is denied -> the access MUST still fault.
+    // ---------------------------------------------
+#ifdef ZICCLSM_EN
+    {
+      const int32_t split_off[2] = {
+        (int32_t)(sizeof(pmp_access) - sizeof(uint32_t) + 1), // +29: word fully in denied region
+        (int32_t)(sizeof(pmp_access) - sizeof(uint32_t) - 3)  // +25: straddles into denied word
+      };
+      const uint32_t mprv_bit = (uint32_t)(1 << CSR_MSTATUS_MPRV);
+      const uint32_t mpp_bits = (uint32_t)(3 << CSR_MSTATUS_MPP_L);
+      const char *split_lbl[2] = {"word in denied region", "2nd sub-access denied"};
+      uint32_t res = 0;
+      int i;
+
+      // misaligned loads
+      for (i = 0; i < 2; i++) {
+        uint32_t addr = pmp_base + (uint32_t)split_off[i];
+        PRINT("[%i] Zicclsm PMP LW (%s) ", cnt_test, split_lbl[i]);
+        neorv32_cpu_csr_write(CSR_MCAUSE, trap_never_c);
+        cnt_test++;
+        // load with U-mode rights (MPRV) and then disable again.
+        asm volatile ("csrc mstatus, %[mpp]  \n"
+                      "csrs mstatus, %[mprv] \n"
+                      "lw   %[d], 0(%[a])    \n"
+                      "csrc mstatus, %[mprv] \n"
+                      : [d] "=&r" (res)
+                      : [a] "r" (addr), [mprv] "r" (mprv_bit), [mpp] "r" (mpp_bits)
+                      : "memory");
+        if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_L_ACCESS) {
+          test_ok();
+        }
+        else {
+          test_fail();
+        }
+      }
+      (void)res;
+
+      // misaligned stores: make region 1 writable so only the denied second
+      // word (pmp_access[7]) can be the source of a fault
+      neorv32_cpu_pmp_configure_region(1, pmp_bound >> 2,
+        (PMP_TOR << PMPCFG_A_LSB) | (1 << PMPCFG_R) | (1 << PMPCFG_W));
+
+      for (i = 0; i < 2; i++) {
+        uint32_t addr = pmp_base + (uint32_t)split_off[i];
+        PRINT("[%i] Zicclsm PMP SW (%s) ", cnt_test, split_lbl[i]);
+        neorv32_cpu_csr_write(CSR_MCAUSE, trap_never_c);
+        cnt_test++;
+        asm volatile ("csrc mstatus, %[mpp]  \n"
+                      "csrs mstatus, %[mprv] \n"
+                      "sw   %[s], 0(%[a])    \n"
+                      "csrc mstatus, %[mprv] \n"
+                      :
+                      : [s] "r" (0xdeadbeef), [a] "r" (addr), [mprv] "r" (mprv_bit), [mpp] "r" (mpp_bits)
+                      : "memory");
+        if (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_S_ACCESS) {
+          test_ok();
+        }
+        else {
+          test_fail();
+        }
+      }
+
+      // restore region 1 to read-only for the following PMP tests
+      neorv32_cpu_pmp_configure_region(1, pmp_bound >> 2,
+        (PMP_TOR << PMPCFG_A_LSB) | (1 << PMPCFG_R));
+    }
+#endif
 
 
     // STORE from M mode using U mode permissions: should fail


### PR DESCRIPTION
This is gated by the `Zicclsm` extension, which is mentioned in "RISC-V Profiles" (v1.0):
"Misaligned loads and stores to main memory regions with both the cacheability and coherence PMAs must be supported"
The extension explicitly mentions that unaligned accesses can be emulated, but the Linux kernel at least assumes that this extension implies HW support (https://lwn.net/Articles/978350/)