### PR TITLE
Two write-back D-cache correctness fixes (fence.i + AMO bypass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 29.04.2026 | 1.13.0.1 | rework cache handling of atomic memory operations: enforce memory synchronization by hardware | [#1540](https://github.com/stnolting/neorv32/pull/1540) |
 | 27.04.2026 | [**1.13.0**](https://github.com/stnolting/neorv32/releases/tag/v1.13.0) | :rocket: **New release** | |
 | 25.04.2026 | 1.12.9.9 | `C` ISA extension: decompressor cleanups and logic optimizations (dead code elimination) | [#1537](https://github.com/stnolting/neorv32/pull/1537) |
 | 24.04.2026 | 1.12.9.8 | minor rtl (corner case) fixes and logic optimizations | [#1534](https://github.com/stnolting/neorv32/pull/1534) |

--- a/docs/datasheet/cpu_isa.adoc
+++ b/docs/datasheet/cpu_isa.adoc
@@ -290,9 +290,11 @@ Example: `MARCH=rv32imc_zca_zcb_...`
 
 ==== `Zifencei` ISA Extension
 
-This instruction is the only standard mechanism to ensure that stores visible to a hart will also be visible to its
-instruction fetches. When executed, the CPU flushes the instruction prefetch buffer and reloads the CPU's
-instruction cache (if enabled). See section <<_memory_coherence>> for more information.
+This instruction is the only standard mechanism to ensure that stores visible to a hart will also be visible to
+its instruction fetches. When executed, the CPU flushes the data cache (if enabled) to main memory, clears the
+instruction prefetch buffer and invalidates the instruction cache (if enabled). The next instruction fetch request
+from the CPU will result in an instruction cache miss that will return up-to-date data from main memory.
+See section <<_memory_coherence>> for more information.
 
 .Instructions and Timing
 [cols="<2,<5,<4"]

--- a/docs/datasheet/cpu_isa.adoc
+++ b/docs/datasheet/cpu_isa.adoc
@@ -101,14 +101,9 @@ extension is shorthand for the following set of other extensions:
 * <<_zaamo_isa_extension>> - Atomic read-modify-write instructions.
 * <<_zalrsc_isa_extension>> - Atomic reservation-set instructions.
 
-.Atomic Variable in C Languages
-[NOTE]
-The C `_Atomic` specifier should be used for atomic variables.
-See section <<_coherence_example>> for more information.
-
 .`A` ISA Extension Exceptions
 [NOTE]
-Note that load and load-reserved instructions generate load exceptions,
+Note that according to the RISC-V spec. load and load-reservate instructions generate load exceptions,
 whereas store, store-conditional, and AMO instructions generate store exceptions.
 
 
@@ -242,6 +237,9 @@ are handled by the processor's <<_atomic_memory_operations_controller>>.
 .`aq` and `rl` Bits
 [NOTE]
 The instruction word's `aq` and `lr` memory ordering bits are not evaluated by the hardware at all.
+However, the CPU and especially the <<_data_cache_dcache>> treats all atomic memory operation as if
+the `aq` and `lr` bits were set (for the targeted address). See <<_memory_coherence>> for more
+information.
 
 
 ==== `Zalrsc` ISA Extension
@@ -262,6 +260,9 @@ are handled by the processor's <<_atomic_reservation_set_controller>>.
 .`aq` and `rl` Bits
 [NOTE]
 The instruction word's `aq` and `lr` memory ordering bits are not evaluated by the hardware at all.
+However, the CPU and especially the <<_data_cache_dcache>> treats all atomic memory operation as if
+the `aq` and `lr` bits were set (for the targeted address). See <<_memory_coherence>> for more
+information.
 
 
 ==== `Zcb` ISA Extension

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -652,7 +652,7 @@ that are executed by processor-external agents.
 :sectnums:
 ==== Memory Coherence
 
-Depending on the configuration, the NEORV32 memory hierarchy consists of several levels.
+Depending on the configuration, the NEORV32 memory hierarchy provides several levels/layers of memory.
 
 [start=1]
 . The CPU execution pipeline and its _instruction prefetch buffer_ (<<_cpu_front_end>>)
@@ -666,12 +666,12 @@ and especially cache synchronization is **not** performed automatically by the h
 is no snooping implemented. NEORV32 supports two RISC-V memory ordering instructions that are used for
 manual memory synchronization:
 
-* `fence.i` (<<_zifencei_isa_extension>>): Clear the CPU's instruction prefetch buffer
-and the CPU's instruction cache. The next cache access therefore results
-in a miss that fetches up-to-date data from main memory.
 * `fence` (<<_i_isa_extension>> / <<_e_isa_extension>>): Flush the CPU's data cache: Modified ("dirty")
 blocks are copied back to main memory; all clean blocks are invalidated so that the next CPU access to
 any block results in a cache miss that reloads the cache with up-to-date data from main memory.
+* `fence.i` (<<_zifencei_isa_extension>>): Perform the same operations as `fence` (i.e. flushing the data
+cache), but also clear the CPU's instruction prefetch buffer and instruction cache. The next instruction
+cache access therefore results in a miss that fetches up-to-date data from main memory.
 
 .Weak Coherence Model
 [IMPORTANT]

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -659,7 +659,7 @@ Depending on the configuration, the NEORV32 memory hierarchy provides several le
 . The optional <<_data_cache_dcache>> and <<_instruction_cache_icache>>
 . Processor-internal and processor-external memories (depending on setup configuration)
 
-Memory accesses are initiated exclusively by the CPU or the <<_direct_memory_access_controller_dma>>.
+NEORV32 can feature up to three bus hosts: up to two CPU cores and the <<_direct_memory_access_controller_dma>>.
 Since the levels of the memory hierarchy are transparent to the software, special care must be taken
 to ensure memory coherence is maintained throughout the entire system/application. Note that coherence
 and especially cache synchronization is **not** performed automatically by the hardware itself as there
@@ -680,43 +680,18 @@ coherence model. A core's `fence` just orders all memory accesses towards main m
 visible by other agents (the secondary CPU core, the DMA, processor-external modules) if these agents also
 synchronize (e.g. reload) their cache(s).
 
-===== Coherence Example
+Atomic memory accesses also require special attention. All atomic memory accesses bypass the CPU caches.
+However, in this case, the caches explicitly ensure memory coherence. If the address of an atomic memory
+access is cached, the corresponding line is first written back to main memory if it has been modified.
+Afterward, the corresponding line is invalidated, and the atomic access is executed as a cache bypass.
+The next access to the atomic address bypasses the cache if it is again an atomic memory operation.
+Normal memory accesses result in a cache miss (since the corresponding line was automatically invalidated
+previously), so that the cache is reloaded with current data from main memory.
 
-The following C example shows how to declare and use an atomic variable using the`_Atomic` specifier:
-
-.Atomic Variables - C Source Code
-[source, c]
-----
-_Atomic int counter = 0;
-
-counter = 3;
-counter++;
-----
-
-.Atomic Variables - According RISC-V Assembly Code
-[source, assembly]
-----
-li a3,3
-li a4,1
-
-fence rw,w
-sw    a3,0(a2)
-fence rw,rw
-
-amoadd.w.aqrl zero,a4,(a2)
-----
-
-The initial assignment `counter = 0` is translated into a store-word instruction (`sw`) that is
-automatically encapsulated within two `fence` instructions. This guarantees memory coherence as each
-`fence` will synchronize the CPU's data cache with upstream/main memory.
-
-The counter increment (`counter++`) is implemented as RISC-V atomic memory operation (`amoadd`). However, the
-compiler does not encapsulate this in within FENCE instructions. Hence, the altered atomic variable
-is **not** updated in the CPU's data cache (but in upstream/main memory).
-
-The above example clearly shows that special attention must be paid to memory coherence when using
-atomic memory operations.
-
+.C-Language `_Atomic` Variables
+[NOTE]
+Using plain `_Atomic` access (e.g., `_Atomic int counter = 0;`) defaults to GCC's `memory_order_seq_cst`
+buildin, which inserts fence instructions _before_ and _after_ the access. This is the safest but slowest option.
 
 <<<
 // ####################################################################################################################

--- a/docs/datasheet/soc_dcache.adoc
+++ b/docs/datasheet/soc_dcache.adoc
@@ -59,8 +59,12 @@ that can be accessed by the cache must also be able to process bursts (including
 
 The cache provides direct/uncached accesses (bypassing the cache) in order to access memory-mapped IO like
 the processor-internal IO/peripheral modules. All accesses that target the address range from `0xF0000000`
-to `0xFFFFFFFF` will bypass the cache. See section <<_address_space>> for more information. Furthermore, atomic
-memory operations  will always **bypass** the cache.
+to `0xFFFFFFFF` will bypass the cache. See section <<_address_space>> for more information.
+
+All atomic memory accesses also bypass the cache; however, in this case, the cache explicitly ensures
+<<_memory_coherence>>: if the address of an atomic memory access is cached, the corresponding line is
+first written back to main memory if it has been modified. The corresponding line is then invalidated,
+and the atomic access is finally executed as a cache-bypassing access.
 
 **Cache Synchronization and Memory Coherence**
 

--- a/docs/datasheet/soc_icache.adoc
+++ b/docs/datasheet/soc_icache.adoc
@@ -57,8 +57,12 @@ that can be accessed by the cache must also be able to process bursts (including
 
 The cache provides direct/uncached accesses (bypassing the cache) in order to access memory-mapped IO like
 the processor-internal IO/peripheral modules. All accesses that target the address range from `0xF0000000`
-to `0xFFFFFFFF` will bypass the cache. See section <<_address_space>> for more information. Furthermore, atomic
-memory operations  will always **bypass** the cache.
+to `0xFFFFFFFF` will bypass the cache. See section <<_address_space>> for more information.
+
+All atomic memory accesses also bypass the cache; however, in this case, the cache explicitly ensures
+<<_memory_coherence>>: if the address of an atomic memory access is cached, the corresponding line is
+first written back to main memory if it has been modified. The corresponding line is then invalidated,
+and the atomic access is finally executed as a cache-bypassing access.
 
 **Cache Synchronization and Memory Coherence**
 

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -219,23 +219,16 @@ begin
         ctrl_nxt.bp_req  <= '1'; -- in case we are doing a bypass request (set STB for one cycle)
         --
         if (ctrl.pnd_bp = '1') then -- cache bypass (uncached or atomic memory operation)
-          -- Coherence with write-back D-cache: an AMO that bypasses the cache
-          -- must NOT see stale memory if the same line is dirty in this cache,
-          -- and must NOT leave a stale (clean) copy behind after the AMO writes
-          -- memory. Three cases:
-          --   * cache HIT, dirty       -> write-back the line first, invalidate,
-          --                               then bypass (S_WRITE_START -> S_WRITE_DONE
-          --                               -> S_BYPASS, see S_WRITE_DONE handling)
-          --   * cache HIT, clean       -> just invalidate inline, then bypass
-          --   * cache MISS             -> direct bypass (no cache state to fix)
-          if (cache_i.hit = '1') and (cache_i.drt = '1') and (READ_ONLY = false) then
-            ctrl_nxt.state <= S_WRITE_START; -- pnd_bp stays via the sticky default
-          else
-            if (cache_i.hit = '1') and (READ_ONLY = false) then
-              cache_o.set <= '1'; -- invalidate the cached copy so post-AMO reads refill from memory
-              cache_o.vld <= '0';
+          if (cache_i.hit = '1') then -- do we have a cached copy of the accessed address (#1540)?
+            if (cache_i.drt = '1') and (READ_ONLY = false) then
+              ctrl_nxt.state <= S_WRITE_START; -- copy modified line to main memory
+            else
+              cache_o.vld    <= '0'; -- invalidate the cached copy so post-BYPASS reads refill from memory
+              cache_o.set    <= '1';
+              ctrl_nxt.state <= S_BYPASS;
             end if;
-            ctrl_nxt.state <= S_BYPASS; -- pnd_bp will be cleared in S_BYPASS on ACK
+          else
+            ctrl_nxt.state <= S_BYPASS;
           end if;
         elsif (cache_i.hit = '1') then -- cache HIT: read/write from/to cache
           if (host_req_i.rw = '1') and (READ_ONLY = false) then -- modify cache

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -160,7 +160,13 @@ begin
     ctrl_nxt.bus_err <= ctrl.bus_err;
     ctrl_nxt.pnd_req <= ctrl.pnd_req or host_req_i.stb;
     ctrl_nxt.pnd_syn <= ctrl.pnd_syn or host_req_i.fence;
-    ctrl_nxt.pnd_bp  <= '0';
+    -- pnd_bp is sticky during the write-back detour from S_CHECK -> S_WRITE_*
+    -- -> S_BYPASS so the bypass survives the flush, but we forcibly clear it
+    -- whenever the FSM is back in S_IDLE so any error/early-terminate path
+    -- (e.g. S_WRITE_DONE bus_err -> S_IDLE) cannot leak a stale '1' into the
+    -- next request. S_IDLE itself sets pnd_bp <= '1' explicitly when the new
+    -- request is uncached/AMO, so this default is safe there too.
+    ctrl_nxt.pnd_bp  <= '0' when (ctrl.state = S_IDLE) else ctrl.pnd_bp;
     ctrl_nxt.bp_req  <= '0';
     ctrl_nxt.hit     <= '0';
     ctrl_nxt.cln     <= '0';
@@ -217,8 +223,25 @@ begin
         ctrl_nxt.pnd_req <= '0'; -- access request accepted
         ctrl_nxt.bp_req  <= '1'; -- in case we are doing a bypass request (set STB for one cycle)
         --
-        if (ctrl.pnd_bp = '1') then -- cache bypass
-          ctrl_nxt.state <= S_BYPASS;
+        if (ctrl.pnd_bp = '1') then -- cache bypass (uncached or atomic memory operation)
+          -- Coherence with write-back D-cache: an AMO that bypasses the cache
+          -- must NOT see stale memory if the same line is dirty in this cache,
+          -- and must NOT leave a stale (clean) copy behind after the AMO writes
+          -- memory. Three cases:
+          --   * cache HIT, dirty       -> write-back the line first, invalidate,
+          --                               then bypass (S_WRITE_START -> S_WRITE_DONE
+          --                               -> S_BYPASS, see S_WRITE_DONE handling)
+          --   * cache HIT, clean       -> just invalidate inline, then bypass
+          --   * cache MISS             -> direct bypass (no cache state to fix)
+          if (cache_i.hit = '1') and (cache_i.drt = '1') and (READ_ONLY = false) then
+            ctrl_nxt.state <= S_WRITE_START; -- pnd_bp stays via the sticky default
+          else
+            if (cache_i.hit = '1') and (READ_ONLY = false) then
+              cache_o.set <= '1'; -- invalidate the cached copy so post-AMO reads refill from memory
+              cache_o.vld <= '0';
+            end if;
+            ctrl_nxt.state <= S_BYPASS; -- pnd_bp will be cleared in S_BYPASS on ACK
+          end if;
         elsif (cache_i.hit = '1') then -- cache HIT: read/write from/to cache
           if (host_req_i.rw = '1') and (READ_ONLY = false) then -- modify cache
             cache_o.we  <= host_req_i.ben;
@@ -238,7 +261,8 @@ begin
         bus_req_o.stb <= ctrl.bp_req; -- one-shot
         host_rsp_o    <= bus_rsp_i;
         if (bus_rsp_i.ack = '1') then
-          ctrl_nxt.state <= S_IDLE;
+          ctrl_nxt.pnd_bp <= '0'; -- clear sticky bypass flag now that the bypass completed
+          ctrl_nxt.state  <= S_IDLE;
         end if;
 
       -- ==========================================================================
@@ -467,12 +491,18 @@ begin
           ctrl_nxt.cln <= '1'; -- force cache clean to skip status flag read latency (for S_CHECK only)
           if (ctrl.sync = '1') then -- block upload caused by cache synchronization
             ctrl_nxt.state <= S_SYNC_NEXT;
-          elsif (ctrl.bus_err = '1') then -- block upload caused by cache miss: BUS ERROR during upload
-            cache_o.set    <= '1'; -- update cache block status
-            cache_o.vld    <= '0'; -- invalidate cache block
-            host_rsp_o.err <= '1';
-            host_rsp_o.ack <= '1'; -- terminate current request and return bus error
-            ctrl_nxt.state <= S_IDLE;
+          elsif (ctrl.bus_err = '1') then -- block upload caused by cache miss or AMO pre-flush: BUS ERROR during upload
+            cache_o.set     <= '1'; -- update cache block status
+            cache_o.vld     <= '0'; -- invalidate cache block
+            host_rsp_o.err  <= '1';
+            host_rsp_o.ack  <= '1'; -- terminate current request and return bus error
+            ctrl_nxt.pnd_bp <= '0'; -- if this writeback was an AMO pre-flush, drop the now-aborted bypass too
+            ctrl_nxt.state  <= S_IDLE;
+          elsif (ctrl.pnd_bp = '1') then -- write-back was for an AMO/uncached pre-flush: invalidate then bypass
+            cache_o.set     <= '1';
+            cache_o.vld     <= '0'; -- invalidate so subsequent cache hits don't return pre-AMO data
+            ctrl_nxt.bp_req <= '1'; -- re-arm one-shot STB for the now-pending bypass
+            ctrl_nxt.state  <= S_BYPASS;
           else -- block upload caused by cache miss: block upload successful
             cache_o.set    <= '1'; -- update cache block status
             cache_o.drt    <= '0'; -- cache block is clean now

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -256,7 +256,6 @@ begin
         bus_req_o.stb <= ctrl.bp_req; -- one-shot
         host_rsp_o    <= bus_rsp_i;
         if (bus_rsp_i.ack = '1') then
-          ctrl_nxt.pnd_bp <= '0'; -- clear sticky bypass flag now that the bypass completed
           ctrl_nxt.state  <= S_IDLE;
         end if;
 
@@ -487,12 +486,11 @@ begin
           if (ctrl.sync = '1') then -- block upload caused by cache synchronization
             ctrl_nxt.state <= S_SYNC_NEXT;
           elsif (ctrl.bus_err = '1') then -- block upload caused by cache miss or AMO pre-flush: BUS ERROR during upload
-            cache_o.set     <= '1'; -- update cache block status
-            cache_o.vld     <= '0'; -- invalidate cache block
-            host_rsp_o.err  <= '1';
-            host_rsp_o.ack  <= '1'; -- terminate current request and return bus error
-            ctrl_nxt.pnd_bp <= '0'; -- if this writeback was an AMO pre-flush, drop the now-aborted bypass too
-            ctrl_nxt.state  <= S_IDLE;
+            cache_o.set    <= '1'; -- update cache block status
+            cache_o.vld    <= '0'; -- invalidate cache block
+            host_rsp_o.err <= '1';
+            host_rsp_o.ack <= '1'; -- terminate current request and return bus error
+            ctrl_nxt.state <= S_IDLE;
           elsif (ctrl.pnd_bp = '1') then -- write-back was for an AMO/uncached pre-flush: invalidate then bypass
             cache_o.set     <= '1';
             cache_o.vld     <= '0'; -- invalidate so subsequent cache hits don't return pre-AMO data

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -160,13 +160,7 @@ begin
     ctrl_nxt.bus_err <= ctrl.bus_err;
     ctrl_nxt.pnd_req <= ctrl.pnd_req or host_req_i.stb;
     ctrl_nxt.pnd_syn <= ctrl.pnd_syn or host_req_i.fence;
-    -- pnd_bp is sticky during the write-back detour from S_CHECK -> S_WRITE_*
-    -- -> S_BYPASS so the bypass survives the flush, but we forcibly clear it
-    -- whenever the FSM is back in S_IDLE so any error/early-terminate path
-    -- (e.g. S_WRITE_DONE bus_err -> S_IDLE) cannot leak a stale '1' into the
-    -- next request. S_IDLE itself sets pnd_bp <= '1' explicitly when the new
-    -- request is uncached/AMO, so this default is safe there too.
-    ctrl_nxt.pnd_bp  <= '0' when (ctrl.state = S_IDLE) else ctrl.pnd_bp;
+    ctrl_nxt.pnd_bp  <= ctrl.pnd_bp;
     ctrl_nxt.bp_req  <= '0';
     ctrl_nxt.hit     <= '0';
     ctrl_nxt.cln     <= '0';
@@ -205,6 +199,7 @@ begin
       -- ------------------------------------------------------------
         ctrl_nxt.bus_err <= '0'; -- reset bus error flag
         ctrl_nxt.sync    <= '0'; -- reset sync-in-progress flag
+        ctrl_nxt.pnd_bp  <= '0'; -- default: no bypass request
         if (ctrl.pnd_syn = '1') then -- pending sync request: invalidate clean blocks & write-back dirty blocks
           ctrl_nxt.state <= S_SYNC_START;
         elsif (host_req_i.stb = '1') or (ctrl.pnd_req = '1') then -- (pending) access request

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -6,10 +6,10 @@
 -- transfers are split into individual single-word transfers. Total cache size in   --
 -- bytes is NUM_BLOCKS x BLOCK_SIZE.                                                --
 --                                                                                  --
--- Access types that will *bypass* the cache:                                       --
--- * any atomic memory operation                                                    --
--- * accesses to the explicit "uncached address space page" (or higher),            --
---   which is defined by the 4 most significant address bits (UC_BEGIN)             --
+-- Handling of (uncached) AMO operations (#1540):                                   --
+-- * AMO cache miss            -> directly execute bypass                           --
+-- * AMO cache hit, line clean -> invalidate line, execute bypass                   --
+-- * AMO cache hit, line dirty -> write back line, invalidate line, execute bypass  --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -484,12 +484,7 @@ begin
             host_rsp_o.err <= '1';
             host_rsp_o.ack <= '1'; -- terminate current request and return bus error
             ctrl_nxt.state <= S_IDLE;
-          elsif (ctrl.pnd_bp = '1') then -- write-back was for an AMO/uncached pre-flush: invalidate then bypass
-            cache_o.set     <= '1';
-            cache_o.vld     <= '0'; -- invalidate so subsequent cache hits don't return pre-AMO data
-            ctrl_nxt.bp_req <= '1'; -- re-arm one-shot STB for the now-pending bypass
-            ctrl_nxt.state  <= S_BYPASS;
-          else -- block upload caused by cache miss: block upload successful
+          else -- block upload caused by cache miss or AMO pre-flush: upload successful
             cache_o.set    <= '1'; -- update cache block status
             cache_o.drt    <= '0'; -- cache block is clean now
             cache_o.vld    <= '1'; -- cache block is still valid

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -386,12 +386,7 @@ begin
 
           -- memory fence operations --
           when opcode_fence_c =>
-            -- RISC-V: fence.i must make prior stores visible to subsequent
-            -- instruction fetches. With a write-back D-cache that means
-            -- fence.i has to drain the D-cache too, not just invalidate the
-            -- I-cache. Always assert lsu_fence so both `fence` and `fence.i`
-            -- flush the D-cache; only `fence.i` additionally invalidates I.
-            ctrl_nxt.lsu_fence <= '1'; -- data fence (fence and fence.i)
+            ctrl_nxt.lsu_fence <= '1'; -- data fence (fence and fence.i); flush $D so $I gets updated data; #1540
             ctrl_nxt.if_fence  <= exec.ir(instr_funct3_lsb_c); -- instruction fence (fence.i only)
             exec_nxt.state     <= S_RESTART; -- reset instruction fetch & IPB via branch to next-PC (actually only required for fence.i)
 

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -386,8 +386,13 @@ begin
 
           -- memory fence operations --
           when opcode_fence_c =>
-            ctrl_nxt.lsu_fence <= not exec.ir(instr_funct3_lsb_c); -- data fence
-            ctrl_nxt.if_fence  <= exec.ir(instr_funct3_lsb_c); -- instruction fence
+            -- RISC-V: fence.i must make prior stores visible to subsequent
+            -- instruction fetches. With a write-back D-cache that means
+            -- fence.i has to drain the D-cache too, not just invalidate the
+            -- I-cache. Always assert lsu_fence so both `fence` and `fence.i`
+            -- flush the D-cache; only `fence.i` additionally invalidates I.
+            ctrl_nxt.lsu_fence <= '1'; -- data fence (fence and fence.i)
+            ctrl_nxt.if_fence  <= exec.ir(instr_funct3_lsb_c); -- instruction fence (fence.i only)
             exec_nxt.state     <= S_RESTART; -- reset instruction fetch & IPB via branch to next-PC (actually only required for fence.i)
 
           -- FPU: floating-point operations --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130000"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130001"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -2168,13 +2168,11 @@ int main() {
     cnt_test++;
 
     amo_var = 0x00cafe00; // initialize
-    asm volatile ("fence"); // flush/reload d-cache
 
     tmp_a = neorv32_cpu_amolr((uint32_t)&amo_var);
     tmp_b = neorv32_cpu_amosc((uint32_t)&amo_var, 0x12345678); // must succeed returning all-zero
     tmp_b = (tmp_b << 1) | (neorv32_cpu_amosc((uint32_t)&amo_var, 0xffffffff) & 1); // another SC: must fail
     tmp_b = (tmp_b << 1) | (neorv32_cpu_amosc((uint32_t)ADDR_UNREACHABLE, 0) & 1); // another SC: must fail; no bus exception
-    asm volatile ("fence"); // flush/reload d-cache
 
     if ((tmp_a   == 0x00cafe00) && // correct LR.W result
         (amo_var == 0x12345678) && // atomic variable NOT updates by SC.W
@@ -2201,12 +2199,10 @@ int main() {
     cnt_test++;
 
     amo_var = 0xcafe1234; // initialize
-    asm volatile ("fence"); // flush/reload d-cache
 
     tmp_a = trap_cnt + 1; // we expect only a single exception here
     tmp_b = neorv32_cpu_amoadd((uint32_t)&amo_var, 0x00001234); // modify data
     neorv32_cpu_amoadd(((uint32_t)&amo_var)+1, 0x00001234); // cause an AMO alignment exception
-    asm volatile ("fence"); // flush/reload d-cache
 
     if ((tmp_a      == trap_cnt)               && // we had only a single exception
         (trap_cause == TRAP_CODE_S_MISALIGNED) && // store exception due to unaligned address of second AMO


### PR DESCRIPTION
Two coherence bugs in the cache architecture introduced by #1513
(write-back & write-allocate). Found while bumping the `neorv32`
submodule in [see_neorv32_run_linux](https://github.com/14sea/see_neorv32_run_linux)
from `v1.12.9` to `origin/main` for an FPGA Linux boot.

The bugs are independent and small. Squashed into one PR because they
both stem from the same write-back-vs-bypass interaction and neither
boots Linux without the other; happy to split into two PRs if preferred.

---

## 1. `fence.i` must drain the D-cache (Zifencei)

**File:** `rtl/core/neorv32_cpu_control.vhd`, `opcode_fence_c` decode.

Zifencei requires that prior stores to instruction memory are made
visible to subsequent instruction fetches. The current decode asserts
`if_fence` (I-cache invalidate) but **not** `lsu_fence` (D-cache drain)
for `fence.i`:

```vhdl
when opcode_fence_c =>
  ctrl_nxt.lsu_fence <= not exec.ir(instr_funct3_lsb_c);  -- '0' for fence.i
  ctrl_nxt.if_fence  <=     exec.ir(instr_funct3_lsb_c);
```

Pre-#1513 this was harmless (write-through cache, no dirty lines).
Post-#1513 dirty stores can sit in the D-cache indefinitely, so the
I-cache refill reads stale memory and the CPU executes garbage.

### Bisect

`git bisect` between `v1.12.9` (good) and `origin/main` (bad) on a
write-then-jump-to-RAM testcase identifies `f774dac6 [cache] first
draft of write-back architecture` as the first bad commit. The bus
reservation logic, CPU control, and LSU are byte-identical across the
bisect window — only the cache write policy changed.

### Reproducer

1. Build a NEORV32 SoC with `ICACHE_EN=true`, `DCACHE_EN=true`,
   write-back cache (current default), and external memory via XBUS.
2. From software running in IMEM/local memory: write a few RV32
   instructions to a cached external-RAM address, issue `fence.i`,
   `jalr` to that address.
3. CPU hangs on the first I-fetch from external RAM.

Disabling D-cache makes the test pass — confirms the dirty stores
never reach memory before the I-cache refills.

### Fix

Always assert `lsu_fence` for `opcode_fence_c`; leave `if_fence` gated
on `funct3 LSB` so plain `fence` still does not bother I.

```vhdl
when opcode_fence_c =>
  ctrl_nxt.lsu_fence <= '1';                            -- always drain D
  ctrl_nxt.if_fence  <= exec.ir(instr_funct3_lsb_c);    -- only fence.i invalidates I
```

One-line cost; no FF/LE change.

---

## 2. AMO/uncached bypass must coordinate with dirty cache lines

**File:** `rtl/core/neorv32_cache.vhd`, `S_CHECK` / `S_BYPASS` /
`S_WRITE_DONE`.

AMO and uncached requests bypass the cache (`pnd_bp = 1` ->
`S_BYPASS`). With a write-back D-cache that breaks coherence in two
directions:

1. **Bypass-read sees stale memory.** A regular store can leave the
   target word dirty in the cache; the AMO bypass reads memory and
   gets the pre-store value.
2. **Cache holds stale value after bypass-write.** The AMO bypass
   writes memory; the cache still holds the pre-AMO value, so a later
   plain load returns it.

Linux exercises this on every spinlock / atomic / rwsem update.
Without the fix the kernel hits `bad: scheduling from the idle thread!`
loops and lock deadlocks during early boot; with D-cache disabled the
same kernel boots cleanly.

### Fix

Before falling through to `S_BYPASS` from `S_CHECK`, look at the cache
line at the same index:

| State                | Action                                                                         |
| -------------------- | ------------------------------------------------------------------------------ |
| HIT, dirty           | Write the line back (`S_WRITE_START` -> `S_WRITE_DONE`), invalidate, then bypass. |
| HIT, clean           | Invalidate the line inline, then bypass. (Memory is already current.)          |
| MISS                 | Bypass directly. (No cache state to repair.)                                   |

`pnd_bp` becomes a sticky flag (default `<= ctrl.pnd_bp` instead of
`<= '0'`) so it survives the write-back detour, and is cleared in
`S_BYPASS` on ACK. `S_WRITE_DONE` gains an `elsif (ctrl.pnd_bp = '1')`
branch that invalidates the line and re-arms the bypass.

`READ_ONLY=true` (I-cache) is untouched: there is no bypass-write case
to fix, and the I-cache never has dirty lines to write back.

### Cost

A handful of LE for the new `S_WRITE_DONE -> S_BYPASS` transition and
one extra mux on `pnd_bp`. No new RAM, no new ports.

---

## Validation

- Both patches apply cleanly on top of current `origin/main` HEAD
  (`e0739e63`); branch synthesizes for Cyclone-IV EP4CE6 with `0`
  errors / standard warnings only.
- The full diff (these two fixes plus a kernel-side LR/SC reservation
  fix and `DCACHE_EN=false` workaround for a separate non-burst-SDRAM
  performance issue) lets Linux 6.6.83 boot to a userspace shell on a
  Cyclone-IV EP4CE6 FPGA in ~36 s wall time.
- Tested on a Heijin AX301 board (50 MHz, 32 MB SDRAM, non-burst
  controller).

Both commits include detailed commit messages with bisect / repro /
fix structure for direct cherry-picking.