### PR TITLE
✨ add support for `time[h]` CSRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 08.05.2026 | 1.13.0.8 | :sparkles: add support for RISC-V `time[h]` CSRs | [#1551](https://github.com/stnolting/neorv32/pull/1551) |
 | 08.05.2026 | 1.13.0.7 | :sparkles: add support for RISC-V `Zbc` ISA extensions (carry-less multiplication) | [#1550](https://github.com/stnolting/neorv32/pull/1550) |
 | 08.05.2026 | 1.13.0.6 | :bug: fix write-only permission config and address/mask storage | [#1549](https://github.com/stnolting/neorv32/pull/1549) |
 | 06.05.2026 | 1.13.0.5 | add support for all hardware performance monitors (HPMs); add high-word event-select CSRs (`mhpmevent*h`); add unprivileged/user-mode CSRs shadow copies (`hpmcounter*[h]`) | [#1546](https://github.com/stnolting/neorv32/pull/1546) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -43,6 +43,7 @@ for the protocol and type documentation.
 | `clk_i`      | 1              | in  | Global clock line, all registers triggering on rising edge.
 | `rstn_i`     | 1              | in  | Global reset, low-active.
 4+^| **Status**
+| `mtime_i`    | 64             | in  | System time from the <<_core_local_interruptor_clint>> (MTIME).
 | `trace_o`    | `trace_port_t` | out | <<_execution_trace_port>>.
 | `sleep_o`    | 1              | out | Set while the CPU is in <<_sleep_mode>>.
 | `fence_o`    | 2              | out | <<_memory_coherence>> / ordering: `[1]` = instruction fence, `[0]` = data fence.

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -65,8 +65,10 @@ to check if the targeted bits can actually be modified.
 | 0xb80 | <<_mcycleh, `mcycleh`>>     | `CSR_MCYCLEH`   | MRW | Machine cycle counter high word
 | 0xb82 | <<_minstreth, `minstreth`>> | `CSR_MINSTRETH` | MRW | Machine instruction-retired counter high word
 | 0xc00 | <<_cycleh, `cycle`>>        | `CSR_CYCLE`     | URO | Cycle counter low word
+| 0xc01 | <<_timeh, `time`>>          | `CSR_TIME`      | URO | System time low word
 | 0xc02 | <<_instreth, `instret`>>    | `CSR_INSTRET`   | URO | Instruction-retired counter low word
 | 0xc80 | <<_cycleh, `cycleh`>>       | `CSR_CYCLEH`    | URO | Cycle counter high word
+| 0xc81 | <<_timeh, `timeh`>>         | `CSR_TIMEH`     | URO | System time high word
 | 0xc82 | <<_instreth, `instreth`>>   | `CSR_INSTRETH`  | URO | Instruction-retired counter high word
 5+^| **<<_hardware_performance_monitors_hpm_csrs>>**
 | 0x323 .. 0x33f | <<_mhpmeventh, `mhpmevent3`>> .. <<_mhpmevent, `mhpmevent31`>>            | `CSR_MHPMEVENT3` .. `CSR_MHPMEVENT31`       | MRW | Machine performance-monitoring event select low word
@@ -571,12 +573,6 @@ All remaining register are hardwired to zero.
 :sectnums:
 ==== (Machine) Counter and Timer CSRs
 
-.`time[h]` CSRs (Wall Clock Time)
-[IMPORTANT]
-The NEORV32 does not implement the `time[h]` CSRs. Any access to these registers will trap. It is
-recommended that the trap handler software provides a means of accessing the machine timer of the
-<<_core_local_interruptor_clint>>.
-
 .Instruction Retired Counter Increment
 [NOTE]
 The `[m]instret[h]` counter always increments when a instruction enters the pipeline's execute stage no matter
@@ -595,6 +591,23 @@ if this instruction is actually going to retire or if it causes an exception.
 | Reset value | `0x00000000_00000000`
 | ISA         | <<_zicsr_isa_extension,`Zicsr`>> & <<_zicntr_isa_extension,`Zicntr`>>
 | Description | The `cycle[h]` CSRs are user-mode shadow copies of the according <<_mcycleh>> CSRs. The user-mode
+counter are read-only. Any write access will raise an illegal instruction exception.
+|=======================
+
+
+{empty} +
+[discrete]
+===== **`time[h]`**
+
+[cols="<1,<8"]
+[grid="none"]
+|=======================
+| Name        | System time counter
+| Address     | `0xc01` (`time`)
+|             | `0xc81` (`timeh`)
+| Reset value | `0x00000000_00000000`
+| ISA         | <<_zicsr_isa_extension,`Zicsr`>> & <<_zicntr_isa_extension,`Zicntr`>>
+| Description | The `instret[h]` CSRs are user-mode shadow copies of the according <<_minstreth>> CSRs. The user-mode
 counter are read-only. Any write access will raise an illegal instruction exception.
 |=======================
 

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -312,9 +312,9 @@ As software does not need to determine the interrupt cause the reduction in late
 [options="header",grid="rows"]
 |=======================
 | Bit | Name [C] | R/W | Function
-| 31:3 | `CSR_MCOUNTEREN_HPM31 : CSR_MCOUNTEREN_HPM3` | r/w | **HPMn**: User-mode is allowed to read <<_hpmcounterh>> (31:3) CSRs when set
+| 31:3 | `CSR_MCOUNTEREN_HPM31 : CSR_MCOUNTEREN_HPM3` | r/w | **HPMn**: User-mode is allowed to read according <<_hpmcounterh>> (31:3) CSRs when set
 | 2    | `CSR_MCOUNTEREN_IR`                          | r/w | **IR**: User-mode is allowed to read <<_instreth>> CSRs when set
-| 1    | -                                            | r/- | **TM**: not implemented, hardwired to zero
+| 1    | `CSR_MCOUNTEREN_TM`                          | r/w | **TM**: User-mode is allowed to read <<_timeh>> CSRs when set
 | 0    | `CSR_MCOUNTEREN_CY`                          | r/w | **CY**: User-mode is allowed to read <<_cycleh>> CSRs when set
 |=======================
 

--- a/docs/datasheet/cpu_isa.adoc
+++ b/docs/datasheet/cpu_isa.adoc
@@ -369,11 +369,6 @@ taken: 5 + `T_inst_latency`
 The `Zicntr` ISA extension adds the basic <<_cycleh>>, <<_mcycleh>>, <<_instreth>> and <<_minstreth>>
 counter CSRs. Section <<_machine_counter_and_timer_csrs>> shows a list of all `Zicntr`-related CSRs.
 
-.Time CSRs
-[NOTE]
-The user-mode `time[h]` CSRs are **not implemented**. Any access will trap allowing the trap handler to
-retrieve system time from the <<_core_local_interruptor_clint>>.
-
 .Constrained Access
 [TIP]
 User-level access to the counter CSRs can be constrained by the <<_mcounteren>> CSR.

--- a/rtl/core/neorv32_clint.vhd
+++ b/rtl/core/neorv32_clint.vhd
@@ -27,7 +27,7 @@ entity neorv32_clint is
     rstn_i    : in  std_ulogic;                              -- global reset line, low-active, async
     bus_req_i : in  bus_req_t;                               -- bus request
     bus_rsp_o : out bus_rsp_t;                               -- bus response
-    time_o    : out std_ulogic_vector(63 downto 0);          -- current system time
+    time_o    : out std_ulogic_vector(63 downto 0);          -- current system time (HI/LO are not synchronized!)
     mti_o     : out std_ulogic_vector(NUM_HARTS-1 downto 0); -- machine timer interrupt
     msi_o     : out std_ulogic_vector(NUM_HARTS-1 downto 0)  -- machine software interrupt
   );
@@ -102,17 +102,8 @@ begin
   mtime_rd <= (others => '0') when (mtime_en = '0') else
               mtime(63 downto 32) when (bus_req_i.addr(2) = '1') else mtime(31 downto 0);
 
-  -- system time output: synchronize low and high words --
-  time_output: process(rstn_i, clk_i)
-  begin
-    if (rstn_i = '0') then
-      time_o(31 downto 0) <= (others => '0');
-    elsif rising_edge(clk_i) then
-      time_o(31 downto 0) <= mtime(31 downto 0);
-    end if;
-  end process time_output;
-
-  time_o(63 downto 32) <= mtime(63 downto 32);
+  -- system time output: high and low word are not synchronized! --
+  time_o <= mtime;
 
 
   -- MTIMECMP - Per-Hart Time Comparator / Interrupt Generator ------------------------------

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -80,6 +80,7 @@ entity neorv32_cpu is
     clk_i      : in  std_ulogic;                     -- global clock, rising edge
     rstn_i     : in  std_ulogic;                     -- global reset, low-active, async
     -- status --
+    mtime_i    : in  std_ulogic_vector(63 downto 0); -- system time input from CLINT/MTIME
     trace_o    : out trace_port_t;                   -- execution trace port (enabled when CPU_TRACE_EN = true)
     sleep_o    : out std_ulogic;                     -- CPU is in sleep mode
     fence_o    : out std_ulogic_vector(1 downto 0);  --
@@ -370,6 +371,8 @@ begin
       clk_i   => clk_i,   -- global clock, rising edge
       rstn_i  => rstn_i,  -- global reset, low-active, async
       ctrl_i  => ctrl,    -- main control bus
+      -- system time --
+      mtime_i => mtime_i, -- from CLINT/MTIME
       -- read back --
       rdata_o => xcsr_cnt -- read data
     );

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -630,7 +630,8 @@ begin
         csr_valid(2) <= bool_to_ulogic_f(RISCV_ISA_Zihpm);
 
       -- counter and timer CSRs --
-      when csr_cycle_c | csr_mcycle_c | csr_instret_c | csr_minstret_c | csr_cycleh_c | csr_mcycleh_c | csr_instreth_c | csr_minstreth_c =>
+      when csr_cycle_c  | csr_time_c  | csr_instret_c  | csr_mcycle_c  | csr_minstret_c |
+           csr_cycleh_c | csr_timeh_c | csr_instreth_c | csr_mcycleh_c | csr_minstreth_c =>
         csr_valid(2) <= bool_to_ulogic_f(RISCV_ISA_Zicntr);
 
       -- counter privilege-mode filtering CSRs --

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1132,8 +1132,6 @@ begin
       -- ********************************************************************************
       -- Override: terminate unavailable registers and bits
       -- ********************************************************************************
-      -- undefined --
-      csr.mcounteren(1) <= '0';
       -- no base counters --
       if not RISCV_ISA_Zicntr then
         csr.mcounteren(2 downto 0) <= (others => '0');

--- a/rtl/core/neorv32_cpu_counters.vhd
+++ b/rtl/core/neorv32_cpu_counters.vhd
@@ -2,9 +2,9 @@
 -- NEORV32 CPU - Hardware Counters                                                  --
 -- -------------------------------------------------------------------------------- --
 -- Implementing hardware counters/control for the following RISC-V ISA extensions:  --
--- + Zicntr:    Base Counters           -> [m]cycle[h]         + [m]instret[h]      --
+-- + Zicntr:    Base Counters           -> [m]cycle[h] + time[h] + [m]instret[h]    --
 -- + Zihpm:     Hardware Perf. Monitors -> [m]hpmcnt[3..31][h] + mhpmevent[3..31]   --
--- + Smcntrpmf: Counter Priv. Filtering -> mcyclecfg[h]        + minstretcfg[h]     --
+-- + Smcntrpmf: Counter Priv. Filtering -> mcyclecfg[h] + minstretcfg[h]            --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
@@ -34,6 +34,8 @@ entity neorv32_cpu_counters is
     clk_i   : in  std_ulogic; -- global clock, rising edge
     rstn_i  : in  std_ulogic; -- global reset, low-active, async
     ctrl_i  : in  ctrl_bus_t; -- main control bus
+    -- system time --
+    mtime_i : in  std_ulogic_vector(63 downto 0); -- from CLINT/MTIME
     -- read back --
     rdata_o : out std_ulogic_vector(31 downto 0) -- read data
   );
@@ -58,7 +60,7 @@ architecture neorv32_cpu_counters_rtl of neorv32_cpu_counters is
   signal hpmcnt_rd : hpmcnt_t;
 
   -- global CSR read-backs --
-  signal rdata64, cycle_rd, time_rd, instret_rd, hpm_rd, inhibit_rd, pmf_rd : std_ulogic_vector(63 downto 0);
+  signal rdata64, cycle_rd, time_q, time_rd, instret_rd, hpm_rd, inhibit_rd, pmf_rd : std_ulogic_vector(63 downto 0);
 
 begin
 
@@ -208,8 +210,16 @@ begin
       cnt_o  => cycle_rd
     );
 
