### PR TITLE
⚠️ rework HPM counter events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 05.06.2026 | 1.13.1.6 | :warning: rework hardware performance counter (HPM) events | [#1569](https://github.com/stnolting/neorv32/pull/1569) |
 | 05.06.2026 | 1.13.1.5 | :bug: minor rtl fixes: fix trace port's RD register signal; fix `Smcntrpmf`'s *cfg CSR address decoding | [#1568](https://github.com/stnolting/neorv32/pull/1568) |
 | 04.06.2026 | 1.13.1.4 | minor rtl edits and cleanups | [#1565](https://github.com/stnolting/neorv32/pull/1565) |
 | 27.05.2026 | 1.13.1.3 | add option to configure start of uncached address space | [#1561](https://github.com/stnolting/neorv32/pull/1561) |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -701,25 +701,21 @@ Note that all `mhpmevent*h` (hogh-word) event-select registers are hardwired to 
 [options="header",grid="rows"]
 |=======================
 | Bit | Name [C]                | R/W | Event Description
-4+^| **NEORV32-specific**
-| 10  | `HPMCNT_EVENT_WAIT_LSU` | r/w | memory/bus/cache/etc. delay/wait cycle while executing any load or store operation (caused by a data bus wait cycle))
-| 9   | `HPMCNT_EVENT_STORE`    | r/w | executed store operation (read-modify-write AMOs are counted as one load and one store operation)
-| 8   | `HPMCNT_EVENT_LOAD`     | r/w | executed load operation (read-modify-write AMOs are counted as one load and one store operation)
-| 7   | `HPMCNT_EVENT_CTRLFLOW` | r/w | control flow transfer (jump, taken branch, trap entry, trap exit)
-| 6   | `HPMCNT_EVENT_BRANCH`   | r/w | executed branch instruction (unconditional, conditional-taken or conditional-not-taken)
-| 5   | `HPMCNT_EVENT_WAIT_ALU` | r/w | delay/wait cycle caused by a _multi-cycle_ <<_cpu_arithmetic_logic_unit>> operation
-| 4   | `HPMCNT_EVENT_WAIT_DIS` | r/w | instruction dispatch wait cycle (wait for instruction prefetch-buffer refill); caused by a fence instruction, a control flow transfer or a instruction fetch bus wait cycle)
-| 3   | `HPMCNT_EVENT_COMPR`    | r/w | executed 16-bit/compressed (<<_c_isa_extension>>) instruction
-4+^| **RISC-V-compatible**
-| 2   | `HPMCNT_EVENT_IR`       | r/w | executed instruction (16-bit/compressed or 32-bit/uncompressed)
-| 1   | `HPMCNT_EVENT_TM`       | r/- | _not implemented_, hardwired to zero
+| 8   | `HPMCNT_EVENT_STORE`    | r/w | memory store operation (read-modify-write AMOs are counted as 1x load + 1x store operation)
+| 7   | `HPMCNT_EVENT_LOAD`     | r/w | memory load operation (read-modify-write AMOs are counted as 1x load + 1x store operation)
+| 6   | `HPMCNT_EVENT_DELTA`    | r/w | control flow transfer (jump, taken branch, trap entry/exit)
+| 5   | `HPMCNT_EVENT_WAIT_LSU` | r/w | memory/bus/cache/etc. delay/wait cycle while executing any load or store operation (caused by a data bus wait cycle))
+| 4   | `HPMCNT_EVENT_WAIT_ALU` | r/w | delay/wait cycle caused by a _multi-cycle_ <<_cpu_arithmetic_logic_unit>> operation (e.g. bit-serial shift)
+| 3   | `HPMCNT_EVENT_WAIT_DIS` | r/w | instruction dispatch wait cycle (wait for instruction prefetch-buffer refill); caused by a fence instruction, a control flow transfer or a instruction fetch bus wait cycle (e.g. cache miss)
+| 2   | `HPMCNT_EVENT_CI`       | r/w | executed 16-bit/compressed (<<_c_isa_extension>>) instruction
+| 1   | `HPMCNT_EVENT_IR`       | r/w | executed instruction (16-bit/compressed or 32-bit/uncompressed)
 | 0   | `HPMCNT_EVENT_CY`       | r/w | active clock cycle (CPU not in <<_sleep_mode>>)
 |=======================
 
 .Instruction Retiring ("Retired == Executed")
 [IMPORTANT]
 The CPU HPM/counter logic treats all executed instruction as "retired" even if they raise an exception,
-cause an interrupt, trigger a privilege mode change or were not meant to retire (i.e. claimed by the RISC-V spec.).
+are intercepted by an interrupt, trigger a privilege mode change or were not meant to retire (i.e. claimed by the RISC-V spec.).
 
 .Atomic Memory Access
 [NOTE]

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -165,7 +165,7 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
   signal monitor_cnt  : std_ulogic_vector(alu_cp_tmo_c downto 0); -- execution monitor cycle counter
   signal csr_valid    : std_ulogic_vector(2 downto 0); -- CSR access: [2] implemented, [1] r/w access, [0] privilege
   signal illegal_cmd  : std_ulogic; -- illegal instruction check
-  signal cnt_event    : std_ulogic_vector(10 downto 0); -- counter events
+  signal cnt_event    : std_ulogic_vector(cnt_event_width_c-1 downto 0); -- counter events
   signal ebreak_trig  : std_ulogic; -- environment break exception trigger
   signal trap_env     : std_ulogic_vector(6 downto 0); -- environment call cause-value helper
 
@@ -533,16 +533,14 @@ begin
   -- Counter Events -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   cnt_event(cnt_event_cy_c)       <= '0' when (exec.state = S_SLEEP)                                     else '1'; -- active cycle
-  cnt_event(cnt_event_tm_c)       <= '0';
   cnt_event(cnt_event_ir_c)       <= '1' when (exec.state = S_EXECUTE)                                   else '0'; -- retired (=executed) instr.
-  cnt_event(cnt_event_compr_c)    <= '1' when (exec.state = S_EXECUTE) and (exec.ci = '1')               else '0'; -- executed compressed instr.
+  cnt_event(cnt_event_ci_c)       <= '1' when (exec.state = S_EXECUTE) and (exec.ci = '1')               else '0'; -- executed compressed instr.
   cnt_event(cnt_event_wait_dis_c) <= '1' when (exec.state = S_DISPATCH) and (frontend_i.valid = '0')     else '0'; -- instruction dispatch wait
   cnt_event(cnt_event_wait_alu_c) <= '1' when (exec.state = S_ALU_WAIT)                                  else '0'; -- multi-cycle ALU wait
-  cnt_event(cnt_event_branch_c)   <= '1' when (exec.state = S_BRANCH)                                    else '0'; -- executed branch instruction
-  cnt_event(cnt_event_ctrlflow_c) <= '1' when (ctrl.if_reset = '1') and (exec.ir(6 downto 2) /= "00011") else '0'; -- control flow transfer
-  cnt_event(cnt_event_load_c)     <= '1' when (ctrl.lsu_req = '1') and (ctrl.lsu_rd = '1')               else '0'; -- executed load operation
-  cnt_event(cnt_event_store_c)    <= '1' when (ctrl.lsu_req = '1') and (ctrl.lsu_wr = '1')               else '0'; -- executed store operation
   cnt_event(cnt_event_wait_lsu_c) <= '1' when (ctrl.lsu_req = '0') and (exec.state = S_MEM_RSP)          else '0'; -- load/store memory wait
+  cnt_event(cnt_event_delta_c)    <= '1' when (ctrl.if_reset = '1') and (exec.ir(6 downto 2) /= "00011") else '0'; -- control flow transfer
+  cnt_event(cnt_event_load_c)     <= '1' when (ctrl.lsu_req = '1') and (ctrl.lsu_rd = '1')               else '0'; -- memory load
+  cnt_event(cnt_event_store_c)    <= '1' when (ctrl.lsu_req = '1') and (ctrl.lsu_wr = '1')               else '0'; -- memory store
 
 
   -- ****************************************************************************************************************************

--- a/rtl/core/neorv32_cpu_counters.vhd
+++ b/rtl/core/neorv32_cpu_counters.vhd
@@ -54,7 +54,7 @@ architecture neorv32_cpu_counters_rtl of neorv32_cpu_counters is
   signal pmf_cy, pmf_ir, pmf_inh : std_ulogic_vector(1 downto 0);
 
   -- HPM read-backs --
-  type hpmevent_t is array (3 to 31) of std_ulogic_vector(10 downto 0);
+  type hpmevent_t is array (3 to 31) of std_ulogic_vector(cnt_event_width_c-1 downto 0);
   type hpmcnt_t   is array (3 to 31) of std_ulogic_vector(63 downto 0);
   signal hpmevent, hpmevent_rd : hpmevent_t;
   signal hpmcnt_rd : hpmcnt_t;
@@ -278,9 +278,8 @@ begin
           hpmevent(i) <= (others => '0');
         elsif rising_edge(clk_i) then
           if (cfg_we(i) = '1') then
-            hpmevent(i) <= ctrl_i.csr_wdata(10 downto 0);
+            hpmevent(i) <= ctrl_i.csr_wdata(cnt_event_width_c-1 downto 0);
           end if;
-          hpmevent(i)(cnt_event_tm_c) <= '0'; -- time: not available
         end if;
       end process hpmevent_reg;
       hpmevent_rd(i) <= hpmevent(i) when (cfg_re(i) = '1') else (others => '0');

--- a/rtl/core/neorv32_cpu_trace.vhd
+++ b/rtl/core/neorv32_cpu_trace.vhd
@@ -66,7 +66,7 @@ begin
       -- trap-entry detector: buffer trap entry until trace commit --
       arbiter.entry <= (arbiter.entry or ctrl_i.cpu_trap) and (not arbiter.valid);
       -- delta detector: buffer delta trigger until we are back in EXECUTE stage --
-      arbiter.delta <= (arbiter.delta or ctrl_i.cnt_event(cnt_event_ctrlflow_c)) and (not ctrl_i.cnt_event(cnt_event_ir_c));
+      arbiter.delta <= (arbiter.delta or ctrl_i.cnt_event(cnt_event_delta_c)) and (not ctrl_i.cnt_event(cnt_event_ir_c));
       -- instruction counter --
       if (arbiter.valid = '1') then
         arbiter.order <= std_ulogic_vector(unsigned(arbiter.order) + 1);
@@ -99,8 +99,8 @@ begin
       if (ctrl_i.cnt_event(cnt_event_ir_c) = '1') then
         trace_buf.mode  <= ctrl_i.cpu_priv & ctrl_i.cpu_priv;
         trace_buf.debug <= ctrl_i.cpu_debug;
-        trace_buf.compr <= ctrl_i.cnt_event(cnt_event_compr_c);
-        if (ctrl_i.cnt_event(cnt_event_compr_c) = '1') then
+        trace_buf.compr <= ctrl_i.cnt_event(cnt_event_ci_c);
+        if (ctrl_i.cnt_event(cnt_event_ci_c) = '1') then
           trace_buf.insn <= x"0000" & ctrl_i.ir_rvc;
         else
           trace_buf.insn <= ctrl_i.ir_funct12 & ctrl_i.rf_rs1 & ctrl_i.ir_funct3 & ctrl_i.rf_rd & ctrl_i.ir_opcode;
@@ -587,7 +587,7 @@ architecture neorv32_cpu_trace_simlog_rtl of neorv32_cpu_trace_simlog is
       when csr_tdata1_c         => return "tdata1";
       when csr_tdata2_c         => return "tdata2";
       when csr_tinfo_c          => return "tinfo";
-      -- debug registers --
+      -- debug-mode registers --
       when csr_dcsr_c           => return "dcsr";
       when csr_dpc_c            => return "dpc";
       when csr_dscratch0_c      => return "dscratch0";

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130105"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130106"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 
@@ -531,7 +531,7 @@ package neorv32_package is
   constant csr_tdata2_c         : std_ulogic_vector(11 downto 0) := x"7a2";
   constant csr_tdata3_c         : std_ulogic_vector(11 downto 0) := x"7a3";
   constant csr_tinfo_c          : std_ulogic_vector(11 downto 0) := x"7a4";
-  -- debug registers --
+  -- debug-mode registers --
   constant csr_dcsr_c           : std_ulogic_vector(11 downto 0) := x"7b0";
   constant csr_dpc_c            : std_ulogic_vector(11 downto 0) := x"7b1";
   constant csr_dscratch0_c      : std_ulogic_vector(11 downto 0) := x"7b2";
@@ -718,7 +718,7 @@ package neorv32_package is
     csr_addr     : std_ulogic_vector(11 downto 0); -- address
     csr_wdata    : std_ulogic_vector(31 downto 0); -- write data
     -- counter events --
-    cnt_event    : std_ulogic_vector(10 downto 0); -- counter increment events
+    cnt_event    : std_ulogic_vector(8 downto 0);  -- counter increment events
     -- instruction word --
     ir_funct3    : std_ulogic_vector(2 downto 0);  -- funct3 bit field
     ir_funct12   : std_ulogic_vector(11 downto 0); -- funct12 bit field
@@ -889,19 +889,16 @@ package neorv32_package is
 
   -- Counter Events -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  -- RISC-V-compliant base counter events --
-  constant cnt_event_cy_c       : natural := 0;  -- active cycle
-  constant cnt_event_tm_c       : natural := 1;  -- time (unused/reserved)
-  constant cnt_event_ir_c       : natural := 2;  -- retired instruction
-  -- NEORV32-specific HPM counter events --
-  constant cnt_event_compr_c    : natural := 3;  -- executed compressed instruction
-  constant cnt_event_wait_dis_c : natural := 4;  -- instruction dispatch wait cycle
-  constant cnt_event_wait_alu_c : natural := 5;  -- multi-cycle ALU co-processor wait cycle
-  constant cnt_event_branch_c   : natural := 6;  -- executed branch instruction
-  constant cnt_event_ctrlflow_c : natural := 7;  -- control flow transfer
-  constant cnt_event_load_c     : natural := 8;  -- load operation
-  constant cnt_event_store_c    : natural := 9;  -- store operation
-  constant cnt_event_wait_lsu_c : natural := 10; -- load-store unit memory wait cycle
+  constant cnt_event_cy_c       : natural := 0; -- active cycle
+  constant cnt_event_ir_c       : natural := 1; -- retired instruction
+  constant cnt_event_ci_c       : natural := 2; -- executed compressed instruction
+  constant cnt_event_wait_dis_c : natural := 3; -- instruction dispatch wait cycle
+  constant cnt_event_wait_alu_c : natural := 4; -- multi-cycle ALU co-processor wait cycle
+  constant cnt_event_wait_lsu_c : natural := 5; -- load-store unit memory wait cycle
+  constant cnt_event_delta_c    : natural := 6; -- control flow transfer
+  constant cnt_event_load_c     : natural := 7; -- load operation
+  constant cnt_event_store_c    : natural := 8; -- store operation
+  constant cnt_event_width_c    : natural := 9; -- length of this list in bits
 
 -- **********************************************************************************************************
 -- Helper Functions

--- a/sw/example/demo_hpm/main.c
+++ b/sw/example/demo_hpm/main.c
@@ -59,13 +59,13 @@ int main() {
 
   // intro
   neorv32_uart0_printf("\n<<< NEORV32 Hardware Performance Monitors (HPMs) Example Program >>>\n\n");
-  neorv32_uart0_printf("[NOTE] This program will use up to 9 HPM counters (if available).\n\n");
+  neorv32_uart0_printf("[NOTE] This program will use up to 7 HPM counters (if available).\n\n");
 
 
   // show HPM hardware configuration
   uint32_t hpm_num = neorv32_cpu_hpm_get_num_counters();
   uint32_t hpm_width = neorv32_cpu_hpm_get_size();
-  neorv32_uart0_printf("%u HPM counters detected, each %u bits wide\n", hpm_num, hpm_width);
+  neorv32_uart0_printf("%u HPM counter(s) detected, each %u bits wide\n", hpm_num, hpm_width);
 
 
   // stop all CPU counters including HPMs
@@ -75,15 +75,13 @@ int main() {
   // clear HPM counters (low and high word);
   // there will be NO exception if we access a HPM counter register that has not been implemented
   // as long as Zihpm is implemented
-  if (hpm_num > 0) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER3,  0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER3H,  0); }
-  if (hpm_num > 1) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER4,  0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER4H,  0); }
-  if (hpm_num > 2) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER5,  0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER5H,  0); }
-  if (hpm_num > 3) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER6,  0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER6H,  0); }
-  if (hpm_num > 4) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER7,  0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER7H,  0); }
-  if (hpm_num > 5) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER8,  0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER8H,  0); }
-  if (hpm_num > 6) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER9,  0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER9H,  0); }
-  if (hpm_num > 7) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER10, 0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER10H, 0); }
-  if (hpm_num > 8) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER11, 0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER11H, 0); }
+  if (hpm_num > 0) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER3, 0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER3H, 0); }
+  if (hpm_num > 1) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER4, 0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER4H, 0); }
+  if (hpm_num > 2) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER5, 0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER5H, 0); }
+  if (hpm_num > 3) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER6, 0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER6H, 0); }
+  if (hpm_num > 4) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER7, 0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER7H, 0); }
+  if (hpm_num > 5) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER8, 0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER8H, 0); }
+  if (hpm_num > 6) { neorv32_cpu_csr_write(CSR_MHPMCOUNTER9, 0); neorv32_cpu_csr_write(CSR_MHPMCOUNTER9H, 0); }
 
   // NOTE regarding HPMs 0..2, which are not "actual" HPMs
   // - HPM 0 is the machine cycle counter
