### PR TITLE
[trace] add RVC trace logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 11.05.2026 | 1.13.0.9 | trace log: add RVC / compressed-instruction logging and decoding | [#1553](https://github.com/stnolting/neorv32/pull/1553) |
 | 08.05.2026 | 1.13.0.8 | :sparkles: add support for RISC-V `time[h]` CSRs | [#1551](https://github.com/stnolting/neorv32/pull/1551) |
 | 08.05.2026 | 1.13.0.7 | :sparkles: add support for RISC-V `Zbc` ISA extensions (carry-less multiplication) | [#1550](https://github.com/stnolting/neorv32/pull/1550) |
 | 08.05.2026 | 1.13.0.6 | :bug: PMP: fix write-only permission config and address/mask storage | [#1549](https://github.com/stnolting/neorv32/pull/1549) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -288,7 +288,7 @@ package file (`neorv32_package.vhd`).
 | `valid`     |     1 | `rvfi_valid`     | All others signals are valid when set; high for one cycle
 4+^| **Instruction Metadata**
 | `order`     |    32 | `rvfi_order`     | Instruction index (linear incrementing counter; resets to zero on overflow)
-| `insn`      |    32 | `rvfi_insn`      | Instruction word; compressed instructions are shown in their decompressed 32-bit format (with `compr = 1`)
+| `insn`      |    32 | `rvfi_insn`      | Instruction word; for compressed instructions the upper 16-bit are set to zero
 | `trap`      |     1 | `rvfi_trap`      | Set if the current instruction causes a synchronous exception
 | `halt`      |     1 | `rvfi_halt`      | Set if the current instruction is last instruction before halting
 | `intr`      |     1 | `rvfi_intr`      | Set if the current instruction is the first instruction of a trap handler
@@ -297,6 +297,7 @@ package file (`neorv32_package.vhd`).
 | `debug`     |     1 | -                | Set if the current instruction is executed in debug-mode
 | `compr`     |     1 | -                | Set if the current instruction is a decompressed instruction
 | `delta`     |     1 | -                | Set if the current instruction is the target of a control-flow transfer
+| `cmd32`     |    32 | -                | 32-bit instruction word; compressed instructions are shown in their decompressed 32-bit format
 4+^| **Integer Register**
 | `rs1_addr`  |     5 | `rvfi_rs1_addr`  | register `rs1` address
 | `rs2_addr`  |     5 | `rvfi_rs2_addr`  | register `rs2` address

--- a/docs/datasheet/soc_tracer.adoc
+++ b/docs/datasheet/soc_tracer.adoc
@@ -153,30 +153,30 @@ The start of an exemplary trace log might look like this:
 .Exemplary cut-out from a simulation trace log (here: `neorv32.tracer1.log` showing boot of core 1)
 [source, log]
 ----
-51 929749 0x0000009c 0xfff44737 M lui           x14, 0xfff44000 <TRAP_ENTRY> <1>
-52 929751 0x000000a0 0x00872103 M lw            x2, 2(x14)
-53 929759 0x000000a4 0x00c72603 M c.lw          x12, 12(x14)
-54 929767 0x000000a6 0xfff40737 M lui           x14, 0xfff40000
-55 929770 0x000000aa 0x00072223 M sw            x14, 4(x0)
-56 929778 0x000000ae 0x04a0006f M c.jal         x0, 74
-57 929798 0x000000f8 0x80000197 M auipc         x3, 0x80000000
-58 929800 0x000000fc 0x70818193 M addi          x3, x8, 1800
-59 929824 0x00000100 0x0ff0000f M fence
-60 929831 0x00000104 0x0000100f M fence.i
-61 929853 0x00000108 0x30029073 M csrrw         x0, mstatus, x5
+52168 256630 0x000024f6 0xc00026f3 U csrrs       x13, cycle, x0
+52169 256633 0x000024fa 0xc02025f3 U csrrs       x11, instret, x0
+52170 256635 0x000024fe 0x0001     U c.addi      x0, x0, 0
+52171 256647 0x00002500 0x0001     U c.addi      x0, x0, 0
+52172 256650 0x00002502 0xc0002673 U csrrs       x12, cycle, x0
+52173 256653 0x00002506 0xc0202573 U csrrs       x10, instret, x0
+52174 256656 0x0000250a 0x00000073 U ecall
+52175 256665 0x00003e94 0x34011073 M csrrw       x0, mscratch, x2 <TRAP_ENTRY> <1>
+52176 256667 0x00003e98 0x7119     M c.addi16sp  x2, x2, -128
+52177 256672 0x00003e9a 0xc206     M c.swsp      x1, 4(x2)
+52178 256675 0x00003e9c 0x340110f3 M csrrw       x1, mscratch, x2
 ----
 <1> This line is used for explanation (see below).
 
 Column structure:
 
 [start=1]
-. `51`: Instruction index ("order"); a linear increasing counter that starts at zero and increments with each executed instruction; printed as decimal integer.
-. `890622`: Time stamp; a linear increasing counter that starts at zero and increments with each clock cycle; printed as decimal integer.
-. `0x000000c8`: Instruction address (program counter); printed as hexadecimal 32-bit value (`0x` prefix).
-. `0xfff44737`: 32-bit instruction word; printed as hexadecimal 32-bit value (`0x` prefix); compressed 16-bit instructions are shown in their decompressed 32-bit format.
-. `M`: Current operating mode / privilege level (`M` = machine-mode, `U` = user-mode, `D` = debug-mode); printed as single character
-. `lui`: The decoded instruction mnemonic. For unknown instructions `INVALID` is printed instead. Decompressed 16-bit instructions have a prefixed `c.` (e.g. `c.lw`).
-. `x14, 0xfff44000`: Operands of the decoded instruction.
+. `52175`: Instruction index ("order"); a linear increasing counter that starts at zero and increments with each executed instruction; printed as decimal integer.
+. `256665`: Time stamp; a linear increasing counter that starts at zero and increments with each clock cycle; printed as decimal integer.
+. `0x00003e94`: Instruction address (program counter); printed as hexadecimal 32-bit value (`0x` prefix).
+. `0x34011073`: instruction word; printed as 32-bit or 16-bit (compressed isntructgion) hexadecimal value (`0x` prefix).
+. `M`: Current operating mode / privilege level (`M` = machine-mode, `U` = user-mode, `D` = debug-mode); printed as single character.
+. `csrrw`: The decoded instruction mnemonic. For unknown instructions `INVALID` is printed instead. Decompressed 16-bit instructions have a prefixed `c.` (e.g. `c.addi`).
+. `x0, mscratch, x2`: Operands of the decoded instruction.
 . If the CPU encounters a trap (synchronous exception or interrupt) `<TRAP_ENTRY>` is printed at the end of the line corresponding to the first instruction of the trap handler.
 
 .Instruction Execution Time

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -521,6 +521,7 @@ begin
   ctrl_o.ir_funct3    <= exec.ir(instr_funct3_msb_c downto instr_funct3_lsb_c);
   ctrl_o.ir_funct12   <= exec.ir(instr_imm12_msb_c downto instr_imm12_lsb_c);
   ctrl_o.ir_opcode    <= exec.ir(instr_opcode_msb_c downto instr_opcode_lsb_c);
+  ctrl_o.ir_rvc       <= exec.irc;
   -- status --
   ctrl_o.cpu_priv     <= csr.prv_level;
   ctrl_o.cpu_trap     <= trap.env_enter;

--- a/rtl/core/neorv32_cpu_trace.vhd
+++ b/rtl/core/neorv32_cpu_trace.vhd
@@ -92,7 +92,6 @@ begin
 
       -- instruction metadata --
       trace_buf.order <= arbiter.order;
-      trace_buf.insn  <= ctrl_i.ir_funct12 & ctrl_i.rf_rs1 & ctrl_i.ir_funct3 & ctrl_i.rf_rd & ctrl_i.ir_opcode;
       trace_buf.trap  <= ctrl_i.cpu_sync_exc;
       trace_buf.halt  <= not ctrl_i.cnt_event(cnt_event_cy_c);
       trace_buf.intr  <= arbiter.entry;
@@ -101,6 +100,12 @@ begin
         trace_buf.mode  <= ctrl_i.cpu_priv & ctrl_i.cpu_priv;
         trace_buf.debug <= ctrl_i.cpu_debug;
         trace_buf.compr <= ctrl_i.cnt_event(cnt_event_compr_c);
+        if (ctrl_i.cnt_event(cnt_event_compr_c) = '1') then
+          trace_buf.insn <= x"0000" & ctrl_i.ir_rvc;
+        else
+          trace_buf.insn <= ctrl_i.ir_funct12 & ctrl_i.rf_rs1 & ctrl_i.ir_funct3 & ctrl_i.rf_rd & ctrl_i.ir_opcode;
+        end if;
+        trace_buf.cmd32 <= ctrl_i.ir_funct12 & ctrl_i.rf_rs1 & ctrl_i.ir_funct3 & ctrl_i.rf_rd & ctrl_i.ir_opcode;
       end if;
       if (arbiter.delta = '1') then
         trace_buf.delta <= '1';
@@ -220,7 +225,7 @@ architecture neorv32_cpu_trace_simlog_rtl of neorv32_cpu_trace_simlog is
     machine  : std_ulogic_vector(31 downto 0); -- instruction word
     mnemonic : string(1 to 11); -- according assembly mnemonic
   end record;
-  type inst_t is array (0 to 192) of inst_touple_c;
+  type inst_t is array (0 to 230) of inst_touple_c;
   constant inst_c : inst_t := (
     ("-------------------------0110111", "lui        "), -- base ISA
     ("-------------------------0010111", "auipc      "),
@@ -414,6 +419,44 @@ architecture neorv32_cpu_trace_simlog_rtl of neorv32_cpu_trace_simlog is
     ("111000000000-----001-----1010011", "fclass.s   "),
     ("110100000000-------------1010011", "fcvt.s.w   "),
     ("110100000001-------------1010011", "fcvt.s.wu  "),
+    ("----------------0000000000000000", "c.illegal  "), -- C / Zca
+    ("----------------000-----------00", "c.addi4spn "),
+    ("----------------010-----------00", "c.lw       "),
+    ("----------------110-----------00", "c.sw       "),
+    ("----------------000-----------01", "c.addi     "),
+    ("----------------001-----------01", "c.jal      "),
+    ("----------------010-----------01", "c.li       "),
+    ("----------------011-00010-----01", "c.addi16sp "),
+    ("----------------011-----------01", "c.lui      "),
+    ("----------------100-00--------01", "c.srli     "),
+    ("----------------100-01--------01", "c.srai     "),
+    ("----------------100-10--------01", "c.andi     "),
+    ("----------------100011---00---01", "c.sub      "),
+    ("----------------100011---01---01", "c.xor      "),
+    ("----------------100011---10---01", "c.or       "),
+    ("----------------100011---11---01", "c.and      "),
+    ("----------------101-----------01", "c.j        "),
+    ("----------------110-----------01", "c.beqz     "),
+    ("----------------111-----------01", "c.bnez     "),
+    ("----------------000-----------10", "c.slli     "),
+    ("----------------010-----------10", "c.lwsp     "),
+    ("----------------1001000000000010", "c.ebreak   "),
+    ("----------------1001-----0000010", "c.jalr     "),
+    ("----------------1000-----0000010", "c.jr       "),
+    ("----------------1001----------10", "c.add      "),
+    ("----------------1000----------10", "c.mv       "),
+    ("----------------110-----------10", "c.swsp     "),
+    ("----------------100000--------00", "c.lbu      "), -- Zcb
+    ("----------------100001---0----00", "c.lhu      "),
+    ("----------------100001---1----00", "c.lh       "),
+    ("----------------100010--------00", "c.sb       "),
+    ("----------------100011---0----00", "c.sh       "),
+    ("----------------100111---1100001", "c.zext.b   "),
+    ("----------------100111---1100101", "c.sext.b   "),
+    ("----------------100111---1101001", "c.zext.h   "),
+    ("----------------100111---1101101", "c.sext.h   "),
+    ("----------------100111---1110101", "c.not      "),
+    ("----------------100111---10---01", "c.mul      "),
     ("--------------------------------", "INVALID    ") -- last entry matches all: invalid
   );
 
@@ -782,8 +825,13 @@ begin
           write(line_v, string'(" "));
           -- instruction word --
           write(line_v, string'("0x"));
-          write(line_v, string'(to_hexstring_f(trace_i.insn)));
-          write(line_v, string'(" "));
+          if (trace_i.compr = '1') then -- compressed instruction
+            write(line_v, string'(to_hexstring_f(trace_i.insn(15 downto 0))));
+            write(line_v, string'("     "));
+          else
+            write(line_v, string'(to_hexstring_f(trace_i.insn)));
+            write(line_v, string'(" "));
+          end if;
           -- privilege level --
           if (trace_i.debug = '1') then
             write(line_v, string'("D "));
@@ -795,14 +843,9 @@ begin
             write(line_v, string'("? "));
           end if;
           -- decoded instruction --
-          if (trace_i.compr = '1') then -- de-compressed instruction
-            write(line_v, string'("c."));
-          else
-            write(line_v, string'("  "));
-          end if;
           write(line_v, string'(decode_mnemonic_f(trace_i.insn)));
           write(line_v, string'(" "));
-          write(line_v, string'(decode_operands_f(trace_i.insn)));
+          write(line_v, string'(decode_operands_f(trace_i.cmd32)));
           -- trap entry --
           if (trace_i.intr = '1') then
             write(line_v, string'(" <TRAP_ENTRY>"));

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130008"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130009"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 
@@ -228,6 +228,7 @@ package neorv32_package is
     debug     : std_ulogic; -- set if instruction is executed in debug-mode
     compr     : std_ulogic; -- set if instruction is a decompressed instruction
     delta     : std_ulogic; -- set if instruction is target of a control-flow transfer
+    cmd32     : std_ulogic_vector(31 downto 0); -- 32-bit (decompressed) instruction word
     -- integer register --
     rs1_addr  : std_ulogic_vector(4 downto 0);  -- rs1 address
     rs2_addr  : std_ulogic_vector(4 downto 0);  -- rs2 address
@@ -263,6 +264,7 @@ package neorv32_package is
     debug     => '0',
     compr     => '0',
     delta     => '0',
+    cmd32     => (others => '0'),
     rs1_addr  => (others => '0'),
     rs2_addr  => (others => '0'),
     rs1_rdata => (others => '0'),
@@ -722,6 +724,7 @@ package neorv32_package is
     ir_funct3    : std_ulogic_vector(2 downto 0);  -- funct3 bit field
     ir_funct12   : std_ulogic_vector(11 downto 0); -- funct12 bit field
     ir_opcode    : std_ulogic_vector(6 downto 0);  -- opcode bit field
+    ir_rvc       : std_ulogic_vector(15 downto 0); -- compressed instruction word
     -- status --
     cpu_priv     : std_ulogic;                     -- effective privilege mode
     cpu_trap     : std_ulogic;                     -- set when CPU is entering trap
@@ -765,6 +768,7 @@ package neorv32_package is
     ir_funct3    => (others => '0'),
     ir_funct12   => (others => '0'),
     ir_opcode    => (others => '0'),
+    ir_rvc       => (others => '0'),
     cpu_priv     => '0',
     cpu_trap     => '0',
     cpu_sync_exc => '0',


### PR DESCRIPTION
### Rework execution trace port signals

* `cmd32` to trace port that always shows a 32-bit instruction word (the decoded instruction in case of a decompressed instruction)
* `insn` now provides the actual instruction word (a full 32-bit instruction word for uncompressed instructions; a zero-extended 16-bit instruction word for compressed instructions) - RVFI compliant

### Rework trace log

Now showing actual compressed instructions, e.g.:

```
52168 256630 0x000024f6 0xc00026f3 U csrrs       x13, cycle, x0
52169 256633 0x000024fa 0xc02025f3 U csrrs       x11, instret, x0
52170 256635 0x000024fe 0x0001     U c.addi      x0, x0, 0
52171 256647 0x00002500 0x0001     U c.addi      x0, x0, 0
52172 256650 0x00002502 0xc0002673 U csrrs       x12, cycle, x0
52173 256653 0x00002506 0xc0202573 U csrrs       x10, instret, x0
52174 256656 0x0000250a 0x00000073 U ecall
52175 256665 0x00003e94 0x34011073 M csrrw       x0, mscratch, x2 <TRAP_ENTRY>
52176 256667 0x00003e98 0x7119     M c.addi16sp  x2, x2, -128
52177 256672 0x00003e9a 0xc206     M c.swsp      x1, 4(x2)
52178 256675 0x00003e9c 0x340110f3 M csrrw       x1, mscratch, x2
```