### PR TITLE
remove `mhpmevent*h` CSRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 15.06.2026 | 1.13.1.9 | remove `mhpmevent*h` CSRs that do not exist on RV32 without `Sscofpmf` | [#1575](https://github.com/stnolting/neorv32/pull/1575) |
 | 14.06.2026 | 1.13.1.8 | close (the last) RVC illegal instruction detection loophole; further shrink bootloader image size; add defaults for CPU-top generics | [#1574](https://github.com/stnolting/neorv32/pull/1574) |
 | 07.06.2026 | 1.13.1.7 | minor rtl edits and optimizations | [#1570](https://github.com/stnolting/neorv32/pull/1570) |
 | 05.06.2026 | 1.13.1.6 | :warning: rework hardware performance counter (HPM) events | [#1569](https://github.com/stnolting/neorv32/pull/1569) |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -71,8 +71,7 @@ to check if the targeted bits can actually be modified.
 | 0xc81 | <<_timeh, `timeh`>>         | `CSR_TIMEH`     | URO | System time high word
 | 0xc82 | <<_instreth, `instreth`>>   | `CSR_INSTRETH`  | URO | Instruction-retired counter high word
 5+^| **<<_hardware_performance_monitors_hpm_csrs>>**
-| 0x323 .. 0x33f | <<_mhpmeventh, `mhpmevent3`>> .. <<_mhpmevent, `mhpmevent31`>>            | `CSR_MHPMEVENT3` .. `CSR_MHPMEVENT31`       | MRW | Machine performance-monitoring event select low word
-| 0x723 .. 0x73f | <<_mhpmeventh, `mhpmevent3h`>> .. <<_mhpmevent, `mhpmevent31h`>>          | `CSR_MHPMEVENT3H` .. `CSR_MHPMEVENT31H`     | MRW | Machine performance-monitoring event select high word
+| 0x323 .. 0x33f | <<_mhpmevent, `mhpmevent3`>> .. <<_mhpmevent, `mhpmevent31`>>             | `CSR_MHPMEVENT3` .. `CSR_MHPMEVENT31`       | MRW | Machine performance-monitoring event select
 | 0xb03 .. 0xb1f | <<_mhpmcounterh, `mhpmcounter3`>> .. <<_mhpmcounterh, `mhpmcounter31`>>   | `CSR_MHPMCOUNTER3` .. `CSR_MHPMCOUNTER31`   | MRW | Machine performance-monitoring counter low word
 | 0xb83 .. 0xb9f | <<_mhpmcounterh, `mhpmcounter3h`>> .. <<_mhpmcounterh, `mhpmcounter31h`>> | `CSR_MHPMCOUNTER3H` .. `CSR_MHPMCOUNTER31H` | MRW | Machine performance-monitoring counter high word
 | 0xc03 .. 0xc1f | <<_hpmcounterh, `hpmcounter3`>> .. <<_hpmcounterh, `hpmcounter31`>>       | `CSR_HPMCOUNTER3` .. `CSR_HPMCOUNTER31`     | URO | Performance-monitoring counter low word
@@ -670,7 +669,7 @@ Note that **all** executed instruction do increment the `[m]instret[h]` counters
 ==== Hardware Performance Monitors (HPM) CSRs
 
 The actual number of implemented hardware performance monitors is configured via the `HPM_NUM_CNTS` top entity generic,
-Note that always all 29 HPM counter and configuration registers (`mhpmcounter*[h]` and `mhpmevent*[h]`) are accessible, but
+Note that always all 29 HPM counter and configuration registers (`mhpmcounter*[h]` and `mhpmevent*`) are accessible, but
 only the actually configured ones are implemented as "real" physical registers - the remaining ones will be hardwired to zero.
 If trying to access an HPM-related CSR beyond `HPM_NUM_CNTS` **no illegal instruction exception is
 triggered**. These CSRs are read-only, writes are ignored and reads always return zero.
@@ -680,20 +679,18 @@ If `HPM_NUM_CNTS` is less than 64, all remaining MSB-aligned bits are hardwired 
 
 
 [discrete]
-===== **`mhpmevent[h]`**
+===== **`mhpmevent`**
 
 [cols="<1,<8"]
 [grid="none"]
 |=======================
 | Name        | Machine hardware performance monitor event select
 | Address     | `0x323` ... `0x33f` (`mhpmevent3` ... `mhpmevent31`)
-|             | `0x723` ... `0x73f` (`mhpmevent3h` ... `mhpmevent31h`)
 | Reset value | all `0x00000000`
 | ISA         | <<_zicsr_isa_extension,`Zicsr`>> & <<_zihpm_isa_extension,`Zihpm`>>
 | Description | The value in these CSRs define the micro-architectural events that cause an increment of the according `mhpmcounter*[h]` counter(s).
 All available events are listed in the table below. If more than one event is enabled, the according counter will increment if _any_ of the enabled
 events is observed (logical OR). Note that the counter will only increment by 1 step per clock cycle even if more than one trigger event is observed.
-Note that all `mhpmevent*h` (hogh-word) event-select registers are hardwired to zero.
 |=======================
 
 .`mhpmevent*` CSR Bits (Micro-Architectural Counter Events)

--- a/docs/datasheet/cpu_isa.adoc
+++ b/docs/datasheet/cpu_isa.adoc
@@ -415,9 +415,9 @@ However, access privileges are still enforced so these instruction variants _do_
 ==== `Zihpm` ISA Extension
 
 In additions to the base counters the NEORV32 CPU provides up to 29 hardware performance monitors (HPM; <<_mhpmcounterh>>
-and <<_hpmcounterh>>), which can be used to benchmark applications. Each HPM consists of a counter and a corresponding event
-configuration CSR (<<_mhpmeventh>>). Bothc CRSs are split into a high-word and a low-word CSR. The effective counter width can
-be defined via the top's `HPM_CNT_WIDTH` generic.
+and <<_hpmcounterh>>), which can be used to benchmark applications. Each HPM consists of a counter (up to 64-bit) and a
+corresponding 32-bit event configuration CSR (<<_mhpmevent>>). The counter CRSs are split into a high-word and a low-word
+CSR. The effective counter width can be defined via the top's `HPM_CNT_WIDTH` generic.
 
 The event configuration CSR defines the architectural events that lead to an increment of the associated HPM counter.
 See section <<_hardware_performance_monitors_hpm_csrs>> for a list of all HPM-related CSRs and event configurations.

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -623,15 +623,7 @@ begin
            csr_mhpmevent19_c    | csr_mhpmevent20_c    | csr_mhpmevent21_c    | csr_mhpmevent22_c    |
            csr_mhpmevent23_c    | csr_mhpmevent24_c    | csr_mhpmevent25_c    | csr_mhpmevent26_c    |
            csr_mhpmevent27_c    | csr_mhpmevent28_c    | csr_mhpmevent29_c    | csr_mhpmevent30_c    |
-           csr_mhpmevent31_c    | -- machine event configuration LOW
-           csr_mhpmevent3h_c    | csr_mhpmevent4h_c    | csr_mhpmevent5h_c    | csr_mhpmevent6h_c    |
-           csr_mhpmevent7h_c    | csr_mhpmevent8h_c    | csr_mhpmevent9h_c    | csr_mhpmevent10h_c   |
-           csr_mhpmevent11h_c   | csr_mhpmevent12h_c   | csr_mhpmevent13h_c   | csr_mhpmevent14h_c   |
-           csr_mhpmevent15h_c   | csr_mhpmevent16h_c   | csr_mhpmevent17h_c   | csr_mhpmevent18h_c   |
-           csr_mhpmevent19h_c   | csr_mhpmevent20h_c   | csr_mhpmevent21h_c   | csr_mhpmevent22h_c   |
-           csr_mhpmevent23h_c   | csr_mhpmevent24h_c   | csr_mhpmevent25h_c   | csr_mhpmevent26h_c   |
-           csr_mhpmevent27h_c   | csr_mhpmevent28h_c   | csr_mhpmevent29h_c   | csr_mhpmevent30h_c   |
-           csr_mhpmevent31h_c => -- machine event configuration HIGH
+           csr_mhpmevent31_c => -- machine event configuration (LOW-word only for RV32 without Sscofpmf)
         csr_valid(2) <= bool_to_ulogic_f(RISCV_ISA_Zihpm);
 
       -- counter and timer CSRs --

--- a/rtl/core/neorv32_cpu_trace.vhd
+++ b/rtl/core/neorv32_cpu_trace.vhd
@@ -553,35 +553,6 @@ architecture neorv32_cpu_trace_simlog_rtl of neorv32_cpu_trace_simlog is
       -- machine counter setup - continued --
       when csr_mcyclecfgh_c     => return "mcyclecfgh";
       when csr_minstretcfgh_c   => return "minstretcfgh";
-      when csr_mhpmevent3h_c    => return "mhpmevent3h";
-      when csr_mhpmevent4h_c    => return "mhpmevent4h";
-      when csr_mhpmevent5h_c    => return "mhpmevent5h";
-      when csr_mhpmevent6h_c    => return "mhpmevent6h";
-      when csr_mhpmevent7h_c    => return "mhpmevent7h";
-      when csr_mhpmevent8h_c    => return "mhpmevent8h";
-      when csr_mhpmevent9h_c    => return "mhpmevent9h";
-      when csr_mhpmevent10h_c   => return "mhpmevent10h";
-      when csr_mhpmevent11h_c   => return "mhpmevent11h";
-      when csr_mhpmevent12h_c   => return "mhpmevent12h";
-      when csr_mhpmevent13h_c   => return "mhpmevent13h";
-      when csr_mhpmevent14h_c   => return "mhpmevent14h";
-      when csr_mhpmevent15h_c   => return "mhpmevent15h";
-      when csr_mhpmevent16h_c   => return "mhpmevent16h";
-      when csr_mhpmevent17h_c   => return "mhpmevent17h";
-      when csr_mhpmevent18h_c   => return "mhpmevent18h";
-      when csr_mhpmevent19h_c   => return "mhpmevent19h";
-      when csr_mhpmevent20h_c   => return "mhpmevent20h";
-      when csr_mhpmevent21h_c   => return "mhpmevent21h";
-      when csr_mhpmevent22h_c   => return "mhpmevent22h";
-      when csr_mhpmevent23h_c   => return "mhpmevent23h";
-      when csr_mhpmevent24h_c   => return "mhpmevent24h";
-      when csr_mhpmevent25h_c   => return "mhpmevent25h";
-      when csr_mhpmevent26h_c   => return "mhpmevent26h";
-      when csr_mhpmevent27h_c   => return "mhpmevent27h";
-      when csr_mhpmevent28h_c   => return "mhpmevent28h";
-      when csr_mhpmevent29h_c   => return "mhpmevent29h";
-      when csr_mhpmevent30h_c   => return "mhpmevent30h";
-      when csr_mhpmevent31h_c   => return "mhpmevent31h";
       -- trigger module registers --
       when csr_tselect_c        => return "tselect";
       when csr_tdata1_c         => return "tdata1";

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130108"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130109"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 
@@ -496,35 +496,6 @@ package neorv32_package is
   -- machine counter setup - continued --
   constant csr_mcyclecfgh_c     : std_ulogic_vector(11 downto 0) := x"721";
   constant csr_minstretcfgh_c   : std_ulogic_vector(11 downto 0) := x"722";
-  constant csr_mhpmevent3h_c    : std_ulogic_vector(11 downto 0) := x"723";
-  constant csr_mhpmevent4h_c    : std_ulogic_vector(11 downto 0) := x"724";
-  constant csr_mhpmevent5h_c    : std_ulogic_vector(11 downto 0) := x"725";
-  constant csr_mhpmevent6h_c    : std_ulogic_vector(11 downto 0) := x"726";
-  constant csr_mhpmevent7h_c    : std_ulogic_vector(11 downto 0) := x"727";
-  constant csr_mhpmevent8h_c    : std_ulogic_vector(11 downto 0) := x"728";
-  constant csr_mhpmevent9h_c    : std_ulogic_vector(11 downto 0) := x"729";
-  constant csr_mhpmevent10h_c   : std_ulogic_vector(11 downto 0) := x"72a";
-  constant csr_mhpmevent11h_c   : std_ulogic_vector(11 downto 0) := x"72b";
-  constant csr_mhpmevent12h_c   : std_ulogic_vector(11 downto 0) := x"72c";
-  constant csr_mhpmevent13h_c   : std_ulogic_vector(11 downto 0) := x"72d";
-  constant csr_mhpmevent14h_c   : std_ulogic_vector(11 downto 0) := x"72e";
-  constant csr_mhpmevent15h_c   : std_ulogic_vector(11 downto 0) := x"72f";
-  constant csr_mhpmevent16h_c   : std_ulogic_vector(11 downto 0) := x"730";
-  constant csr_mhpmevent17h_c   : std_ulogic_vector(11 downto 0) := x"731";
-  constant csr_mhpmevent18h_c   : std_ulogic_vector(11 downto 0) := x"732";
-  constant csr_mhpmevent19h_c   : std_ulogic_vector(11 downto 0) := x"733";
-  constant csr_mhpmevent20h_c   : std_ulogic_vector(11 downto 0) := x"734";
-  constant csr_mhpmevent21h_c   : std_ulogic_vector(11 downto 0) := x"735";
-  constant csr_mhpmevent22h_c   : std_ulogic_vector(11 downto 0) := x"736";
-  constant csr_mhpmevent23h_c   : std_ulogic_vector(11 downto 0) := x"737";
-  constant csr_mhpmevent24h_c   : std_ulogic_vector(11 downto 0) := x"738";
-  constant csr_mhpmevent25h_c   : std_ulogic_vector(11 downto 0) := x"739";
-  constant csr_mhpmevent26h_c   : std_ulogic_vector(11 downto 0) := x"73a";
-  constant csr_mhpmevent27h_c   : std_ulogic_vector(11 downto 0) := x"73b";
-  constant csr_mhpmevent28h_c   : std_ulogic_vector(11 downto 0) := x"73c";
-  constant csr_mhpmevent29h_c   : std_ulogic_vector(11 downto 0) := x"73d";
-  constant csr_mhpmevent30h_c   : std_ulogic_vector(11 downto 0) := x"73e";
-  constant csr_mhpmevent31h_c   : std_ulogic_vector(11 downto 0) := x"73f";
   -- trigger module registers --
   constant csr_tselect_c        : std_ulogic_vector(11 downto 0) := x"7a0";
   constant csr_tdata1_c         : std_ulogic_vector(11 downto 0) := x"7a1";

--- a/sw/lib/include/neorv32_csr.h
+++ b/sw/lib/include/neorv32_csr.h
@@ -108,37 +108,6 @@ enum NEORV32_CSR_enum {
   CSR_MCYCLECFGH     = 0x721, /**< 0x721 - mcyclecfgh:   Machine cycle counter privilege mode filtering - high word */
   CSR_MINSTRETCFGH   = 0x722, /**< 0x722 - minstretcfgh: Machine instret counter privilege mode filtering - high word */
 
-  /* hardware performance monitors - event configuration - continued */
-  CSR_MHPMEVENT3H    = 0x723, /**< 0x723 - mhpmevent3h:  Machine hardware performance monitor event selector 3  high word */
-  CSR_MHPMEVENT4H    = 0x724, /**< 0x724 - mhpmevent4h:  Machine hardware performance monitor event selector 4  high word */
-  CSR_MHPMEVENT5H    = 0x725, /**< 0x725 - mhpmevent5h:  Machine hardware performance monitor event selector 5  high word */
-  CSR_MHPMEVENT6H    = 0x726, /**< 0x726 - mhpmevent6h:  Machine hardware performance monitor event selector 6  high word */
-  CSR_MHPMEVENT7H    = 0x727, /**< 0x727 - mhpmevent7h:  Machine hardware performance monitor event selector 7  high word */
-  CSR_MHPMEVENT8H    = 0x728, /**< 0x728 - mhpmevent8h:  Machine hardware performance monitor event selector 8  high word */
-  CSR_MHPMEVENT9H    = 0x729, /**< 0x729 - mhpmevent9h:  Machine hardware performance monitor event selector 9  high word */
-  CSR_MHPMEVENT10H   = 0x72a, /**< 0x72a - mhpmevent10h: Machine hardware performance monitor event selector 10 high word */
-  CSR_MHPMEVENT11H   = 0x72b, /**< 0x72b - mhpmevent11h: Machine hardware performance monitor event selector 11 high word */
-  CSR_MHPMEVENT12H   = 0x72c, /**< 0x72c - mhpmevent12h: Machine hardware performance monitor event selector 12 high word */
-  CSR_MHPMEVENT13H   = 0x72d, /**< 0x72d - mhpmevent13h: Machine hardware performance monitor event selector 13 high word */
-  CSR_MHPMEVENT14H   = 0x72e, /**< 0x72e - mhpmevent14h: Machine hardware performance monitor event selector 14 high word */
-  CSR_MHPMEVENT15H   = 0x72f, /**< 0x72f - mhpmevent15h: Machine hardware performance monitor event selector 15 high word */
-  CSR_MHPMEVENT16H   = 0x730, /**< 0x730 - mhpmevent16h: Machine hardware performance monitor event selector 16 high word */
-  CSR_MHPMEVENT17H   = 0x731, /**< 0x731 - mhpmevent17h: Machine hardware performance monitor event selector 17 high word */
-  CSR_MHPMEVENT18H   = 0x732, /**< 0x732 - mhpmevent18h: Machine hardware performance monitor event selector 18 high word */
-  CSR_MHPMEVENT19H   = 0x733, /**< 0x733 - mhpmevent19h: Machine hardware performance monitor event selector 19 high word */
-  CSR_MHPMEVENT20H   = 0x734, /**< 0x734 - mhpmevent20h: Machine hardware performance monitor event selector 20 high word */
-  CSR_MHPMEVENT21H   = 0x735, /**< 0x735 - mhpmevent21h: Machine hardware performance monitor event selector 21 high word */
-  CSR_MHPMEVENT22H   = 0x736, /**< 0x736 - mhpmevent22h: Machine hardware performance monitor event selector 22 high word */
-  CSR_MHPMEVENT23H   = 0x737, /**< 0x737 - mhpmevent23h: Machine hardware performance monitor event selector 23 high word */
-  CSR_MHPMEVENT24H   = 0x738, /**< 0x738 - mhpmevent24h: Machine hardware performance monitor event selector 24 high word */
-  CSR_MHPMEVENT25H   = 0x739, /**< 0x739 - mhpmevent25h: Machine hardware performance monitor event selector 25 high word */
-  CSR_MHPMEVENT26H   = 0x73a, /**< 0x73a - mhpmevent26h: Machine hardware performance monitor event selector 26 high word */
-  CSR_MHPMEVENT27H   = 0x73b, /**< 0x73b - mhpmevent27h: Machine hardware performance monitor event selector 27 high word */
-  CSR_MHPMEVENT28H   = 0x73c, /**< 0x73c - mhpmevent28h: Machine hardware performance monitor event selector 28 high word */
-  CSR_MHPMEVENT29H   = 0x73d, /**< 0x73d - mhpmevent29h: Machine hardware performance monitor event selector 29 high word */
-  CSR_MHPMEVENT30H   = 0x73e, /**< 0x73e - mhpmevent30h: Machine hardware performance monitor event selector 30 high word */
-  CSR_MHPMEVENT31H   = 0x73f, /**< 0x73f - mhpmevent31h: Machine hardware performance monitor event selector 31 high word */
-
   /* on-chip debugger - hardware trigger module */
   CSR_TSELECT        = 0x7a0, /**< 0x7a0 - tselect:  Trigger select */
   CSR_TDATA1         = 0x7a1, /**< 0x7a1 - tdata1:   Trigger data register 0 */


### PR DESCRIPTION
These CSRs do not exist on rv32 (without `Sscofpmf`).