@@ -97,18 +95,16 @@ int main() {
     neorv32_cpu_csr_write(CSR_MINSTRET, 0); neorv32_cpu_csr_write(CSR_MINSTRETH, 0);
   }
 
-  // configure events - one event per counter;
-  // we can also configure more than one event; the HPM will increment if _any_ event triggers (logical OR);
-  // there will be NO exception if we access a HPM event register that has not been implemented
-  // as long as Zihpm is implemented
-  if (hpm_num > 0) { neorv32_cpu_csr_write(CSR_MHPMEVENT3,  1 << HPMCNT_EVENT_COMPR);    } // executed compressed instruction
+  // configure events, one event per counter;
+  // we can also configure more than one event; the HPM will increment if _any_ configured event triggers (logical OR);
+  // there will be NO exception if we access a HPM event register that has not been implemented as long as Zihpm is implemented
+  if (hpm_num > 0) { neorv32_cpu_csr_write(CSR_MHPMEVENT3,  1 << HPMCNT_EVENT_CI);       } // executed compressed instruction
   if (hpm_num > 1) { neorv32_cpu_csr_write(CSR_MHPMEVENT4,  1 << HPMCNT_EVENT_WAIT_DIS); } // instruction dispatch wait cycle
   if (hpm_num > 2) { neorv32_cpu_csr_write(CSR_MHPMEVENT5,  1 << HPMCNT_EVENT_WAIT_ALU); } // multi-cycle ALU co-processor wait cycle
