### PR TITLE
⚠️ simplify CFU interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 06.04.2026 | 1.12.9.3 | :warning: CFU: rework/simplify interface; add support for RISC-V `OP-32` and `OP-IMM-32` opcodes / instructions | [#1524](https://github.com/stnolting/neorv32/pull/1524) |
 | 06.04.2026 | 1.12.9.2 | :test_tube: rework intrinsics (use `.insn` pseudo directive) | [#](https://github.com/stnolting/neorv32/pull/1523) |
 | 05.04.2026 | 1.12.9.1 | :sparkles: add cache write-back & write-allocate policies | [#1513](https://github.com/stnolting/neorv32/pull/1513) |
 | 03.04.2026 | [**1.12.9**](https://github.com/stnolting/neorv32/releases/tag/v1.12.9) | :rocket: **New release** | |

--- a/docs/datasheet/cpu_cfu.adoc
+++ b/docs/datasheet/cpu_cfu.adoc
@@ -22,16 +22,22 @@ as example application. The according demo program is located in `sw/example/dem
 :sectnums:
 ==== CFU Instruction Formats
 
-The CFU instructions can utilize a limited set of RISC-V OPCODESin `rv32` 32-bit instruction encoding space
-for custom purpose. So far, two OPCODES are supported that have been explicitly reserved by the RISC-V ISA spec.
-for user-defined extensions ("Guaranteed Non-Standard Encoding Space"). It is up to the designer to decide exactly what
-function these opcodes serve and what type of instruction type/format they use.
+The CFU instructions can utilize a limited set of RISC-V OPCODES in `rv32` 32-bit instruction encoding space for
+custom purpose. It is up to the designer to decide exactly what function these opcodes serve and what type of instruction
+type/format they use. So far, four OPCODES are supported. Two of them ("custom-0" and "custom-1") have been explicitly
+reserved by the RISC-V ISA spec. for user-defined extensions ("Guaranteed Non-Standard Encoding Space"). These should be
+the first choice for implementing custom CFU instruction.
+
+The other two OPCODES ("op-32" and "op-imm-32") are reserved by the RISC-V spec. for extended operations and future
+ISA extensions. Note that the support/handling of the latter two OPCODES in NEORV32 might change in future.
 
 .Available CFU OPCODES (defined in `sw/lib/include/neorv32_intrinsics.h`)
 [source,c]
 ----
 #define RISCV_OPCODE_CUSTOM0 0b0001011 // RISC-V "CUSTOM-0"
 #define RISCV_OPCODE_CUSTOM1 0b0101011 // RISC-V "CUSTOM-1"
+#define RISCV_OPCODE_OP32    0b0111011 // RISC-V "OP-32"
+#define RISCV_OPCODE_OPIMM32 0b0011011 // RISC-V "OP-IMM-32"
 ----
 
 .Default CFU Example
@@ -53,12 +59,12 @@ always compile-time-static.
 [wavedrom, format="svg", align="center"]
 ----
 {reg: [
-    {bits: 7, name: 'opcode', type: 1},
-    {bits: 5, name: 'rd'      },
-    {bits: 3, name: 'funct3', type: 1},
-    {bits: 5, name: 'rs1'     },
-    {bits: 5, name: 'rs2'     },
-    {bits: 7, name: 'funct7', type: 1}
+  {bits: 7, name: 'opcode', type: 1},
+  {bits: 5, name: 'rd'      },
+  {bits: 3, name: 'funct3', type: 1},
+  {bits: 5, name: 'rs1'     },
+  {bits: 5, name: 'rs2'     },
+  {bits: 7, name: 'funct7', type: 1}
 ]}
 ----
 
@@ -76,11 +82,11 @@ all immediate values are always compile-time-static.
 [wavedrom, format="svg", align="center"]
 ----
 {reg: [
-    {bits:  7, name: 'opcode', type: 1},
-    {bits:  5, name: 'rd'      },
-    {bits:  3, name: 'funct3', type: 1},
-    {bits:  5, name: 'rs1'     },
-    {bits: 12, name: 'imm12',  type: 1}
+  {bits:  7, name: 'opcode', type: 1},
+  {bits:  5, name: 'rd'      },
+  {bits:  3, name: 'funct3', type: 1},
+  {bits:  5, name: 'rs1'     },
+  {bits: 12, name: 'imm12',  type: 1}
 ]}
 ----
 

--- a/docs/datasheet/cpu_cfu.adoc
+++ b/docs/datasheet/cpu_cfu.adoc
@@ -122,51 +122,52 @@ The CFU hardware module (`rtl/core/neorv32_cpu_alu_cfu.vhd`) is tightly integrat
 co-processor. A simple interface is used to communicate operands, operation definition and the processing result.
 
 .CFU Interface
-[cols="^1,^1,^2,<8"]
+[cols="^2,^1,^1,<8"]
 [options="header",grid="rows"]
 |=======================
-| Signal  | Width | Instruction Type | Description
+| Signal | Direction | Width | Description
+4+^| **Global**
+| `clk_i`    |  in |  1 | CPU clock, registers trigger on a rising-edge
+| `rstn_i`   |  in |  1 | CPU reset, low-active, asynchronous
 4+^| **Request**
-| `start`  |     1 | all    | Trigger CFU operation; high for exactly one cycle
-| `type`   |     1 | all    | CFU instruction type (`0` = R-type, `1` = I-type); defined by the opcode
-| `funct3` |     3 | all    | 3-bit function select from the according custom instruction word
-| `funct7` |     7 | R-type | 7-bit function select from the according custom instruction word (**)
-| `imm12`  |    12 | I-type | 12-bit immediate from the custom according instruction word
-| `rs1`    |    32 | all    | Register operand 1 (addresses by the `rs1` instruction word bit field)
-| `rs2`    |    32 | R-type | Register operand 2 (addresses by the `rs2` instruction word bit field)
+| `start_i`  |  in |  1 | Trigger CFU operation; high for exactly one cycle
+| `inst_i`   |  in | 32 | CFU instruction word
+| `rs1_i`    |  in | 32 | Register operand 1 read from the CPU register file
+| `rs2_i`    |  in | 32 | Register operand 2 read from the CPU register file
 4+^| **Response**
-| `result` |     1 | all    | Processing result that is written to `rd`
-| `valid`  |    32 | all    | High for exactly one cycle when the CFU operation is done an `result` is valid
+| `result_o` | out |  1 | Processing result that is written to the destination register (`rd`)
+| `valid_o`  | out | 32 | High for exactly one cycle when the CFU operation is done an `result` is valid
 |=======================
 
-.CFU Interface Timing Examples
-[wavedrom, format="svg", align="center"]
-----
-{signal: [
-  {name: 'clk',    wave: 'p....|.......|..'},
-  {name: 'start',  wave: '01010|...1010|..', node: '.a.c.....e.g.'},
-  {name: 'type',   wave: 'x0x0.|.x.1x1.|.0'},
-  {name: 'funct3', wave: 'x3x4.|.x.5x6.|.x'},
-  {name: 'funct7', wave: 'x3x4.|.x.....|..'},
-  {name: 'imm12',  wave: 'x....|...5x6.|.x'},
-  {name: 'rs1',    wave: 'x3x4.|.x.5x6.|.x'},
-  {name: 'rs2',    wave: 'x3x4.|.x.....|..'},
-  {},
-  {name: 'result', wave: 'x3x..|4x.5x..|6x'},
-  {name: 'valid',  wave: '010..|10.10..|10', node: '.b....d..f....h'},
-],
- edge: ['a~>b', 'c~>d', 'e~>f', 'g~>h']
-}
-----
-
-CFU operations can be entirely combinatorial (e.g. for a bit-reversal operation) so the result is available at
-the end of the current clock cycle. However, operations can also take several clock cycles to complete (like
-multiplications) and may also include internal states and memories. However, the CFU has to complete computation
-within a **bound time window** (default = 512 clock cycles). Otherwise, an illegal instruction exception is raised.
-See section <<_cpu_arithmetic_logic_unit>> for more information.
+CFU operations can be entirely combinatorial (e.g. for simple operation like bit-reversal) so the result is already
+valid at the end of the current clock cycle. CFU operations can also take several clock cycles to complete (like an
+iterative multiplications) and may also include internal states and memories. However, the CFU has to complete
+its operation within a **bound time window** (default = 512 clock cycles). Otherwise, an illegal instruction
+exception is raised. See section <<_cpu_arithmetic_logic_unit>> for more information.
 
 .CFU Exception
 [NOTE]
 The CFU can intentionally raise an illegal instruction exception by not asserting the `valid` signal at all which
 will cause an execution timeout. For example this can be used to signal invalid configurations/operations to the
-runtime environment. See the documentation in the CFU's VHDL source file for more information.
+runtime environment. See the documentation in the CFU's HDL source file for more information.
+
+The following figure shows two timing sequences for CFU operations. The first one (orange) resembles a pure
+combinatorial operation that completes within the same cycle in which it was triggered. The second (blue)
+one performs a multi-cycle operation and is completed after several clock cycles.
+
+.CFU Interface Timing Examples
+[wavedrom, format="svg", align="center"]
+----
+{signal: [
+  {name: 'clk_i',    wave: 'p....|..'},
+  {name: 'start_i',  wave: '01010|..', node: '.a.c'},
+  {name: 'inst_i',   wave: 'x4x5.|.0'},
+  {name: 'rs1_i',    wave: 'x4x5.|.x'},
+  {name: 'rs2_i',    wave: 'x4x5.|.x'},
+  {},
+  {name: 'result_o', wave: 'x4x..|5x'},
+  {name: 'valid_o',  wave: '010..|10', node: '.b....d'},
+],
+  edge: ['a~>b', 'c~>d']
+}
+----

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -45,8 +45,8 @@ entity neorv32_cpu_alu is
     rstn_i : in  std_ulogic; -- global reset, low-active, async
     ctrl_i : in  ctrl_bus_t; -- main control bus
     -- data input --
-    rs1_i  : in  std_ulogic_vector(31 downto 0); -- rf source 1
-    rs2_i  : in  std_ulogic_vector(31 downto 0); -- rf source 2
+    rs1_i  : in  std_ulogic_vector(31 downto 0); -- register source 1
+    rs2_i  : in  std_ulogic_vector(31 downto 0); -- register source 2
     -- data output --
     cmp_o  : out std_ulogic_vector(1 downto 0);  -- comparator status
     res_o  : out std_ulogic_vector(31 downto 0); -- ALU result
@@ -80,6 +80,7 @@ architecture neorv32_cpu_alu_rtl of neorv32_cpu_alu is
   type cp_data_t  is array (0 to 6) of std_ulogic_vector(31 downto 0);
   signal cp_result : cp_data_t;
   signal cp_valid : std_ulogic_vector(6 downto 0);
+  signal cfu_inst : std_ulogic_vector(31 downto 0);
   signal fpu_csr_en, fpu_csr_we, cfu_done, cfu_busy : std_ulogic;
   signal fpu_csr_rd, cfu_res : std_ulogic_vector(31 downto 0);
 
@@ -151,14 +152,14 @@ begin
     rstn_i  => rstn_i,          -- global reset, low-active, async
     ctrl_i  => ctrl_i,          -- main control bus
     -- data input --
-    rs1_i   => rs1_i,           -- rf source 1
+    rs1_i   => rs1_i,           -- register source 1
     shamt_i => opb(4 downto 0), -- shift amount
     -- result and status --
     res_o   => cp_result(0),    -- operation result
     valid_o => cp_valid(0)      -- data output valid
   );
 
-  -- ALU-Opcode Co-Processor: Integer Multiplication/Division Unit ('M' ISA Extension) ------
+  -- ALU-Opcode Co-Processor: Integer Multiplication/Division Unit (M ISA Extension) --------
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_alu_muldiv_enabled:
   if RISCV_ISA_M or RISCV_ISA_Zmmul generate
@@ -173,8 +174,8 @@ begin
       rstn_i  => rstn_i,       -- global reset, low-active, async
       ctrl_i  => ctrl_i,       -- main control bus
       -- data input --
-      rs1_i   => rs1_i,        -- rf source 1
-      rs2_i   => rs2_i,        -- rf source 2
+      rs1_i   => rs1_i,        -- register source 1
+      rs2_i   => rs2_i,        -- register source 2
       -- result and status --
       res_o   => cp_result(1), -- operation result
       valid_o => cp_valid(1)   -- data output valid
@@ -187,7 +188,7 @@ begin
     cp_valid(1)  <= '0';
   end generate;
 
-  -- ALU[I]-Opcode Co-Processor: Bit-Manipulation Unit ('B' ISA Extension) ------------------
+  -- ALU[I]-Opcode Co-Processor: Bit-Manipulation Unit (B ISA Extension) --------------------
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_alu_bitmanip_enabled:
   if RISCV_ISA_Zba or RISCV_ISA_Zbb or RISCV_ISA_Zbkb or RISCV_ISA_Zbkc or RISCV_ISA_Zbkx or RISCV_ISA_Zbs generate
@@ -208,8 +209,8 @@ begin
       ctrl_i  => ctrl_i,          -- main control bus
       -- data input --
       less_i  => cmp(1),          -- compare less
-      rs1_i   => rs1_i,           -- rf source 1
-      rs2_i   => rs2_i,           -- rf source 2
+      rs1_i   => rs1_i,           -- register source 1
+      rs2_i   => rs2_i,           -- register source 2
       shamt_i => opb(4 downto 0), -- shift amount
       -- result and status --
       res_o   => cp_result(2),    -- operation result
@@ -223,7 +224,7 @@ begin
     cp_valid(2)  <= '0';
   end generate;
 
-  -- FLOAT-Opcode Co-Processor: Single-Precision FPUUnit ('Zfinx' ISA Extension) ------------
+  -- FLOAT-Opcode Co-Processor: Single-Precision FPUUnit (Zfinx ISA Extension) --------------
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_alu_fpu_enabled:
   if RISCV_ISA_Zfinx generate
@@ -241,8 +242,8 @@ begin
       -- data input --
       equal_i     => cmp(0),                      -- compare equal
       less_i      => cmp(1),                      -- compare less
-      rs1_i       => rs1_i,                       -- rf source 1
-      rs2_i       => rs2_i,                       -- rf source 2
+      rs1_i       => rs1_i,                       -- register source 1
+      rs2_i       => rs2_i,                       -- register source 2
       -- result and status --
       res_o       => cp_result(3),                -- operation result
       valid_o     => cp_valid(3)                  -- data output valid
@@ -264,28 +265,28 @@ begin
     cp_valid(3)  <= '0';
   end generate;
 
-  -- CUSTOM-Opcode Co-Processor: Custom Functions Unit ('Xcfu' ISA Extension) ---------------
+  -- CUSTOM/OP32-Opcode Co-Processor: Custom Functions Unit (Xcfu ISA Extension) ------------
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_alu_cfu_enabled:
   if RISCV_ISA_Xcfu generate
     neorv32_cpu_alu_cfu_inst: entity neorv32.neorv32_cpu_alu_cfu
     port map (
       -- global control --
-      clk_i    => clk_i,                          -- global clock, rising edge
-      rstn_i   => rstn_i,                         -- global reset, low-active, async
-      -- operation trigger --
-      start_i  => ctrl_i.alu_cp_cfu,              -- start trigger, single-shot
-      -- operands --
-      type_i   => ctrl_i.ir_opcode(5),            -- instruction type
-      funct3_i => ctrl_i.ir_funct3,               -- "funct3" bit-field
-      funct7_i => ctrl_i.ir_funct12(11 downto 5), -- "funct7" bit-field
-      imm12_i  => ctrl_i.ir_funct12(11 downto 0), -- "imm12" bit-field
-      rs1_i    => rs1_i,                          -- rf source 1
-      rs2_i    => rs2_i,                          -- rf source 2
-      -- result and status --
-      result_o => cfu_res,                        -- operation result
-      valid_o  => cfu_done                        -- result valid, operation done
+      clk_i    => clk_i,             -- global clock, rising edge
+      rstn_i   => rstn_i,            -- global reset, low-active, async
+      -- request
+      start_i  => ctrl_i.alu_cp_cfu, -- start trigger, single-shot
+      inst_i   => cfu_inst,          -- instruction word
+      rs1_i    => rs1_i,             -- register source 1
+      rs2_i    => rs2_i,             -- register source 2
+      -- response --
+      result_o => cfu_res,           -- operation result
+      valid_o  => cfu_done           -- result valid, operation done
     );
+
+    -- CFU instruction word --
+    cfu_inst <= ctrl_i.ir_funct12 & ctrl_i.rf_rs1 & ctrl_i.ir_funct3 & ctrl_i.rf_rd &
+                opcode_cust0_c(6) & ctrl_i.ir_opcode(5 downto 4) & opcode_cust0_c(3 downto 0); -- constrained OPCODE
 
     -- response proxy --
     cfu_proxy: process(rstn_i, clk_i)
@@ -311,14 +312,15 @@ begin
 
   neorv32_cpu_alu_cfu_disabled:
   if not RISCV_ISA_Xcfu generate
-    cfu_done     <= '0';
+    cfu_inst     <= (others => '0');
     cfu_res      <= (others => '0');
+    cfu_done     <= '0';
     cfu_busy     <= '0';
     cp_result(4) <= (others => '0');
     cp_valid(4)  <= '0';
   end generate;
 
-  -- ALU-Opcode Co-Processor: Conditional Operations Unit ('Zicond' ISA Extension) ----------
+  -- ALU-Opcode Co-Processor: Conditional Operations Unit (Zicond ISA Extension) ------------
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_alu_cond_enabled:
   if RISCV_ISA_Zicond generate
@@ -329,8 +331,8 @@ begin
       rstn_i  => rstn_i,       -- global reset, low-active, async
       ctrl_i  => ctrl_i,       -- main control bus
       -- data input --
-      rs1_i   => rs1_i,        -- rf source 1
-      rs2_i   => rs2_i,        -- rf source 2
+      rs1_i   => rs1_i,        -- register source 1
+      rs2_i   => rs2_i,        -- register source 2
       -- result and status --
       res_o   => cp_result(5), -- operation result
       valid_o => cp_valid(5)   -- data output valid
@@ -343,7 +345,7 @@ begin
     cp_valid(5)  <= '0';
   end generate;
 
-  -- ALU[I]-Opcode Co-Processor: Scalar Cryptography Unit ('Zk*' ISA Extensions) ------------
+  -- ALU[I]-Opcode Co-Processor: Scalar Cryptography Unit (Zk* ISA Extensions) --------------
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_alu_crypto_enabled:
   if RISCV_ISA_Zknd or RISCV_ISA_Zkne or RISCV_ISA_Zknh or RISCV_ISA_Zksed or RISCV_ISA_Zksh generate
@@ -352,7 +354,7 @@ begin
       EN_ZKND  => RISCV_ISA_Zknd,  -- enable NIST AES decryption extension
       EN_ZKNE  => RISCV_ISA_Zkne,  -- enable NIST AES encryption extension
       EN_ZKNH  => RISCV_ISA_Zknh,  -- enable NIST hash extension
-      EN_ZKSED => RISCV_ISA_Zksed, -- enable ShangMi block cypher extension
+      EN_ZKSED => RISCV_ISA_Zksed, -- enable ShangMi block cipher extension
       EN_ZKSH  => RISCV_ISA_Zksh   -- enable ShangMi hash extension
     )
     port map (
@@ -361,8 +363,8 @@ begin
       rstn_i  => rstn_i,       -- global reset, low-active, async
       ctrl_i  => ctrl_i,       -- main control bus
       -- data input --
-      rs1_i   => rs1_i,        -- rf source 1
-      rs2_i   => rs2_i,        -- rf source 2
+      rs1_i   => rs1_i,        -- register source 1
+      rs2_i   => rs2_i,        -- register source 2
       -- result and status --
       res_o   => cp_result(6), -- operation result
       valid_o => cp_valid(6)   -- data output valid

--- a/rtl/core/neorv32_cpu_alu_cfu.vhd
+++ b/rtl/core/neorv32_cpu_alu_cfu.vhd
@@ -15,25 +15,32 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
+library neorv32;
+use neorv32.neorv32_package.all;
+
 entity neorv32_cpu_alu_cfu is
   port (
     -- global control --
     clk_i    : in  std_ulogic; -- global clock, rising edge
     rstn_i   : in  std_ulogic; -- global reset, low-active, async
-    -- operation trigger --
+    -- request --
     start_i  : in  std_ulogic; -- start trigger, single-shot
-    -- operands --
-    type_i   : in  std_ulogic;                     -- instruction type (0 = R-type, 1 = I-type)
-    funct3_i : in  std_ulogic_vector(2 downto 0);  -- "funct3" bit-field from instruction word
-    funct7_i : in  std_ulogic_vector(6 downto 0);  -- "funct7" bit-field from instruction word (R-type only)
-    imm12_i  : in  std_ulogic_vector(11 downto 0); -- "imm12" bit-field from instruction word (I-type only)
-    rs1_i    : in  std_ulogic_vector(31 downto 0); -- rf source 1 via "rs1" bit-field from instruction word
-    rs2_i    : in  std_ulogic_vector(31 downto 0); -- rf source 2 via "rs2" bit-field from instruction word
-    -- result and status --
+    inst_i   : in  std_ulogic_vector(31 downto 0); -- full instruction word
+    rs1_i    : in  std_ulogic_vector(31 downto 0); -- register source operand 1
+    rs2_i    : in  std_ulogic_vector(31 downto 0); -- register source operand 2
+    -- response --
     result_o : out std_ulogic_vector(31 downto 0); -- operation result
-    valid_o  : out std_ulogic                      -- operation done
+    valid_o  : out std_ulogic                      -- operation done; result valid
   );
 end neorv32_cpu_alu_cfu;
+
+architecture neorv32_cpu_alu_cfu_rtl of neorv32_cpu_alu_cfu is
+
+  -- supported CFU opcodes --
+  constant opcode_custom0_c : std_ulogic_vector(6 downto 0) := "0001011"; -- CUSTOM-0 opcode
+  constant opcode_custom1_c : std_ulogic_vector(6 downto 0) := "0101011"; -- CUSTOM-1 opcode
+  constant opcode_op32_c    : std_ulogic_vector(6 downto 0) := "0011011"; -- OP-32 opcode
+  constant opcode_opimm32_c : std_ulogic_vector(6 downto 0) := "0111011"; -- OP-IMM-32 opcode
 
   -- **********************************************************
   -- CFU Example: XTEA - Extended Tiny Encryption Algorithm
@@ -46,11 +53,9 @@ end neorv32_cpu_alu_cfu;
   -- The RTL code was implemented according to an open-source C reference:
   -- https://de.wikipedia.org/wiki/Extended_Tiny_Encryption_Algorithm
 
-architecture neorv32_cpu_alu_cfu_rtl of neorv32_cpu_alu_cfu is
-
-  -- instruction type identifiers --
-  constant r_type_c : std_ulogic := '0'; -- R-type CFU instructions (custom-0 opcode)
-  constant i_type_c : std_ulogic := '1'; -- I-type CFU instructions (custom-1 opcode)
+  -- instruction types (opcode field) --
+  constant xtea_r_type_c : std_ulogic_vector(6 downto 0) := opcode_custom0_c; -- XTEA R-type instructions
+  constant xtea_i_type_c : std_ulogic_vector(6 downto 0) := opcode_custom1_c; -- XTEA I-type instructions
 
   -- instruction identifiers (funct3 bit-field) --
   constant xtea_enc_v0_c : std_ulogic_vector(2 downto 0) := "000";
@@ -58,6 +63,12 @@ architecture neorv32_cpu_alu_cfu_rtl of neorv32_cpu_alu_cfu is
   constant xtea_dec_v0_c : std_ulogic_vector(2 downto 0) := "010";
   constant xtea_dec_v1_c : std_ulogic_vector(2 downto 0) := "011";
   constant xtea_init_c   : std_ulogic_vector(2 downto 0) := "100";
+
+  -- instruction decoder --
+  signal start  : std_ulogic; -- start valid CFU instruction
+  signal itype  : std_ulogic; -- XTEA instruction type (0 = r-type, 1 = i-type)
+  signal funct3 : std_ulogic_vector(2 downto 0); -- i-type/r-type function select
+  signal imm12  : std_ulogic_vector(11 downto 0); -- i-type immediate
 
   -- round-key update --
   constant xtea_delta_c : std_ulogic_vector(31 downto 0) := x"9e3779b9";
@@ -81,6 +92,14 @@ architecture neorv32_cpu_alu_cfu_rtl of neorv32_cpu_alu_cfu is
 
 begin
 
+  -- XTEA Instruction Decode ----------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  start  <= start_i when (inst_i(6 downto 0) = xtea_r_type_c) or (inst_i(6 downto 0) = xtea_i_type_c) else '0'; -- valid instruction?
+  itype  <= '0' when (inst_i(6 downto 0) = xtea_r_type_c) else '1'; -- XTEA r-type or i-type?
+  funct3 <= inst_i(14 downto 12); -- i-type/r-type 2-bit function select
+  imm12  <= inst_i(31 downto 20); -- i-type 12-bit immediate
+
+
   -- XTEA Processing Core ------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   xtea_core: process(rstn_i, clk_i)
@@ -98,14 +117,14 @@ begin
       xtea.done(1) <= xtea.done(0); -- arbitration shift register
 
       -- trigger new operation --
-      if (start_i = '1') then
-        if (type_i = r_type_c) then -- R-type for computational instructions
+      if (start = '1') then
+         if (itype = '0') then -- R-type for computational instructions
           xtea.opa     <= rs1_i; -- buffer input operand rs1
           xtea.opb     <= rs2_i; -- buffer input operand rs2
           xtea.done(0) <= '1'; -- start data processing
         else -- I-type is used for key access instructions
-          if (funct3_i(0) = '1') then -- key write-enable
-            key_mem(to_integer(unsigned(imm12_i(1 downto 0)))) <= rs1_i; -- write key data at imm12(1:0)
+          if (funct3(0) = '1') then -- key write-enable
+            key_mem(to_integer(unsigned(imm12(1 downto 0)))) <= rs1_i; -- write key data at imm12(1:0)
           end if;
         end if;
       end if;
@@ -113,15 +132,15 @@ begin
       -- data processing --
       if (xtea.done(0) = '1') then -- second-stage execution trigger
         -- update "sum" round key --
-        if (funct3_i(2) = '1') then -- initialize
+        if (funct3(2) = '1') then -- initialize
           xtea.sum <= xtea.opa; -- set initial round key
-        elsif (funct3_i(1 downto 0) = xtea_enc_v0_c(1 downto 0)) then -- encrypt v0
+        elsif (funct3(1 downto 0) = xtea_enc_v0_c(1 downto 0)) then -- encrypt v0
           xtea.sum <= std_ulogic_vector(unsigned(xtea.sum) + unsigned(xtea_delta_c));
-        elsif (funct3_i(1 downto 0) = xtea_dec_v1_c(1 downto 0)) then -- decrypt v1
+        elsif (funct3(1 downto 0) = xtea_dec_v1_c(1 downto 0)) then -- decrypt v1
           xtea.sum <= std_ulogic_vector(unsigned(xtea.sum) - unsigned(xtea_delta_c));
         end if;
         -- process "v" operands --
-        if (funct3_i(1) = '0') then -- encrypt
+        if (funct3(1) = '0') then -- encrypt
           xtea.res <= std_ulogic_vector(unsigned(tmp_b) + unsigned(tmp_r));
         else -- decrypt
           xtea.res <= std_ulogic_vector(unsigned(tmp_b) - unsigned(tmp_r));
@@ -132,22 +151,22 @@ begin
   end process xtea_core;
 
   -- helpers --
-  tmp_a <= xtea.opb when (funct3_i(0) = '0') else xtea.opa; -- v1 / v0 select
-  tmp_b <= xtea.opa when (funct3_i(0) = '0') else xtea.opb; -- v0 / v1 select
-  tmp_x <= xtea.opb(27 downto 0) & "0000"  when (funct3_i(0) = '0') else xtea.opa(27 downto 0) & "0000";  -- v << 4
-  tmp_y <= "00000" & xtea.opb(31 downto 5) when (funct3_i(0) = '0') else "00000" & xtea.opa(31 downto 5); -- v >> 5
-  tmp_z <= key_mem(to_integer(unsigned(xtea.sum(1 downto 0)))) when (funct3_i(0) = '0') else -- key[sum & 3]
+  tmp_a <= xtea.opb when (funct3(0) = '0') else xtea.opa; -- v1 / v0 select
+  tmp_b <= xtea.opa when (funct3(0) = '0') else xtea.opb; -- v0 / v1 select
+  tmp_x <= xtea.opb(27 downto 0) & "0000"  when (funct3(0) = '0') else xtea.opa(27 downto 0) & "0000";  -- v << 4
+  tmp_y <= "00000" & xtea.opb(31 downto 5) when (funct3(0) = '0') else "00000" & xtea.opa(31 downto 5); -- v >> 5
+  tmp_z <= key_mem(to_integer(unsigned(xtea.sum(1 downto 0)))) when (funct3(0) = '0') else -- key[sum & 3]
            key_mem(to_integer(unsigned(xtea.sum(12 downto 11)))); -- key[(sum >> 11) & 3]
   tmp_r <= std_ulogic_vector(unsigned(tmp_x xor tmp_y) + unsigned(tmp_a)) xor std_ulogic_vector(unsigned(xtea.sum) + unsigned(tmp_z));
 
 
   -- Function Result Select -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  result_select: process(type_i, funct3_i, imm12_i, xtea, key_mem)
+  result_select: process(itype, funct3, imm12, xtea, key_mem)
   begin -- no need for a register stage here; the CFU output is registered inside the ALU module anyway
-    if (type_i = r_type_c) then -- R-type instructions; function select via "funct3" and ""funct7
+    if (itype = '0') then -- R-type instructions; function select via "funct3"
     -- ----------------------------------------------------------------------
-      case funct3_i is -- just check "funct3" here; "funct7" bit-field is ignored in this example
+      case funct3 is -- just check "funct3" here
         when xtea_enc_v0_c | xtea_enc_v1_c | xtea_dec_v0_c | xtea_dec_v1_c => -- encryption/decryption
           result_o <= xtea.res; -- processing result
           valid_o  <= xtea.done(1); -- multi-cycle processing done when set
@@ -160,7 +179,7 @@ begin
       end case;
     else -- I-type instructions; used for key access
     -- ----------------------------------------------------------------------
-      result_o <= key_mem(to_integer(unsigned(imm12_i(1 downto 0))));
+      result_o <= key_mem(to_integer(unsigned(imm12(1 downto 0))));
       valid_o  <= '1'; -- pure-combinatorial, so we are done "immediately"
     end if;
   end process result_select;

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -341,7 +341,7 @@ begin
               ctrl_nxt.alu_sub <= '1';
             end if;
 
-            -- is base rv32i/e ALU[I] instruction (excluding shifts)? --
+            -- base rv32 ALU[I] instruction (excluding shifts) --
             if ((opcode_v(5) = '0') and (funct3_v /= funct3_sll_c) and (funct3_v /= funct3_sr_c)) or -- base ALUI instruction (excluding SLLI, SRLI, SRAI)
                ((opcode_v(5) = '1') and (((funct3_v = funct3_sadd_c) and (funct7_v = "0000000")) or ((funct3_v = funct3_sadd_c) and (funct7_v = "0100000")) or
                                          ((funct3_v = funct3_slt_c)  and (funct7_v = "0000000")) or ((funct3_v = funct3_sltu_c) and (funct7_v = "0000000")) or
@@ -350,7 +350,7 @@ begin
               ctrl_nxt.rf_wb_en <= '1'; -- valid RF write-back (won't happen if exception)
               exec_nxt.state    <= S_DISPATCH;
             else -- [NOTE] illegal ALU[I] instructions are handled as multi-cycle operations that will time-out if no ALU co-processor responds
-              ctrl_nxt.alu_cp_alu <= '1'; -- trigger ALU[I] opcode co-processor
+              ctrl_nxt.alu_cp_alu <= '1'; -- trigger ALU[I] co-processor
               exec_nxt.state      <= S_ALU_WAIT;
             end if;
 
@@ -395,8 +395,8 @@ begin
             ctrl_nxt.alu_cp_fpu <= '1';
             exec_nxt.state      <= S_ALU_WAIT; -- will be aborted by monitor timeout if FPU is not implemented
 
-          -- CFU: custom RISC-V instructions --
-          when opcode_cust0_c | opcode_cust1_c =>
+          -- CFU: custom / extended RISC-V instructions --
+          when opcode_cust0_c | opcode_cust1_c | opcode_op32_c | opcode_op32i_c =>
             ctrl_nxt.alu_cp_cfu <= '1';
             exec_nxt.state      <= S_ALU_WAIT; -- will be aborted by monitor timeout if CFU is not implemented
 
@@ -691,8 +691,8 @@ begin
           end case;
         end if;
 
-      -- ALU[I] / FPU / custom operations --
-      when opcode_alu_c | opcode_alui_c | opcode_fpu_c | opcode_cust0_c | opcode_cust1_c =>
+      -- ALU[I] / FPU / OP32 / custom operations --
+      when opcode_alu_c | opcode_alui_c | opcode_fpu_c | opcode_op32_c | opcode_op32i_c | opcode_cust0_c | opcode_cust1_c =>
         illegal_cmd <= '0'; -- [NOTE] valid if not terminated/invalidated by the "instruction execution monitor"
 
       -- memory ordering --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01120902"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01120903"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 
@@ -332,6 +332,9 @@ package neorv32_package is
   -- official custom opcodes - free for custom instructions --
   constant opcode_cust0_c  : std_ulogic_vector(6 downto 0) := "0001011"; -- custom-0 (NEORV32 CFU)
   constant opcode_cust1_c  : std_ulogic_vector(6 downto 0) := "0101011"; -- custom-1 (NEORV32 CFU)
+  -- extended opcodes --
+  constant opcode_op32_c   : std_ulogic_vector(6 downto 0) := "0111011"; -- OP-32 (NEORV32 CFU)
+  constant opcode_op32i_c  : std_ulogic_vector(6 downto 0) := "0011011"; -- OP-IMM-32 (NEORV32 CFU)
 
   -- RISC-V Funct3 --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/sw/lib/include/neorv32_intrinsics.h
+++ b/sw/lib/include/neorv32_intrinsics.h
@@ -23,8 +23,10 @@
  * @name RISC-V opcodes for custom instructions / NEORV32 CFU
  **************************************************************************/
 /**@{*/
-#define RISCV_OPCODE_CUSTOM0 0b0001011
-#define RISCV_OPCODE_CUSTOM1 0b0101011
+#define RISCV_OPCODE_CUSTOM0 0b0001011 // RISC-V "CUSTOM-0"
+#define RISCV_OPCODE_CUSTOM1 0b0101011 // RISC-V "CUSTOM-1"
+#define RISCV_OPCODE_OP32    0b0111011 // RISC-V "OP-32", experimental!
+#define RISCV_OPCODE_OPIMM32 0b0011011 // RISC-V "OP-IMM-32", experimental!
 /**@}*/
 
 /**********************************************************************//**


### PR DESCRIPTION
The goal of this PR is to simplify the CFU interface while making it even more flexible. Instead of pre-decoding specific bit fields of the instruction, the entire instruction word is now passed to the CFU. The CFU is then responsible for decoding the instruction. This allows for complete freedom in choosing the instruction format (not just R-type and I-type).

```vhdl
entity neorv32_cpu_alu_cfu is
  port (
    -- global control --
    clk_i    : in  std_ulogic; -- global clock, rising edge
    rstn_i   : in  std_ulogic; -- global reset, low-active, async
    -- request --
    start_i  : in  std_ulogic; -- start trigger, single-shot
    inst_i   : in  std_ulogic_vector(31 downto 0); -- full instruction word
    rs1_i    : in  std_ulogic_vector(31 downto 0); -- register source operand 1
    rs2_i    : in  std_ulogic_vector(31 downto 0); -- register source operand 2
    -- response --
    result_o : out std_ulogic_vector(31 downto 0); -- operation result
    valid_o  : out std_ulogic                      -- operation done; result valid
  );
end neorv32_cpu_alu_cfu;
```

From the API's perspective, the changes in this PR are fully backward-compatible.

Additionally, the CFU now supports the RISC-V `OP-32` and `OP-IMM-32` opcodes. These should not be used for custom instructions, but rather for additional RISC-V instructions that the core does not (yet) support.