### PR TITLE
🐛 [pmp] fix reserved permissions and address/mask storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 08.05.2026 | 1.13.0.6 | :bug: fix write-only permission config and address/mask storage | [#1549](https://github.com/stnolting/neorv32/pull/1549) |
 | 06.05.2026 | 1.13.0.5 | add support for all hardware performance monitors (HPMs); add high-word event-select CSRs (`mhpmevent*h`); add unprivileged/user-mode CSRs shadow copies (`hpmcounter*[h]`) | [#1546](https://github.com/stnolting/neorv32/pull/1546) |
 | 03.05.2026 | 1.13.0.4 | rework on-chip debugger (OCD) fixing minor spec incompatibilities | [#1544](https://github.com/stnolting/neorv32/pull/1544) |
 | 02.05.2026 | 1.13.0.3 | minor rtl fixes, edits and cleanups (PMP, TWD, bus | [#1543](https://github.com/stnolting/neorv32/pull/1543) |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -551,7 +551,7 @@ implementation of the according modes.
 |             | `0x3bf` (`pmpaddr15`)
 | Reset value | all `0x00000000`
 | ISA         | <<_zicsr_isa_extension,`Zicsr`>> & <<_smpmp_isa_extension,`Smpmp`>>
-| Description | Region address/boundaries configuration.
+| Description | Region address/boundaries configuration (address/mask bits `33:2`).
 Note that, depending on `PMP_NUM_REGIONS`, a **maximum** of the lowest 16 address registers are physically implemented (`pmpaddr0 .. pmpaddr15`).
 All remaining register are hardwired to zero.
 |=======================

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -122,9 +122,15 @@ begin
       elsif rising_edge(clk_i) then
         if (pmpcfg_we(i/4) = '1') and (pmpcfg(i)(cfg_l_c) = '0') then -- unlocked write access
           -- permissions --
-          pmpcfg(i)(cfg_r_c) <= ctrl_i.csr_wdata((i mod 4)*8+cfg_r_c); -- R (read)
-          pmpcfg(i)(cfg_w_c) <= ctrl_i.csr_wdata((i mod 4)*8+cfg_w_c); -- W (write)
-          pmpcfg(i)(cfg_x_c) <= ctrl_i.csr_wdata((i mod 4)*8+cfg_x_c); -- X (execute)
+          if (ctrl_i.csr_wdata((i mod 4)*8+cfg_w_c) = '1') and (ctrl_i.csr_wdata((i mod 4)*8+cfg_r_c) = '0') then -- W-only = reserved
+            pmpcfg(i)(cfg_r_c) <= '0';
+            pmpcfg(i)(cfg_w_c) <= '0';
+            pmpcfg(i)(cfg_x_c) <= '0';
+          else
+            pmpcfg(i)(cfg_r_c) <= ctrl_i.csr_wdata((i mod 4)*8+cfg_r_c); -- R (read)
+            pmpcfg(i)(cfg_w_c) <= ctrl_i.csr_wdata((i mod 4)*8+cfg_w_c); -- W (write)
+            pmpcfg(i)(cfg_x_c) <= ctrl_i.csr_wdata((i mod 4)*8+cfg_x_c); -- X (execute)
+          end if;
           -- mode --
           mode_v := ctrl_i.csr_wdata((i mod 4)*8+cfg_ah_c downto (i mod 4)*8+cfg_al_c);
           if ((mode_v = mode_tor_c)   and (not TOR_EN)) or -- TOR mode not implemented

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -72,7 +72,7 @@ architecture neorv32_cpu_pmp_rtl of neorv32_cpu_pmp is
   signal pmpcfg_we : std_ulogic_vector(3 downto 0);
 
   -- address CSRs --
-  type pmpaddr_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(29 downto pmp_alsb_c);
+  type pmpaddr_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(31 downto pmp_alsb_c);
   signal pmpaddr    : pmpaddr_t;
   signal pmpaddr_we : std_ulogic_vector(15 downto 0);
 
@@ -166,10 +166,10 @@ begin
         if (pmpaddr_we(i) = '1') and (pmpcfg(i)(cfg_l_c) = '0') then -- unlocked write access
           if (i < NUM_REGIONS-1) then
             if (pmpcfg(i+1)(cfg_l_c) = '0') or (pmpcfg(i+1)(cfg_ah_c downto cfg_al_c) /= mode_tor_c) then -- pmpcfg(i+1) not "LOCKED TOR"
-              pmpaddr(i) <= ctrl_i.csr_wdata(29 downto pmp_alsb_c);
+              pmpaddr(i) <= ctrl_i.csr_wdata(31 downto pmp_alsb_c);
             end if;
           else -- very last entry
-            pmpaddr(i) <= ctrl_i.csr_wdata(29 downto pmp_alsb_c);
+            pmpaddr(i) <= ctrl_i.csr_wdata(31 downto pmp_alsb_c);
           end if;
         end if;
       end if;
@@ -198,7 +198,7 @@ begin
     address_read_back: process(pmpaddr, pmpcfg)
     begin
       addr_rd(i) <= (others => '0');
-      addr_rd(i)(29 downto pmp_alsb_c) <= pmpaddr(i);
+      addr_rd(i)(31 downto pmp_alsb_c) <= pmpaddr(i)(31 downto pmp_alsb_c);
       if (pmp_lsb_c > 2) then -- G >= 1
         if (pmpcfg(i)(cfg_ah_c) = '0') then -- TOR/OFF mode
           addr_rd(i)(pmp_lsb_c-3 downto 0) <= (others => '0'); -- [G-1:0] read as zero

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130005"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130006"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 


### PR DESCRIPTION
* setting a write-only region is _reserved_; fall back to no permissions
* store full 32-bit address/mask in `pmpaddri` (bits 33:2) 