-  if (hpm_num > 3) { neorv32_cpu_csr_write(CSR_MHPMEVENT6,  1 << HPMCNT_EVENT_BRANCH);   } // executed branch instruction
-  if (hpm_num > 4) { neorv32_cpu_csr_write(CSR_MHPMEVENT7,  1 << HPMCNT_EVENT_CTRLFLOW); } // control flow transfer
-  if (hpm_num > 5) { neorv32_cpu_csr_write(CSR_MHPMEVENT8,  1 << HPMCNT_EVENT_LOAD);     } // executed load operation
-  if (hpm_num > 6) { neorv32_cpu_csr_write(CSR_MHPMEVENT9,  1 << HPMCNT_EVENT_STORE);    } // executed store operation
-  if (hpm_num > 7) { neorv32_cpu_csr_write(CSR_MHPMEVENT10, 1 << HPMCNT_EVENT_WAIT_LSU); } // load-store unit memory wait cycle
+  if (hpm_num > 3) { neorv32_cpu_csr_write(CSR_MHPMEVENT6,  1 << HPMCNT_EVENT_WAIT_LSU); } // load-store unit wait cycle
+  if (hpm_num > 4) { neorv32_cpu_csr_write(CSR_MHPMEVENT7,  1 << HPMCNT_EVENT_DELTA);    } // control flow transfer
+  if (hpm_num > 5) { neorv32_cpu_csr_write(CSR_MHPMEVENT8,  1 << HPMCNT_EVENT_LOAD);     } // memory load operation
+  if (hpm_num > 6) { neorv32_cpu_csr_write(CSR_MHPMEVENT9,  1 << HPMCNT_EVENT_STORE);    } // memory store operation
 
 
   // enable all CPU counters including HPMs
