### PR TITLE
[rtl] minor fixes, edits and cleanups (PMP, TWD, bus)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ build/
 !rtl/core/*_image.vhd
 
 # logs and dumps
-*.gdb_history
+*.gdb*
 *.log
 *.vcd
 *.fst

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 02.05.2026 | 1.13.0.3 | minor rtl fixes, edits and cleanups (PMP, TWD, bus | [#1543](https://github.com/stnolting/neorv32/pull/1543) |
 | 01.05.2026 | 1.13.0.2 | :warning: rework trap CSRs: remove `mtinst`; make `mtval` more verbose; add full WARL access for `mcause` and `mtval` | [#1524](https://github.com/stnolting/neorv32/pull/1542) |
 | 29.04.2026 | 1.13.0.1 | rework cache handling of atomic memory operations: enforce memory synchronization by hardware | [#1540](https://github.com/stnolting/neorv32/pull/1540) |
 | 27.04.2026 | [**1.13.0**](https://github.com/stnolting/neorv32/releases/tag/v1.13.0) | :rocket: **New release** | |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -722,7 +722,7 @@ columns show the value being written to the according CSRs when a trap is encoun
 [options="header",grid="rows"]
 |=======================
 | Priority | `mcause`     | RTE Trap ID              | Cause                             | `mepc` | `mtval`
-7+^| **Exceptions** (_synchronous_ to instruction execution)
+6+^| **Exceptions** (_synchronous_ to instruction execution)
 | highest  | `0x00000001` | `TRAP_CODE_I_ACCESS`     | illegal access fault              | PC     | 0
 |          | `0x00000002` | `TRAP_CODE_I_ILLEGAL`    | illegal instruction               | PC     | INST
 |          | `0x00000000` | `TRAP_CODE_I_MISALIGNED` | instruction address misaligned    | PC     | ADDR
@@ -733,7 +733,7 @@ columns show the value being written to the according CSRs when a trap is encoun
 |          | `0x00000004` | `TRAP_CODE_L_MISALIGNED` | load address misaligned           | PC     | ADDR
 |          | `0x00000007` | `TRAP_CODE_S_ACCESS`     | store access fault                | PC     | ADDR
 |          | `0x00000005` | `TRAP_CODE_L_ACCESS`     | load access fault                 | PC     | ADDR
-7+^| **Interrupts** (_asynchronous_ to instruction execution)
+6+^| **Interrupts** (_asynchronous_ to instruction execution)
 |          | `0x80000010` | `TRAP_CODE_FIRQ_0`       | fast interrupt request channel 0  | I-PC   | 0
 |          | `0x80000011` | `TRAP_CODE_FIRQ_1`       | fast interrupt request channel 1  | I-PC   | 0
 |          | `0x80000012` | `TRAP_CODE_FIRQ_2`       | fast interrupt request channel 2  | I-PC   | 0

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -29,11 +29,12 @@ RISC-V _User_ and _Privileged Architecture_ specifications.
 :sectnums:
 === CPU Top Entity - Signals
 
-The following table shows all interface signals of the CPU top entity `rtl/core/neorv32_cpu.vhd`. The
-type of all signals is _std_ulogic_ or _std_ulogic_vector_, respectively. The "Dir." column shows the signal
-direction as seen from the CPU.
+The following table shows all interface signals of the CPU top entity `rtl/core/neorv32_cpu.vhd`. All ports
+(except for the data/instruction bus interfaces) use _std_ulogic_ or _std_ulogic_vector_ types, respectively.
+The bus ports are wrapped as custom interface types (`bus_req_t` and `bus_rsp_t`). See section <<_bus_interface>>
+for the protocol and type documentation.
 
-.NEORV32 CPU Signal List
+.NEORV32 CPU Signal List (Dir = direction seen from the CPU)
 [cols="^2,^2,^1,<8"]
 [options="header", grid="rows"]
 |=======================
@@ -44,6 +45,7 @@ direction as seen from the CPU.
 4+^| **Status**
 | `trace_o`    | `trace_port_t` | out | <<_execution_trace_port>>.
 | `sleep_o`    | 1              | out | Set while the CPU is in <<_sleep_mode>>.
+| `fence_o`    | 2              | out | <<_memory_coherence>> / ordering: `[1]` = instruction fence, `[0]` = data fence.
 4+^| **Interrupts (<<_traps_exceptions_and_interrupts>>)**
 | `msi_i`      | 1              | in  | RISC-V machine software interrupt.
 | `mei_i`      | 1              | in  | RISC-V machine external interrupt.
@@ -57,11 +59,6 @@ direction as seen from the CPU.
 | `dbus_req_o` | `bus_req_t`    | out | Data access (load/store) bus request.
 | `dbus_rsp_i` | `bus_rsp_t`    | in  | Data access (load/store) bus response.
 |=======================
-
-.Bus Interface Protocol
-[TIP]
-See section <<_bus_interface>> for the instruction fetch and data access interface protocol and the
-according interface types (`bus_req_t` and `bus_rsp_t`).
 
 
 <<<

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -459,22 +459,12 @@ from a host to a device. These signals are driven by the request-issuing device 
 is used to return the bus response upstream from a device back to the host and is driven by the accessed device or bus system
 (i.e. a processor-internal memory or IO device).
 
-The signals of the request bus are split in to two categories: _in-band_ signals and _out-of-band_ signals. In-band
-signals always belong to a certain bus transaction and are valid between `stb` (request) being set and the according
-`err` or `ack` (response) being set. In contrast, the out-of-band signals are not associated with any bus transaction
-and are always valid when set.
-
-.Adding Register Stages
-[TIP]
-Arbitrary pipeline stages can be added to the request and response buses at any point to relax timing (at the cost of
-additional latency). However, _all_ bus signals (request and response) need to be registered.
-
-.Bus Interface - Request Bus (`bus_req_t`)
+.Bus Interface Signals
 [cols="^1,^1,<8"]
 [options="header",grid="rows"]
 |=======================
 | Signal  | Width | Description
-3+^| **In-Band Signals**
+3+^| **Request Bus (VHDL `bus_req_t` type)**
 | `meta`  |     5 | Access meta information. +
 `meta(4:3)`: core ID from the lowest two bits of the <<_mhartid>> CSR; the DMA has core ID `0b10` +
 `meta(2)`: set when CPU is in debug-mode +
@@ -483,25 +473,22 @@ additional latency). However, _all_ bus signals (request and response) need to b
 | `addr`  |    32 | Access address using byte-wise addressing. Half-word (16-bit) and word (32-bit) addresses are aligned accordingly (e.g. LSB = 0 for half-word accesses).
 | `data`  |    32 | Write data. Writing individual bytes is controlled via `ben`.
 | `ben`   |     4 | Byte-enable for each byte in `data`. This signal is used for the write-data as well as for the read-data.
-| `stb`   |     1 | Request trigger ("strobe"). This signal is high for exactly one cycle starting a bus request. All other _in-band_ signals are valid only if `stb` is set.
+| `stb`   |     1 | **Request trigger ("strobe")**. This signal is high for exactly one cycle triggering a bus request.
 | `rw`    |     1 | Access direction (`0` = read, `1` = write).
 | `amo`   |     1 | Set if current access is an atomic memory operation.
 | `amoop` |     4 | Actual type of atomic memory operation. Irrelevant if `amo` is not set.
 | `burst` |     1 | Set during a burst transaction (always set together with `lock`).
 | `lock`  |     1 | Set if locked access; allow exclusive access to the bus system.
-3+^| **Out-Of-Band Signals**
-| `fence` |     1 | Data (load/store; `fence`) or instruction (instruction-fetch; `fence.i`) fence request; single-shot; see <<_memory_coherence>>.
+3+^| **Response Bus (VHDL `bus_rsp_t` type)**
+| `ack`   |     1 | Transfer acknowledge, single-shot.
+| `err`   |     1 | Transfer error when set, valid if `ack = 1`.
+| `data`  |    32 | Read data, valid if `ack = 1`.
 |=======================
 
-.Bus Interface - Response Bus (`bus_rsp_t`)
-[cols="^1,^1,<6"]
-[options="header",grid="rows"]
-|=======================
-| Signal | Width | Description
-| `ack`  |     1 | Transfer acknowledge, single-shot.
-| `err`  |     1 | Transfer error when set, valid if `ack = 1`.
-| `data` |    32 | Read data, valid if `ack = 1`.
-|=======================
+.Adding Register Stages
+[TIP]
+Arbitrary pipeline stages can be added to the request and response buses at any point to relax timing (at the cost of
+additional latency).
 
 
 :sectnums:
@@ -539,7 +526,6 @@ The figure below shows three exemplary single-access bus transactions:
     {name: 'amoop', wave: 'x..|.......|..'},
     {name: 'lock',  wave: 'x0.|.......|.x'},
     {name: 'burst', wave: 'x0.|.......|.x'},
-    {name: 'fence', wave: '0..|.......|..'},
   ],
   {},
   [
@@ -581,7 +567,6 @@ exclusive bus access and a 4-word incrementing-address read burst.
     {name: 'amoop', wave: 'x2...x.|.........'},
     {name: 'burst', wave: 'x0....x|.1...0..x', node: '.............m..'},
     {name: 'lock',  wave: 'x1...0x|.1.....0x', node: '.b...f...i.....n'},
-    {name: 'fence', wave: '0................'},
   ],
   {},
   [

--- a/docs/datasheet/cpu_isa.adoc
+++ b/docs/datasheet/cpu_isa.adoc
@@ -238,8 +238,8 @@ are handled by the processor's <<_atomic_memory_operations_controller>>.
 [NOTE]
 The instruction word's `aq` and `lr` memory ordering bits are not evaluated by the hardware at all.
 However, the CPU and especially the <<_data_cache_dcache>> treats all atomic memory operation as if
-the `aq` and `lr` bits were set (for the targeted address). See <<_memory_coherence>> for more
-information.
+the `aq` and `lr` bits were set (**for the targeted address / cache line**). See <<_memory_coherence>>
+for more information.
 
 
 ==== `Zalrsc` ISA Extension
@@ -261,8 +261,8 @@ are handled by the processor's <<_atomic_reservation_set_controller>>.
 [NOTE]
 The instruction word's `aq` and `lr` memory ordering bits are not evaluated by the hardware at all.
 However, the CPU and especially the <<_data_cache_dcache>> treats all atomic memory operation as if
-the `aq` and `lr` bits were set (for the targeted address). See <<_memory_coherence>> for more
-information.
+the `aq` and `lr` bits were set (**for the targeted address / cache line**). See <<_memory_coherence>>
+for more information.
 
 
 ==== `Zcb` ISA Extension

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -283,7 +283,7 @@ shows all available data registers and their addresses:
 | Bit(s) | Name   | R/W | Description
 | 40:34  | `addr` | r/w | 7-bit address, see <<_dm_registers>>
 | 33:2   | `data` | r/w | 32-bit data to write/read to/from the addresses DM register
-| 1:0    | `op`   | r/w | 2-bit operation (`00` = NOP; `10` = write; `01` = read)
+| 1:0    | `op`   | r/w | Write access: 2-bit operation (`00` = NOP; `10` = write; `01` = read); Read access: DMI error if nonzero
 |=======================
 
 
@@ -808,7 +808,7 @@ asynchronous interrupts) that are handled transparently by the control logic.
 ** for all other exception sources the CPU jumps to the exception entry point (defined by the <<_cpu_top_entity_generics, `CPU_DEBUG_EXC_ADDR`>> generic)
 to signal an exception to the DM; the CPU restarts the park loop again afterwards
 * interrupts are disabled; however, they will remain pending and will get executed after the CPU has left debug mode and is not being single-stepped
-* if the DM makes a resume request, the park loop exits and the CPU leaves debug mode (executing `dret`)
+* if the DM makes a resume request, the park loop exits and the CPU leaves debug mode by executing `dret`
 * the standard counters <<_machine_counter_and_timer_csrs>> `[m]cycle[h]` and `[m]instret[h]` are stopped
 * all <<_hardware_performance_monitors_hpm_csrs>> are stopped
 

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -633,7 +633,7 @@ to memory and will return a "failed" state (i.e. `rd` = 1).
 
 The reservation-set controller implements the _strong semnatics_. A reservation is created when executing
 an `LR` instruction. Any other data memory access (for example by the DMA) will invalidate any active reservation
-(note that instruction fetch accesses do not affect the reservations at all). Furthermore, `fence[.i]` also do not
+(note that instruction fetch accesses do not affect the reservations at all). Furthermore, `fence[.i]` also does not
 impact the reservation state at all.
 
 The reservation-set controller implements a **single, global reservation set only** which is used by both cores

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -3,7 +3,7 @@
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -138,7 +138,6 @@ begin
   x_req_o.amoop <= a_req_i.amoop when (sel = '0') else b_req_i.amoop;
   x_req_o.burst <= a_req_i.burst when (sel = '0') else b_req_i.burst;
   x_req_o.lock  <= a_req_i.lock  when (sel = '0') else b_req_i.lock;
-  x_req_o.fence <= a_req_i.fence or b_req_i.fence;
   x_req_o.stb   <= stb;
 
   -- Response Switch ------------------------------------------------------------------------
@@ -159,7 +158,7 @@ end neorv32_bus_switch_rtl;
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -207,8 +206,6 @@ begin
         device_req_o.stb   <= host_req_i.stb;
         device_req_o.burst <= host_req_i.burst;
         device_req_o.lock  <= host_req_i.lock;
-        -- pass-through out-of-band signals --
-        device_req_o.fence <= host_req_i.fence;
       end if;
     end process request_reg;
   end generate;
@@ -251,7 +248,7 @@ end neorv32_bus_reg_rtl;
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -455,7 +452,7 @@ end neorv32_bus_gateway_rtl;
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -689,7 +686,7 @@ end neorv32_bus_io_switch_rtl;
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -802,7 +799,6 @@ begin
   sys_req_o.amoop <= core_req_i.amoop;
   sys_req_o.burst <= core_req_i.burst;
   sys_req_o.lock  <= core_req_i.lock;
-  sys_req_o.fence <= core_req_i.fence;
 
   -- response switch --
   core_rsp_o.data <= sys_rsp_i.data when (arbiter.state = S_IDLE) else arbiter.rdata;

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -840,7 +840,7 @@ end neorv32_bus_amo_rmw_rtl;
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -878,9 +878,7 @@ begin
     if (rstn_i = '0') then
       valid <= '0';
     elsif rising_edge(clk_i) then
-      if (core_req_i.fence = '1') then
-        valid <= '0';
-      elsif (core_req_i.stb = '1') and (core_req_i.meta(0) = '0') then -- data memory access?
+      if (core_req_i.stb = '1') and (core_req_i.meta(0) = '0') then -- data memory access?
         valid <= lr; -- set on load-reservate; clear for all other memory requests
       end if;
     end if;

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -36,6 +36,7 @@ entity neorv32_cache is
   port (
     clk_i      : in  std_ulogic; -- global clock, rising edge
     rstn_i     : in  std_ulogic; -- global reset, low-active, async
+    sync_i     : in  std_ulogic; -- perform full synchronization with main memory
     host_req_i : in  bus_req_t;  -- host request
     host_rsp_o : out bus_rsp_t;  -- host response
     bus_req_o  : out bus_req_t;  -- bus request
@@ -152,14 +153,14 @@ begin
 
   -- Control Engine Comb --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  ctrl_engine_comb: process(ctrl, host_req_i, cache_i, bus_rsp_i)
+  ctrl_engine_comb: process(ctrl, sync_i, host_req_i, cache_i, bus_rsp_i)
   begin
     -- control engine defaults --
     ctrl_nxt.state   <= ctrl.state;
     ctrl_nxt.sync    <= ctrl.sync;
     ctrl_nxt.bus_err <= ctrl.bus_err;
     ctrl_nxt.pnd_req <= ctrl.pnd_req or host_req_i.stb;
-    ctrl_nxt.pnd_syn <= ctrl.pnd_syn or host_req_i.fence;
+    ctrl_nxt.pnd_syn <= ctrl.pnd_syn or sync_i;
     ctrl_nxt.pnd_bp  <= ctrl.pnd_bp;
     ctrl_nxt.bp_req  <= '0';
     ctrl_nxt.hit     <= '0';
@@ -258,7 +259,6 @@ begin
 
       when S_SYNC_START => -- start synchronization
       -- ------------------------------------------------------------
-        bus_req_o.fence  <= '1'; -- send downstream fence request
         ctrl_nxt.pnd_syn <= '0'; -- sync request accepted
         ctrl_nxt.sync    <= '1'; -- syncing in progress
         ctrl_nxt.idx     <= (others => '0');

--- a/rtl/core/neorv32_cache.vhd
+++ b/rtl/core/neorv32_cache.vhd
@@ -126,6 +126,12 @@ architecture neorv32_cache_rtl of neorv32_cache is
 
 begin
 
+  -- Configuration Checks -------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  assert not (BURSTS_EN and (BLOCK_SIZE < 8)) report
+    "[NEORV32] Cache cannot emit burst if BLOCK_SIZE < 8." severity error;
+
+
   -- Control Engine Sync --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   ctrl_engine_sync: process(rstn_i, clk_i)

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -81,6 +81,7 @@ entity neorv32_cpu is
     -- status --
     trace_o    : out trace_port_t;                   -- execution trace port (enabled when CPU_TRACE_EN = true)
     sleep_o    : out std_ulogic;                     -- CPU is in sleep mode
+    fence_o    : out std_ulogic_vector(1 downto 0);  --
     -- interrupts --
     msi_i      : in  std_ulogic;                     -- RISC-V machine software interrupt
     mei_i      : in  std_ulogic;                     -- RISC-V machine external interrupt
@@ -314,6 +315,9 @@ begin
 
   -- CPU is sleeping --
   sleep_o <= not ctrl.cnt_event(cnt_event_cy_c);
+
+  -- memory ordering / synchronization --
+  fence_o <= ctrl.cpu_fence;
 
 
   -- Hardware Trigger Module (Sdtrig) -------------------------------------------------------

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -388,7 +388,7 @@ begin
 
           -- memory fence operations --
           when opcode_fence_c =>
-            ctrl_nxt.cpu_fence <= exec.ir(instr_funct3_lsb_c) & '1'; -- fence.i & fence ; always flush D$ so I$ gets updated data; #1540
+            ctrl_nxt.cpu_fence <= exec.ir(instr_funct3_lsb_c) & '1'; -- fence.i & fence; always flush D$ (so I$ gets updated data; #1540)
             exec_nxt.state     <= S_RESTART; -- reset instruction fetch & IPB via branch to next-PC (actually only required for fence.i)
 
           -- FPU: floating-point operations --

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -388,8 +388,7 @@ begin
 
           -- memory fence operations --
           when opcode_fence_c =>
-            ctrl_nxt.lsu_fence <= '1'; -- data fence (fence and fence.i); flush $D so $I gets updated data; #1540
-            ctrl_nxt.if_fence  <= exec.ir(instr_funct3_lsb_c); -- instruction fence (fence.i only)
+            ctrl_nxt.cpu_fence <= exec.ir(instr_funct3_lsb_c) & '1'; -- fence.i & fence ; always flush D$ so I$ gets updated data; #1540
             exec_nxt.state     <= S_RESTART; -- reset instruction fetch & IPB via branch to next-PC (actually only required for fence.i)
 
           -- FPU: floating-point operations --
@@ -481,7 +480,6 @@ begin
   -- CPU Control Bus Output -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   -- instruction fetch --
-  ctrl_o.if_fence     <= ctrl.if_fence;
   ctrl_o.if_reset     <= ctrl_nxt.if_reset; -- this is an ASYNC control signal!
   ctrl_o.if_ready     <= '1' when (exec.state = S_DISPATCH) else '0';
   -- program counter --
@@ -510,7 +508,6 @@ begin
   ctrl_o.lsu_wr       <= ctrl.lsu_wr;
   ctrl_o.lsu_mo_en    <= '1' when (exec.state = S_MEM_REQ) else '0'; -- write memory output registers
   ctrl_o.lsu_mi_en    <= '1' when (exec.state = S_MEM_RSP) else '0'; -- write memory input registers
-  ctrl_o.lsu_fence    <= ctrl.lsu_fence;
   ctrl_o.lsu_priv     <= csr.mstatus_mpp when (csr.mstatus_mprv = '1') else csr.prv_level; -- effective privilege level for loads/stores in M-mode
   -- control and status registers --
   ctrl_o.csr_we       <= ctrl.csr_we;
@@ -528,6 +525,7 @@ begin
   ctrl_o.cpu_trap     <= trap.env_enter;
   ctrl_o.cpu_sync_exc <= trap.exc_fire;
   ctrl_o.cpu_debug    <= debug_ctrl.run;
+  ctrl_o.cpu_fence    <= ctrl.cpu_fence;
 
 
   -- Counter Events -------------------------------------------------------------------------

--- a/rtl/core/neorv32_cpu_frontend.vhd
+++ b/rtl/core/neorv32_cpu_frontend.vhd
@@ -162,12 +162,11 @@ begin
   ibus_req_o.stb   <= '1' when (fetch.state = S_REQUEST) and (ipb.free = "11") else '0';
   ibus_req_o.data  <= (others => '0'); -- read-only
   ibus_req_o.ben   <= (others => '1'); -- always full-word access
-  ibus_req_o.rw    <= '0';             -- read-only
-  ibus_req_o.amo   <= '0';             -- cannot be an atomic memory operation
+  ibus_req_o.rw    <= '0'; -- read-only
+  ibus_req_o.amo   <= '0'; -- cannot be an atomic memory operation
   ibus_req_o.amoop <= (others => '0'); -- cannot be an atomic memory operation
-  ibus_req_o.burst <= '0';             -- only single-access
-  ibus_req_o.lock  <= '0';             -- always unlocked access
-  ibus_req_o.fence <= ctrl_i.if_fence; -- fence request, valid without STB being set ("out-of-band" signal)
+  ibus_req_o.burst <= '0'; -- only single-access
+  ibus_req_o.lock  <= '0'; -- always unlocked access
 
   -- IPB instruction data and status --
   ipb.wdata(0) <= (ibus_rsp_i.err or pmp_err_i) & ibus_rsp_i.data(15 downto 0);

--- a/rtl/core/neorv32_cpu_lsu.vhd
+++ b/rtl/core/neorv32_cpu_lsu.vhd
@@ -134,18 +134,10 @@ begin
     end if;
   end process mem_do_reg;
 
-  -- direct output --
-  req.burst <= '0'; -- only non-burst/single-accesses
-  req.fence <= ctrl_i.lsu_fence;
-
-  -- access request (all source signals are driven by registers) --
-  req.stb <= ctrl_i.lsu_req and (not misalign) and (not pmp_fault_i);
-
-  -- output bus request --
-  dbus_req_o <= req;
-
-  -- address feedback for MTVAL CSR --
-  mar_o <= req.addr;
+  req.burst  <= '0'; -- only non-burst/single-accesses
+  req.stb    <= ctrl_i.lsu_req and (not misalign) and (not pmp_fault_i); -- access request (all source signals are driven by registers)
+  dbus_req_o <= req; -- output bus request
+  mar_o      <= req.addr; -- address feedback for MTVAL CSR
 
 
   -- Response -------------------------------------------------------------------------------

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -21,7 +21,7 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_pmp is
   generic (
-    NUM_REGIONS : natural range 0 to 16; -- number of regions (0..16)
+    NUM_REGIONS : natural range 0 to 16; -- number of regions
     GRANULARITY : natural; -- minimal region granularity in bytes, has to be a power of 2, min 4 bytes
     TOR_EN      : boolean; -- implement TOR mode
     NAP_EN      : boolean  -- implement NAPOT/NA4 modes

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -89,7 +89,8 @@ architecture neorv32_cpu_pmp_rtl of neorv32_cpu_pmp is
 
   -- address comparators, region-match and permission check --
   type cmp_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(1 downto 0); -- 0 = instruction fetch, 1 = data access
-  signal cmp_na, cmp_ge, cmp_lt, match : cmp_t;
+  signal cmp_na, cmp_ge, match : cmp_t;
+  signal cmp_lt : std_ulogic_vector(1 downto 0); -- 0 = instruction fetch, 1 = data access
 
   -- permission check --
   signal allow_ex, allow_rw : std_ulogic_vector(NUM_REGIONS-1 downto 0);
@@ -183,7 +184,7 @@ begin
 
   -- CSR Read Access ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  csr_read_access: process(ctrl_i.csr_addr, cfg_rd32, addr_rd)
+  csr_read_access: process(ctrl_i, cfg_rd32, addr_rd)
   begin
     if (ctrl_i.csr_addr(11 downto 5) = csr_pmpcfg0_c(11 downto 5)) then -- PMP CSR
       if (ctrl_i.csr_addr(4) = '0') then -- PMP configuration CSR
@@ -275,23 +276,20 @@ begin
   region_gen:
   for r in 0 to NUM_REGIONS-1 generate
 
-    -- check region address match --
     -- NA4 and NAPOT --
     cmp_na(r)(0) <= '1' when ((i_addr_i(31 downto pmp_lsb_c) and addr_mask(r)) = (pmpaddr(r)(29 downto pmp_lsb_c-2) and addr_mask(r))) and NAP_EN else '0';
     cmp_na(r)(1) <= '1' when ((d_addr_i(31 downto pmp_lsb_c) and addr_mask(r)) = (pmpaddr(r)(29 downto pmp_lsb_c-2) and addr_mask(r))) and NAP_EN else '0';
+
     -- TOR region 0 --
     addr_match_r0_gen:
     if (r = 0) generate -- first entry: use ZERO as base and current entry as bound
       cmp_ge(r) <= (others => '1'); -- address is always greater than or equal to zero
-      cmp_lt(r) <= (others => '0'); -- cannot be less then zero
     end generate;
     -- TOR region above 0 --
     addr_match_rn_gen:
     if (r > 0) generate -- use previous entry as base and current entry as bound
       cmp_ge(r)(0) <= '1' when (unsigned(i_addr_i(31 downto pmp_lsb_c)) >= unsigned(pmpaddr(r-1)(29 downto pmp_lsb_c-2))) and TOR_EN else '0';
-      cmp_lt(r)(0) <= '1' when (unsigned(i_addr_i(31 downto pmp_lsb_c)) <  unsigned(pmpaddr(r  )(29 downto pmp_lsb_c-2))) and TOR_EN else '0';
       cmp_ge(r)(1) <= '1' when (unsigned(d_addr_i(31 downto pmp_lsb_c)) >= unsigned(pmpaddr(r-1)(29 downto pmp_lsb_c-2))) and TOR_EN else '0';
-      cmp_lt(r)(1) <= '1' when (unsigned(d_addr_i(31 downto pmp_lsb_c)) <  unsigned(pmpaddr(r  )(29 downto pmp_lsb_c-2))) and TOR_EN else '0';
     end generate;
 
     -- check region match according to configured mode --
@@ -299,7 +297,7 @@ begin
     begin
       if (pmpcfg(r)(cfg_ah_c downto cfg_al_c) = mode_tor_c) and TOR_EN then -- TOR
         if (r = (NUM_REGIONS-1)) then -- very last region
-          match(r) <= cmp_ge(r) and cmp_lt(r);
+          match(r) <= cmp_ge(r) and cmp_lt;
         else -- any other region
           match(r) <= cmp_ge(r) and (not cmp_ge(r+1)); -- this saves a LOT of comparators
         end if;
@@ -311,6 +309,10 @@ begin
     end process match_gen;
 
   end generate;
+
+  -- TOR last region --
+  cmp_lt(0) <= '1' when (unsigned(i_addr_i(31 downto pmp_lsb_c)) < unsigned(pmpaddr(NUM_REGIONS-1)(29 downto pmp_lsb_c-2))) and TOR_EN else '0';
+  cmp_lt(1) <= '1' when (unsigned(d_addr_i(31 downto pmp_lsb_c)) < unsigned(pmpaddr(NUM_REGIONS-1)(29 downto pmp_lsb_c-2))) and TOR_EN else '0';
 
 
   -- Permission Check -----------------------------------------------------------------------

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -46,7 +46,11 @@ end neorv32_cpu_pmp;
 architecture neorv32_cpu_pmp_rtl of neorv32_cpu_pmp is
 
   -- auto-configuration --
-  constant g_c : natural := sel_natural_f(boolean(GRANULARITY < 4), 4, 2**index_size_f(GRANULARITY));
+  -- G=0: store all bits [29:0] (pmp_lsb_c-2 = 0)
+  -- G>=1: store bits [29:G-1] -> one extra bit for NAPOT min. granularity
+  constant g_c        : natural := sel_natural_f(boolean(GRANULARITY < 4), 4, 2**index_size_f(GRANULARITY));
+  constant pmp_lsb_c  : natural := index_size_f(g_c); -- lowest bit of the addr. comparison (= G+2 = log2(g_c)), min = 2
+  constant pmp_alsb_c : natural := pmp_lsb_c - sel_natural_f(boolean(pmp_lsb_c > 2), 3, pmp_lsb_c); -- address LSB
 
   -- configuration register bits --
   constant cfg_r_c  : natural := 0; -- read permission
@@ -62,16 +66,13 @@ architecture neorv32_cpu_pmp_rtl of neorv32_cpu_pmp is
   constant mode_na4_c   : std_ulogic_vector(1 downto 0) := "10"; -- naturally aligned four-byte region
   constant mode_napot_c : std_ulogic_vector(1 downto 0) := "11"; -- naturally aligned power-of-two region (> 4 bytes)
 
-  -- address LSB according to granularity --
-  constant pmp_lsb_c : natural := index_size_f(g_c); -- min = 2
-
   -- configuration CSRs --
   type pmpcfg_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(7 downto 0);
   signal pmpcfg    : pmpcfg_t;
   signal pmpcfg_we : std_ulogic_vector(3 downto 0);
 
   -- address CSRs --
-  type pmpaddr_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(31 downto 0);
+  type pmpaddr_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(29 downto pmp_alsb_c);
   signal pmpaddr    : pmpaddr_t;
   signal pmpaddr_we : std_ulogic_vector(15 downto 0);
 
@@ -165,10 +166,10 @@ begin
         if (pmpaddr_we(i) = '1') and (pmpcfg(i)(cfg_l_c) = '0') then -- unlocked write access
           if (i < NUM_REGIONS-1) then
             if (pmpcfg(i+1)(cfg_l_c) = '0') or (pmpcfg(i+1)(cfg_ah_c downto cfg_al_c) /= mode_tor_c) then -- pmpcfg(i+1) not "LOCKED TOR"
-              pmpaddr(i) <= "00" & ctrl_i.csr_wdata(29 downto 0);
+              pmpaddr(i) <= ctrl_i.csr_wdata(29 downto pmp_alsb_c);
             end if;
           else -- very last entry
-            pmpaddr(i) <= "00" & ctrl_i.csr_wdata(29 downto 0);
+            pmpaddr(i) <= ctrl_i.csr_wdata(29 downto pmp_alsb_c);
           end if;
         end if;
       end if;
@@ -197,18 +198,13 @@ begin
     address_read_back: process(pmpaddr, pmpcfg)
     begin
       addr_rd(i) <= (others => '0');
-      addr_rd(i)(29 downto pmp_lsb_c-2) <= pmpaddr(i)(29 downto pmp_lsb_c-2);
-      if (g_c = 8) and TOR_EN then -- bit G-1 reads as zero in TOR or OFF mode
+      addr_rd(i)(29 downto pmp_alsb_c) <= pmpaddr(i);
+      if (pmp_lsb_c > 2) then -- G >= 1
         if (pmpcfg(i)(cfg_ah_c) = '0') then -- TOR/OFF mode
-          addr_rd(i)(pmp_lsb_c) <= '0';
-        end if;
-      elsif (g_c > 8) then
-        if NAP_EN then
-          addr_rd(i)(pmp_lsb_c-2 downto 0) <= (others => '1'); -- in NAPOT mode bits G-2:0 must read as one
-        end if;
-        if TOR_EN then
-          if (pmpcfg(i)(cfg_ah_c) = '0') then -- TOR/OFF mode
-            addr_rd(i)(pmp_lsb_c-1 downto 0) <= (others => '0'); -- in TOR or OFF mode bits G-1:0 must read as zero
+          addr_rd(i)(pmp_lsb_c-3 downto 0) <= (others => '0'); -- [G-1:0] read as zero
+        else -- NAPOT mode (cfg_ah = '1')
+          if (pmp_alsb_c > 0) then -- G >= 2: set bits [G-2:0] to all-ones
+            addr_rd(i)(pmp_alsb_c-1 downto 0) <= (others => '1'); -- bits [G-2:0] read as one (only when G >= 2)
           end if;
         end if;
       end if;
@@ -235,8 +231,17 @@ begin
   mask_gen:
   for r in 0 to NUM_REGIONS-1 generate
 
-    -- NAPOT address mask generator --
-    addr_mask_napot(r)(pmp_lsb_c) <= '0';
+    -- NAPOT address mask seed bit --
+    addr_mask_napot_seed_g0:
+    if (pmp_lsb_c <= 2) generate
+      addr_mask_napot(r)(pmp_lsb_c) <= '0';
+    end generate;
+    addr_mask_napot_seed_gn:
+    if (pmp_lsb_c > 2) generate
+      addr_mask_napot(r)(pmp_lsb_c) <= not pmpaddr(r)(pmp_alsb_c);
+    end generate;
+
+    -- NAPOT address mask propagation --
     addr_mask_napot_gen:
     for i in pmp_lsb_c+1 to 31 generate
       addr_mask_napot(r)(i) <= addr_mask_napot(r)(i-1) or (not pmpaddr(r)(i-3));

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -100,12 +100,6 @@ architecture neorv32_cpu_pmp_rtl of neorv32_cpu_pmp is
 
 begin
 
-  -- Configuration Checks -------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  assert (GRANULARITY = g_c) report
-    "[NEORV32] Auto-adjusting invalid PMP granularity configuration." severity warning;
-
-
   -- CSR Write Access: Configuration (PMPCFG) -----------------------------------------------
   -- -------------------------------------------------------------------------------------------
   csr_we_cfg: process(ctrl_i) -- write enable decoder
@@ -200,9 +194,6 @@ begin
   -- CSR read-back --
   csr_read_back_gen:
   for i in 0 to NUM_REGIONS-1 generate
-    -- configuration --
-    cfg_rd(i) <= pmpcfg(i);
-    -- address --
     address_read_back: process(pmpaddr, pmpcfg)
     begin
       addr_rd(i) <= (others => '0');
@@ -222,6 +213,7 @@ begin
         end if;
       end if;
     end process address_read_back;
+    cfg_rd(i) <= pmpcfg(i);
   end generate;
 
   -- terminate unused CSR read-backs --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130002"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130003"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 
@@ -110,8 +110,6 @@ package neorv32_package is
     amoop : std_ulogic_vector(3 downto 0); -- type of atomic memory operation
     burst : std_ulogic; -- set if part of burst access
     lock  : std_ulogic; -- set if exclusive access request
-    -- out-of-band signals --
-    fence : std_ulogic; -- set if fence(.i) operation, single-shot
   end record;
 
   -- bus request termination --
@@ -125,8 +123,7 @@ package neorv32_package is
     amo   => '0',
     amoop => (others => '0'),
     burst => '0',
-    lock  => '0',
-    fence => '0'
+    lock  => '0'
   );
 
   -- bus response --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -572,7 +572,6 @@ package neorv32_package is
   -- -------------------------------------------------------------------------------------------
   type ctrl_bus_t is record
     -- instruction fetch --
-    if_fence     : std_ulogic;                     -- fence.i operation
     if_reset     : std_ulogic;                     -- restart instruction fetch
     if_ready     : std_ulogic;                     -- ready for next instruction
     -- program counter --
@@ -601,7 +600,6 @@ package neorv32_package is
     lsu_wr       : std_ulogic;                     -- write access
     lsu_mo_en    : std_ulogic;                     -- output register write enable
     lsu_mi_en    : std_ulogic;                     -- input register write enable
-    lsu_fence    : std_ulogic;                     -- fence operation
     lsu_priv     : std_ulogic;                     -- effective privilege mode for load/store
     -- control and status registers --
     csr_we       : std_ulogic;                     -- write-enable
@@ -619,11 +617,11 @@ package neorv32_package is
     cpu_trap     : std_ulogic;                     -- set when CPU is entering trap
     cpu_sync_exc : std_ulogic;                     -- set when CPU encounters a synchronous exception
     cpu_debug    : std_ulogic;                     -- set when CPU is in debug mode
+    cpu_fence    : std_ulogic_vector(1 downto 0);  -- memory ordering; [1] = instructions, [0] = data
   end record;
 
   -- control bus reset termination --
   constant ctrl_bus_zero_c : ctrl_bus_t := (
-    if_fence     => '0',
     if_reset     => '0',
     if_ready     => '0',
     pc_cur       => (others => '0'),
@@ -648,7 +646,6 @@ package neorv32_package is
     lsu_wr       => '0',
     lsu_mo_en    => '0',
     lsu_mi_en    => '0',
-    lsu_fence    => '0',
     lsu_priv     => '0',
     csr_we       => '0',
     csr_re       => '0',
@@ -661,7 +658,8 @@ package neorv32_package is
     cpu_priv     => '0',
     cpu_trap     => '0',
     cpu_sync_exc => '0',
-    cpu_debug    => '0'
+    cpu_debug    => '0',
+    cpu_fence    => (others => '0')
   );
 
   -- Instruction Fetch Interface ------------------------------------------------------------

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -330,6 +330,10 @@ architecture neorv32_top_rtl of neorv32_top is
   type cpu_trace_t is array (0 to num_cores_c-1) of trace_port_t;
   signal cpu_trace : cpu_trace_t;
 
+  -- CPU memory ordering --
+  type cpu_fence_t is array (0 to num_cores_c-1) of std_ulogic_vector(1 downto 0);
+  signal cpu_fence : cpu_fence_t;
+
   -- bus: CPU core complex --
   type core_complex_req_t is array (0 to num_cores_c-1) of bus_req_t;
   type core_complex_rsp_t is array (0 to num_cores_c-1) of bus_rsp_t;
@@ -576,6 +580,7 @@ begin
       -- status --
       trace_o    => cpu_trace(i),
       sleep_o    => open,
+      fence_o    => cpu_fence(i),
       -- interrupts --
       msi_i      => msi(i),
       mei_i      => irq_mei_i,
@@ -605,6 +610,7 @@ begin
       port map (
         clk_i      => clk_i,
         rstn_i     => rstn_sys,
+        sync_i     => cpu_fence(i)(1),
         host_req_i => cpu_i_req(i),
         host_rsp_o => cpu_i_rsp(i),
         bus_req_o  => icache_req(i),
@@ -633,6 +639,7 @@ begin
       port map (
         clk_i      => clk_i,
         rstn_i     => rstn_sys,
+        sync_i     => cpu_fence(i)(0),
         host_req_i => cpu_d_req(i),
         host_rsp_o => cpu_d_rsp(i),
         bus_req_o  => dcache_req(i),

--- a/rtl/core/neorv32_tracer.vhd
+++ b/rtl/core/neorv32_tracer.vhd
@@ -3,7 +3,7 @@
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -77,9 +77,8 @@ architecture neorv32_tracer_rtl of neorv32_tracer is
   signal fifo : fifo_t;
 
   -- misc --
-  signal over_check : std_ulogic; -- FIFO overflow checker
-  signal over_trash : std_ulogic; -- discard data from trace buffer
-  signal trace_src  : trace_port_t; -- trace input stream
+  signal discard   : std_ulogic; -- discard data from trace buffer
+  signal trace_src : trace_port_t; -- trace input stream
 
 begin
 
@@ -233,25 +232,17 @@ begin
   fifo.clear <= not ctrl_en;
   fifo.we    <= arbiter.push;
   fifo.wdata <= arbiter.dst & arbiter.src;
-  fifo.re    <= '1' when (over_trash = '1') or
-                         ((bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(3 downto 2) = "11")) else '0';
+  fifo.re    <= '1' when (discard = '1') or ((bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(3 downto 2) = "11")) else '0';
 
   -- discard oldest entry if overflowing --
-  discard: process(rstn_i, clk_i)
+  fifo_overflow: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      over_check <= '0';
-      over_trash <= '0';
+      discard <= '0';
     elsif rising_edge(clk_i) then
-      if (over_check = '0') or (ctrl_en = '0') or (arbiter.run = '0') then
-        over_check <= not fifo.free;
-        over_trash <= '0';
-      else
-        over_check <= '0';
-        over_trash <= '1';
-      end if;
+      discard <= ctrl_en and arbiter.run and (not fifo.free);
     end if;
-  end process discard;
+  end process fifo_overflow;
 
 
   -- Simulation Trace Logging ---------------------------------------------------------------

--- a/rtl/core/neorv32_twd.vhd
+++ b/rtl/core/neorv32_twd.vhd
@@ -400,13 +400,15 @@ begin
         -- ------------------------------------------------------------
           if (ctrl.enable = '0') or (smp.stop = '1') then -- disabled or stop-condition
             engine.state <= S_IDLE;
+          elsif (smp.start = '1') then -- start-condition
+            engine.state <= S_INIT;
           else
             if (engine.cmd = '0') then -- WRITE operation
               engine.sda   <= not rx_fifo.free; -- ACK if RX FIFO is not full; NACK if RX FIFO is full
               engine.rx_we <= smp.scl_fall; -- push to RX FIFO at end of bit slot (if RX FIFO not full)
             else -- READ operation
               engine.sda   <= '1'; -- keep high-Z so we can sample the ACK/NACK from the host
-              engine.tx_re <= smp.scl_rise and (not smp.sda); -- pop from RX FIFO if ACK at sample point
+              engine.tx_re <= smp.scl_rise and (not smp.sda); -- pop from TX FIFO if ACK at sample point
             end if;
             if (smp.scl_fall = '1') then -- end of bit slot
               engine.state <= S_PREP;

--- a/sw/bootloader/main.c
+++ b/sw/bootloader/main.c
@@ -168,7 +168,7 @@ skip_auto_boot:
       uart_puth(neorv32_cpu_csr_read(CSR_MISA));
       uart_puts("\nXISA: ");
       uart_puth(neorv32_cpu_csr_read(CSR_MXISAH));
-      uart_putc(':');
+      uart_putc('_');
       uart_puth(neorv32_cpu_csr_read(CSR_MXISA));
       uart_puts("\nSOC:  ");
       uart_puth(NEORV32_SYSINFO->SOC);


### PR DESCRIPTION
* remove `fence` from internal bus - no more "out-of-band" signals; add a dedicated fence port to the CPU (to connect to the caches)
* fix: `fence[.i]` instruction do not invalidate any reservation
* TWD: also check for an incoming START condition while waiting for a (N)ACK
* simplify trace buffer overflow/discard logic
* PMP: fix granularity configuration and according address (read-back) masking
* PMP: logic optimizations