### PR TITLE
Bootloader updates

### DIFF
--- a/docs/datasheet/software_bootloader.adoc
+++ b/docs/datasheet/software_bootloader.adoc
@@ -184,9 +184,10 @@ Depending on the configuration (<<_customizing_the_internal_bootloader>>) the bo
 executable from different sources:
 
 [start=1]
-. Try to load an executable from TWI flash (default device ID is `0xA0`).
-. Try to load an executable from SPI flash (default SPI chip select line is `spi_csn_o(0)`).
-. Try to load file `boot.bin` from SD flash (default SPI chip select line is `spi_csn_o(1)`).
+. **TWI boot**: Try to load an executable from TWI flash (default device ID is `0xA0`); if enabled.
+. **SPI boot**: Try to load an executable from SPI flash (default SPI chip select line is `spi_csn_o(0)`); if enabled.
+. **SD boot**: Try to load file `boot.bin` from SD flash (default SPI chip select line is `spi_csn_o(1)`); if enabled.
+. **Direct boot**: Directly execute the code at a pre-configured address; if enabled.
 
 If a valid boot image is loaded it will be immediately started. If no valid executable can be fetched the interactive
 bootloader console is started.
@@ -308,6 +309,9 @@ overridden by Makefile directives.
 4+<| **Auto-boot** - requires <<_core_local_interruptor_clint>>
 | `AUTO_BOOT_EN`          | `1`  | `0,1` | Auto-boot enabled when `1`.
 | `AUTO_BOOT_TIMEOUT`     | `8`  | any   | Timeout in seconds after which the auto-boot sequence starts (if there is no UART input by the user).
+4+<| **Direct-boot**
+| `DIRECT_BOOT_EN`        | `0`          | `0,1`  | Enable direct-boot option when `1`.
+| `DIRECT_BOOT_ADDR`      | `0x00000000` | 32-bit | Direct boot address of executable; can be used to directly execute from pre-initialized memory.
 4+<| **TWI flash** - requires <<_two_wire_serial_interface_controller_twi>>
 | `TWI_FLASH_EN`          | `0`             | `0,1`     | Set to `1` to enable the TWI flash (boot) options.
 | `TWI_FLASH_PROG_EN`     | `1`             | `0,1`     | Set to `1` to enable programming the TWI flash from the bootloader menu.
@@ -336,8 +340,6 @@ overridden by Makefile directives.
 | `THEME_EXE`             | `"neorv32_exe.bin"`    | any string | Name of executable that is shown in the upload menu.
 4+<| **Custom Code**
 | `USER_CODE_INIT`        | `(void)0` (_empty statement_) | any code | User-defined initialization code (wrapped in a macro) that is executed right after the bootloader's hardware initialization.
-4+<| **Miscellaneous**
-| `DEFAULT_EXE_ADDR`      | `0x00000000` | 32-bit | Default base address of executable; can be used to directly execute from main memory.
 |=======================
 
 

--- a/docs/datasheet/software_bootloader.adoc
+++ b/docs/datasheet/software_bootloader.adoc
@@ -55,7 +55,7 @@ at 2Hz and the <<_auto_boot_sequence>> is started. This auto-boot sequence can b
 [source]
 ----
 NEORV32 Bootloader
-build: Dec 13 2025 <1>
+build: Jul 18 2026 <1>
 
 Auto-boot in 8s. Press any key to abort. <2>
 Aborted. <3>
@@ -114,12 +114,12 @@ the general system configuration is printed:
 [source]
 ----
 CMD:> i
-HWV:  0x01120101 <1>
-CLK:  0x05f5e100 <2>
-MISA: 0x40901107 <3>
-XISA: 0x00000000:0x0fc06fd3 <4>
-SOC:  0x38efc87b <5>
-MISC: 0x0a010d00 <6>
+HWV:  0x01130207 <1>
+CLK:  0x05F5E100 <2>
+MISA: 0x40901104 <3>
+XISA: 0x00000000_0x10000F93 <4>
+SOC:  0x18BF80FF <5>
+MISC: 0x59011010 <6>
 CMD:>
 ----
 <1> Processor hardware version in BCD format (<<_mimpid>> CSR).

