### PR TITLE
Please initialise SPRAM array to zero

### DIFF
--- a/rtl/core/neorv32_prim.vhd
+++ b/rtl/core/neorv32_prim.vhd
@@ -186,7 +186,13 @@ end neorv32_prim_spram;
 architecture neorv32_prim_spram_rtl of neorv32_prim_spram is
 
   type ram_t is array ((2**AWIDTH)-1 downto 0) of std_ulogic_vector(DWIDTH-1 downto 0);
-  signal spram : ram_t;
+  -- Initialise to zero so simulators don't see 'U' on reads before first write.
+  -- 'U' propagates into loads/addresses and can trigger spurious access faults
+  -- (e.g. in newlib malloc's heap-metadata reads) that do not reflect real
+  -- hardware behaviour. On FPGA, inferred BRAMs power up to zero, so this
+  -- initialiser folds into the default BRAM INIT values and is a no-op for
+  -- synthesis / resource usage.
+  signal spram : ram_t := (others => (others => '0'));
   signal rdata : std_ulogic_vector(DWIDTH-1 downto 0);
 
 begin


### PR DESCRIPTION
## Summary

I'd like to add an explicit zero-initialiser to the storage signal inside
`neorv32_prim_spram`:

```vhdl
signal spram : ram_t := (others => (others => '0'));
```

## Motivation

Without the initialiser, `spram` starts at `'U'` in VHDL simulation.
Reads before the first write return `'U'`in simulation, which propagates into loads
and address calculations and can trigger spurious access faults in
simulators — observed in NVC during NEORV32 + newlib bring-up, where
the C runtime reads from uninitialised `.bss`/heap regions during
malloc initialisation. This was obnoxious to see in simulation until I dug into it.

Initialising to zero matches inferred-BRAM power-up behaviour on
mainstream FPGA targets, no-op for synthesis: the
initialiser folds into the default BRAM `INIT_*` strings (already 0).

## Scope

`neorv32_prim_spram` is used by `neorv32_dmem_ram`, `neorv32_imem_ram`,
and `neorv32_cache_ram`, so DMEM, IMEM (RAM mode), and cache arrays
all benefit.

## Test plan

- [x] Vivado 2025.2 / xcau15p synthesis: resource report unchanged
- [x] NVC 1.20-devel: DMEM reads of previously-unwritten addresses now
      return `0`; no more phantom access faults during crt0 bring-up