### PR TITLE
[sw/example] fixup twi demo SDL & SCL signal sense

### DIFF
--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -782,7 +782,7 @@ However, only the specified memory-mapped registers addresses should be used.
 
 .Unimplemented Modules / Address Holes
 [NOTE]
-When accessing an IO device tha hast not been implemented (disabled via the according generic)
+When accessing an IO device that has not been implemented (disabled via the according generic)
 or when accessing an address that is actually unused, a load/store access fault exception is raised.
 
 .Writing to Read-Only Registers

--- a/sw/example/demo_twi/main.c
+++ b/sw/example/demo_twi/main.c
@@ -111,8 +111,8 @@ int main() {
       send_twi();
     }
     else if (!strcmp(buffer, "sense")) {
-      neorv32_uart0_printf(" SCL: %u\n", neorv32_twi_sense_scl());
-      neorv32_uart0_printf(" SDA: %u\n", neorv32_twi_sense_sda());
+      neorv32_uart0_printf(" SCL: %u\n", neorv32_twi_sense_scl() == 0 ? 0 : 1);
+      neorv32_uart0_printf(" SDA: %u\n", neorv32_twi_sense_sda() == 0 ? 0 : 1);
     }
     else {
       neorv32_uart0_printf("Invalid command. Type 'help' to see all commands.\n");
@@ -174,10 +174,10 @@ void set_clock(void) {
   neorv32_uart0_printf("\nNew I2C clock: %u Hz\n", clock);
 
   // check if bus lines are OK
-  if (neorv32_twi_sense_scl() != 1) {
+  if (neorv32_twi_sense_scl() == 0) {
     neorv32_uart0_printf("WARNING! SCL bus line is not idle-high! Pull-up missing?\n");
   }
-  if (neorv32_twi_sense_sda() != 1) {
+  if (neorv32_twi_sense_sda() == 0) {
     neorv32_uart0_printf("WARNING! SDA bus line is not idle-high! Pull-up missing?\n");
   }
 }


### PR DESCRIPTION
Hi there fabulous @stnolting.

First of all:
 - Huge respect to the amount of work you pour into this absolute fantastic beast of a softcore every day. I had to fast-forward my stale fork by about 1000 commits. Insane! :smile:
 - Oh and congrats on more than 1000 closed PRs! :fireworks: :rocket:

I've noticed that in `demo_twi` the sensing of the SDL and SCL lines was a bit weird. I guess `neorv32_twi_sense_{scl,sda}()` used to return a 1?. Instead now it directly returns the bit from the register which is `> 1`. So I've changed the demo such that it considers `== 0` as `0` and anything else as `1`. This then fixes the erroneous warning and it now prints nice values when `sense`ing via the command line.

Cheers,
Nik