--- a/docs/datasheet/software_bootloader.adoc
+++ b/docs/datasheet/software_bootloader.adoc
@@ -302,6 +302,9 @@ overridden by Makefile directives.
 4+<| **Status LED** - requires <<_general_purpose_input_and_output_port_gpio>>
 | `STATUS_LED_EN`         | `1` | `0,1`   | Enable bootloader status led ("heart beat") at `GPIO` output port pin `STATUS_LED_PIN` when `1`.
 | `STATUS_LED_PIN`        | `0` | `0..31` | `GPIO` output pin used for the high-active status LED. Note that if the GPIO module's direction control feature is enabled only this pin is configured as output.
+4+<| **Serial memory** - requires <<_serial_memory_controller_smc>>
+| `SMC_EN`                | `0` | `0,1` | Enable initialization of <<_serial_memory_controller_smc>>.
+| `SMC_SETUP_ARGS`        | ... | ...   | List of configuration arguments for SMC setup function (`neorv32_smc_setup(...)`).
 4+<| **Auto-boot** - requires <<_core_local_interruptor_clint>>
 | `AUTO_BOOT_EN`          | `1`  | `0,1` | Auto-boot enabled when `1`.
 | `AUTO_BOOT_TIMEOUT`     | `8`  | any   | Timeout in seconds after which the auto-boot sequence starts (if there is no UART input by the user).

--- a/docs/datasheet/software_bootloader.adoc
+++ b/docs/datasheet/software_bootloader.adoc
@@ -220,10 +220,11 @@ The serial interface device is defined by `UART_TTY` .
 
 .UART Overflow Detection and Hardware Flow Control
 [NOTE]
-For setups that use very high custom baud rates values and/or provide very high main memory latency (e.g. external
-DDR-RAM with several cache layers), it is recommended to enable the UART RTS/CTS hardware flow control. In addition,
-enabling overflow detection can make debugging easier. See <<_customizing_the_internal_bootloader>> for more information.
-
+The bootloader **does not check for UART RX overflows** during transmissions. However, such an error during
+transmission will most likely result in a checksum error, so the error will certainly be detected anyway.
+For setups that use very high custom baud rates values and/or provide very high main memory latency (e.g.
+external serial RAM), it is recommended to enable the UART RTS/CTS hardware flow control.
+See <<_customizing_the_internal_bootloader>> for more information.
 
 :sectnums:
 ==== Programming an SPI or TWI Flash
@@ -297,7 +298,6 @@ overridden by Makefile directives.
 4+<| **Serial console** - requires <<_primary_universal_asynchronous_receiver_and_transmitter_uart0>>
 | `UART_EN`               | `1`     | `0,1` | Set to `1` to enable the serial console.
 | `UART_BAUD`             | `19200` | any   | Baud rate of UART0.
-| `UART_OVERFLOW`         | `0`     | `0,1` | Enable RX overflow detection. Recommended for high baud rates / high memory latency.
 | `UART_HWFC`             | `0`     | `0,1` | Enable RTS/CTS hardware flow control. Recommended for very high baud rates / high memory latency.
 4+<| **Status LED** - requires <<_general_purpose_input_and_output_port_gpio>>
 | `STATUS_LED_EN`         | `1` | `0,1`   | Enable bootloader status led ("heart beat") at `GPIO` output port pin `STATUS_LED_PIN` when `1`.

--- a/sw/bootloader/config.h
+++ b/sw/bootloader/config.h
@@ -89,6 +89,20 @@
 #endif
 
 /**********************************************************************
+ * Direct boot (execute in-place)
+ **********************************************************************/
+
+// Enable direct boot / execute in-place option (0,1)
+#ifndef DIRECT_BOOT_EN
+#define DIRECT_BOOT_EN 0
+#endif
+
+// Direct boot / execute in-place base address (32-bit, has to be 4-byte-aligned)
+#ifndef DIRECT_BOOT_ADDR
+#define DIRECT_BOOT_ADDR 0xffe00000
+#endif
+
+/**********************************************************************
  * TWI flash
  **********************************************************************/
 
@@ -224,15 +238,6 @@
 ({                     \
   (void)0;             \
 })