-    -- [m]time[h] --
-    time_rd <= (others => '0'); -- not implemented
+    -- time[h] --
+    mtime: process(rstn_i, clk_i)
+    begin
+      if (rstn_i = '0') then
+        time_q <= (others => '0');
+      elsif rising_edge(clk_i) then
+        time_q <= mtime_i;
+      end if;
+    end process mtime;
+    time_rd <= time_q when (cnt_re(1) = '1') else (others => '0');
 
     -- [m]instret[h] --
     instret_inst: entity neorv32.neorv32_prim_cnt
@@ -232,6 +242,7 @@ begin
   base_disabled:
   if not ZICNTR_EN generate
     cycle_rd   <= (others => '0');
+    time_q     <= (others => '0');
     time_rd    <= (others => '0');
     instret_rd <= (others => '0');
   end generate;

--- a/rtl/core/neorv32_cpu_trace.vhd
+++ b/rtl/core/neorv32_cpu_trace.vhd
@@ -550,7 +550,6 @@ architecture neorv32_cpu_trace_simlog_rtl of neorv32_cpu_trace_simlog is
       when csr_dscratch0_c      => return "dscratch0";
       -- machine counters/timers --
       when csr_mcycle_c         => return "mcycle";
-      when csr_mtime_c          => return "mtime";
       when csr_minstret_c       => return "minstret";
       when csr_mhpmcounter3_c   => return "mhpmcounter3";
       when csr_mhpmcounter4_c   => return "mhpmcounter4";
