### PR TITLE
[slink] Assert ready signal only when enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 25.05.2026 | 1.13.1.2 | :bug: fix stream link's `rx_ready_o` signal (zero when module is disabled) | [#1558](https://github.com/stnolting/neorv32/pull/1558) |
 | 16.05.2026 | 1.13.1.1 | :bug: fix/rework reservation station of `Zalrsc` ISA extension; `sc` can also cause a bus access fault even if the reservation failes | [#1556](https://github.com/stnolting/neorv32/pull/1556) |
 | 14.05.2026 | [**1.13.1**](https://github.com/stnolting/neorv32/releases/tag/v1.13.1) | :rocket: **New release** | |
 | 11.05.2026 | 1.13.0.9 | trace log: add RVC / compressed-instruction logging and decoding | [#1553](https://github.com/stnolting/neorv32/pull/1553) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130101"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130102"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_slink.vhd
+++ b/rtl/core/neorv32_slink.vhd
@@ -174,7 +174,7 @@ begin
   rx_fifo.re       <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(3) = '1') else '0';
   rx_fifo.we       <= slink_rx_valid_i;
   rx_fifo.wdata    <= slink_rx_last_i & slink_rx_src_i & slink_rx_data_i;
-  slink_rx_ready_o <= rx_fifo.free;
+  slink_rx_ready_o <= rx_fifo.free and ctrl.enable;
 
   -- backup RX attributes for current access --
   rx_attributes: process(rstn_i, clk_i)

--- a/rtl/core/neorv32_slink.vhd
+++ b/rtl/core/neorv32_slink.vhd
@@ -184,9 +184,7 @@ begin
       rx_route <= (others => '0');
     elsif rising_edge(clk_i) then
       if (rx_fifo.re = '1') then
-        rx_last <= rx_fifo.rdata(36);
-      end if;
-      if (rx_fifo.re = '1') then
+        rx_last  <= rx_fifo.rdata(36);
         rx_route <= rx_fifo.rdata(35 downto 32);
       end if;
     end if;


### PR DESCRIPTION
The slink_rx_ready_o signal of the RX FIFO was
always the same as the rx_fifo.free signal.
When the signal rx_fifo.clr to clear the FIFO is
asserted, free will be asserted aswell.
As the clear signal is defined as `not ctrl.enable` the slink_rx_ready_o signal is always asserted,
when the RX module is NOT enabled.
If a module attached to the SLINK interface wants
to send data to it while the RX module is not
enabled, it will send them anyway, as the ready
signal is asserted. Thus the data sent to the
RX module during this state will be dismissed.

My change changes this concurrent signal assignment to `rx_fifo.free and ctrl.enable`, so data will
only be received when the RX fifo is free AND the
module is enabled.