-#endif
-
-/**********************************************************************
- * Misc
- **********************************************************************/
-
-// Default executable address; e.g. for directly executing from main memory (32-bit, has to be 4-byte-aligned)
-#ifndef DEFAULT_EXE_ADDR
-#define DEFAULT_EXE_ADDR 0x00000000
 #endif
 
 #endif // CONFIG_H

--- a/sw/bootloader/config.h
+++ b/sw/bootloader/config.h
@@ -59,6 +59,27 @@
 #endif
 
 /**********************************************************************
+ * Serial memory controller (PSRAM / XIP flash)
+ **********************************************************************/
+
+// Enable serial memory controller (0,1)
+#ifndef SMC_EN
+#define SMC_EN 0
+#endif
+
+// Serial memory controller setup argument list (neorv32_smc_setup())
+#ifndef SMC_SETUP_ARGS
+#define SMC_SETUP_ARGS \
+  0,             /* chip select: single-chip mode, use only one PSRAM        */ \
+  SMC_MSIZE_2MB, /* PSRAM size = 2MB (#NEORV32_SMC_MSIZE_enum)               */ \
+  6,             /* clock prescaler: second-slowest PSRAM clock              */ \
+  0,             /* wait cycles for read access (0)                          */ \
+  0x03,          /* read command                                             */ \
+  0x02,          /* write command                                            */ \
+  0x996600u      /* init sequence: 1. NOP(0x00) 2. RST-EN(0x66) 3. RST(0x99) */
+#endif
+
+/**********************************************************************
  * Auto-boot
  **********************************************************************/
 

--- a/sw/bootloader/config.h
+++ b/sw/bootloader/config.h
@@ -39,11 +39,6 @@
 #define UART_HWFC 0
 #endif
 
-// Enable UART0 RX overflow detection (0,1)
-#ifndef UART_OVERFLOW
-#define UART_OVERFLOW 0
-#endif
-
 /**********************************************************************
  * Status LED (high-active)
  **********************************************************************/

