### PR TITLE
Rework on-chip debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 03.05.2026 | 1.13.0.4 | rework on-chip debugger (OCD) fixing minor spec incompatibilities | [#1544](https://github.com/stnolting/neorv32/pull/1544) |
 | 02.05.2026 | 1.13.0.3 | minor rtl fixes, edits and cleanups (PMP, TWD, bus | [#1543](https://github.com/stnolting/neorv32/pull/1543) |
 | 01.05.2026 | 1.13.0.2 | :warning: rework trap CSRs: remove `mtinst`; make `mtval` more verbose; add full WARL access for `mcause` and `mtval` | [#1524](https://github.com/stnolting/neorv32/pull/1542) |
 | 29.04.2026 | 1.13.0.1 | rework cache handling of atomic memory operations: enforce memory synchronization by hardware | [#1540](https://github.com/stnolting/neorv32/pull/1540) |

--- a/docs/datasheet/on_chip_debugger.adoc
+++ b/docs/datasheet/on_chip_debugger.adoc
@@ -1017,6 +1017,20 @@ Write accesses from machine-mode are ignored (because `tdata1.dmode` is hardwire
 
 
 :sectnums!:
+===== **`tdata3`**
+
+[cols="<1,<8"]
+[frame="topbot",grid="none"]
+|=======================
+| Name        | Trigger data register 3
+| Address     | `0x7a3`
+| Reset value | `0x00000000`
+| ISA         | `Zicsr` & `Sdtrig`
+| Description | The features provided by this CSR are not implemented. Hence, this CSR is hardwired to all-zero.
+|=======================
+
+
+:sectnums!:
 ===== **`tinfo`**
 
 [cols="<1,<8"]

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -818,8 +818,8 @@ begin
     ((csr.mstatus_mie = '1') or (csr.prv_level = priv_mode_u_c)) and -- IRQ only when in M-mode and MIE=1 OR when in U-mode
     (debug_ctrl.run = '0') and (csr.dcsr_step = '0') else '0'; -- no system IRQs when in debug-mode / during single-stepping
 
-  -- debug-entry halt interrupt? allow halt also after "reset" (#879) --
-  trap.irq_fire(1) <= trap.irq_buf(irq_db_halt_c) when (exec.state = S_RESTART) or (exec.state = S_EXECUTE) or (exec.state = S_SLEEP) else '0';
+  -- debug halt request interrupt? --
+  trap.irq_fire(1) <= trap.irq_buf(irq_db_halt_c);
 
 
   -- Trap Priority Encoder ------------------------------------------------------------------

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -603,7 +603,7 @@ begin
         csr_valid(2) <= bool_to_ulogic_f(RISCV_ISA_Sdext);
 
       -- trigger module CSRs --
-      when csr_tselect_c | csr_tdata1_c | csr_tdata2_c | csr_tinfo_c =>
+      when csr_tselect_c | csr_tdata1_c | csr_tdata2_c | csr_tdata3_c | csr_tinfo_c =>
         csr_valid(2) <= bool_to_ulogic_f(RISCV_ISA_Sdtrig);
 
       -- undefined / not implemented --

--- a/rtl/core/neorv32_cpu_hwtrig.vhd
+++ b/rtl/core/neorv32_cpu_hwtrig.vhd
@@ -6,7 +6,7 @@
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -201,7 +201,7 @@ begin
       for i in 0 to NUM_TRIGGERS-1 loop
         if (tdata1_hit(i) = '0') then
           tdata1_hit(i) <= match(i); -- any match?
-        elsif (sel(i) = '1') and (ctrl_i.csr_we = '1') and (csr_en = '1') and
+        elsif (sel(i) = '1') and (ctrl_i.csr_we = '1') and (csr_en = '1') and (ctrl_i.cpu_debug = '1') and
               (ctrl_i.csr_addr(2 downto 0) = csr_tdata1_c(2 downto 0)) and
               (ctrl_i.csr_wdata(22) = '0') then -- clear currently selected tdata1.hit0 by debugger
           tdata1_hit(i) <= '0';

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -139,8 +139,7 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   -- CPU Bus and Debug Interfaces
   -- ----------------------------------------------------------
 
-  -- code ROM containing "park loop" --
-  -- copied manually from 'sw/ocd-firmware/neorv32_application_image.vhd' --
+  -- code ROM containing "park loop"; copied manually from 'sw/ocd-firmware/neorv32_application_image.vhd' --
   type code_rom_t is array (0 to 15) of std_ulogic_vector(31 downto 0);
   constant code_rom_c : code_rom_t := (
     x"fc0001a3",
@@ -149,7 +148,7 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
     x"fc204403",
     x"02041063",
     x"fc104403",
-    x"fe040ae3",
+    x"fe0408e3",
     x"fc0000a3",
     x"7b202473",
     x"0ff0000f",

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -47,12 +47,6 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   constant dm_data_base_c : std_ulogic_vector(31 downto 0) := x"ffffff80"; -- abstract data buffer (DATA)
   constant dm_sreg_base_c : std_ulogic_vector(31 downto 0) := x"ffffffc0"; -- status register (SREG)
 
-  -- rv32i instruction prototypes --
-  constant instr_nop_c    : std_ulogic_vector(31 downto 0) := x"00000013"; -- nop
-  constant instr_lw_c     : std_ulogic_vector(31 downto 0) := x"00002003"; -- lw zero, 0(zero)
-  constant instr_sw_c     : std_ulogic_vector(31 downto 0) := x"00002023"; -- sw zero, 0(zero)
-  constant instr_ebreak_c : std_ulogic_vector(31 downto 0) := x"00100073"; -- ebreak
-
   -- ----------------------------------------------------------
   -- DMI Access
   -- ----------------------------------------------------------
@@ -111,13 +105,12 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
 
   -- command execution arbiter --
   type cmd_state_t is (CMD_IDLE, CMD_CHECK, CMD_START, CMD_PENDING);
-  type cmd_t is record
-    state : cmd_state_t;
-    busy  : std_ulogic;
-    ldsw  : std_ulogic_vector(31 downto 0); -- load/store instruction buffer
-    err   : std_ulogic_vector(2 downto 0);
-  end record;
-  signal cmd : cmd_t;
+  signal cmd_state : cmd_state_t;
+  signal cmd_err   : std_ulogic_vector(2 downto 0);
+  signal cmd_busy  : std_ulogic;
+  signal cmd_sw, cmd_lw, cmd_op : std_ulogic_vector(31 downto 0); -- transfer instruction (first progbuf entry)
+  constant cmd_nop : std_ulogic_vector(31 downto 0) := x"00000013"; -- RV32 nop
+  constant cmd_brk : std_ulogic_vector(31 downto 0) := x"00100073"; -- RV32 ebreak
 
   -- hart status controller --
   type hart_t is record
@@ -473,26 +466,23 @@ begin
   cmd_arbiter: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      cmd.state <= CMD_IDLE;
-      cmd.ldsw  <= instr_sw_c;
-      cmd.err   <= (others => '0');
+      cmd_state <= CMD_IDLE;
+      cmd_err   <= (others => '0');
     elsif rising_edge(clk_i) then
-      if (dm_reg.dmactive = '0') then -- DM reset / DM disabled
-        cmd.state <= CMD_IDLE;
-        cmd.ldsw  <= instr_sw_c;
-        cmd.err   <= (others => '0');
+      if (dm_reg.ndmreset = '1') or (dm_reg.dmactive = '0') then -- hart/DM reset
+        cmd_state <= CMD_IDLE;
+        cmd_err   <= (others => '0');
       else
-        case cmd.state is
+        case cmd_state is
 
           when CMD_IDLE => -- wait for new abstract command
           -- ------------------------------------------------------------
-            if (cmd.err = "000") and -- execute only if there is no error yet
-               (((dmi_wren_auth = '1') and (dmi_req_i.addr = addr_command_c)) or -- manual execution trigger
-                ((dm_reg.autoexec_rd = '1') or (dm_reg.autoexec_wr = '1'))) then -- auto execution trigger
-              cmd.state <= CMD_CHECK;
+            if (cmd_err = "000") and -- execute only if there is no error yet
+               (((dmi_wren = '1') and (dmi_req_i.addr = addr_command_c)) or (dm_reg.autoexec = '1')) then -- manual/auto execution trigger
+              cmd_state <= CMD_CHECK;
             end if;
             if (dm_reg.clr_acc_err = '1') then -- clear error flags
-              cmd.err <= "000";
+              cmd_err <= "000";
             end if;
 
           when CMD_CHECK => -- check if command is valid / supported
@@ -502,71 +492,64 @@ begin
                (dm_reg.command(19) = '0') and -- aarpostincrement: not supported
                ((dm_reg.command(17) = '0') or -- ignore aarsize and regno if transfer = 0
                 ((dm_reg.command(15 downto 5) = "00010000000") and -- regno: only GPRs are supported: 0x1000..0x101f
-                 (dm_reg.command(22 downto 20) = "010"))) then -- aarsize: has to be 32-bit
+                 (dm_reg.command(22 downto 20) = "010"))) then -- aarsize == 32-bit
               if (or_reduce_f(hart.halted and hartselect) = '1') then -- selected CPU is halted
-                cmd.state <= CMD_START;
+                cmd_state <= CMD_START;
               else -- cannot execute since hart is not in expected state
-                cmd.err   <= "100";
-                cmd.state <= CMD_IDLE;
+                cmd_err   <= "100";
+                cmd_state <= CMD_IDLE;
               end if;
             else -- unsupported command
-              cmd.err   <= "010";
-              cmd.state <= CMD_IDLE;
+              cmd_err   <= "010";
+              cmd_state <= CMD_IDLE;
             end if;
 
-          when CMD_START => -- setup program buffer and trigger execution
+          when CMD_START => -- trigger execution
           -- ------------------------------------------------------------
-            if (dm_reg.command(17) = '1') then -- "transfer" (GPR <-> DM.data0)
-              if (dm_reg.command(16) = '0') then -- "write" = 0: data0 <- GPR
-                cmd.ldsw <= instr_sw_c;
-                cmd.ldsw(31 downto 25) <= dataaddr_c(11 downto 5); -- destination address = DM.data0
-                cmd.ldsw(24 downto 20) <= dm_reg.command(4 downto 0); -- "regno" = source register
-                cmd.ldsw(11 downto 07) <= dataaddr_c(4 downto 0); -- destination address = DM.data0
-              else -- "write" = 1: data0 -> GPR
-                cmd.ldsw <= instr_lw_c;
-                cmd.ldsw(31 downto 20) <= dataaddr_c(11 downto 0); -- source address = DM.data0
-                cmd.ldsw(11 downto 07) <= dm_reg.command(4 downto 0); -- "regno" = destination register
-              end if;
-            else
-              cmd.ldsw <= instr_nop_c; -- NOP - do nothing
-            end if;
-            -- wait until selected CPU starts executing --
-            if (or_reduce_f(dci.ack_exe and hartselect) = '1') then
-              cmd.state <= CMD_PENDING;
+            if (or_reduce_f(dci.ack_exe and hartselect) = '1') then -- wait until selected CPU starts executing
+              cmd_state <= CMD_PENDING;
             end if;
 
           when CMD_PENDING => -- wait for CPU to complete execution
           -- ------------------------------------------------------------
-            if (or_reduce_f(dci.ack_exc and hartselect) = '1') then -- exception during execution?
-              cmd.err <= "011";
-            elsif (cmd.err = "000") and ((dm_reg.rd_acc_err or dm_reg.wr_acc_err) = '1') then -- invalid read/write while command is executing?
-              cmd.err <= "001";
+            if (cmd_err = "000") then -- cmd_err is sticky - do not alter if already nonzero
+              if (or_reduce_f(dci.ack_exc and hartselect) = '1') then -- exception during execution?
+                cmd_err <= "011";
+              elsif (dm_reg.set_acc_err = '1') then -- invalid read/write while command is executing?
+                cmd_err <= "001";
+              end if;
             end if;
-            -- wait until selected CPU is halted again -> execution done --
+            -- wait until selected CPU is halted again --
             if (or_reduce_f(dci.ack_hlt and hartselect) = '1') then
-              cmd.state <= CMD_IDLE;
+              cmd_state <= CMD_IDLE;
             end if;
 
           when others => -- undefined
           -- ------------------------------------------------------------
-            cmd.state <= CMD_IDLE;
+            cmd_state <= CMD_IDLE;
 
         end case;
       end if;
     end if;
   end process cmd_arbiter;
 
-  -- assemble program buffer array --
-  cpu_progbuf(0) <= cmd.ldsw; -- pseudo program buffer for GPR<->DM.data0 transfer
-  cpu_progbuf(1) <= instr_nop_c when (dm_reg.command(18) = '0') else dm_reg.progbuf(0); -- postexec: execute program buffer instruction when set
-  cpu_progbuf(2) <= instr_nop_c when (dm_reg.command(18) = '0') else dm_reg.progbuf(1);
-  cpu_progbuf(3) <= instr_ebreak_c; -- implicit ebreak instruction
+  -- assemble transfer instruction --
+  cmd_sw <= dataaddr_c(11 downto 5) & dm_reg.command(4 downto 0) & "00000010" & dataaddr_c(4 downto 0)     & "0100011"; -- store word
+  cmd_lw <= dataaddr_c(11 downto 0)                              & "00000010" & dm_reg.command(4 downto 0) & "0000011"; -- load word
+  cmd_op <= cmd_nop when (dm_reg.command(17) = '0') else -- no transfer: execute NOP
+            cmd_sw  when (dm_reg.command(16) = '0') else cmd_lw; -- write=0: data0 <= GPR (SW); write=1: data0 => GPR (LW)
+
+  -- assemble program buffer --
+  cpu_progbuf(0) <= cmd_op; -- pseudo program buffer for GPR<->DM.data0 transfer
+  cpu_progbuf(1) <= cmd_nop when (dm_reg.command(18) = '0') else dm_reg.progbuf(0); -- postexec: execute program buffer, else -> NOPs
+  cpu_progbuf(2) <= cmd_nop when (dm_reg.command(18) = '0') else dm_reg.progbuf(1);
+  cpu_progbuf(3) <= cmd_brk; -- implicit ebreak instruction
 
   -- controller busy flag --
-  cmd.busy <= '0' when (cmd.state = CMD_IDLE) else '1';
+  cmd_busy <= '0' when (cmd_state = CMD_IDLE) else '1';
 
   -- request execution --
-  dci.req_exe <= hartselect when (cmd.state = CMD_START) else (others => '0');
+  dci.req_exe <= hartselect when (cmd_state = CMD_START) else (others => '0');
 
 
   -- Bus Access (from CPU) ------------------------------------------------------------------

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -6,7 +6,7 @@
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -48,7 +48,7 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   constant dm_sreg_base_c : std_ulogic_vector(31 downto 0) := x"ffffffc0"; -- status register (SREG)
 
   -- ----------------------------------------------------------
-  -- DMI Access
+  -- Debug Module Interface (DMI)
   -- ----------------------------------------------------------
 
   -- physical DMI registers --
@@ -96,10 +96,6 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   type cpu_progbuf_t is array (0 to 3) of std_ulogic_vector(31 downto 0);
   signal cpu_progbuf : cpu_progbuf_t;
 
-  -- ----------------------------------------------------------
-  -- DM Control
-  -- ----------------------------------------------------------
-
   -- signed base address of data registers in memory/CSR space --
   constant dataaddr_c : std_ulogic_vector(11 downto 0) := dm_data_base_c(11 downto 0);
 
@@ -118,7 +114,7 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   end record;
   signal hart : hart_t;
 
-  -- authentication --
+  -- authenticator interface --
   type auth_t is record
     busy  : std_ulogic; -- authenticator is busy when set
     valid : std_ulogic; -- authentication successful
@@ -129,7 +125,7 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   signal auth : auth_t;
 
   -- ----------------------------------------------------------
-  -- CPU Bus and Debug Interfaces
+  -- Debug Core Interface (DCI)
   -- ----------------------------------------------------------
 
   -- code ROM containing "park loop"; copied manually from 'sw/ocd-firmware/neorv32_application_image.vhd' --
@@ -154,9 +150,7 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   );
 
   -- CPU access helpers --
-  signal accen, rden, wren : std_ulogic;
-
-  -- CPU ID decoder --
+  signal accen : std_ulogic;
   signal cpu_id_dec : std_ulogic_vector(NUM_HARTS-1 downto 0);
 
   -- Debug Core Interface --
@@ -567,22 +561,22 @@ begin
       -- bus handshake --
       bus_rsp_o.ack <= accen;
       bus_rsp_o.err <= '0';
-      -- data buffer write access --
-      if (dci.data_reg_we = '1') then -- DM write access
+      -- data0 write access --
+      if (dmi_wren = '1') and (dmi_req_i.addr = addr_data0_c) and (cmd_busy = '0') then -- DM write access
         dci.data_reg <= dmi_req_i.data;
-      elsif (wren = '1') and (bus_req_i.addr(7 downto 6) = dm_data_base_c(7 downto 6)) then -- CPU write access
+      elsif (accen = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(7 downto 6) = dm_data_base_c(7 downto 6)) then -- CPU write access
         for i in 0 to 3 loop
           if (bus_req_i.ben(i) = '1') then
             dci.data_reg(8*i+7 downto 8*i) <= bus_req_i.data(8*i+7 downto 8*i);
           end if;
         end loop;
       end if;
-      -- CPU status register write access --
-      dci.ack_hlt <= (others => '0'); -- all flags auto-clear
+      -- CPU status register write access; all flags auto-clear --
+      dci.ack_hlt <= (others => '0');
       dci.ack_res <= (others => '0');
       dci.ack_exe <= (others => '0');
       dci.ack_exc <= (others => '0');
-      if (wren = '1') and (bus_req_i.addr(7 downto 6) = dm_sreg_base_c(7 downto 6)) then
+      if (accen = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(7 downto 6) = dm_sreg_base_c(7 downto 6)) then
         for i in 0 to NUM_HARTS-1 loop
           if (bus_req_i.ben(0) = '1') then dci.ack_hlt(i) <= cpu_id_dec(i); end if; -- CPU has HALTED
           if (bus_req_i.ben(1) = '1') then dci.ack_res(i) <= cpu_id_dec(i); end if; -- CPU starts RESUMING
@@ -592,7 +586,7 @@ begin
       end if;
       -- CPU read access --
       bus_rsp_o.data <= (others => '0'); -- default
-      if (rden = '1') then -- output enable
+      if (accen = '1') and (bus_req_i.rw = '0') then
         case bus_req_i.addr(7 downto 6) is -- module select
           when "00" => -- dm_code_base_c: code ROM
             bus_rsp_o.data <= code_rom_c(to_integer(unsigned(bus_req_i.addr(5 downto 2))));
@@ -608,10 +602,8 @@ begin
     end if;
   end process bus_access;
 
-  -- access helpers --
-  accen <= bus_req_i.stb and bus_req_i.meta(2); -- access only when hart is in debug mode
-  rden  <= accen and (not bus_req_i.rw);
-  wren  <= accen and (    bus_req_i.rw);
+  -- access only when hart is in debug mode --
+  accen <= bus_req_i.stb and bus_req_i.meta(2);
 
   -- CPU ID decoder --
   hart_id_decode_gen:

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -199,7 +199,17 @@ begin
       dm_reg.req_res     <= '0';
       dm_reg.reset_ack   <= '0';
       dm_reg.clr_acc_err <= '0';
-      if (dmi_wren_auth = '1') then
+
+      -- ------------------------------------------------------
+      -- DMI write access
+      -- ------------------------------------------------------
+      if (dm_reg.dmactive = '0') then -- DM reset (only reset critical registers)
+        dm_reg.ndmreset        <= '0';
+        dm_reg.autoexecdata    <= '0';
+        dm_reg.autoexecprogbuf <= (others => '0');
+        dm_reg.halt_req        <= '0';
+        dm_reg.hartsel         <= (others => '0');
+      elsif (dmi_wren = '1') then
         case dmi_req_i.addr is
 
           -- debug module control --

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -155,14 +155,13 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
 
   -- Debug Core Interface --
   type dci_t is record
-    ack_hlt     : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU (re-)entered HALT state (single-shot)
-    req_res     : std_ulogic_vector(NUM_HARTS-1 downto 0); -- DM wants the CPU to resume when set
-    ack_res     : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU starts resuming when set (single-shot)
-    req_exe     : std_ulogic_vector(NUM_HARTS-1 downto 0); -- DM wants CPU to execute program buffer when set
-    ack_exe     : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU starts executing program buffer when set (single-shot)
-    ack_exc     : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU has detected an exception (single-shot)
-    data_reg_we : std_ulogic; -- write abstract data
-    data_reg    : std_ulogic_vector(31 downto 0); -- memory-mapped data exchange register
+    ack_hlt  : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU (re-)entered HALT state (single-shot)
+    req_res  : std_ulogic_vector(NUM_HARTS-1 downto 0); -- DM wants the CPU to resume when set
+    ack_res  : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU starts resuming when set (single-shot)
+    req_exe  : std_ulogic_vector(NUM_HARTS-1 downto 0); -- DM wants CPU to execute program buffer when set
+    ack_exe  : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU starts executing program buffer when set (single-shot)
+    ack_exc  : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU has detected an exception (single-shot)
+    data_reg : std_ulogic_vector(31 downto 0); -- memory-mapped data exchange register
   end record;
   signal dci : dci_t;
 
@@ -416,41 +415,36 @@ begin
       hart.reset      <= (others => '0');
     elsif rising_edge(clk_i) then
       for i in 0 to NUM_HARTS-1 loop
-        if (dm_reg.ndmreset = '1') then -- DM reset
-          hart.halted(i)     <= '0';
+        -- halted ACK --
+        if (dm_reg.ndmreset = '1') or (dm_reg.dmactive = '0') or (dci.ack_res(i) = '1') then
+          hart.halted(i) <= '0';
+        elsif (dci.ack_hlt(i) = '1') then
+          hart.halted(i) <= '1';
+        end if;
+        -- resume REQ --
+        if (dm_reg.ndmreset = '1') or (dm_reg.dmactive = '0') or (dci.ack_res(i) = '1') then
           hart.resume_req(i) <= '0';
+        elsif (dm_reg.req_res = '1') and (hartselect(i) = '1') then
+          hart.resume_req(i) <= '1';
+        end if;
+        -- resume ACK --
+        if (dm_reg.ndmreset = '1') or (dm_reg.dmactive = '0') or ((dm_reg.req_res = '1') and (hartselect(i) = '1')) then
           hart.resume_ack(i) <= '0';
-          hart.reset(i)      <= '1';
-        else
-          -- halted ACK --
-          if (dci.ack_hlt(i) = '1') then
-            hart.halted(i) <= '1';
-          elsif (dci.ack_res(i) = '1') then
-            hart.halted(i) <= '0';
-          end if;
-          -- resume REQ --
-          if (dm_reg.req_res = '1') and (dm_reg.halt_req = '0') and (hartselect(i) = '1') then -- ignore resume if halt is requested
-            hart.resume_req(i) <= '1';
-          elsif (dci.ack_res(i) = '1') then
-            hart.resume_req(i) <= '0';
-          end if;
-          -- resume ACK --
-          if (dci.ack_res(i) = '1') then
-            hart.resume_ack(i) <= '1';
-          elsif (dm_reg.req_res = '1') and (hartselect(i) = '1') then
-            hart.resume_ack(i) <= '0';
-          end if;
-          -- reset ACK --
-          if (dm_reg.reset_ack = '1') and (hartselect(i) = '1') then
-            hart.reset(i) <= '0';
-          end if;
+        elsif (dci.ack_res(i) = '1') then
+          hart.resume_ack(i) <= '1';
+        end if;
+        -- reset ACK --
+        if (dm_reg.ndmreset = '1') or (dm_reg.dmactive = '0') then
+          hart.reset(i) <= '1';
+        elsif (dm_reg.reset_ack = '1') and (hartselect(i) = '1') then
+          hart.reset(i) <= '0';
         end if;
       end loop;
     end if;
   end process hart_status;
 
   -- resume request(s) --
-  dci.req_res <= hart.resume_req;
+  dci.req_res <= hart.resume_req; -- resume
 
 
   -- Command Execution Arbiter --------------------------------------------------------------
@@ -638,9 +632,9 @@ begin
     auth.rdata <= (others => '0');
   end generate;
 
-  -- authenticator access --
-  auth.re <= '1' when (dmi_rden = '1') and (dmi_req_i.addr = addr_authdata_c) else '0';
-  auth.we <= '1' when (dmi_wren = '1') and (dmi_req_i.addr = addr_authdata_c) else '0';
+  -- authenticator access (always accessible) --
+  auth.we <= '1' when (dmi_req_i.op = dmi_req_wr_c) and (dmi_req_i.addr = addr_authdata_c) else '0';
+  auth.re <= '1' when (dmi_req_i.op = dmi_req_rd_c) and (dmi_req_i.addr = addr_authdata_c) else '0';
 
 
 end neorv32_debug_dm_rtl;

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -80,11 +80,9 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
     req_res         : std_ulogic;
     reset_ack       : std_ulogic;
     hartsel         : std_ulogic_vector(1+1 downto 0); -- plus one bit to detect "unavailable hart"
-    wr_acc_err      : std_ulogic;
-    rd_acc_err      : std_ulogic;
+    set_acc_err     : std_ulogic;
     clr_acc_err     : std_ulogic;
-    autoexec_wr     : std_ulogic;
-    autoexec_rd     : std_ulogic;
+    autoexec        : std_ulogic;
   end record;
   signal dm_reg : dm_reg_t;
 
@@ -188,9 +186,9 @@ begin
       dm_reg.req_res         <= '0';
       dm_reg.reset_ack       <= '0';
       dm_reg.hartsel         <= (others => '0');
-      dm_reg.wr_acc_err      <= '0';
+      dm_reg.set_acc_err     <= '0';
       dm_reg.clr_acc_err     <= '0';
-      dm_reg.autoexec_wr     <= '0';
+      dm_reg.autoexec        <= '0';
     elsif rising_edge(clk_i) then
       -- authenticated DMI write access --
       dm_reg.req_res     <= '0';
@@ -244,24 +242,31 @@ begin
         dm_reg.dmactive <= dmi_req_i.data(0);
       end if;
 
-      -- auto execution trigger --
-      if (((dmi_req_i.addr = addr_data0_c)    and (dm_reg.autoexecdata = '1')) or
+      -- ------------------------------------------------------
+      -- auto-execution triggers
+      -- ------------------------------------------------------
+
+      -- trigger execution on data0/progbuf0/progbuf1 access --
+      if ((dmi_wren = '1') or (dmi_rden = '1')) and
+         (((dmi_req_i.addr = addr_data0_c)    and (dm_reg.autoexecdata = '1')) or
           ((dmi_req_i.addr = addr_progbuf0_c) and (dm_reg.autoexecprogbuf(0) = '1')) or
-          ((dmi_req_i.addr = addr_progbuf1_c) and (dm_reg.autoexecprogbuf(1) = '1'))) and (dmi_wren_auth = '1') then
-        dm_reg.autoexec_wr <= '1';
+          ((dmi_req_i.addr = addr_progbuf1_c) and (dm_reg.autoexecprogbuf(1) = '1'))) then
+        dm_reg.autoexec <= '1';
       else
-        dm_reg.autoexec_wr <= '0';
+        dm_reg.autoexec <= '0';
       end if;
 
       -- invalid access while command is executing --
-      if (cmd.busy = '0') then
-        dm_reg.wr_acc_err <= '0'; -- reset error trigger when command arbiter is in idle state again
-      elsif ((dmi_req_i.addr = addr_abstractcs_c)   or (dmi_req_i.addr = addr_command_c)  or
-             (dmi_req_i.addr = addr_abstractauto_c) or (dmi_req_i.addr = addr_data0_c) or
-             (dmi_req_i.addr = addr_progbuf0_c)     or (dmi_req_i.addr = addr_progbuf1_c)) and (dmi_wren_auth = '1') then
-        dm_reg.wr_acc_err <= '1';
+      if (cmd_busy = '0') then
+        dm_reg.set_acc_err <= '0'; -- reset error trigger when command arbiter is in idle state again
+      elsif ((dmi_req_i.addr = addr_abstractcs_c)   and (dmi_wren = '1')) or
+            ((dmi_req_i.addr = addr_command_c)      and (dmi_wren = '1')) or
+            ((dmi_req_i.addr = addr_abstractauto_c) and (dmi_wren = '1')) or
+            ((dmi_req_i.addr = addr_data0_c)        and ((dmi_wren or dmi_rden) = '1')) or
+            ((dmi_req_i.addr = addr_progbuf0_c)     and ((dmi_wren or dmi_rden) = '1')) or
+            ((dmi_req_i.addr = addr_progbuf1_c)     and ((dmi_wren or dmi_rden) = '1')) then
+        dm_reg.set_acc_err <= '1';
       end if;
-
     end if;
   end process dmi_write_access;
 
@@ -379,25 +384,6 @@ begin
           null;
 
       end case;
-
-      -- invalid read access while command is executing --
-      if (cmd.busy = '0') then
-        dm_reg.rd_acc_err <= '0'; -- reset error trigger when command arbiter is in idle state again
-      elsif (dmi_rden_auth = '1') and
-            ((dmi_req_i.addr = addr_data0_c) or (dmi_req_i.addr = addr_progbuf0_c) or (dmi_req_i.addr = addr_progbuf1_c)) then
-        dm_reg.rd_acc_err <= '1';
-      end if;
-
-      -- auto execution trigger --
-      if (dmi_rden_auth = '1') and
-         (((dmi_req_i.addr = addr_data0_c)    and (dm_reg.autoexecdata = '1')) or
-          ((dmi_req_i.addr = addr_progbuf0_c) and (dm_reg.autoexecprogbuf(0) = '1')) or
-          ((dmi_req_i.addr = addr_progbuf1_c) and (dm_reg.autoexecprogbuf(1) = '1'))) then
-        dm_reg.autoexec_rd <= '1';
-      else
-        dm_reg.autoexec_rd <= '0';
-      end if;
-
     end if;
   end process dmi_read_access;
 

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -290,37 +290,35 @@ begin
   dmi_read_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      dmi_rsp_o.ack      <= '0';
-      dmi_rsp_o.data     <= (others => '0');
-      dm_reg.rd_acc_err  <= '0';
-      dm_reg.autoexec_rd <= '0';
+      dmi_rsp_o.ack  <= '0';
+      dmi_rsp_o.data <= (others => '0');
     elsif rising_edge(clk_i) then
-      dmi_rsp_o.ack  <= dmi_wren or dmi_rden; -- always ACK any request
+      dmi_rsp_o.ack  <= or_reduce_f(dmi_req_i.op); -- always ACK any request
       dmi_rsp_o.data <= (others => '0');
       case dmi_req_i.addr is
 
         -- debug module status register --
         when addr_dmstatus_c =>
-          if (auth.valid = '1') then
-            dmi_rsp_o.data(24)           <= dm_reg.ndmreset;                                         -- ndmresetpending
-            dmi_rsp_o.data(23)           <= '0';                                                     -- stickyunavail
-            dmi_rsp_o.data(22)           <= '1';                                                     -- impebreak
-            dmi_rsp_o.data(19 downto 18) <= (others => or_reduce_f(hart.reset and hartselect));      -- all/any_havereset
-            dmi_rsp_o.data(17 downto 16) <= (others => or_reduce_f(hart.resume_ack and hartselect)); -- all/any_resumeack
-            dmi_rsp_o.data(15 downto 14) <= (others => hartselect_inv);                              -- all/any_nonexistent
-            dmi_rsp_o.data(13 downto 12) <= (others => dm_reg.ndmreset);                             -- all/any_unavail
-            dmi_rsp_o.data(11 downto 10) <= (others => not or_reduce_f(hart.halted and hartselect)); -- all/any_running
-            dmi_rsp_o.data(9 downto 8)   <= (others => or_reduce_f(hart.halted and hartselect));     -- all/any_halted
-            dmi_rsp_o.data(5)            <= '0';                                                     -- hasresethaltreq
-            dmi_rsp_o.data(4)            <= '0';                                                     -- confstrptrvalid
+          if (dmi_rden = '1') then
+            dmi_rsp_o.data(24)           <= dm_reg.ndmreset;                                                            -- ndmresetpending
+            dmi_rsp_o.data(23)           <= '0';                                                                        -- stickyunavail
+            dmi_rsp_o.data(22)           <= '1';                                                                        -- impebreak
+            dmi_rsp_o.data(19 downto 18) <= (others => (hart_exist and or_reduce_f(hart.reset      and hartselect)));   -- all/any_havereset
+            dmi_rsp_o.data(17 downto 16) <= (others => (hart_avail and or_reduce_f(hart.resume_ack and hartselect)));   -- all/any_resumeack
+            dmi_rsp_o.data(15 downto 14) <= (others => (not hart_exist));                                               -- all/any_nonexistent
+            dmi_rsp_o.data(13 downto 12) <= (others => (hart_exist and dm_reg.ndmreset));                               -- all/any_unavail
+            dmi_rsp_o.data(11 downto 10) <= (others => (hart_avail and (not or_reduce_f(hart.halted and hartselect)))); -- all/any_running
+            dmi_rsp_o.data(9 downto 8)   <= (others => (hart_avail and      or_reduce_f(hart.halted and hartselect)));  -- all/any_halted
+            dmi_rsp_o.data(5)            <= '0';                                                                        -- hasresethaltreq
+            dmi_rsp_o.data(4)            <= '0';                                                                        -- confstrptrvalid
           end if;
-         dmi_rsp_o.data(7)          <= auth.valid; -- authenticated
-         dmi_rsp_o.data(6)          <= auth.busy;  -- authbusy
-         dmi_rsp_o.data(3 downto 0) <= "0011";     -- version
+          dmi_rsp_o.data(7)          <= auth.valid; -- authenticated
+          dmi_rsp_o.data(6)          <= auth.busy;  -- authbusy
+          dmi_rsp_o.data(3 downto 0) <= "0011";     -- version
 
         -- debug module control --
         when addr_dmcontrol_c =>
-          if (auth.valid = '1') then
+          if (dmi_rden = '1') then
             dmi_rsp_o.data(31)           <= '0';                        -- haltreq
             dmi_rsp_o.data(30)           <= '0';                        -- resumereq
             dmi_rsp_o.data(29)           <= '0';                        -- hartreset
@@ -336,7 +334,7 @@ begin
 
         -- hart info --
         when addr_hartinfo_c =>
-          if (auth.valid = '1') then
+          if (dmi_rden = '1') then
             dmi_rsp_o.data(23 downto 20) <= "0001";                  -- nscratch
             dmi_rsp_o.data(16)           <= '1';                     -- dataaccess
             dmi_rsp_o.data(15 downto 12) <= "0001";                  -- datasize
@@ -345,40 +343,40 @@ begin
 
         -- abstract control and status --
         when addr_abstractcs_c =>
-          if (auth.valid = '1') then
+          if (dmi_rden = '1') then
             dmi_rsp_o.data(28 downto 24) <= "00010";  -- progbufsize
-            dmi_rsp_o.data(12)           <= cmd.busy; -- busy
+            dmi_rsp_o.data(12)           <= cmd_busy; -- busy
             dmi_rsp_o.data(11)           <= '1';      -- relaxedpriv
-            dmi_rsp_o.data(10 downto 8)  <= cmd.err;  -- cmderr
+            dmi_rsp_o.data(10 downto 8)  <= cmd_err;  -- cmderr
             dmi_rsp_o.data(3 downto 0)   <= "0001";   -- datacount
           end if;
 
         -- abstract command autoexec --
         when addr_abstractauto_c =>
-          if (auth.valid = '1') then
+          if (dmi_rden = '1') then
             dmi_rsp_o.data(17 downto 16) <= dm_reg.autoexecprogbuf;
             dmi_rsp_o.data(0)            <= dm_reg.autoexecdata;
           end if;
 
         -- abstract data 0 --
         when addr_data0_c =>
-          if (auth.valid = '1') then
+          if (dmi_rden = '1') then
             dmi_rsp_o.data <= dci.data_reg;
           end if;
 
-        -- authentication --
+        -- authentication data (can always be read) --
         when addr_authdata_c =>
           dmi_rsp_o.data <= auth.rdata;
 
         -- halt summary 0 --
         when addr_haltsum0_c =>
-          if (auth.valid = '1') then
+          if (dmi_rden = '1') then
             dmi_rsp_o.data(NUM_HARTS-1 downto 0) <= hart.halted(NUM_HARTS-1 downto 0);
           end if;
 
         -- not implemented or read-only-zero --
         when others =>
-          dmi_rsp_o.data <= (others => '0');
+          null;
 
       end case;
 

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -65,7 +65,11 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   constant addr_haltsum0_c     : std_ulogic_vector(6 downto 0) := "1000000";
 
   -- DMI access --
-  signal dmi_wren, dmi_wren_auth, dmi_rden, dmi_rden_auth : std_ulogic;
+  signal dmi_wren, dmi_rden : std_ulogic;
+
+  -- ----------------------------------------------------------
+  -- DM Control
+  -- ----------------------------------------------------------
 
   -- debug module DMI registers / access --
   type progbuf_t is array (0 to 1) of std_ulogic_vector(31 downto 0);
@@ -180,9 +184,9 @@ begin
       dm_reg.ndmreset        <= '0';
       dm_reg.dmactive        <= '0';
       dm_reg.autoexecdata    <= '0';
-      dm_reg.autoexecprogbuf <= "00";
+      dm_reg.autoexecprogbuf <= (others => '0');
+      dm_reg.progbuf         <= (others => cmd_nop);
       dm_reg.command         <= (others => '0');
-      dm_reg.progbuf         <= (others => instr_nop_c);
       dm_reg.halt_req        <= '0';
       dm_reg.req_res         <= '0';
       dm_reg.reset_ack       <= '0';
@@ -191,7 +195,7 @@ begin
       dm_reg.clr_acc_err     <= '0';
       dm_reg.autoexec        <= '0';
     elsif rising_edge(clk_i) then
-      -- authenticated DMI write access --
+      -- defaults --
       dm_reg.req_res     <= '0';
       dm_reg.reset_ack   <= '0';
       dm_reg.clr_acc_err <= '0';
@@ -200,21 +204,19 @@ begin
 
           -- debug module control --
           when addr_dmcontrol_c =>
-            dm_reg.halt_req  <= dmi_req_i.data(31);           -- haltreq
-            dm_reg.req_res   <= dmi_req_i.data(30);           -- resumereq
-            dm_reg.reset_ack <= dmi_req_i.data(28);           -- ackhavereset
-            if (cmd.busy = '0') then -- no update while abstract command is executing
-              dm_reg.hartsel <= dmi_req_i.data(18 downto 16); -- hartsello
-            end if;
-            dm_reg.ndmreset  <= dmi_req_i.data(1);            -- ndmreset
+            dm_reg.halt_req  <= dmi_req_i.data(31);                                          -- haltreq
+            dm_reg.req_res   <= dmi_req_i.data(30) and (not dmi_req_i.data(31));             -- resumereq, ignore if halt request
+            dm_reg.reset_ack <= dmi_req_i.data(28);                                          -- ackhavereset
+            if (cmd_busy = '0') then dm_reg.hartsel <= dmi_req_i.data(18 downto 16); end if; -- hartsello, no update while CMD is executing
+            dm_reg.ndmreset  <= dmi_req_i.data(1);                                           -- ndmreset
 
           -- write abstract command (only when idle and no error yet) --
           when addr_command_c =>
-            if (cmd.busy = '0') and (cmd.err = "000") then dm_reg.command <= dmi_req_i.data; end if;
+            if (cmd_busy = '0') and (cmd_err = "000") then dm_reg.command <= dmi_req_i.data; end if;
 
           -- write abstract command autoexec (only when idle) --
           when addr_abstractauto_c =>
-            if (cmd.busy = '0') then
+            if (cmd_busy = '0') then
               dm_reg.autoexecprogbuf <= dmi_req_i.data(17 downto 16);
               dm_reg.autoexecdata    <= dmi_req_i.data(0);
             end if;
@@ -225,21 +227,21 @@ begin
 
           -- write program buffer 0 (only when idle) --
           when addr_progbuf0_c =>
-            if (cmd.busy = '0') then dm_reg.progbuf(0) <= dmi_req_i.data; end if;
+            if (cmd_busy = '0') then dm_reg.progbuf(0) <= dmi_req_i.data; end if;
 
           -- write program buffer 1 (only when idle) --
           when addr_progbuf1_c =>
-            if (cmd.busy = '0') then dm_reg.progbuf(1) <= dmi_req_i.data; end if;
+            if (cmd_busy = '0') then dm_reg.progbuf(1) <= dmi_req_i.data; end if;
 
           -- undefined --
           when others =>
-            NULL;
+            null;
 
         end case;
       end if;
 
-      -- dmactive can also be written if not authenticated --
-      if (dmi_req_i.addr = addr_dmcontrol_c) and (dmi_wren = '1') then
+      -- dmactive can always be written --
+      if (dmi_req_i.op = dmi_req_wr_c) and (dmi_req_i.addr = addr_dmcontrol_c) then
         dm_reg.dmactive <= dmi_req_i.data(0);
       end if;
 
@@ -274,10 +276,7 @@ begin
   -- SoC reset --
   ndmrstn_o <= '0' when (dm_reg.ndmreset = '1') and (dm_reg.dmactive = '1') else '1';
 
-  -- write to abstract data register --
-  dci.data_reg_we <= '1' when (dmi_wren_auth = '1') and (dmi_req_i.addr = addr_data0_c) and (cmd.busy = '0') else '0';
-
-  -- hart select decoder (one-hot) --
+  -- hart select --
   hartsel_decode:
   for i in 0 to NUM_HARTS-1 generate
     hartselect(i) <= '1' when (dm_reg.hartsel(2) = '0') and (dm_reg.hartsel(1 downto 0) = std_ulogic_vector(to_unsigned(i, 2))) else '0';

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -170,10 +170,8 @@ begin
 
   -- DMI Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  dmi_wren <= '1' when (dmi_req_i.op = dmi_req_wr_c) else '0'; -- any access
-  dmi_rden <= '1' when (dmi_req_i.op = dmi_req_rd_c) else '0';
-  dmi_wren_auth <= dmi_wren and auth.valid; -- authenticated access
-  dmi_rden_auth <= dmi_rden and auth.valid;
+  dmi_wren <= '1' when (dmi_req_i.op = dmi_req_wr_c) and (auth.valid = '1') and (dm_reg.dmactive = '1') else '0';
+  dmi_rden <= '1' when (dmi_req_i.op = dmi_req_rd_c) and (auth.valid = '1') and (dm_reg.dmactive = '1') else '0';
 
 
   -- Debug Module Interface - Write Access --------------------------------------------------

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -87,8 +87,9 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   signal dm_reg : dm_reg_t;
 
   -- currently selected hart --
-  signal hartselect     : std_ulogic_vector(NUM_HARTS-1 downto 0);
-  signal hartselect_inv : std_ulogic; -- invalid/unavailable hart selection
+  signal hartselect : std_ulogic_vector(NUM_HARTS-1 downto 0);
+  signal hart_exist : std_ulogic; -- selected hart exists
+  signal hart_avail : std_ulogic; -- selected hart is available
 
   -- CPU program buffer --
   type cpu_progbuf_t is array (0 to 3) of std_ulogic_vector(31 downto 0);
@@ -281,7 +282,8 @@ begin
   for i in 0 to NUM_HARTS-1 generate
     hartselect(i) <= '1' when (dm_reg.hartsel(2) = '0') and (dm_reg.hartsel(1 downto 0) = std_ulogic_vector(to_unsigned(i, 2))) else '0';
   end generate;
-  hartselect_inv <= '0' when (unsigned(dm_reg.hartsel) < NUM_HARTS) else '1'; -- invalid/unavailable hart selection
+  hart_exist <= '1' when (unsigned(dm_reg.hartsel) < to_unsigned(NUM_HARTS, 3)) else '0'; -- selected hart exists
+  hart_avail <= hart_exist and (not dm_reg.ndmreset); -- selected hart is available
 
   -- CPU halt request --
   request_gen:

--- a/rtl/core/neorv32_debug_dtm.vhd
+++ b/rtl/core/neorv32_debug_dtm.vhd
@@ -5,7 +5,7 @@
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  --
+-- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
 -- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
 -- SPDX-License-Identifier: BSD-3-Clause                                            --
 -- ================================================================================ --
@@ -151,12 +151,11 @@ begin
       end if;
       -- data register input --
       if (state = DR_CAPTURE) then -- capture phase
-        dreg <= (others => '0');
-        case ireg is -- make data MSB-aligned
-          when addr_idcode_c => dreg(dreg'left downto dreg'left-(size_idcode_c-1)) <= IDCODE_VERSION & IDCODE_PARTID & IDCODE_MANID & '1';
-          when addr_dtmcs_c  => dreg(dreg'left downto dreg'left-(size_dtmcs_c-1))  <= x"00000071";
-          when addr_dmi_c    => dreg(dreg'left downto dreg'left-(size_dmi_c-1))    <= dmi.addr & dmi.data & err & err;
-          when others        => dreg(dreg'left downto dreg'left-(size_bypass_c-1)) <= (others => '0');
+        case ireg is -- [NOTE] make data MSB-aligned and fill with zeros
+          when addr_idcode_c => dreg <= IDCODE_VERSION & IDCODE_PARTID & IDCODE_MANID & '1' & "000000000";
+          when addr_dtmcs_c  => dreg <= x"00000071" & "000000000";
+          when addr_dmi_c    => dreg <= dmi.addr & dmi.data & err & err;
+          when others        => dreg <= (others => '0');
         end case;
       elsif (state = DR_SHIFT) and (tck_rise = '1') then -- access phase; [JTAG-SYNC] evaluate TDI on rising edge of TCK
         dreg <= tdi & dreg(dreg'left downto 1);
@@ -177,9 +176,9 @@ begin
     end if;
   end process reg_access;
 
-  -- reset control --
-  dmihardreset <= '1' when (update = '1') and (ireg = addr_dtmcs_c) and (dreg(17) = '1') else '0';
-  dmireset     <= '1' when (update = '1') and (ireg = addr_dtmcs_c) and (dreg(16) = '1') else '0';
+  -- reset control; [NOTE] dreg bits are LSB-aligned --
+  dmihardreset <= '1' when (update = '1') and (ireg = addr_dtmcs_c) and (dreg((dreg'left - (size_dtmcs_c-1)) + 17) = '1') else '0';
+  dmireset     <= '1' when (update = '1') and (ireg = addr_dtmcs_c) and (dreg((dreg'left - (size_dtmcs_c-1)) + 16) = '1') else '0';
 
 
   -- Debug Module Interface -----------------------------------------------------------------
@@ -191,10 +190,10 @@ begin
       err  <= '0';
       dmi  <= dmi_req_terminate_c;
     elsif rising_edge(clk_i) then
-      -- sticky error: access attempt while DMI is busy --
+      -- sticky error: access attempt while DMI is busy or invalid operation --
       if (dmireset = '1') or (dmihardreset = '1') then
         err <= '0';
-      elsif (update = '1') and (ireg = addr_dmi_c) and (busy = '1') then
+      elsif (update = '1') and (ireg = addr_dmi_c) and ((busy = '1') or (dmi.op = "11")) then
         err <= '1';
       end if;
       -- interface arbiter --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -483,6 +483,7 @@ package neorv32_package is
   constant csr_tselect_c        : std_ulogic_vector(11 downto 0) := x"7a0";
   constant csr_tdata1_c         : std_ulogic_vector(11 downto 0) := x"7a1";
   constant csr_tdata2_c         : std_ulogic_vector(11 downto 0) := x"7a2";
+  constant csr_tdata3_c         : std_ulogic_vector(11 downto 0) := x"7a3";
   constant csr_tinfo_c          : std_ulogic_vector(11 downto 0) := x"7a4";
   -- debug registers --
   constant csr_dcsr_c           : std_ulogic_vector(11 downto 0) := x"7b0";

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130003"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130004"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/sw/ocd-firmware/park_loop.S
+++ b/sw/ocd-firmware/park_loop.S
@@ -6,7 +6,7 @@
 // -------------------------------------------------------------------------------- //
 // The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
 // Copyright (c) NEORV32 contributors.                                              //
-// Copyright (c) 2020 - 2025 Stephan Nolting. All rights reserved.                  //
+// Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  //
 // Licensed under the BSD-3-Clause license, see LICENSE for details.                //
 // SPDX-License-Identifier: BSD-3-Clause                                            //
 // ================================================================================ //
@@ -40,10 +40,11 @@ ocd_entry_exception:
 // DM_CODE_BASE + 4: normal entry - halt CPU and enter park loop
 ocd_entry_park:
   csrw dscratch0, x8                       // backup x8 to dscratch0 so we have a GPR available
-  sb   zero, (DM_SREG_BASE+SREG_HLT)(zero) // send halt-acknowledge
 
 // polling loop (wait for debugger requests)
 ocd_park_loop:
+  sb   zero, (DM_SREG_BASE+SREG_HLT)(zero) // (re-)send halt-acknowledge: CPU is (still) halted
+
   lbu  x8, (DM_SREG_BASE+SREG_EXE)(zero)   // check if pending execute request
   bnez x8, ocd_execute
 


### PR DESCRIPTION
* add `tdata3` CSR (not used by openOCD/GDB but required by the RISC-V debug spec; hardwired to all-zero)
* :bug: debug transfer module (DTM): fix position of reset bits (this is a bug; however, it looks like openOCD never uses these bits... perhaps because it never encounters a DTM error)
* rework park loop code and hart status logic: as a result, a halted CPU core continuously reports that it has been halted; this allows to interrupt and re-establish an openOCD connection at any time
* debug module interface (DMI): ensure that only the minimum number of status register bits can be read when the DM is disabled or not authenticated
* reset most of the DM's internal state when deactivated
* RTL cleanups
* logic optimization