### PR TITLE
[image_gen] Squashed ugly silent-corruption bug — linker alignment padding between sections was being dropped from the IMEM image

### DIFF
--- a/sw/image_gen/image_gen.c
+++ b/sw/image_gen/image_gen.c
@@ -201,6 +201,7 @@ int main(int argc, char *argv[]) {
   unsigned int text_size = 0;
   unsigned int rodata_size = 0;
   unsigned int data_size = 0;
+  uint32_t text_vma = 0, rodata_vma = 0, data_vma = 0;
 
   // scan section headers
   for (i = 0; i < elf.e_shnum; i++) {
@@ -208,36 +209,109 @@ int main(int argc, char *argv[]) {
     if (strcmp(section_name, ".text") == 0) {
       text = read_section(input, &shdrs[i]);
       text_size = (unsigned int)shdrs[i].sh_size;
+      text_vma  = (uint32_t)shdrs[i].sh_addr;
     }
     if (strcmp(section_name, ".rodata") == 0) {
       rodata = read_section(input, &shdrs[i]);
       rodata_size = (unsigned int)shdrs[i].sh_size;
+      rodata_vma  = (uint32_t)shdrs[i].sh_addr;
     }
     if (strcmp(section_name, ".data") == 0) {
       data = read_section(input, &shdrs[i]);
       data_size = (unsigned int)shdrs[i].sh_size;
+      data_vma  = (uint32_t)shdrs[i].sh_addr;
+    }
+  }
+
+  // ****************************************
+  // parse program headers to translate each section's VMA -> LMA.
+  //
+  // The linker may insert alignment padding between sections (e.g. a 4-byte
+  // gap between .text and .rodata when .rodata requires 8-byte alignment).
+  // Concatenating sections back-to-back by size drops those gaps and shifts
+  // every byte after the first gap backward, quietly corrupting .rodata
+  // loads and crt0's .data init. Lay sections out at their LMAs and
+  // zero-fill gaps instead.
+  //
+  // For ROM-resident sections (.text, .rodata) LMA == VMA. For .data the
+  // linker script uses `AT > rom`, so VMA is in RAM and LMA lives in ROM;
+  // only a program-header walk recovers the correct LMA.
+  // ****************************************
+
+  Elf32_Phdr *phdrs = NULL;
+  if (elf.e_phnum > 0) {
+    phdrs = malloc((size_t)elf.e_phentsize * elf.e_phnum);
+    if (!phdrs) {
+      printf("[ERROR] malloc failed!\n");
+      return -1;
+    }
+    fseek(input, elf.e_phoff, SEEK_SET);
+    if (fread(phdrs, elf.e_phentsize, elf.e_phnum, input) <= 0) {
+      printf("[ERROR] Input file read error (%s)!\n", input_file);
+      return -2;
     }
   }
 
   fclose(input);
+
+  // Resolve each section's LMA by finding the PT_LOAD segment that covers its VMA.
+  // Default to VMA (LMA == VMA) if no PT_LOAD matches, which is the common case
+  // for ROM-resident sections.
+  uint32_t text_lma = text_vma, rodata_lma = rodata_vma, data_lma = data_vma;
+  for (i = 0; i < elf.e_phnum; i++) {
+    if (phdrs[i].p_type != PT_LOAD) continue;
+    uint32_t vlo = (uint32_t)phdrs[i].p_vaddr;
+    uint32_t vhi = vlo + (uint32_t)phdrs[i].p_memsz;
+    uint32_t plo = (uint32_t)phdrs[i].p_paddr;
+    if (text_size   && text_vma   >= vlo && text_vma   <  vhi) text_lma   = plo + (text_vma   - vlo);
+    if (rodata_size && rodata_vma >= vlo && rodata_vma <  vhi) rodata_lma = plo + (rodata_vma - vlo);
+    if (data_size   && data_vma   >= vlo && data_vma   <  vhi) data_lma   = plo + (data_vma   - vlo);
+  }
 
   // ****************************************
   // generate raw image
   // ****************************************
 
   // debug
-//printf(".text:   %d bytes\n", text_size);
-//printf(".rodata: %d bytes\n", rodata_size);
-//printf(".data:   %d bytes\n", data_size);
+//printf(".text:   %u bytes @ LMA 0x%08x\n", text_size,   text_lma);
+//printf(".rodata: %u bytes @ LMA 0x%08x\n", rodata_size, rodata_lma);
+//printf(".data:   %u bytes @ LMA 0x%08x\n", data_size,   data_lma);
 
-  // final image size
-  raw_exe_size = text_size + rodata_size + data_size;
+  // rom_base = minimum LMA across present sections (image byte 0 <-> rom_base)
+  uint32_t rom_base = 0xFFFFFFFFU;
+  if (text_size   && text_lma   < rom_base) rom_base = text_lma;
+  if (rodata_size && rodata_lma < rom_base) rom_base = rodata_lma;
+  if (data_size   && data_lma   < rom_base) rom_base = data_lma;
+  if (rom_base == 0xFFFFFFFFU) rom_base = 0;
+
+  uint32_t text_off   = text_size   ? (text_lma   - rom_base) : 0;
+  uint32_t rodata_off = rodata_size ? (rodata_lma - rom_base) : 0;
+  uint32_t data_off   = data_size   ? (data_lma   - rom_base) : 0;
+
+  // image size spans the highest section end relative to rom_base
+  uint32_t img_end = 0;
+  if (text_size   && text_off   + text_size   > img_end) img_end = text_off   + text_size;
+  if (rodata_size && rodata_off + rodata_size > img_end) img_end = rodata_off + rodata_size;
+  if (data_size   && data_off   + data_size   > img_end) img_end = data_off   + data_size;
+  raw_exe_size = (unsigned int)img_end;
+
   if (raw_exe_size == 0) {// input file empty?
     printf("[ERROR] Image is empty!\n");
+    free(phdrs);
     return -2;
   }
   if ((raw_exe_size % 4) != 0) {
     printf("[WARNING] Image size is not a multiple of 4 bytes!\n");
+  }
+
+  // report any alignment gap (zero-filled) so silent regressions are visible
+  if (text_size && rodata_size && rodata_off > text_off + text_size) {
+    printf("[INFO] %u-byte LMA gap before .rodata (zero-filled)\n",
+           (unsigned)(rodata_off - (text_off + text_size)));
+  }
+  if (rodata_size && data_size && data_off > rodata_off + rodata_size) {
+    printf("[INFO] %u-byte LMA gap before .data (zero-filled)\n",
+           (unsigned)(data_off - (rodata_off + rodata_size)));
   }
 
   // make sure memory array is a power of two
@@ -246,16 +320,18 @@ int main(int argc, char *argv[]) {
     ext_exe_size *= 2;
   }
 
-  // construct raw image
-  uint8_t *raw_image = malloc(raw_exe_size);
+  // construct raw image (zero-fill ensures inter-section gaps are defined)
+  uint8_t *raw_image = calloc(raw_exe_size, 1);
   uint32_t *raw_image32 = (uint32_t *)raw_image;
   if (!raw_image) {
-    printf("[ERROR] malloc failed!\n");
+    printf("[ERROR] calloc failed!\n");
+    free(phdrs);
     return -1;
   }
-  memcpy(raw_image,                           text,   text_size);   // start with .text
-  memcpy(raw_image + text_size,               rodata, rodata_size); // append .rodata
-  memcpy(raw_image + text_size + rodata_size, data,   data_size);   // append .data
+  if (text)   memcpy(raw_image + text_off,   text,   text_size);
+  if (rodata) memcpy(raw_image + rodata_off, rodata, rodata_size);
+  if (data)   memcpy(raw_image + data_off,   data,   data_size);
+  free(phdrs);
 
   // --------------------------------------------------------------------------
   // executable for bootloader upload (including header)


### PR DESCRIPTION
Identified and squashed an ugly silent-corruption bug: the image generator was concatenating ELF sections by size and silently dropping the alignment padding the linker inserts between `.text` and `.rodata`, shifting every byte after the gap by −N in ROM and corrupting boot.

## Summary

`sw/image_gen/image_gen.c` builds the IMEM/BOOTROM image by raw concatenation of the ELF's `.text`, `.rodata`, and `.data` sections using each section's *size*, ignoring each section's *LMA*. If the linker inserts alignment padding between sections, that padding is silently dropped from the image and every byte after the gap is shifted by −N. The CPU then reads `.rodata` at the wrong offset; `crt0`'s `.data` copy pulls the wrong bytes from `LOADADDR(.data)`; newlib's `_impure_ptr` and the malloc heap metadata get corrupted; boot dies in an RTE access fault.

The offending lines on `main` are:

```c
memcpy(raw_image,                           text,   text_size);   // start with .text
memcpy(raw_image + text_size,               rodata, rodata_size); // append .rodata
memcpy(raw_image + text_size + rodata_size, data,   data_size);   // append .data
```

## Trigger condition

`.rodata`'s required alignment > `.text`'s end alignment.

The default linker script (`sw/common/neorv32.ld`) declares `.rodata : ALIGN(4)`, but the output section's actual alignment is `max(ALIGN(4), max(input section alignment))`. So as soon as the wildcard `*(.rodata .rodata* .rodata.* ...)` pulls in a `.rodata.cst8` input section (8-byte alignment) — which happens with:

- any `double` constant in code,
- `printf`/`scanf` with `%f`/`%lf` (newlib's float format tables are 8-byte aligned),
- merged `.rodata.cst8` constants,

…and `.text` happens to end at a 4-byte-but-not-8-byte boundary, the linker inserts 4 bytes of padding and the bug fires. Whether you hit it depends on `.text`'s size parity, so two compiles of "almost the same" program can behave differently — which is exactly why it's so nasty. Simple bare-metal blinkies that never touch float printf will likely never trip it; anything pulling in newlib heap/stdio is at risk.

## Fix

Walk the ELF program headers, resolve each section's LMA via `p_paddr + (sh_addr - p_vaddr)`, and lay sections out in a zero-filled image at their LMA offsets. `.text`/`.rodata`/`.data` `sh_addr` fall through PT_LOAD lookup; if no PT_LOAD covers a section the LMA defaults to its VMA. A diagnostic prints the gap size when one is detected so silent regressions surface at image-gen time.

Behaviour is byte-identical to the old generator when no gap exists.

## Test plan

- [x] Build a program that does *not* pull in `.rodata.cst8` (e.g. `sw/example/demo_blink_led`) — image must be byte-identical to pre-fix output.
- [x] Build a program that *does* pull in `.rodata.cst8` (any newlib float printf, or a TU containing a `double` constant). Pre-fix: silent corruption / RTE fault on boot. Post-fix: clean boot, and the gap diagnostic prints at image-gen time.
- [x] CI sanity (existing image-gen invocations across the standard examples should be unaffected).