### PR TITLE
[cpu] Add optional CPU_FAST_MUL_REG generic for the fast multiplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 20.07.2026 | 1.13.2.9 | :sparkles: add optional `CPU_FAST_MUL_REG` generic: pipeline register for the fast multiplier (shortens critical path on narrow-DSP FPGAs; +1 multiply latency cycle) | [#1603](https://github.com/stnolting/neorv32/pull/1603) |
 | 20.07.2026 | 1.13.2.8 | comprehensive VHDL coding style edits | [#1602](https://github.com/stnolting/neorv32/pull/1602) |
 | 17.07.2026 | 1.13.2.7 | :sparkles: add new SoC module: serial memory controller (SMC) to attach external serial memory (PSRAM or flash; supports XIP) | [#1599](https://github.com/stnolting/neorv32/pull/1599) |
 | 11.07.2026 | 1.13.2.6 | :bug: fix another RVFI memory address & data signal alignment bug | [#1597](https://github.com/stnolting/neorv32/pull/1597) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
-| 20.07.2026 | 1.13.2.9 | :sparkles: add optional `CPU_FAST_MUL_REG` generic: pipeline register for the fast multiplier (shortens critical path on narrow-DSP FPGAs; +1 multiply latency cycle) | [#1603](https://github.com/stnolting/neorv32/pull/1603) |
+| 23.07.2026 | 1.13.2.9 | :sparkles: add optional `CPU_FAST_MUL_REG` generic: pipeline register for the fast multiplier (shortens critical path on narrow-DSP FPGAs; +1 multiply latency cycle) | [#1603](https://github.com/stnolting/neorv32/pull/1603) |
 | 20.07.2026 | 1.13.2.8 | comprehensive VHDL coding style edits | [#1602](https://github.com/stnolting/neorv32/pull/1602) |
 | 17.07.2026 | 1.13.2.7 | :sparkles: add new SoC module: serial memory controller (SMC) to attach external serial memory (PSRAM or flash; supports XIP) | [#1599](https://github.com/stnolting/neorv32/pull/1599) |
 | 11.07.2026 | 1.13.2.6 | :bug: fix another RVFI memory address & data signal alignment bug | [#1597](https://github.com/stnolting/neorv32/pull/1597) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -385,6 +385,23 @@ result bit in every cycle. Multiplication operations always require 32 clock cyc
 
 {empty} +
 [discrete]
+===== **`CPU_FAST_MUL_REG`**
+
+[cols="<1,<8"]
+[frame="topbot",grid="none"]
+|=======================
+| Name        | Fast multiplier pipeline register
+| Type        | `boolean`
+| Default     | `false` (disabled)
+| Description | Only effective together with <<_cpu_fast_mul_en>>. When **enabled** a pipeline register is added to the fast
+multiplier so the synthesis tool can retime it into the DSP cascade that is inferred when the DSP blocks are narrower than the
+operands, shortening the critical path. Costs one extra latency cycle per multiplication (`T_mul_latency` = 2).
+|             | When **disabled** the fast multiplier is bit-identical to before. Wide-DSP targets (e.g. Xilinx UltraScale+) do not need this.
+|=======================
+
+
+{empty} +
+[discrete]
 ===== **`CPU_FAST_SHIFT_EN`**
 
 [cols="<1,<8"]

--- a/docs/datasheet/cpu_isa.adoc
+++ b/docs/datasheet/cpu_isa.adoc
@@ -92,7 +92,7 @@ uncached accesses via the <<_processor_external_bus_interface_xbus>> may have ad
 2 for accessing the default processor-internal peripherals; +
 uncached accesses via the <<_processor_external_bus_interface_xbus>> may have additional wait states; +
 branches to an unaligned address require additional `2 x T_inst_latency` cycles
-| `T_mul_latency` | 1 if <<_cpu_fast_mul_en>> is `true`; 32 otherwise
+| `T_mul_latency` | 1 if <<_cpu_fast_mul_en>> is `true` (2 if <<_cpu_fast_mul_reg>> is also `true`); 32 otherwise
 | `T_cust_latency` | latency is defined by the custom <<_custom_functions_unit_cfu>> logic; +
 however, the minimum is 1 and the maximum is 512
 | `T_cache_sync` | cycles required to clear/flush the CPU cache(s) (D$ and/or I$); +

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -117,6 +117,7 @@ can be determined via the <<_system_configuration_information_memory_sysinfo, SY
 4+^| **<<_cpu_tuning_options>>**
 | `CPU_CONSTT_BR_EN`    | boolean   | false         | Implement constant-time branches (same execution times for taken and not-taken branches).
 | `CPU_FAST_MUL_EN`     | boolean   | false         | Implement fast but large full-parallel multipliers (trying to infer DSP blocks); see section <<_cpu_arithmetic_logic_unit>>.
+| `CPU_FAST_MUL_REG` | boolean | false         | Add a pipeline register to the fast multiplier (requires `CPU_FAST_MUL_EN`); shortens the critical path on narrow-DSP FPGAs at the cost of one extra multiply latency cycle. See section <<_cpu_arithmetic_logic_unit>>.
 | `CPU_FAST_SHIFT_EN`   | boolean   | false         | Implement fast but large full-parallel barrel shifters; see section <<_cpu_arithmetic_logic_unit>>.
 | `CPU_RF_ARCH_SEL`     | natural   | 0             | CPU register file implementation style select; see section <<_cpu_register_file>>.
 4+^| **Physical Memory Protection (<<_smpmp_isa_extension>>)**

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -117,7 +117,7 @@ can be determined via the <<_system_configuration_information_memory_sysinfo, SY
 4+^| **<<_cpu_tuning_options>>**
 | `CPU_CONSTT_BR_EN`    | boolean   | false         | Implement constant-time branches (same execution times for taken and not-taken branches).
 | `CPU_FAST_MUL_EN`     | boolean   | false         | Implement fast but large full-parallel multipliers (trying to infer DSP blocks); see section <<_cpu_arithmetic_logic_unit>>.
-| `CPU_FAST_MUL_REG` | boolean | false         | Add a pipeline register to the fast multiplier (requires `CPU_FAST_MUL_EN`); shortens the critical path on narrow-DSP FPGAs at the cost of one extra multiply latency cycle. See section <<_cpu_arithmetic_logic_unit>>.
+| `CPU_FAST_MUL_REG`    | boolean   | false         | Add a pipeline register to the fast multiplier (requires `CPU_FAST_MUL_EN`); see section <<_cpu_arithmetic_logic_unit>>.
 | `CPU_FAST_SHIFT_EN`   | boolean   | false         | Implement fast but large full-parallel barrel shifters; see section <<_cpu_arithmetic_logic_unit>>.
 | `CPU_RF_ARCH_SEL`     | natural   | 0             | CPU register file implementation style select; see section <<_cpu_register_file>>.
 4+^| **Physical Memory Protection (<<_smpmp_isa_extension>>)**

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -202,6 +202,7 @@ begin
       sel_string_f(CPU_TRACE_EN,                 "trace ",              "") &
       sel_string_f(CPU_CONSTT_BR_EN,             "constt_br ",          "") &
       sel_string_f(CPU_FAST_MUL_EN,              "fast_mul ",           "") &
+      sel_string_f(CPU_FAST_MUL_REG,             "fast_mul_reg ",       "") &
       sel_string_f(CPU_FAST_SHIFT_EN,            "fast_shift ",         "") &
       sel_string_f(boolean(CPU_RF_ARCH_SEL = 0), "rf_arch=sram_sync ",  "") &
       sel_string_f(boolean(CPU_RF_ARCH_SEL = 1), "rf_arch=sram_async ", "") &
@@ -441,9 +442,9 @@ begin
     RISCV_ISA_Zmmul  => RISCV_ISA_Zmmul,  -- multiply-only M sub-extension
     RISCV_ISA_Xcfu   => RISCV_ISA_Xcfu,   -- custom (instr.) functions unit
     -- Tuning Options --
-    FAST_MUL_EN       => CPU_FAST_MUL_EN,       -- use DSPs for M extension's multiplier
-    FAST_MUL_REG => CPU_FAST_MUL_REG, -- add a pipeline register to the fast multiplier
-    FAST_SHIFT_EN     => CPU_FAST_SHIFT_EN       -- use barrel shifter for shift operations
+    FAST_MUL_EN      => CPU_FAST_MUL_EN,  -- use DSPs for M extension's multiplier
+    FAST_MUL_REG     => CPU_FAST_MUL_REG, -- add a pipeline register to the fast multiplier
+    FAST_SHIFT_EN    => CPU_FAST_SHIFT_EN -- use barrel shifter for shift operations
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -63,6 +63,7 @@ entity neorv32_cpu is
     CPU_TRACE_EN        : boolean                        := false;       -- enable CPU execution trace generator
     CPU_CONSTT_BR_EN    : boolean                        := false;       -- constant-time branches
     CPU_FAST_MUL_EN     : boolean                        := false;       -- use DSPs for M extension's multiplier
+    CPU_FAST_MUL_REG    : boolean                        := false;       -- add a pipeline register to the fast multiplier (needs CPU_FAST_MUL_EN)
     CPU_FAST_SHIFT_EN   : boolean                        := false;       -- use barrel shifter for shift operations
     CPU_RF_ARCH_SEL     : natural range 0 to 3           := 0;           -- register file implementation style select
     -- Physical Memory Protection (PMP) --
@@ -440,8 +441,9 @@ begin
     RISCV_ISA_Zmmul  => RISCV_ISA_Zmmul,  -- multiply-only M sub-extension
     RISCV_ISA_Xcfu   => RISCV_ISA_Xcfu,   -- custom (instr.) functions unit
     -- Tuning Options --
-    FAST_MUL_EN      => CPU_FAST_MUL_EN,  -- use DSPs for M extension's multiplier
-    FAST_SHIFT_EN    => CPU_FAST_SHIFT_EN -- use barrel shifter for shift operations
+    FAST_MUL_EN       => CPU_FAST_MUL_EN,       -- use DSPs for M extension's multiplier
+    FAST_MUL_REG => CPU_FAST_MUL_REG, -- add a pipeline register to the fast multiplier
+    FAST_SHIFT_EN     => CPU_FAST_SHIFT_EN       -- use barrel shifter for shift operations
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -37,9 +37,9 @@ entity neorv32_cpu_alu is
     RISCV_ISA_Zmmul  : boolean; -- multiply-only M sub-extension
     RISCV_ISA_Xcfu   : boolean; -- custom (instr.) functions unit
     -- Tuning Options --
-    FAST_MUL_EN       : boolean; -- use DSPs for M extension's multiplier
-    FAST_MUL_REG      : boolean; -- add a pipeline register to the fast multiplier
-    FAST_SHIFT_EN     : boolean  -- use barrel shifter for shift operations
+    FAST_MUL_EN      : boolean; -- use DSPs for M extension's multiplier
+    FAST_MUL_REG     : boolean; -- add a pipeline register to the fast multiplier
+    FAST_SHIFT_EN    : boolean  -- use barrel shifter for shift operations
   );
   port (
     -- global control --
@@ -168,9 +168,9 @@ begin
   if RISCV_ISA_M or RISCV_ISA_Zmmul generate
     neorv32_cpu_alu_muldiv_inst: entity neorv32.neorv32_cpu_alu_muldiv
     generic map (
-      FAST_MUL_EN       => FAST_MUL_EN,       -- use DSPs for faster multiplication
+      FAST_MUL_EN  => FAST_MUL_EN,  -- use DSPs for faster multiplication
       FAST_MUL_REG => FAST_MUL_REG, -- add a pipeline register to the fast multiplier
-      DIVISION_EN       => RISCV_ISA_M        -- implement divider hardware
+      DIVISION_EN  => RISCV_ISA_M   -- implement divider hardware
     )
     port map (
       -- global control --

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -37,8 +37,9 @@ entity neorv32_cpu_alu is
     RISCV_ISA_Zmmul  : boolean; -- multiply-only M sub-extension
     RISCV_ISA_Xcfu   : boolean; -- custom (instr.) functions unit
     -- Tuning Options --
-    FAST_MUL_EN      : boolean; -- use DSPs for M extension's multiplier
-    FAST_SHIFT_EN    : boolean  -- use barrel shifter for shift operations
+    FAST_MUL_EN       : boolean; -- use DSPs for M extension's multiplier
+    FAST_MUL_REG      : boolean; -- add a pipeline register to the fast multiplier
+    FAST_SHIFT_EN     : boolean  -- use barrel shifter for shift operations
   );
   port (
     -- global control --
@@ -167,8 +168,9 @@ begin
   if RISCV_ISA_M or RISCV_ISA_Zmmul generate
     neorv32_cpu_alu_muldiv_inst: entity neorv32.neorv32_cpu_alu_muldiv
     generic map (
-      FAST_MUL_EN => FAST_MUL_EN, -- use DSPs for faster multiplication
-      DIVISION_EN => RISCV_ISA_M  -- implement divider hardware
+      FAST_MUL_EN       => FAST_MUL_EN,       -- use DSPs for faster multiplication
+      FAST_MUL_REG => FAST_MUL_REG, -- add a pipeline register to the fast multiplier
+      DIVISION_EN       => RISCV_ISA_M        -- implement divider hardware
     )
     port map (
       -- global control --

--- a/rtl/core/neorv32_cpu_alu_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_alu_muldiv.vhd
@@ -22,8 +22,9 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_alu_muldiv is
   generic (
-    FAST_MUL_EN : boolean; -- use DSPs for faster multiplication
-    DIVISION_EN : boolean  -- implement divider hardware
+    FAST_MUL_EN       : boolean; -- use DSPs for faster multiplication
+    FAST_MUL_REG      : boolean; -- add a pipeline register to the fast multiplier (needs FAST_MUL_EN)
+    DIVISION_EN       : boolean  -- implement divider hardware
   );
   port (
     -- global control --
@@ -67,7 +68,8 @@ architecture neorv32_cpu_alu_muldiv_rtl of neorv32_cpu_alu_muldiv is
   signal valid_cmd : std_ulogic;
 
   -- controller --
-  type state_t is (S_IDLE, S_BUSY, S_DONE);
+  -- S_PIPE: single extra cycle for the pipelined fast multiplier (FAST_MUL_REG)
+  type state_t is (S_IDLE, S_BUSY, S_PIPE, S_DONE);
   type ctrl_t is record
     state  : state_t;
     cnt    : std_ulogic_vector(4 downto 0);
@@ -125,6 +127,14 @@ begin
             ctrl.state <= S_DONE;
           end if;
 
+        when S_PIPE => -- extra cycle for the fast multiplier's pipeline register
+        -- ------------------------------------------------------------
+          if (ctrl_i.cpu_trap = '1') then -- abort on trap
+            ctrl.state <= S_IDLE;
+          else
+            ctrl.state <= S_DONE;
+          end if;
+
         when S_DONE => -- S_DONE: final step / enable output for one cycle
         -- ------------------------------------------------------------
           ctrl.out_en <= '1';
@@ -134,7 +144,11 @@ begin
         -- ------------------------------------------------------------
           if (valid_cmd = '1') then -- trigger new operation
             if (ctrl_i.ir_funct3(2) = '0') and FAST_MUL_EN then -- is fast multiplication?
-              ctrl.state <= S_DONE;
+              if FAST_MUL_REG then -- pipelined product needs one more cycle
+                ctrl.state <= S_PIPE;
+              else
+                ctrl.state <= S_DONE;
+              end if;
             else -- serial division or serial multiplication
               ctrl.state <= S_BUSY;
             end if;
@@ -164,7 +178,8 @@ begin
   if FAST_MUL_EN generate
     multiplier_inst: entity neorv32.neorv32_prim_mul
     generic map (
-      DWIDTH => 32
+      DWIDTH   => 32,
+      PIPELINE => FAST_MUL_REG
     )
     port map (
       clk_i    => clk_i,

--- a/rtl/core/neorv32_cpu_alu_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_alu_muldiv.vhd
@@ -22,9 +22,9 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_alu_muldiv is
   generic (
-    FAST_MUL_EN       : boolean; -- use DSPs for faster multiplication
-    FAST_MUL_REG      : boolean; -- add a pipeline register to the fast multiplier (needs FAST_MUL_EN)
-    DIVISION_EN       : boolean  -- implement divider hardware
+    FAST_MUL_EN  : boolean; -- use DSPs for faster multiplication
+    FAST_MUL_REG : boolean; -- add a pipeline register to the fast multiplier (needs FAST_MUL_EN)
+    DIVISION_EN  : boolean  -- implement divider hardware
   );
   port (
     -- global control --
@@ -68,7 +68,6 @@ architecture neorv32_cpu_alu_muldiv_rtl of neorv32_cpu_alu_muldiv is
   signal valid_cmd : std_ulogic;
 
   -- controller --
-  -- S_PIPE: single extra cycle for the pipelined fast multiplier (FAST_MUL_REG)
   type state_t is (S_IDLE, S_BUSY, S_PIPE, S_DONE);
   type ctrl_t is record
     state  : state_t;
@@ -118,6 +117,20 @@ begin
       -- fsm --
       case ctrl.state is
 
+        when S_IDLE => -- wait for start signal
+        -- ------------------------------------------------------------
+          if (valid_cmd = '1') then -- trigger new operation
+            if (ctrl_i.ir_funct3(2) = '0') and FAST_MUL_EN then -- is fast multiplication?
+              if FAST_MUL_REG then -- pipelined product needs one more cycle
+                ctrl.state <= S_PIPE;
+              else
+                ctrl.state <= S_DONE;
+              end if;
+            else -- serial division or serial multiplication
+              ctrl.state <= S_BUSY;
+            end if;
+          end if;
+
         when S_BUSY => -- processing
         -- ------------------------------------------------------------
           ctrl.cnt <= std_ulogic_vector(unsigned(ctrl.cnt) - 1);
@@ -139,20 +152,6 @@ begin
         -- ------------------------------------------------------------
           ctrl.out_en <= '1';
           ctrl.state  <= S_IDLE;
-
-        when others => -- S_IDLE: wait for start signal
-        -- ------------------------------------------------------------
-          if (valid_cmd = '1') then -- trigger new operation
-            if (ctrl_i.ir_funct3(2) = '0') and FAST_MUL_EN then -- is fast multiplication?
-              if FAST_MUL_REG then -- pipelined product needs one more cycle
-                ctrl.state <= S_PIPE;
-              else
-                ctrl.state <= S_DONE;
-              end if;
-            else -- serial division or serial multiplication
-              ctrl.state <= S_BUSY;
-            end if;
-          end if;
 
       end case;
     end if;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130208"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130209"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 
@@ -941,6 +941,7 @@ package neorv32_package is
       -- Tuning Options --
       CPU_CONSTT_BR_EN    : boolean                        := false;
       CPU_FAST_MUL_EN     : boolean                        := false;
+      CPU_FAST_MUL_REG    : boolean                        := false;
       CPU_FAST_SHIFT_EN   : boolean                        := false;
       CPU_RF_ARCH_SEL     : natural range 0 to 3           := 0;
       -- Physical Memory Protection (PMP) --

--- a/rtl/core/neorv32_prim.vhd
+++ b/rtl/core/neorv32_prim.vhd
@@ -259,7 +259,8 @@ use ieee.numeric_std.all;
 
 entity neorv32_prim_mul is
   generic (
-    DWIDTH : natural -- operand width
+    DWIDTH   : natural;            -- operand width
+    PIPELINE : boolean := false    -- add a second (output) register stage
   );
   port (
     -- global control --
@@ -278,7 +279,8 @@ end entity;
 architecture neorv32_prim_mul_rtl of neorv32_prim_mul is
 
   signal opa, opb : signed(DWIDTH downto 0);
-  signal res : signed((2*DWIDTH)+1 downto 0);
+  signal res      : signed((2*DWIDTH)+1 downto 0);
+  signal res_pipe : signed((2*DWIDTH)+1 downto 0);
 
 begin
 
@@ -306,8 +308,28 @@ begin
     end if;
   end process;
 
+  -- Optional Pipeline Register -------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  -- Second register layer, giving synthesis a register to retime into a DSP
+  -- cascade (needed when DSP blocks are narrower than the operands). Shortens
+  -- the critical path at the cost of one latency cycle (handled by the caller).
+  pipe_true:
+  if PIPELINE generate
+    pipe_reg: process(clk_i)
+    begin
+      if rising_edge(clk_i) then -- no reset to improve DSP mapping
+        res_pipe <= res;
+      end if;
+    end process;
+  end generate;
+
+  pipe_false:
+  if not PIPELINE generate
+    res_pipe <= res;
+  end generate;
+
   -- result --
-  res_o <= std_ulogic_vector(res((2*DWIDTH)-1 downto 0));
+  res_o <= std_ulogic_vector(res_pipe((2*DWIDTH)-1 downto 0));
 
 end architecture;
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -69,6 +69,7 @@ entity neorv32_top is
     -- Tuning Options --
     CPU_CONSTT_BR_EN    : boolean                        := false;         -- enable constant-time branches
     CPU_FAST_MUL_EN     : boolean                        := false;         -- use DSPs for M extension's multiplier
+    CPU_FAST_MUL_REG    : boolean                        := false;         -- add a pipeline register to the fast multiplier (needs CPU_FAST_MUL_EN)
     CPU_FAST_SHIFT_EN   : boolean                        := false;         -- use barrel shifter for shift operations
     CPU_RF_ARCH_SEL     : natural range 0 to 3           := 0;             -- register file implementation style select
 
@@ -588,6 +589,7 @@ begin
       CPU_TRACE_EN        => trace_en_c,
       CPU_CONSTT_BR_EN    => CPU_CONSTT_BR_EN,
       CPU_FAST_MUL_EN     => CPU_FAST_MUL_EN,
+      CPU_FAST_MUL_REG => CPU_FAST_MUL_REG,
       CPU_FAST_SHIFT_EN   => CPU_FAST_SHIFT_EN,
       CPU_RF_ARCH_SEL     => CPU_RF_ARCH_SEL,
       -- Physical Memory Protection (PMP) --

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -589,7 +589,7 @@ begin
       CPU_TRACE_EN        => trace_en_c,
       CPU_CONSTT_BR_EN    => CPU_CONSTT_BR_EN,
       CPU_FAST_MUL_EN     => CPU_FAST_MUL_EN,
-      CPU_FAST_MUL_REG => CPU_FAST_MUL_REG,
+      CPU_FAST_MUL_REG    => CPU_FAST_MUL_REG,
       CPU_FAST_SHIFT_EN   => CPU_FAST_SHIFT_EN,
       CPU_RF_ARCH_SEL     => CPU_RF_ARCH_SEL,
       -- Physical Memory Protection (PMP) --

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -310,6 +310,7 @@ proc setup_ip_gui {} {
   add_params $group {
     { CPU_CONSTT_BR_EN  {Constant-time branches} {Identical execution times for taken and not-taken branches} }
     { CPU_FAST_MUL_EN   {DSP-based multiplier}   {Use DSP block instead of bit-serial multipliers} }
+    { CPU_FAST_MUL_REG  {Multiplier register}   {Add a pipeline register to the DSP-based multiplier to improve timing closure} }
     { CPU_FAST_SHIFT_EN {Barrel shifter}         {Use full-parallel shifters instead of of bit-serial shifters} }
     { CPU_RF_ARCH_SEL   {Register file style}    {Select implementation style of CPU register file} }
   }

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -69,6 +69,7 @@ entity neorv32_vivado_ip is
     -- Tuning Options --
     CPU_CONSTT_BR_EN      : boolean                        := false;
     CPU_FAST_MUL_EN       : boolean                        := false;
+    CPU_FAST_MUL_REG      : boolean                        := false;
     CPU_FAST_SHIFT_EN     : boolean                        := false;
     CPU_RF_ARCH_SEL       : natural range 0 to 3           := 1; -- map to distributed RAM
     -- Physical Memory Protection (PMP) --
@@ -441,6 +442,7 @@ begin
     -- Extension Options --
     CPU_CONSTT_BR_EN    => CPU_CONSTT_BR_EN,
     CPU_FAST_MUL_EN     => CPU_FAST_MUL_EN,
+    CPU_FAST_MUL_REG    => CPU_FAST_MUL_REG,
     CPU_FAST_SHIFT_EN   => CPU_FAST_SHIFT_EN,
     CPU_RF_ARCH_SEL     => CPU_RF_ARCH_SEL,
     -- Physical Memory Protection --

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -58,6 +58,7 @@ entity neorv32_tb is
     RISCV_ISA_Xcfu    : boolean                        := true;        -- custom (instr.) functions unit
     CPU_CONSTT_BR_EN  : boolean                        := false;       -- constant-time branches
     CPU_FAST_MUL_EN   : boolean                        := true;        -- use DSPs for M extension's multiplier
+    CPU_FAST_MUL_REG  : boolean                        := false;       -- add a pipeline register to the fast multiplier (override with nvc -g)
     CPU_FAST_SHIFT_EN : boolean                        := true;        -- use barrel shifter for shift operations
     CPU_RF_ARCH_SEL   : natural range 0 to 3           := 0;           -- register file implementation style select
     IMEM_EN           : boolean                        := true;        -- implement processor-internal instruction memory
@@ -298,6 +299,7 @@ begin
     -- Extension Options --
     CPU_CONSTT_BR_EN    => CPU_CONSTT_BR_EN,
     CPU_FAST_MUL_EN     => CPU_FAST_MUL_EN,
+    CPU_FAST_MUL_REG => CPU_FAST_MUL_REG,
     CPU_FAST_SHIFT_EN   => CPU_FAST_SHIFT_EN,
     CPU_RF_ARCH_SEL     => CPU_RF_ARCH_SEL,
     -- Physical Memory Protection (PMP) --


### PR DESCRIPTION
# Add optional pipeline register for the fast (DSP) multiplier

## Summary

Solves issue that came up with using non-Xilinx and non-Altera FPGAs: 
their DSP slices are much slower. Adds an opt-in generic 
**`CPU_FAST_MUL_REG`** (default `false`) that inserts
a second pipeline register into the DSP-based fast multiplier (`neorv32_prim_mul`),
with matching one-cycle wait state in the `M`/`Zmmul` control FSM. 
Default is off, so every existing configuration is bit-identical.

## Motivation

`neorv32_prim_mul` has a single register after the `opa * opb` product. On FPGAs
whose DSP blocks are narrower than the 32-bit operands, that product is inferred
as a **cascade** of DSP slices - e.g. three 18×18 MACCs on Microchip PolarFire,
versus two 27×18 DSP48E2s (one cascade hop) on Xilinx UltraScale+. With only one
register the whole cascade is a single combinational path.

On a test PolarFire MPF300 (−1 speed grade) at 125 MHz this multiplier path was the
worst setup path at **8.66 ns**, ~6.8 ns of it inside the DSP hard
macros. It's fixed delay that placement/routing/retiming cannot reduce (retiming
relocates registers, it cannot create the second one a 3-deep cascade needs).

Enabling the pipeline lets synthesis retime a register into the DSP cascade
(the DSP's own output register), which dropped the multiplier path to ~4.95 ns
and moved the CPU clock domain from **−0.99 ns (fails, ~112 MHz) to +1.14 ns
(meets 125 MHz)**, post-layout / multi-corner. This is a portability fix for
narrow-DSP families (PolarFire, Lattice ECP5/Nexus, …);
wide-DSP targets are unaffected at the default.

## Cost

`T_mul_latency` goes 1 → 2 when enabled, i.e. `mul`/`mulh`/`mulhsu`/`mulhu` take
5 instead of 4 cycles (datasheet formula `3 + T_mul_latency`). No ISA change, no
software change (multiply is fixed-latency behind the existing valid handshake);
division, area, and all other instructions are unaffected.

## Why it is correct

The CPU already stalls the pipeline on a co-processor completion handshake
(`valid_o` → `done_o`), not on a fixed cycle count. This is why the same core
tolerates a 4-cycle fast multiply, a 35-cycle serial multiply, a divide, and a
CFU of up to 512 cycles. Adding a cycle needs no new control interface.

The extra register stays correct because latency and `valid` move together: the
new `res_pipe` register adds one data-delay cycle, and the new `S_PIPE` state
adds exactly one cycle before `valid_o`/`out_en` assert in `S_DONE`. So when
`valid_o` fires, the product has fully propagated through the register. (Adding
the register *without* `S_PIPE` would fire `valid_o` a cycle early — that is the
bug this state prevents.) The FPU, which also uses `neorv32_prim_mul` but times
it with a fixed-length shift register rather than a handshake, keeps
`PIPELINE = false` and is untouched.

## Verification

- **`sw/example/processor_check`** (full M-extension self-check, verifies
  multiply *results*) run under NVC with `CPU_FAST_MUL_REG = true`:
  **PASS 62/62, FAIL 0/62 — `PROCESSOR CHECK COMPLETED SUCCESSFULLY!`**
- **`sw/example/performance_tests/M`** (instruction timing), baseline vs.
  pipelined, same RTL and image, generic toggled at elaboration:
  `mul`/`mulh`/`mulhsu`/`mulhu` 4 → 5 cycles; `div`/`divu`/`rem`/`remu`
  unchanged at 35 — change isolated to the fast multiplier.

## Files

RTL: `neorv32_prim.vhd`, `neorv32_cpu_alu_muldiv.vhd`, `neorv32_cpu_alu.vhd`,
`neorv32_cpu.vhd`, `neorv32_top.vhd`, `neorv32_package.vhd` (component
declaration + `hw_version_c` bump to `1.13.2.9`).
Docs: `CHANGELOG.md`, `docs/datasheet/{soc,cpu,cpu_isa}.adoc`.
Testbench: `sim/neorv32_tb.vhd` exposes the generic (default `false`) so it can
be toggled for verification.