@@ -582,7 +581,6 @@ architecture neorv32_cpu_trace_simlog_rtl of neorv32_cpu_trace_simlog is
       when csr_mhpmcounter30_c  => return "mhpmcounter30";
       when csr_mhpmcounter31_c  => return "mhpmcounter31";
       when csr_mcycleh_c        => return "mcycleh";
-      when csr_mtimeh_c         => return "mtimeh";
       when csr_minstreth_c      => return "minstreth";
       when csr_mhpmcounter3h_c  => return "mhpmcounter3h";
       when csr_mhpmcounter4h_c  => return "mhpmcounter4h";

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130007"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130008"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -536,7 +536,6 @@ package neorv32_package is
   constant csr_dscratch0_c      : std_ulogic_vector(11 downto 0) := x"7b2";
   -- machine counters/timers --
   constant csr_mcycle_c         : std_ulogic_vector(11 downto 0) := x"b00";
-  constant csr_mtime_c          : std_ulogic_vector(11 downto 0) := x"b01";
   constant csr_minstret_c       : std_ulogic_vector(11 downto 0) := x"b02";
   constant csr_mhpmcounter3_c   : std_ulogic_vector(11 downto 0) := x"b03";
   constant csr_mhpmcounter4_c   : std_ulogic_vector(11 downto 0) := x"b04";
