### PR TITLE
add NEORV32-specific `mxisah` CSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 11.04.2026 | 1.12.9.4 | add NEORV32-specific `MXISAH` CSR | [#1527](https://github.com/stnolting/neorv32/pull/1527) |
 | 06.04.2026 | 1.12.9.3 | :warning: CFU: rework/simplify interface; add support for RISC-V `OP-32` and `OP-IMM-32` opcodes / instructions | [#1524](https://github.com/stnolting/neorv32/pull/1524) |
-| 06.04.2026 | 1.12.9.2 | :test_tube: rework intrinsics (use `.insn` pseudo directive) | [#](https://github.com/stnolting/neorv32/pull/1523) |
+| 06.04.2026 | 1.12.9.2 | :test_tube: rework intrinsics (use `.insn` pseudo directive) | [#1523](https://github.com/stnolting/neorv32/pull/1523) |
 | 05.04.2026 | 1.12.9.1 | :sparkles: add cache write-back & write-allocate policies | [#1513](https://github.com/stnolting/neorv32/pull/1513) |
 | 03.04.2026 | [**1.12.9**](https://github.com/stnolting/neorv32/releases/tag/v1.12.9) | :rocket: **New release** | |
 | 03.04.2026 | 1.12.8.10 | :bug: fix `sc.w` reservation set instruction: return all-zero on success | [#1520](https://github.com/stnolting/neorv32/pull/1520) |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -49,7 +49,7 @@ In the following table these CSRs are highlighted with "⚠️".
 5+^| **<<_machine_trap_handling_csrs>>**
 | 0x340 | <<_mscratch>> | `CSR_MSCRATCH` | MRW | Machine scratch register
 | 0x341 | <<_mepc>>     | `CSR_MEPC`     | MRW | Machine exception program counter
-| 0x342 | <<_mcause>>   | `CSR_MCAUSE`   | MRW ⚠️| Machine trap cause
+| 0x342 | <<_mcause>>   | `CSR_MCAUSE`   | MRW ⚠️ | Machine trap cause
 | 0x343 | <<_mtval>>    | `CSR_MTVAL`    | MRW ⚠️ | Machine trap value
 | 0x344 | <<_mip>>      | `CSR_MIP`      | MRW | Machine interrupt pending register
 | 0x34a | <<_mtinst>>   | `CSR_MTINST`   | MRW ⚠️ | Machine trap instruction
@@ -62,9 +62,9 @@ In the following table these CSRs are highlighted with "⚠️".
 | 0x7a2 | <<_tdata2>>   | `CSR_TDATA2`   | MRW | Trigger data register 2
 | 0x7a4 | <<_tinfo>>    | `CSR_TINFO`    | MRW | Trigger information register
 5+^| **<<_cpu_debug_mode_csrs>>**
-| 0x7b0 | <<_dcsr>>      | - | DRW | Debug control and status register
-| 0x7b1 | <<_dpc>>       | - | DRW | Debug program counter
-| 0x7b2 | <<_dscratch0>> | - | DRW | Debug scratch register 0
+| 0x7b0 | <<_dcsr>>      | `CSR_DCSR`      | DRW | Debug control and status register
+| 0x7b1 | <<_dpc>>       | `CSR_DPC`       | DRW | Debug program counter
+| 0x7b2 | <<_dscratch0>> | `CSR_DSCRATCH0` | DRW | Debug scratch register 0
 5+^| **<<_machine_counter_and_timer_csrs>>**
 | 0xb00 | <<_mcycleh, `mcycle`>>      | `CSR_MCYCLE`    | MRW | Machine cycle counter low word
 | 0xb02 | <<_minstreth, `minstret`>>  | `CSR_MINSTRET`  | MRW | Machine instruction-retired counter low word
@@ -85,7 +85,8 @@ In the following table these CSRs are highlighted with "⚠️".
 | 0xf14 | <<_mhartid>>    | `CSR_MHARTID`    | MRO | Machine hardware thread ID
 | 0xf15 | <<_mconfigptr>> | `CSR_MCONFIGPTR` | MRO | Machine configuration pointer register
 5+^| **<<_neorv32_specific_csrs>>**
-| 0xfc0 | <<_mxisa>> | `CSR_MXISA` | MRO | Extended machine CPU ISA and extensions
+| 0xfc0 | <<_mxisah, `mxisa`>>  | `CSR_MXISA`  | MRO | Extended machine CPU ISA and extensions low word
+| 0xfc1 | <<_mxisah, `mxisah`>> | `CSR_MXISAH` | MRO | Extended machine CPU ISA and extensions high word
 |=======================
 
 
@@ -234,7 +235,7 @@ will _not_ cause an illegal instruction exception.
 
 [TIP]
 Machine-mode software can discover available `Z*` sub-extensions (like `Zicsr` or `Zfinx`) by checking the NEORV32-specific
-<<_mxisa>> CSR.
+<<_mxisah>> CSRs.
 
 
 {empty} +
@@ -989,17 +990,18 @@ NEORV32-specific CSRs are mapped to addresses that are explicitly reserved for c
 
 
 [discrete]
-===== **`mxisa`**
+===== **`mxisa[h]`**
 
 [cols="<1,<8"]
 [grid="none"]
 |=======================
 | Name        | Machine extended ISA and extensions register
-| Address     | `0xfc0`
+| Address     | `0xfc0` (`mxisa`, low word)
+|             | `0xfc1` (`mxisah`, high word)
 | Reset value | `DEFINED`
 | ISA         | <<_zicsr_isa_extension,`Zicsr`>> & <<_x_isa_extension,`X`>>
-| Description | The `mxisa` CSR is a NEORV32-specific read-only CSR that helps machine-mode software to
-discover additional ISA (sub-)extensions and CPU configuration options.
+| Description | The `mxisa[h]` CSRs are NEORV32-specific read-only CSRs that help machine-mode software to
+discover additional ISA (sub-)extensions (beyond the _base_ extensions listed in <<_misa>>).
 |=======================
 
 .`mxisa` CSR Bits
@@ -1039,4 +1041,12 @@ discover additional ISA (sub-)extensions and CPU configuration options.
 | 29  | `CSR_MXISA_ZIBI`      | r/- | <<_zibi_isa_extension>> available
 | 30  | `CSR_MXISA_ZIMOP`     | r/- | <<_zimop_isa_extension>> available
 | 31  | `CSR_MXISA_SMCNTRPMF` | r/- | <<_smcntrpmf_isa_extension>> available
+|=======================
+
+.`mxisah` CSR Bits
+[cols="^1,<2,^1,<6"]
+[options="header",grid="rows"]
+|=======================
+| Bit | Name [C] | R/W | Description
+| 31:0 | - | r/- | _reserved_, read as zero
 |=======================

--- a/docs/datasheet/cpu_isa.adoc
+++ b/docs/datasheet/cpu_isa.adoc
@@ -60,7 +60,7 @@ documents can be found in the projects `docs/references` folder.
 
 .Discovering ISA Extensions
 [TIP]
-Software can discover available ISA extensions via the <<_misa>> and <<_mxisa>> CSRs or by executing an instruction
+Software can discover available ISA extensions via the <<_misa>> and <<_mxisah>> CSRs or by executing an instruction
 and checking for an illegal instruction exception (i.e. <<_full_virtualization>>).
 
 

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -189,7 +189,7 @@ By default, all configuration options are **disabled**.
 
 .Software Discovery of Configuration
 [TIP]
-Software can determine the actual CPU configuration via the <<_misa>> and <<_mxisa>> CSRs. The SoC/Processor configuration
+Software can determine the actual CPU configuration via the <<_misa>> and <<_mxisah>> CSRs. The SoC/Processor configuration
 can be determined via the <<_system_configuration_information_memory_sysinfo, SYSINFO>> memory-mapped registers.
 
 .NEORV32 Processor Generic List; table abbreviations: the generic type "`suv(x:y)`" is an abbreviation for "`std_ulogic_vector(x downto y)`"

--- a/docs/datasheet/software_bootloader.adoc
+++ b/docs/datasheet/software_bootloader.adoc
@@ -117,7 +117,7 @@ CMD:> i
 HWV:  0x01120101 <1>
 CLK:  0x05f5e100 <2>
 MISA: 0x40901107 <3>
-XISA: 0x0fc06fd3 <4>
+XISA: 0x00000000:0x0fc06fd3 <4>
 SOC:  0x38efc87b <5>
 MISC: 0x0a010d00 <6>
 CMD:>
@@ -125,7 +125,7 @@ CMD:>
 <1> Processor hardware version in BCD format (<<_mimpid>> CSR).
 <2> Processor clock speed in Hz (`CLK` register of <<_system_configuration_information_memory_sysinfo>>.
 <3> RISC-V CPU extensions (<<_misa>> CSR).
-<4> NEORV32-specific CPU extensions (<<_mxisa>> CSR).
+<4> Additional RISC-V CPU (sub-)extensions (high & low words of <<_mxisah>> CSRs).
 <5> Processor configuration (`SOC` register of <<_system_configuration_information_memory_sysinfo>>.
 <6> Miscellaneous memory and SoC configuration (`MISC` register of <<_system_configuration_information_memory_sysinfo>>.
 

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -564,7 +564,7 @@ begin
       when csr_mstatus_c  | csr_mstatush_c      | csr_misa_c      | csr_mie_c     | csr_mtvec_c  |
            csr_mscratch_c | csr_mepc_c          | csr_mcause_c    | csr_mip_c     | csr_mtval_c  |
            csr_mtinst_c   | csr_mcountinhibit_c | csr_mvendorid_c | csr_marchid_c | csr_mimpid_c |
-           csr_mhartid_c  | csr_mconfigptr_c    | csr_mxisa_c =>
+           csr_mhartid_c  | csr_mconfigptr_c    | csr_mxisa_c     | csr_mxisah_c =>
         csr_valid(2) <= '1';
 
       -- machine-controlled user-mode CSRs --
@@ -1207,7 +1207,7 @@ begin
           -- --------------------------------------------------------------------
           -- NEORV32-specific
           -- --------------------------------------------------------------------
-          when csr_mxisa_c => -- machine extended ISA extensions information
+          when csr_mxisa_c => -- machine extended ISA extensions information, low-word
             csr_rdata(0)  <= '1';                                   -- Zicsr: CSR access (always enabled)
             csr_rdata(1)  <= '1';                                   -- Zifencei: instruction stream sync. (always enabled)
             csr_rdata(2)  <= bool_to_ulogic_f(RISCV_ISA_Zmmul);     -- Zmmul: mul/div
@@ -1240,6 +1240,9 @@ begin
             csr_rdata(29) <= bool_to_ulogic_f(RISCV_ISA_Zibi);      -- Zibi: branch with immediate-comparison
             csr_rdata(30) <= bool_to_ulogic_f(RISCV_ISA_Zimop);     -- Zimop: may-be-operations
             csr_rdata(31) <= bool_to_ulogic_f(RISCV_ISA_Smcntrpmf); -- Smcntrpmf: counter privilege-mode filtering
+
+          when csr_mxisah_c => -- machine extended ISA extensions information, high-word
+            csr_rdata <= (others => '0'); -- reserved
 
           -- --------------------------------------------------------------------
           -- undefined/unavailable or implemented externally

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01120903"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01120904"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 
@@ -566,7 +566,7 @@ package neorv32_package is
   constant csr_mconfigptr_c     : std_ulogic_vector(11 downto 0) := x"f15";
   -- NEORV32-specific machine registers --
   constant csr_mxisa_c          : std_ulogic_vector(11 downto 0) := x"fc0";
---constant csr_mxisah_c         : std_ulogic_vector(11 downto 0) := x"fc1"; -- to be implemented...
+  constant csr_mxisah_c         : std_ulogic_vector(11 downto 0) := x"fc1";
 
 -- **********************************************************************************************************
 -- CPU Control

--- a/sw/bootloader/main.c
+++ b/sw/bootloader/main.c
@@ -8,7 +8,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause                                            */
 /* ================================================================================ */
 
-// libraries
 #include <stdint.h>
 #include <neorv32.h>
 #include <config.h>
@@ -168,6 +167,8 @@ skip_auto_boot:
       uart_puts("\nMISA: ");
       uart_puth(neorv32_cpu_csr_read(CSR_MISA));
       uart_puts("\nXISA: ");
+      uart_puth(neorv32_cpu_csr_read(CSR_MXISAH));
+      uart_putc(':');
       uart_puth(neorv32_cpu_csr_read(CSR_MXISA));
       uart_puts("\nSOC:  ");
       uart_puth(NEORV32_SYSINFO->SOC);
@@ -213,10 +214,8 @@ skip_auto_boot:
   }
 #endif
 
-  // raise exception and halt
+  // bootloader should never return: raise exception and halt
   asm volatile ("ebreak");
   __builtin_unreachable();
-
-  // bootloader should never return
   return -1;
 }

--- a/sw/lib/include/neorv32_csr.h
+++ b/sw/lib/include/neorv32_csr.h
@@ -152,7 +152,8 @@ enum NEORV32_CSR_enum {
   CSR_MCONFIGPTR     = 0xf15, /**< 0xf15 - mconfigptr: Machine configuration pointer register */
 
   /* NEORV32-specific */
-  CSR_MXISA          = 0xfc0  /**< 0xfc0 - mxisa: Machine extended ISA and extensions (#NEORV32_CSR_MXISA_enum) */
+  CSR_MXISA          = 0xfc0, /**< 0xfc0 - mxisa:  Machine extended ISA and extensions, low word (#NEORV32_CSR_MXISA_enum) */
+  CSR_MXISAH         = 0xfc1  /**< 0xfc1 - mxisah: Machine extended ISA and extensions, high word (#NEORV32_CSR_MXISAH_enum) */
 };
 
 

--- a/sw/openocd/lib/target.cfg
+++ b/sw/openocd/lib/target.cfg
@@ -39,6 +39,7 @@ if { $NUMCORES == 1 } {
 
 # expose NEORV32-specific CSRs
 riscv expose_csrs 4032=mxisa
+riscv expose_csrs 4033=mxisah
 
 # initialize target
 init


### PR DESCRIPTION
To have more space for flags that represent enabled ISA extensions (in addition to [`misa`](https://stnolting.github.io/neorv32/#_misa) and [`mxisa`](https://stnolting.github.io/neorv32/#_mxisa)),

`mxisah` is mapped to the RISC-V platform-specific machine-read-only CSR address space (address 0xFC1) and is currently hardwired to all-zero.