### PR TITLE
🐛 [pmp] fix `pmpaddr*[31:30]` - must be read-only and zero 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
-| 24.06.2026 | [**1.13.3**](https://github.com/stnolting/neorv32/releases/tag/v1.13.3) | :rocket: **New release** | |
+| 24.07.2026 | 1.13.3.1 | :bug: fix PMP's `pmpaddr*[31:30]` bits: must be read-only and zero | [#1605](https://github.com/stnolting/neorv32/pull/1605) |
+| 24.07.2026 | [**1.13.3**](https://github.com/stnolting/neorv32/releases/tag/v1.13.3) | :rocket: **New release** | |
 | 23.07.2026 | 1.13.2.9 | :sparkles: add optional `CPU_FAST_MUL_REG` generic: pipeline register for the fast multiplier (shortens critical path on narrow-DSP FPGAs; +1 multiply latency cycle) | [#1603](https://github.com/stnolting/neorv32/pull/1603) |
 | 20.07.2026 | 1.13.2.8 | comprehensive VHDL coding style edits | [#1602](https://github.com/stnolting/neorv32/pull/1602) |
 | 17.07.2026 | 1.13.2.7 | :sparkles: add new SoC module: serial memory controller (SMC) to attach external serial memory (PSRAM or flash; supports XIP) | [#1599](https://github.com/stnolting/neorv32/pull/1599) |

--- a/docs/datasheet/overview.adoc
+++ b/docs/datasheet/overview.adoc
@@ -375,9 +375,9 @@ https://github.com/stnolting/neorv32-riscv-act.
 
 ++++
 <details>
-<summary><b>ACT Results</b> for NEORV32 v1.13.2.5, 4th of July, 2026 (click to expand)</summary>
+<summary><b>ACT Results</b> for NEORV32 v1.13.3.1, 24th of July, 2026 (click to expand)</summary>
 <pre>
-RESULT: All 293 tests passed.
+RESULT: All 301 tests passed.
 priv/ExceptionsSm/ExceptionsSm-00.log              RVCP-SUMMARY: TEST PASSED - Test File "ExceptionsSm-00.S"
 priv/ExceptionsU/ExceptionsU-00.log                RVCP-SUMMARY: TEST PASSED - Test File "ExceptionsU-00.S"
 priv/ExceptionsZaamo/ExceptionsZaamo-00.log        RVCP-SUMMARY: TEST PASSED - Test File "ExceptionsZaamo-00.S"
@@ -404,6 +404,7 @@ priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-01.log      RVCP-SUMMARY: TEST PASSED - T
 priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-02.log      RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_cfg_XWR_all-02.S"
 priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-03.log      RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_cfg_XWR_all-03.S"
 priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-04.log      RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_cfg_XWR_all-04.S"
+priv/pmp/pmp32/PMPSm/pmpsm_cfg_na4_all.log         RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_cfg_na4_all.S"
 priv/pmp/pmp32/PMPSm/pmpsm_cfg_napot_all.log       RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_cfg_napot_all.S"
 priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_all.log         RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_cfg_tor_all.S"
 priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-01.log    RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_cfg_tor_check-01.S"
@@ -421,26 +422,33 @@ priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-8.log          RVCP-SUMMARY: TEST PASSED - T
 priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-9.log          RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_csr_walk-09.S"
 priv/pmp/pmp32/PMPSm/pmpsm_grain.log               RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_grain.S"
 priv/pmp/pmp32/PMPSm/pmpsm_grain_check.log         RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_grain_check.S"
+priv/pmp/pmp32/PMPSm/pmpsm_na4_legal_lwxr.log      RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_cfg_napot_all.S"
 priv/pmp/pmp32/PMPSm/pmpsm_napot_legal_lwxr.log    RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_napot_legal_lwxr.S"
 priv/pmp/pmp32/PMPSm/pmpsm_priority.log            RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_priority.S"
 priv/pmp/pmp32/PMPSm/pmpsm_priority_off.log        RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_priority_off.S"
-priv/pmp/pmp32/PMPSm/pmpsm_tor_legal_lwxr.log      RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_tor_legal_lwxr.S"
+priv/pmp/pmp32/PMPSm/pmpsm_tor_legal_lwxr-01.log   RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_tor_legal_lwxr.S"
+priv/pmp/pmp32/PMPSm/pmpsm_tor_legal_lwxr-02.log   RVCP-SUMMARY: TEST PASSED - Test File "pmpsm_tor_legal_lwxr.S"
 priv/pmp/pmp32/PMPU/pmpu_cfg_A_off.log             RVCP-SUMMARY: TEST PASSED - Test File "pmpu_cfg_A_all.S"
 priv/pmp/pmp32/PMPU/pmpu_cfg_XWR.log               RVCP-SUMMARY: TEST PASSED - Test File "pmpu_cfg_XWR.S"
+priv/pmp/pmp32/PMPU/pmpu_cfg_XWR_unlocked.log      RVCP-SUMMARY: TEST PASSED - Test File "pmpu_cfg_XWR_unlocked.S"
 priv/pmp/pmp32/PMPU/pmpu_csr_access.log            RVCP-SUMMARY: TEST PASSED - Test File "pmpu_csr_access.S"
 priv/pmp/pmp32/PMPU/pmpu_mprv_check-01.log         RVCP-SUMMARY: TEST PASSED - Test File "pmpu_mprv_check-01.S"
 priv/pmp/pmp32/PMPU/pmpu_mprv_check-02.log         RVCP-SUMMARY: TEST PASSED - Test File "pmpu_mprv_check-02.S"
 priv/pmp/pmp32/PMPU/pmpu_napot_legal_lxwr-01.log   RVCP-SUMMARY: TEST PASSED - Test File "pmpu_napot_legal_lxwr.S"
 priv/pmp/pmp32/PMPU/pmpu_napot_legal_lxwr-02.log   RVCP-SUMMARY: TEST PASSED - Test File "pmps_napot_legal_lxwr.S"
-priv/pmp/pmp32/PMPU/pmpu_tor_legal_lxwr.log        RVCP-SUMMARY: TEST PASSED - Test File "pmpu_tor_legal_lxwr.S"
+priv/pmp/pmp32/PMPU/pmpu_tor_legal_lxwr-01.log     RVCP-SUMMARY: TEST PASSED - Test File "pmpu_tor_legal_lxwr.S"
+priv/pmp/pmp32/PMPU/pmpu_tor_legal_lxwr-02.log     RVCP-SUMMARY: TEST PASSED - Test File "pmpu_tor_legal_lxwr.S"
 priv/pmp/pmp32/PMPZaamo/pmpzaamo_cfg_wr.log        RVCP-SUMMARY: TEST PASSED - Test File "pmpzaamo_cfg_wr.S"
 priv/pmp/pmp32/PMPZalrsc/pmpzalrsc_cfg_wr.log      RVCP-SUMMARY: TEST PASSED - Test File "pmpzalrsc_cfg_wrS"
+priv/pmp/pmp32/PMPZca/pmpzca_aligned_na4.log       RVCP-SUMMARY: TEST PASSED - Test File "pmpzca_aligned_na4.S"
 priv/pmp/pmp32/PMPZca/pmpzca_aligned_napot.log     RVCP-SUMMARY: TEST PASSED - Test File "pmpzca_aligned_napot.S"
-priv/pmp/pmp32/PMPZca/pmpzca_aligned_off.log       RVCP-SUMMARY: TEST PASSED - Test File "pmpzca_aligned_tor.S"
+priv/pmp/pmp32/PMPZca/pmpzca_aligned_off.log       RVCP-SUMMARY: TEST PASSED - Test File "pmpzca_aligned_off.S"
 priv/pmp/pmp32/PMPZca/pmpzca_aligned_tor.log       RVCP-SUMMARY: TEST PASSED - Test File "pmpzca_aligned_tor.S"
+priv/pmp/pmp32/PMPZca/pmpzca_cret_na4.log          RVCP-SUMMARY: TEST PASSED - Test File "pmpzca_cret_napot.S"
 priv/pmp/pmp32/PMPZca/pmpzca_cret_napot.log        RVCP-SUMMARY: TEST PASSED - Test File "pmpzca_cret_napot.S"
 priv/pmp/pmp32/PMPZca/pmpzca_cret_tor.log          RVCP-SUMMARY: TEST PASSED - Test File "pmpzca_cret_napot.S"
 priv/pmp/pmp32/PMPZca/pmpzca_legal_lwrx.log        RVCP-SUMMARY: TEST PASSED - Test File "pmpzca_legal_lxwr.S"
+priv/pmp/pmp32/PMPZca/pmpzca_misaligned_na4.log    RVCP-SUMMARY: TEST PASSED - Test File "pmpzca_aligned_na4.S"
 priv/pmp/pmp32/PMPZca/pmpzca_misaligned_napot.log  RVCP-SUMMARY: TEST PASSED - Test File "pmpzca_misaligned_napot.S"
 priv/pmp/pmp32/PMPZca/pmpzca_misaligned_off.log    RVCP-SUMMARY: TEST PASSED - Test File "pmpzca_misaligned_off.S"
 priv/pmp/pmp32/PMPZca/pmpzca_misaligned_tor.log    RVCP-SUMMARY: TEST PASSED - Test File "pmpzca_misaligned_tor.S"

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -72,7 +72,7 @@ architecture neorv32_cpu_pmp_rtl of neorv32_cpu_pmp is
   signal pmpcfg_we : std_ulogic_vector(3 downto 0);
 
   -- address CSRs --
-  type pmpaddr_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(31 downto pmp_alsb_c);
+  type pmpaddr_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(29 downto pmp_alsb_c);
   signal pmpaddr    : pmpaddr_t;
   signal pmpaddr_we : std_ulogic_vector(15 downto 0);
 
@@ -172,10 +172,10 @@ begin
         if (pmpaddr_we(i) = '1') and (pmpcfg(i)(cfg_l_c) = '0') then -- unlocked write access
           if (i < NUM_REGIONS-1) then
             if (pmpcfg(i+1)(cfg_l_c) = '0') or (pmpcfg(i+1)(cfg_ah_c downto cfg_al_c) /= mode_tor_c) then -- pmpcfg(i+1) not "LOCKED TOR"
-              pmpaddr(i) <= ctrl_i.csr_wdata(31 downto pmp_alsb_c);
+              pmpaddr(i) <= ctrl_i.csr_wdata(29 downto pmp_alsb_c);
             end if;
           else -- very last entry
-            pmpaddr(i) <= ctrl_i.csr_wdata(31 downto pmp_alsb_c);
+            pmpaddr(i) <= ctrl_i.csr_wdata(29 downto pmp_alsb_c);
           end if;
         end if;
       end if;
@@ -204,7 +204,7 @@ begin
     address_read_back: process(pmpaddr, pmpcfg)
     begin
       addr_rd(i) <= (others => '0');
-      addr_rd(i)(31 downto pmp_alsb_c) <= pmpaddr(i)(31 downto pmp_alsb_c);
+      addr_rd(i)(29 downto pmp_alsb_c) <= pmpaddr(i)(29 downto pmp_alsb_c);
       if (pmp_lsb_c > 2) then -- G >= 1
         if (pmpcfg(i)(cfg_ah_c) = '0') then -- TOR/OFF mode
           addr_rd(i)(pmp_lsb_c-3 downto 0) <= (others => '0'); -- [G-1:0] read as zero

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130300"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130301"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 


### PR DESCRIPTION
The `pmpaddr*` CSRs store address mask bits 33:2. Since NEORV32 uses only 32-bit addresses, the top two bits must be read-only and hardwired to zero.

This is not a true bug, but a specification incompatibility.