@@ -569,7 +568,6 @@ package neorv32_package is
   constant csr_mhpmcounter31_c  : std_ulogic_vector(11 downto 0) := x"b1f";
   -- machine counters HIGH --
   constant csr_mcycleh_c        : std_ulogic_vector(11 downto 0) := x"b80";
-  constant csr_mtimeh_c         : std_ulogic_vector(11 downto 0) := x"b81";
   constant csr_minstreth_c      : std_ulogic_vector(11 downto 0) := x"b82";
   constant csr_mhpmcounter3h_c  : std_ulogic_vector(11 downto 0) := x"b83";
   constant csr_mhpmcounter4h_c  : std_ulogic_vector(11 downto 0) := x"b84";

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -584,6 +584,7 @@ begin
       clk_i      => clk_i,
       rstn_i     => rstn_sys,
       -- status --
+      mtime_i    => mtime,
       trace_o    => cpu_trace(i),
       sleep_o    => open,
       fence_o    => cpu_fence(i),

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -367,6 +367,10 @@ architecture neorv32_top_rtl of neorv32_top is
   signal cpu_firq : std_ulogic_vector(15 downto 0);
   signal mti, msi : std_ulogic_vector(num_cores_c-1 downto 0);
 
+  -- system time (mtime) --
+  signal mtime : std_ulogic_vector(63 downto 0);
+  signal mtime_lo : std_ulogic_vector(31 downto 0);
+
 begin
 
   -- **************************************************************************************************************************