--- a/sw/bootloader/hal/include/system.h
+++ b/sw/bootloader/hal/include/system.h
@@ -36,6 +36,7 @@ typedef struct __attribute__((packed,aligned(4))) {
 void system_setup(void);
 int  system_app_load(int (*dev_init)(void), int (*stream_get)(uint32_t* rdata));
 int  system_app_store(int (*dev_init)(void), int (*dev_erase)(void), int (*stream_put)(uint32_t wdata));
+void system_direct_boot(uint32_t addr);
 void system_app_boot(void);
 
 #endif // SYSTEM_H

--- a/sw/bootloader/hal/source/system.c
+++ b/sw/bootloader/hal/source/system.c
@@ -17,7 +17,7 @@
 #include <uart.h>
 
 // global variables
-uint32_t g_exe_base   = (uint32_t)DEFAULT_EXE_ADDR; // (default) base/entry-point of executable
+uint32_t g_exe_base   = 0; // base/entry-point of executable
 uint32_t g_exe_size   = 0; // size of the loaded executable; 0 if no executable available
 uint32_t g_flash_addr = 0; // current flash/stream address
 
@@ -272,9 +272,29 @@ int system_app_store(int (*dev_init)(void), int (*dev_erase)(void), int (*stream
 
 
 /**********************************************************************//**
+ * Boot application right from address.
+ *
+ * @param addr Base address of executable.
+ **************************************************************************/
+void system_direct_boot(uint32_t addr) {
+
+  g_exe_base = addr;
+  g_exe_size = 0xFFFFFFFFu; // to skip size-check in system_app_boot
+
+  system_app_boot();
+
+  __builtin_unreachable();
+  while (1); // should never be reached
+}
+
+
+/**********************************************************************//**
  * Boot application executable at address "g_exe_base".
  **************************************************************************/
 void system_app_boot(void) {
+
+  // boot address - local copy
+  uint32_t boot_addr = g_exe_base;
 
   // executable available?
   if (g_exe_size == 0) {
@@ -283,9 +303,6 @@ void system_app_boot(void) {
       return;
     }
   }
-
-  // boot address - local copy
-  uint32_t boot_addr = g_exe_base;
 
   // start application in machine mode; disable interrupts
   neorv32_cpu_csr_write(CSR_MSTATUS, (1 << CSR_MSTATUS_MPP_H) + (1 << CSR_MSTATUS_MPP_L));
@@ -298,9 +315,9 @@ void system_app_boot(void) {
 #endif
 
 #if (UART_EN == 1)
-  uart_puts("Booting from ");
+  uart_puts("Booting (@");
   uart_puth(boot_addr);
-  uart_puts("...\n\n");
+  uart_puts(")...\n\n");
   while (neorv32_uart0_tx_busy()); // wait for UART0 to complete transmission
 #endif
 

--- a/sw/bootloader/hal/source/system.c
+++ b/sw/bootloader/hal/source/system.c
@@ -105,6 +105,13 @@ void system_setup(void) {
     neorv32_cpu_csr_set(CSR_MSTATUS, 1 << CSR_MSTATUS_MIE); // enable machine-mode interrupts
   }
 
+  // setup serial memory controller
+#if (SMC_EN == 1)
+  if (neorv32_smc_available()) {
+    neorv32_smc_setup(SMC_SETUP_ARGS);
+  }
+#endif
+
   // user-defined initialization code; macro defined in config.h
   USER_CODE_INIT;
 }

--- a/sw/bootloader/hal/source/uart.c
+++ b/sw/bootloader/hal/source/uart.c
@@ -118,11 +118,7 @@ int uart_stream_get(uint32_t* rdata) {
     tmp.uint8[i] = (uint8_t)uart_getc();
   }
   *rdata = tmp.uint32;
-#if (UART_OVERFLOW == 1)
-  return (int)(NEORV32_UART0->CTRL & (1<<UART_CTRL_RX_OVER)); // RX overflow?
-#else
   return 0;
-#endif
 #else
   return 1;
 #endif

--- a/sw/bootloader/main.c
+++ b/sw/bootloader/main.c
@@ -43,7 +43,7 @@ int main(void) {
   // wait for timeout or user abort
   if (neorv32_clint_available()) {
     uart_puts(" in "xstr(AUTO_BOOT_TIMEOUT)"s. Press any key to abort.\n");
-    uint64_t timeout_time = neorv32_clint_time_get() + (uint64_t)(AUTO_BOOT_TIMEOUT * NEORV32_SYSINFO->CLK);
+    uint64_t timeout_time = neorv32_clint_time_get() + (AUTO_BOOT_TIMEOUT * (uint64_t)(NEORV32_SYSINFO->CLK));
     while (1) {
 
       // wait for user input via UART0

--- a/sw/bootloader/main.c
+++ b/sw/bootloader/main.c
@@ -89,6 +89,13 @@ int main(void) {
   }
 #endif
 
+  // directly execute from memory address
+#if (DIRECT_BOOT_EN == 1)
+  uart_putc('\n');
+  uart_puts("Direct boot...\n");
+  system_direct_boot((uint32_t)DIRECT_BOOT_ADDR);
+#endif
+
 skip_auto_boot:
 #endif
 
@@ -137,6 +144,9 @@ skip_auto_boot:
         "h: Help\n"
         "i: System info\n"
         "r: Restart\n"
+#if (DIRECT_BOOT_EN == 1)
+        "d: Direct boot\n"
+#endif
         "u: Upload via UART\n"
 #if (TWI_FLASH_EN == 1)
         "t: TWI flash - load\n"
@@ -208,6 +218,14 @@ skip_auto_boot:
     if (cmd == 'c') {
       uart_puts("Loading SD card file "SPI_SDCARD_FILE"... ");
       system_app_load(sdcard_setup, sdcard_stream_get);
+    }
+#endif
+
+    /**** direct boot / execute in-place ****/
+#if (DIRECT_BOOT_EN == 1)
+    if (cmd == 'd') {
+      uart_puts("Direct execute in-place...\n");
+      system_direct_boot((uint32_t)DIRECT_BOOT_ADDR);
     }
 #endif
 


### PR DESCRIPTION
* remove UART RX overflow option; an RX overflow error error during transmission will most likely result in a checksum error, so the error will certainly be detected anyway.
* add optional "direct boot" mode: execute from (XIP) memory address like pre-initialized non-volatile on-chip memory
* add optional SMC setup; e.g. to initialize PSRAM so it can be used by the bootloader to store an executable image