### PR TITLE
🐛 [Zalrsc] rework/fix reservation station and `SC` operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 16.05.2026 | 1.13.1.1 | :bug: fix/rework reservation station of `Zalrsc` ISA extension; `sc` can also cause a bus access fault even if the reservation failes | [#1556](https://github.com/stnolting/neorv32/pull/1556) |
 | 14.05.2026 | [**1.13.1**](https://github.com/stnolting/neorv32/releases/tag/v1.13.1) | :rocket: **New release** | |
 | 11.05.2026 | 1.13.0.9 | trace log: add RVC / compressed-instruction logging and decoding | [#1553](https://github.com/stnolting/neorv32/pull/1553) |
 | 08.05.2026 | 1.13.0.8 | :sparkles: add support for RISC-V `time[h]` CSRs | [#1551](https://github.com/stnolting/neorv32/pull/1551) |

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -624,30 +624,40 @@ content of the accessed address) is sent back to the requesting CPU.
 
 ===== Atomic Reservation-Set Controller
 
-A "reservation"  is defined by an address or address range that provides a guarding mechanism to support atomic
-accesses (as specified by the RISC-V <<_zalrsc_isa_extension>>). A new reservation is registered by the `LR`
-instruction. The address provided by this instruction defines the memory location(s) that is/are monitored for
-exclusive accesses. The according `SC` instruction evaluates the state of this reservation. If the reservation
-is still valid the write access performed by the `SC` instruction is finally executed and the instruction returns
-a "success" state (i.e. `rd` = 0). If the reservation has been invalidated the `SC` instruction will not write
-to memory and will return a "failed" state (i.e. `rd` = 1).
+In NEORV32 a reservation is defined by a 64-byte address granule that provides a guarding mechanism to support
+atomic accesses (as specified by the RISC-V <<_zalrsc_isa_extension>>). A new reservation is registered by the
+`LR` instruction. The address provided by this instruction defines the 64-byte-aligned memory region that is
+monitored for exclusive accesses. The according `SC` instruction evaluates the state of this reservation. If the
+reservation is still valid (same owner core / issueing core and same address granule) the write access performed by
+the `SC` instruction is finally executed and the instruction returns a _success_ state (i.e. `rd = 0`). If the
+reservation has been invalidated or does not match, the `SC` instruction will not update main memory and will return
+a _failed_ state (i.e. `rd = 1`).
 
-The reservation-set controller implements the _strong semnatics_. A reservation is created when executing
-an `LR` instruction. Any other data memory access (for example by the DMA) will invalidate any active reservation
-(note that instruction fetch accesses do not affect the reservations at all). Furthermore, `fence[.i]` also does not
-impact the reservation state at all.
+[IMPORTANT]
+In either case, the `SC` instruction issues a downstream bus access to main memory (converted to a READ in case
+of failure) to allow the detection of access faults for the target address also for failed `SC` instructions
+which is required by the RISC-V specs.
 
-The reservation-set controller implements a **single, global reservation set only** which is used by both cores
-of the SMP <<_dual_core_configuration>>. The `LR` operation of any CPU core creates a new reservation (for the
-entire address space as the reservation is global) that is also used by the other CPUs. However, only one CPU will
-receive a success state for the according `SC` operation, which - in term - invalidates the reservation again.
-This guarantees atomic accesses and thus, mutually exclusive access.
+The reservation-set controller implements a single reservation set per instance with a fixed granularity of 64 bytes.
+Each reservation tracks the owning core's ID and the aligned base address. A reservation is invalidated only when a
+write access targets the same 64-byte address granule - read accesses, instruction fetches, and `fence[.i]` instructions
+do not affect the reservation state.
+
+The reservation-set controller is shared by both cores in the SMP <<_dual_core_configuration>>.
+To ensure forward progress during concurrent atomic sequences, a turn-based arbitration mechanism is implemented:
+
+[start=1]
+. An `LR` instruction can create (or update) a reservation if no reservation is active, if the requesting core already
+owns the current reservation, or if it is the requesting core's "turn" (priority).
+. A successful `SC` flips the turn, ensuring that the other core receives priority for its next `LR` attempt.
+. A failed `SC` from the owning core also clears the reservation, preventing stale reservations from blocking progress.
+
+This guarantees atomic accesses and mutually exclusive access without starvation.
 
 .External Reservations
-[IMPORTANT]
-Note that the reservation-set controller cannot track memory accesses outside
-of the NEORV32 processor (i.e. atomic accesses via the external bus interface)
-that are executed by processor-external agents.
+[WARNING]
+Note that the reservation-set controller cannot track memory accesses outside of the NEORV32 processor
+(i.e. atomic accesses via the external bus interface) that are executed by processor-external agents.
 
 
 :sectnums:

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -836,7 +836,8 @@ end neorv32_bus_amo_rmw_rtl;
 -- NEORV32 SoC - Processor Bus Infrastructure: Reservation Station                  --
 -- -------------------------------------------------------------------------------- --
 -- Reservation set controller for the RISC-V A/Zalrsc ISA extension.                --
--- [NOTE] Only a single global reservation set is implemented.                      --
+-- [NOTE] Only a single 64-byte-wide reservation set is implemented. A simple turn- --
+-- based arbitration ensures forward progress during consecutive SMP accesses.      --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
@@ -867,67 +868,103 @@ end neorv32_bus_amo_rvs;
 
 architecture neorv32_bus_amo_rvs_rtl of neorv32_bus_amo_rvs is
 
-  signal valid, lr, sc, sc_fail, sc_pend : std_ulogic;
+  type rsv_t is record
+    set  : std_ulogic; -- valid
+    id   : std_ulogic; -- core ID
+    addr : std_ulogic_vector(31 downto 6); -- base address (64-byte granule)
+  end record;
+  signal rsv : rsv_t;
+
+  signal lr, sc, turn, lr_allow, sc_valid, sc_pend_pass, sc_pend_fail : std_ulogic;
 
 begin
 
-  -- Reservation Set Control ----------------------------------------------------------------
+  -- Reservation Station --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  rvs_control: process(rstn_i, clk_i)
+  reservation_station: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      valid <= '0';
+      rsv.set  <= '0';
+      rsv.id   <= '0';
+      rsv.addr <= (others => '0');
+      turn     <= '0';
     elsif rising_edge(clk_i) then
-      if (core_req_i.stb = '1') and (core_req_i.meta(0) = '0') then -- data memory access?
-        valid <= lr; -- set on load-reservate; clear for all other memory requests
+      if (core_req_i.stb = '1') and (core_req_i.meta(0) = '0') then -- data access request
+        if (lr = '1') then -- set new reservation
+          if (lr_allow = '1') then -- allowed by scheduling?
+            rsv.set  <= '1';
+            rsv.id   <= core_req_i.meta(3);
+            rsv.addr <= core_req_i.addr(31 downto 6);
+          end if;
+        elsif (sc = '1') then -- evaluate reservation
+          if (sc_valid = '1') then -- successful SC
+            rsv.set <= '0';
+            turn    <= not turn; -- flip turn for "fairness"
+          elsif (rsv.set = '1') and (rsv.id = core_req_i.meta(3)) then -- failed SC from owning core
+            rsv.set <= '0';
+          end if;
+        elsif (core_req_i.rw = '1') then -- any other write access
+          if (core_req_i.addr(31 downto 6) = rsv.addr) then -- invalidate on address match
+            rsv.set <= '0';
+          end if;
+        end if;
       end if;
     end if;
-  end process rvs_control;
+  end process reservation_station;
 
   -- check if reservation-set operation --
   lr <= '1' when (core_req_i.amo = '1') and (core_req_i.amoop = "1000") else '0';
   sc <= '1' when (core_req_i.amo = '1') and (core_req_i.amoop = "1001") else '0';
 
+  -- LR can set reservation if: no reservation yet OR same owner OR this core has turn priority --
+  lr_allow <= '1' when (rsv.set = '0')               else -- no active reservation
+              '1' when (rsv.id = core_req_i.meta(3)) else -- same owner (update reservation)
+              '1' when (turn = core_req_i.meta(3))   else -- priority: allowed to steal
+              '0';                                        -- blocked
+
+  -- SC valid if sent by the same core to the same address granule and reservation still active --
+  sc_valid <= rsv.set when (rsv.id = core_req_i.meta(3)) and (rsv.addr = core_req_i.addr(31 downto 6)) else '0';
+
+
   -- System Bus Interface -------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_request: process(core_req_i, sc, valid)
+  bus_request: process(core_req_i, sc, sc_valid)
   begin
-    sys_req_o <= core_req_i; -- pass-through everything except STB
-    if (sc = '1') then -- store-conditional operation
-      sys_req_o.stb <= core_req_i.stb and valid; -- write allowed if reservation still valid
-    else -- normal memory request or load-reservate operation
-      sys_req_o.stb <= core_req_i.stb;
+    sys_req_o <= core_req_i; -- default: pass-through
+    if (sc = '1') and (sc_valid = '0') then -- SC fails: issue bus request, but as READ to check for access faults
+      sys_req_o.rw  <= '0'; -- read instead of write
+      sys_req_o.amo <= '0'; -- no longer an AMO operation
     end if;
   end process bus_request;
 
-  -- if the store-conditional instruction fails there will be no memory request
-  -- so we need to provide a local ACK to complete the bus access;
-  -- sc_pend tracks that a successful SC is in flight (for zeroing response data)
+  -- track pending SC operation --
   sc_result: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      sc_fail <= '0';
-      sc_pend <= '0';
+      sc_pend_pass <= '0';
+      sc_pend_fail <= '0';
     elsif rising_edge(clk_i) then
-      sc_fail <= core_req_i.stb and sc and (not valid);
-      -- set on SC success request, clear on ACK
-      if (core_req_i.stb = '1') and (sc = '1') and (valid = '1') then
-        sc_pend <= '1';
-      elsif (sys_rsp_i.ack = '1') then
-        sc_pend <= '0';
+      if (core_req_i.stb = '1') and (sc = '1') then -- set on SC request
+        if (sc_valid = '1') then
+          sc_pend_pass <= '1';
+        else
+          sc_pend_fail <= '1';
+        end if;
+      elsif (sys_rsp_i.ack = '1') then -- clear on bus response
+        sc_pend_pass <= '0';
+        sc_pend_fail <= '0';
       end if;
     end if;
   end process sc_result;
 
   -- response --
-  -- SC.W must return 0 on success and nonzero on failure in rd (RISC-V spec).
-  -- On failure, no bus request is issued; we generate a local ACK and return 1.
-  -- On success, the bus performs a write; memory returns ACK with undefined data
-  -- on the read-back bus, so we must override data to all-zeros.
+  -- SC fail + bus ok    -> access OK, reservation invalid -> return 1
+  -- SC success + bus ok -> write completed                -> return 0
+  -- SC any + bus err    -> propagate access fault         -> trap
   core_rsp_o.err  <= sys_rsp_i.err;
-  core_rsp_o.ack  <= sys_rsp_i.ack or sc_fail; -- generate local ACK if SC fails
-  core_rsp_o.data <= x"00000001" when (sc_fail = '1') else -- SC failed: return 1
-                     x"00000000" when (sc_pend = '1') else -- SC succeeded: return 0
-                     sys_rsp_i.data; -- normal access: pass-through
+  core_rsp_o.ack  <= sys_rsp_i.ack;
+  core_rsp_o.data <= x"00000001" when (sc_pend_fail = '1') else -- SC failed: return 1
+                     x"00000000" when (sc_pend_pass = '1') else -- SC passed: return 0
+                     sys_rsp_i.data;                            -- normal access / pass-through
 
 end neorv32_bus_amo_rvs_rtl;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130100"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130101"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -2195,13 +2195,13 @@ int main() {
 
     tmp_a = neorv32_cpu_amolr((uint32_t)&amo_var);
     tmp_b = neorv32_cpu_amosc((uint32_t)&amo_var, 0x12345678); // must succeed returning all-zero
-    tmp_b = (tmp_b << 1) | (neorv32_cpu_amosc((uint32_t)&amo_var, 0xffffffff) & 1); // another SC: must fail
-    tmp_b = (tmp_b << 1) | (neorv32_cpu_amosc((uint32_t)ADDR_UNREACHABLE, 0) & 1); // another SC: must fail; no bus exception
+    tmp_b = (tmp_b << 1) | neorv32_cpu_amosc((uint32_t)&amo_var, 0xffffffff); // another SC: must fail returning 1
+    neorv32_cpu_amosc((uint32_t)ADDR_UNREACHABLE, 0); // failing SC to faulty address -> must trap
 
     if ((tmp_a   == 0x00cafe00) && // correct LR.W result
         (amo_var == 0x12345678) && // atomic variable NOT updates by SC.W
-        (tmp_b   == 0x00000003) && // 1st SC.W success, 2nd SC.W failed, 3rd SC.W failed
-        (neorv32_cpu_csr_read(CSR_MCAUSE) == trap_never_c)) { // no exception
+        (tmp_b   == 0x00000001) && // 1st SC.W succeeded, 2nd SC.W failed
+        (neorv32_cpu_csr_read(CSR_MCAUSE) == TRAP_CODE_S_ACCESS)) { // access fault exception
       test_ok();
     }
     else {


### PR DESCRIPTION
Fixing the reservation station of the `Zalrsc` ISA extension.

* replace _global_ reservation station by a reservation station that actually tracks the access address grnaule (64-bytes) and the issueing core ID
* `SC` instructions can also cause a bus access fault even if the `SC` operation fails (reservation lost); required by the RISC-V spec.
* add a "round robing" arbitration for setting up a new reservation to ensure forward progress for the dual-core configuration