@@ -1168,15 +1172,27 @@ begin
         rstn_i    => rstn_sys,
         bus_req_i => iodev_req(IODEV_CLINT),
         bus_rsp_o => iodev_rsp(IODEV_CLINT),
-        time_o    => mtime_time_o,
+        time_o    => mtime,
         mti_o     => mti,
         msi_o     => msi
       );
+
+      -- synchronize high and low words --
+      mtime_sync: process(rstn_i, clk_i)
+      begin
+        if (rstn_i = '0') then
+          mtime_lo(31 downto 0) <= (others => '0');
+        elsif rising_edge(clk_i) then
+          mtime_lo(31 downto 0) <= mtime(31 downto 0);
+        end if;
+      end process mtime_sync;
+      mtime_time_o <= mtime(63 downto 32) & mtime_lo;
     end generate;
 
     neorv32_clint_disabled:
     if not IO_CLINT_EN generate
       iodev_rsp(IODEV_CLINT) <= rsp_terminate_c;
+      mtime_lo               <= (others => '0');
       mtime_time_o           <= (others => '0');
       mti                    <= (others => irq_mti_i); -- TODO: provide individual top ports for dual-core w/o internal CLINT
       msi                    <= (others => irq_msi_i); -- TODO: provide individual top ports for dual-core w/o internal CLINT

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -411,15 +411,15 @@ int main() {
     // read base counter from user mode
     goto_user_mode();
     {
-      asm volatile ("addi      %[cy], zero, 123 \n"
-                    "rdcycle   %[cy]            \n"
-                    "addi      %[ir], zero, 123 \n" // this value must not change
-                    "rdinstret %[ir]            \n" // has to trap
-                    : [cy] "=r" (tmp_a), [ir] "=r" (tmp_b) : );
+      asm volatile ("addi    %[cy], zero, 111 \n"
+                    "rdcycle %[cy]            \n"
+                    "addi    %[tm], zero, 222 \n" // this value must not change
+                    "rdtime  %[tm]            \n" // has to trap
+                    : [cy] "=r" (tmp_a), [tm] "=r" (tmp_b) : );
     }
 
     if ((tmp_a == neorv32_cpu_csr_read(CSR_CYCLE)) &&
-        (tmp_b == 123) &&
+        (tmp_b == 222) &&
         (neorv32_cpu_csr_read(CSR_MCOUNTEREN) == (1<<CSR_MCOUNTEREN_CY)) &&
         (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_I_ILLEGAL)) {
       test_ok();
@@ -1078,7 +1078,7 @@ int main() {
 
     if ((neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_MTI) &&
         (neorv32_cpu_csr_read(CSR_MTVAL) == 0) &&
-        (NEORV32_CLINT->MTIME.uint32[1] == 0x00000001) &&
+        (neorv32_cpu_csr_read(CSR_TIMEH) == 0x00000001) &&
         neorv32_clint_mtimecmp_get() == 0x0000000100000000ULL) {
       test_ok();
     }

--- a/sw/lib/include/neorv32_cpu.h
+++ b/sw/lib/include/neorv32_cpu.h
@@ -23,6 +23,7 @@
 /**@{*/
 uint64_t neorv32_cpu_get_cycle(void);
 void     neorv32_cpu_set_mcycle(uint64_t value);
+uint64_t neorv32_cpu_get_time(void);
 uint64_t neorv32_cpu_get_instret(void);
 void     neorv32_cpu_set_minstret(uint64_t value);
 uint32_t neorv32_cpu_pmp_get_num_regions(void);

--- a/sw/lib/include/neorv32_csr.h
+++ b/sw/lib/include/neorv32_csr.h
@@ -312,6 +312,7 @@ enum NEORV32_CSR_FFLAGS_enum {
  **************************************************************************/
 enum NEORV32_CSR_MCOUNTEREN_enum {
   CSR_MCOUNTEREN_CY    = 0, /**< mcountern CSR  (0):  CY    - cycle counter (r/w) */
+  CSR_MCOUNTEREN_TM    = 1, /**< mcountern CSR  (1):  TM    - system time counter (r/w) */
   CSR_MCOUNTEREN_IR    = 2, /**< mcountern CSR  (2):  IR    - instruction-retired counter (r/w) */
   CSR_MCOUNTEREN_HPM3  = 3,  /**< mcountern CSR (3):  HPM3  - hardware performance counter 3  (r/w) */
   CSR_MCOUNTEREN_HPM4  = 4,  /**< mcountern CSR (4):  HPM4  - hardware performance counter 4  (r/w) */

--- a/sw/lib/include/neorv32_csr.h
+++ b/sw/lib/include/neorv32_csr.h
@@ -217,6 +217,7 @@ enum NEORV32_CSR_enum {
 
   /* user counters and timers */
   CSR_CYCLE          = 0xc00, /**< 0xc00 - cycle:        User cycle counter low word */
+  CSR_TIME           = 0xc01, /**< 0xc01 - time:         User system time counter low word */
   CSR_INSTRET        = 0xc02, /**< 0xc02 - instret:      User instructions-retired counter low word */
   CSR_HPMCOUNTER3    = 0xc03, /**< 0xc03 - hpmcounter3:  User hardware performance monitor 3  counter low word */
   CSR_HPMCOUNTER4    = 0xc04, /**< 0xc04 - hpmcounter4:  User hardware performance monitor 4  counter low word */
@@ -249,6 +250,7 @@ enum NEORV32_CSR_enum {
   CSR_HPMCOUNTER31   = 0xc1f, /**< 0xc1f - hpmcounter31: User hardware performance monitor 31 counter low word */
 
   CSR_CYCLEH         = 0xc80, /**< 0xc80 - cycleh:        User cycle counter high word */
+  CSR_TIMEH          = 0xc81, /**< 0xc81 - timeh:         User system time counter high word */
   CSR_INSTRETH       = 0xc82, /**< 0xc82 - instreth:      User instructions-retired counter high word */
   CSR_HPMCOUNTER3H   = 0xc83, /**< 0xc83 - hpmcounter3 :  User hardware performance monitor 3  counter high word */
   CSR_HPMCOUNTER4H   = 0xc84, /**< 0xc84 - hpmcounter4h:  User hardware performance monitor 4  counter high word */
@@ -362,7 +364,6 @@ enum NEORV32_CSR_MSTATUS_enum {
 enum NEORV32_CSR_MCOUNTINHIBIT_enum {
   CSR_MCOUNTINHIBIT_CY    = 0,  /**< mcountinhibit CSR (0): CY - Enable auto-increment of [m]cycle[h]   CSR when set (r/w) */
   CSR_MCOUNTINHIBIT_IR    = 2,  /**< mcountinhibit CSR (2): IR - Enable auto-increment of [m]instret[h] CSR when set (r/w) */
-
   CSR_MCOUNTINHIBIT_HPM3  = 3,  /**< mcountinhibit CSR (3):  HPM3  - Enable auto-increment of hpmcnt3[h]  when set (r/w) */
   CSR_MCOUNTINHIBIT_HPM4  = 4,  /**< mcountinhibit CSR (4):  HPM4  - Enable auto-increment of hpmcnt4[h]  when set (r/w) */
   CSR_MCOUNTINHIBIT_HPM5  = 5,  /**< mcountinhibit CSR (5):  HPM5  - Enable auto-increment of hpmcnt5[h]  when set (r/w) */
@@ -402,7 +403,6 @@ enum NEORV32_CSR_MIE_enum {
   CSR_MIE_MSIE    =  3, /**< mie CSR  (3): MSIE - Machine software interrupt enable (r/w) */
   CSR_MIE_MTIE    =  7, /**< mie CSR  (7): MTIE - Machine timer interrupt enable bit (r/w) */
   CSR_MIE_MEIE    = 11, /**< mie CSR (11): MEIE - Machine external interrupt enable bit (r/w) */
-
   /* NEORV32-specific extension: Fast Interrupt Requests (FIRQ) */
   CSR_MIE_FIRQ0E  = 16, /**< mie CSR (16): FIRQ0E - Fast interrupt channel 0 enable bit (r/w) */
   CSR_MIE_FIRQ1E  = 17, /**< mie CSR (17): FIRQ1E - Fast interrupt channel 1 enable bit (r/w) */

--- a/sw/lib/source/neorv32_aux.c
+++ b/sw/lib/source/neorv32_aux.c
@@ -17,7 +17,7 @@
 /**********************************************************************//**
  * Simple delay function using busy-wait.
  *
- * @warning Timing is imprecise! Use CLINT.MTIME or CYCLE CSRs for precise timing.
+ * @warning Timing is imprecise! Use TIME or CYCLE CSRs for precise timing.
  *
  * @param[in] clock_hz CPU clock speed in Hz.
  * @param[in] time_ms Time in ms to wait (unsigned 32-bit).

--- a/sw/lib/source/neorv32_cpu.c
+++ b/sw/lib/source/neorv32_cpu.c
@@ -31,11 +31,11 @@ uint64_t neorv32_cpu_get_cycle(void) {
     }
   }
 
-  subwords64_t cycles;
-  cycles.uint32[0] = tmp2;
-  cycles.uint32[1] = tmp3;
+  subwords64_t data;
+  data.uint32[0] = tmp2;
+  data.uint32[1] = tmp3;
 
-  return cycles.uint64;
+  return data.uint64;
 }
 
 
@@ -46,13 +46,38 @@ uint64_t neorv32_cpu_get_cycle(void) {
  **************************************************************************/
 void neorv32_cpu_set_mcycle(uint64_t value) {
 
-  subwords64_t cycles;
-  cycles.uint64 = value;
+  subwords64_t data;
+  data.uint64 = value;
 
   // prevent low-to-high carry while writing
   neorv32_cpu_csr_write(CSR_MCYCLE,  0);
-  neorv32_cpu_csr_write(CSR_MCYCLEH, cycles.uint32[1]);
-  neorv32_cpu_csr_write(CSR_MCYCLE,  cycles.uint32[0]);
+  neorv32_cpu_csr_write(CSR_MCYCLEH, data.uint32[1]);
+  neorv32_cpu_csr_write(CSR_MCYCLE,  data.uint32[0]);
+}
+
+
+/**********************************************************************//**
+ * Get system time counter from time[h] (from CLINT.MTIME).
+ *
+ * @return Current system time (64 bit).
+ **************************************************************************/
+uint64_t neorv32_cpu_get_time(void) {
+
+  uint32_t tmp1 = 0, tmp2 = 0, tmp3 = 0;
+  while(1) {
+    tmp1 = neorv32_cpu_csr_read(CSR_TIMEH);
+    tmp2 = neorv32_cpu_csr_read(CSR_TIME);
+    tmp3 = neorv32_cpu_csr_read(CSR_TIMEH);
+    if (tmp1 == tmp3) {
+      break;
+    }
+  }
+
+  subwords64_t data;
+  data.uint32[0] = tmp2;
+  data.uint32[1] = tmp3;
+
+  return data.uint64;
 }
 
 
@@ -73,11 +98,11 @@ uint64_t neorv32_cpu_get_instret(void) {
     }
   }
 
-  subwords64_t cycles;
-  cycles.uint32[0] = tmp2;
-  cycles.uint32[1] = tmp3;
+  subwords64_t data;
+  data.uint32[0] = tmp2;
+  data.uint32[1] = tmp3;
 
-  return cycles.uint64;
+  return data.uint64;
 }
 
 
@@ -88,13 +113,13 @@ uint64_t neorv32_cpu_get_instret(void) {
  **************************************************************************/
 void neorv32_cpu_set_minstret(uint64_t value) {
 
-  subwords64_t cycles;
-  cycles.uint64 = value;
+  subwords64_t data;
+  data.uint64 = value;
 
   // prevent low-to-high carry while writing
   neorv32_cpu_csr_write(CSR_MINSTRET,  0);
-  neorv32_cpu_csr_write(CSR_MINSTRETH, cycles.uint32[1]);
-  neorv32_cpu_csr_write(CSR_MINSTRET,  cycles.uint32[0]);
+  neorv32_cpu_csr_write(CSR_MINSTRETH, data.uint32[1]);
+  neorv32_cpu_csr_write(CSR_MINSTRET,  data.uint32[0]);
 }
 
 


### PR DESCRIPTION
* `Zicntr` ISA extension: add `time` and `timeh` CSRs: read-only shadow copies of the machine timer (MTIME) / CLINT.MTIME
* add support for `mcounteren(1)` bit (allow user-mode software to access `time[h]` CSRs)