@@ -116,15 +112,10 @@ int main() {
 
 
   // this is the part of the the program that is going to be "benchmarked" using the HPMs
-  // here we are just doing some pointless stuff that will trigger the configured HPM events;
-  // note that ALL code being executed will be benchmarked - including traps
+  // here we are just doing some pointless stuff that will trigger the configured HPM events
   {
     neorv32_uart0_printf("\nDoing dummy operations to increment counters...\n");
     neorv32_uart0_printf("> Print some number: %u\n", 52983740);
-    neorv32_uart0_printf("> An exception (environment call) handled by the RTE:\n");
-    asm volatile ("ecall"); // environment call
-    neorv32_uart0_printf("> An invalid instruction handled by the RTE:\n");
-    asm volatile ("csrwi marchid, 1"); // illegal instruction (writing to read-only CSR)
   }
 
 
@@ -136,17 +127,16 @@ int main() {
   // print HPM counter values (low word only); read from unprivileged HPM CSRs
   neorv32_uart0_printf("\nHPM results (low-words only):\n");
   if ((neorv32_cpu_csr_read(CSR_MXISA) & (1 << CSR_MXISA_ZICNTR))) {
-    neorv32_uart0_printf(" cycle (active clock cycles)         : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_CYCLE));
-    neorv32_uart0_printf(" instret (retired instructions)      : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_INSTRET));
+    neorv32_uart0_printf("[CY]   active clock cycles     : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_CYCLE));
+    neorv32_uart0_printf("[IR]   retired instructions    : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_INSTRET));
   }
-  if (hpm_num > 0) { neorv32_uart0_printf(" HPM03 (compressed instructions)     : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER3));  }
-  if (hpm_num > 1) { neorv32_uart0_printf(" HPM04 (instr. dispatch wait cycles) : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER4));  }
-  if (hpm_num > 2) { neorv32_uart0_printf(" HPM05 (ALU wait cycles)             : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER5));  }
-  if (hpm_num > 3) { neorv32_uart0_printf(" HPM06 (branch instructions)         : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER6));  }
-  if (hpm_num > 4) { neorv32_uart0_printf(" HPM07 (control flow transfers)      : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER7));  }
-  if (hpm_num > 5) { neorv32_uart0_printf(" HPM08 (load instructions)           : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER8));  }
-  if (hpm_num > 6) { neorv32_uart0_printf(" HPM09 (store instructions)          : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER9));  }
-  if (hpm_num > 7) { neorv32_uart0_printf(" HPM10 (load/store wait cycles)      : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER10)); }
+  if (hpm_num > 0) { neorv32_uart0_printf("[HPM3] compressed instructions : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER3));  }
+  if (hpm_num > 1) { neorv32_uart0_printf("[HPM4] dispatch wait cycles    : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER4));  }
+  if (hpm_num > 2) { neorv32_uart0_printf("[HPM5] ALU wait cycles         : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER5));  }
+  if (hpm_num > 3) { neorv32_uart0_printf("[HPM6] LSU wait cycles         : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER6));  }
+  if (hpm_num > 4) { neorv32_uart0_printf("[HPM7] control flow transfers  : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER7));  }
+  if (hpm_num > 5) { neorv32_uart0_printf("[HPM8] load operation          : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER8));  }
+  if (hpm_num > 6) { neorv32_uart0_printf("[HPM9] store operation         : %u\n", (uint32_t)neorv32_cpu_csr_read(CSR_HPMCOUNTER9));  }
 
   neorv32_uart0_printf("\nProgram completed.\n");
 

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -242,14 +242,13 @@ int main() {
   if (num_hpm_cnts_global != 0) {
     cnt_test++;
 
-    neorv32_cpu_csr_write(CSR_MHPMCOUNTER3,  0); neorv32_cpu_csr_write(CSR_MHPMEVENT3,  1 << HPMCNT_EVENT_COMPR);
-    neorv32_cpu_csr_write(CSR_MHPMCOUNTER4,  0); neorv32_cpu_csr_write(CSR_MHPMEVENT4,  1 << HPMCNT_EVENT_WAIT_DIS);
-    neorv32_cpu_csr_write(CSR_MHPMCOUNTER5,  0); neorv32_cpu_csr_write(CSR_MHPMEVENT5,  1 << HPMCNT_EVENT_WAIT_ALU);
-    neorv32_cpu_csr_write(CSR_MHPMCOUNTER6,  0); neorv32_cpu_csr_write(CSR_MHPMEVENT6,  1 << HPMCNT_EVENT_BRANCH);
-    neorv32_cpu_csr_write(CSR_MHPMCOUNTER7,  0); neorv32_cpu_csr_write(CSR_MHPMEVENT7,  1 << HPMCNT_EVENT_CTRLFLOW);
-    neorv32_cpu_csr_write(CSR_MHPMCOUNTER8,  0); neorv32_cpu_csr_write(CSR_MHPMEVENT8,  1 << HPMCNT_EVENT_LOAD);
-    neorv32_cpu_csr_write(CSR_MHPMCOUNTER9,  0); neorv32_cpu_csr_write(CSR_MHPMEVENT9,  1 << HPMCNT_EVENT_STORE);
-    neorv32_cpu_csr_write(CSR_MHPMCOUNTER10, 0); neorv32_cpu_csr_write(CSR_MHPMEVENT10, 1 << HPMCNT_EVENT_WAIT_LSU);
+    neorv32_cpu_csr_write(CSR_MHPMCOUNTER3, 0); neorv32_cpu_csr_write(CSR_MHPMEVENT3, 1 << HPMCNT_EVENT_CI);
+    neorv32_cpu_csr_write(CSR_MHPMCOUNTER4, 0); neorv32_cpu_csr_write(CSR_MHPMEVENT4, 1 << HPMCNT_EVENT_WAIT_DIS);
+    neorv32_cpu_csr_write(CSR_MHPMCOUNTER5, 0); neorv32_cpu_csr_write(CSR_MHPMEVENT5, 1 << HPMCNT_EVENT_WAIT_ALU);
+    neorv32_cpu_csr_write(CSR_MHPMCOUNTER6, 0); neorv32_cpu_csr_write(CSR_MHPMEVENT6, 1 << HPMCNT_EVENT_WAIT_LSU);
+    neorv32_cpu_csr_write(CSR_MHPMCOUNTER7, 0); neorv32_cpu_csr_write(CSR_MHPMEVENT7, 1 << HPMCNT_EVENT_DELTA);
+    neorv32_cpu_csr_write(CSR_MHPMCOUNTER8, 0); neorv32_cpu_csr_write(CSR_MHPMEVENT8, 1 << HPMCNT_EVENT_LOAD);
+    neorv32_cpu_csr_write(CSR_MHPMCOUNTER9, 0); neorv32_cpu_csr_write(CSR_MHPMEVENT9, 1 << HPMCNT_EVENT_STORE);
 
     // make sure there was no exception
     if (neorv32_cpu_csr_read(CSR_MCAUSE) == trap_never_c) {
@@ -2457,32 +2456,34 @@ int main() {
 
 
   // ----------------------------------------------------------
-  // HPM reports
+  // counter reports
   // ----------------------------------------------------------
-  neorv32_cpu_csr_write(CSR_MCOUNTINHIBIT, -1); // stop all HPM counters
+  neorv32_cpu_csr_write(CSR_MCOUNTINHIBIT, -1); // stop all counters
+  PRINT("\n\nBase Counters & HPMs\n");
+  if (neorv32_cpu_csr_read(CSR_MXISA) & (1 << CSR_MXISA_ZICNTR)) {
+    PRINT(
+      "[CY]   Clock cycles : %u\n"
+      "[IR]   Instructions : %u\n",
+      neorv32_cpu_csr_read(CSR_CYCLE),
+      neorv32_cpu_csr_read(CSR_INSTRET)
+    );
+  }
   if (neorv32_cpu_csr_read(CSR_MXISA) & (1 << CSR_MXISA_ZIHPM)) {
     PRINT(
-      "\n\nHPMs:\n"
-      "#00 clock cycles  : %u\n"
-      "#02 instructions  : %u\n"
-      "#03 compr. instr. : %u\n"
-      "#04 DISP waits    : %u\n"
-      "#05 ALU waits     : %u\n"
-      "#06 branch instr. : %u\n"
-      "#07 control flow  : %u\n"
-      "#08 MEM loads     : %u\n"
-      "#09 MEM stores    : %u\n"
-      "#10 MEM waits     : %u\n",
-      neorv32_cpu_csr_read(CSR_CYCLE),
-      neorv32_cpu_csr_read(CSR_INSTRET),
+      "[HPM3] Compressed   : %u\n"
+      "[HPM4] DISP waits   : %u\n"
+      "[HPM5] ALU waits    : %u\n"
+      "[HPM6] LSU waits    : %u\n"
+      "[HPM7] Deltas       : %u\n"
+      "[HPM8] Loads        : %u\n"
+      "[HPM9] Stores       : %u\n",
       neorv32_cpu_csr_read(CSR_MHPMCOUNTER3),
       neorv32_cpu_csr_read(CSR_MHPMCOUNTER4),
       neorv32_cpu_csr_read(CSR_MHPMCOUNTER5),
       neorv32_cpu_csr_read(CSR_MHPMCOUNTER6),
       neorv32_cpu_csr_read(CSR_MHPMCOUNTER7),
       neorv32_cpu_csr_read(CSR_MHPMCOUNTER8),
-      neorv32_cpu_csr_read(CSR_MHPMCOUNTER9),
-      neorv32_cpu_csr_read(CSR_MHPMCOUNTER10)
+      neorv32_cpu_csr_read(CSR_MHPMCOUNTER9)
     );
   }
 

--- a/sw/lib/include/neorv32_csr.h
+++ b/sw/lib/include/neorv32_csr.h
@@ -294,7 +294,6 @@ enum NEORV32_CSR_enum {
   CSR_MXISAH         = 0xfc1  /**< 0xfc1 - mxisah: Machine extended ISA and extensions high word */
 };
 
-
 /**********************************************************************//**
  * fflags (fcsr)</b> CSR (r/w): FPU accrued exception flags
  **************************************************************************/
@@ -306,14 +305,13 @@ enum NEORV32_CSR_FFLAGS_enum {
   CSR_FFLAGS_NV = 4  /**< fflags CSR (4): NV - invalid operation (r/w) */
 };
 
-
 /**********************************************************************//**
  * mcountern CSR (r/w): Machine counter-enable register
  **************************************************************************/
 enum NEORV32_CSR_MCOUNTEREN_enum {
-  CSR_MCOUNTEREN_CY    = 0, /**< mcountern CSR  (0):  CY    - cycle counter (r/w) */
-  CSR_MCOUNTEREN_TM    = 1, /**< mcountern CSR  (1):  TM    - system time counter (r/w) */
-  CSR_MCOUNTEREN_IR    = 2, /**< mcountern CSR  (2):  IR    - instruction-retired counter (r/w) */
+  CSR_MCOUNTEREN_CY    = 0,  /**< mcountern CSR (0):  CY    - cycle counter (r/w) */
+  CSR_MCOUNTEREN_TM    = 1,  /**< mcountern CSR (1):  TM    - system time counter (r/w) */
+  CSR_MCOUNTEREN_IR    = 2,  /**< mcountern CSR (2):  IR    - instruction-retired counter (r/w) */
   CSR_MCOUNTEREN_HPM3  = 3,  /**< mcountern CSR (3):  HPM3  - hardware performance counter 3  (r/w) */
   CSR_MCOUNTEREN_HPM4  = 4,  /**< mcountern CSR (4):  HPM4  - hardware performance counter 4  (r/w) */
   CSR_MCOUNTEREN_HPM5  = 5,  /**< mcountern CSR (5):  HPM5  - hardware performance counter 5  (r/w) */
@@ -345,7 +343,6 @@ enum NEORV32_CSR_MCOUNTEREN_enum {
   CSR_MCOUNTEREN_HPM31 = 31  /**< mcountern CSR (31): HPM31 - hardware performance counter 31 (r/w) */
 };
 
-
 /**********************************************************************//**
  * mstatus CSR (r/w): Machine status - low word
  **************************************************************************/
@@ -357,7 +354,6 @@ enum NEORV32_CSR_MSTATUS_enum {
   CSR_MSTATUS_MPRV  = 17, /**< mstatus CSR (17): MPRV - Use MPP as effective privilege for M-mode load/stores when set (r/w) */
   CSR_MSTATUS_TW    = 21  /**< mstatus CSR (21): TW - Disallow execution of wfi instruction in user mode when set (r/w) */
 };
-
 
 /**********************************************************************//**
  * mcountinhibitCSR (r/w): Machine counter-inhibit
@@ -396,7 +392,6 @@ enum NEORV32_CSR_MCOUNTINHIBIT_enum {
   CSR_MCOUNTINHIBIT_HPM31 = 31  /**< mcountinhibit CSR (31): HPM31 - Enable auto-increment of hpmcnt31[h] when set (r/w) */
 };
 
-
 /**********************************************************************//**
  * mie CSR (r/w): Machine interrupt enable
  **************************************************************************/
@@ -422,7 +417,6 @@ enum NEORV32_CSR_MIE_enum {
   CSR_MIE_FIRQ14E = 30, /**< mie CSR (30): FIRQ14E - Fast interrupt channel 14 enable bit (r/w) */
   CSR_MIE_FIRQ15E = 31  /**< mie CSR (31): FIRQ15E - Fast interrupt channel 15 enable bit (r/w) */
 };
-
 
 /**********************************************************************//**
  * mip CSR (r/-): Machine interrupt pending
@@ -450,7 +444,6 @@ enum NEORV32_CSR_MIP_enum {
   CSR_MIP_FIRQ15P = 31  /**< mip CSR (31): FIRQ15P - Fast interrupt channel 15 pending (r/-) */
 };
 
-
 /**********************************************************************//**
  * misa CSR (r/-): Machine instruction set extensions
  **************************************************************************/
@@ -466,7 +459,6 @@ enum NEORV32_CSR_MISA_enum {
   CSR_MISA_MXL_LO = 30, /**< misa CSR (30): MXL.lo: CPU data width (r/-) */
   CSR_MISA_MXL_HI = 31  /**< misa CSR (31): MXL.Hi: CPU data width (r/-) */
 };
-
 
 /**********************************************************************//**
  * mxisa[h] CSR (r/-): Machine extended instruction set extensions (NEORV32-specific)
@@ -510,7 +502,6 @@ enum NEORV32_CSR_MXISAH_enum {
   CSR_MXISAH_ZBC = 0 /**< mxisah CSR (0): carry-less multiplication (r/-)*/
 };
 
-
 /**********************************************************************//**
  * mcyclecfgh CSR (r/w): Machine cycle counter privilege-mode filtering
  **************************************************************************/
@@ -518,7 +509,6 @@ enum NEORV32_CSR_MCYCLECFGH_enum {
   CSR_MCYCLECFGH_UINH = 28, /**< mcyclecfgh CSR (28): inhibit cycle counter when in user-mode when set (r/w) */
   CSR_MCYCLECFGH_MINH = 30  /**< mcyclecfgh CSR (30): inhibit cycle counter when in machine-mode when set (r/w) */
 };
-
 
 /**********************************************************************//**
  * minstretcfgh CSR (r/w): Machine instret counter privilege-mode filtering
@@ -528,24 +518,20 @@ enum NEORV32_CSR_MINSTRETCFGH_enum {
   CSR_MINSTRETCFGH_MINH = 30  /**< minstretcfgh CSR (30): inhibit instret counter when in machine-mode when set (r/w) */
 };
 
-
 /**********************************************************************//**
  * mhpmevent hardware performance monitor events
  **************************************************************************/
 enum NEORV32_HPMCNT_EVENT_enum {
-  HPMCNT_EVENT_CY       = 0, /**< mhpmevent CSR (0):  Active cycle */
-  HPMCNT_EVENT_TM       = 1, /**< mhpmevent CSR (1):  Reserved */
-  HPMCNT_EVENT_IR       = 2, /**< mhpmevent CSR (2):  Retired instruction */
-  HPMCNT_EVENT_COMPR    = 3, /**< mhpmevent CSR (3):  Executed compressed instruction */
-  HPMCNT_EVENT_WAIT_DIS = 4, /**< mhpmevent CSR (4):  Instruction dispatch wait cycle */
-  HPMCNT_EVENT_WAIT_ALU = 5, /**< mhpmevent CSR (5):  Multi-cycle ALU co-processor wait cycle */
-  HPMCNT_EVENT_BRANCH   = 6, /**< mhpmevent CSR (6):  Executed branch instruction */
-  HPMCNT_EVENT_CTRLFLOW = 7, /**< mhpmevent CSR (7):  Control flow transfer */
-  HPMCNT_EVENT_LOAD     = 8, /**< mhpmevent CSR (8):  Executed load operation */
-  HPMCNT_EVENT_STORE    = 9, /**< mhpmevent CSR (9):  Executed store operation */
-  HPMCNT_EVENT_WAIT_LSU = 10 /**< mhpmevent CSR (10): Load-store unit memory wait cycle */
+  HPMCNT_EVENT_CY       = 0, /**< mhpmevent CSR (0): Active cycle */
+  HPMCNT_EVENT_IR       = 1, /**< mhpmevent CSR (1): Retired instruction */
+  HPMCNT_EVENT_CI       = 2, /**< mhpmevent CSR (2): Compressed instruction */
+  HPMCNT_EVENT_WAIT_DIS = 3, /**< mhpmevent CSR (3): Instruction dispatch wait cycle */
+  HPMCNT_EVENT_WAIT_ALU = 4, /**< mhpmevent CSR (4): Multi-cycle ALU co-processor wait cycle */
+  HPMCNT_EVENT_WAIT_LSU = 5, /**< mhpmevent CSR (5): Load-store unit memory wait cycle */
+  HPMCNT_EVENT_DELTA    = 6, /**< mhpmevent CSR (6): Control flow transfer */
+  HPMCNT_EVENT_LOAD     = 7, /**< mhpmevent CSR (7): Memory load operation */
+  HPMCNT_EVENT_STORE    = 8  /**< mhpmevent CSR (8): Memory store operation */
 };
-
 
 /**********************************************************************//**
  * pmpcfg PMP configuration attributes
@@ -568,7 +554,6 @@ enum NEORV32_PMP_MODES_enum {
   PMP_NA4   = 2, /**< '10': Naturally-aligned power of two region (4 bytes) */
   PMP_NAPOT = 3  /**< '11': Naturally-aligned power of two region (greater than 4 bytes )*/
 };
-
 
 /**********************************************************************//**
  * Trap codes from mcause CSR
@@ -604,6 +589,5 @@ enum NEORV32_EXCEPTION_CODES_enum {
   TRAP_CODE_FIRQ_14      = 0x8000001eU, /**< 1.30: Fast interrupt channel 14 */
   TRAP_CODE_FIRQ_15      = 0x8000001fU  /**< 1.31: Fast interrupt channel 15 */
 };
-
 
 #endif // NEORV32_CSR_H


### PR DESCRIPTION
Simplify counter events:

### `mhpmevent*` CSRs

| Bit | Name [C] | Event Description |
|:----|:---------|:------------------|
| 8   | `HPMCNT_EVENT_STORE`    | memory store operation (read-modify-write AMOs are counted as 1x load + 1x store operation) |
| 7   | `HPMCNT_EVENT_LOAD`     | memory load operation (read-modify-write AMOs are counted as 1x load + 1x store operation) |
| 6   | `HPMCNT_EVENT_DELTA`    | control flow transfer (jump, taken branch, trap entry/exit) |
| 5   | `HPMCNT_EVENT_WAIT_LSU` | memory/bus/cache/etc. delay/wait cycle while executing any load or store operation (caused by a data bus wait cycle)) |
| 4   | `HPMCNT_EVENT_WAIT_ALU` | delay/wait cycle caused by a _multi-cycle_ ALU operation (e.g. bit-serial shift) |
| 3   | `HPMCNT_EVENT_WAIT_DIS` | instruction dispatch wait cycle (wait for instruction prefetch-buffer refill); caused by a fence instruction, a control flow transfer or a instruction fetch bus wait cycle (e.g. cache miss)  |
| 2   | `HPMCNT_EVENT_CI`       | executed 16-bit/compressed `C` instruction |
| 1   | `HPMCNT_EVENT_IR`       | executed instruction (16-bit/compressed or 32-bit/uncompressed) |
| 0   | `HPMCNT_EVENT_CY`       | active clock cycle (CPU not in sleep mode) |