### PR TITLE
[rtl] minor updates und cleanups; simpplify CFS bus interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
-| 24.07.2026 | 1.13.3.1 | :bug: fix PMP's `pmpaddr*[31:30]` bits: must be read-only and zero | [#1605](https://github.com/stnolting/neorv32/pull/1605) |
+| 26.07.2026 | 1.13.3.2 | minor rtl edits and cleanups; :warning: simplify CFS bus interface | [#1606](https://github.com/stnolting/neorv32/pull/1606) |
+| 24.07.2026 | 1.13.3.1 | :bug: fix PMP `pmpaddr*[31:30]` bits: must be read-only and zero | [#1605](https://github.com/stnolting/neorv32/pull/1605) |
 | 24.07.2026 | [**1.13.3**](https://github.com/stnolting/neorv32/releases/tag/v1.13.3) | :rocket: **New release** | |
 | 23.07.2026 | 1.13.2.9 | :sparkles: add optional `CPU_FAST_MUL_REG` generic: pipeline register for the fast multiplier (shortens critical path on narrow-DSP FPGAs; +1 multiply latency cycle) | [#1603](https://github.com/stnolting/neorv32/pull/1603) |
 | 20.07.2026 | 1.13.2.8 | comprehensive VHDL coding style edits | [#1602](https://github.com/stnolting/neorv32/pull/1602) |

--- a/docs/datasheet/soc_cfs.adoc
+++ b/docs/datasheet/soc_cfs.adoc
@@ -18,23 +18,24 @@
 
 * Tightly-coupled co-processor unit for custom hardware accelerators
 * Can operate independently of the CPU
-* CPU access via memory-mapped registers (16kB)
-* Custom 256-bit input and output conduits for custom IO
+* Access via memory-mapped registers (64kB)
+* Pre-defined 256-bit input and output conduits for custom IO
+* One dedicated interrupt channel
 
 
 **Overview**
 
-The custom functions subsystem is meant for implementing custom tightly-coupled co-processors or interfaces.
-It provides up to 16384 32-bit memory-mapped read/write registers (`REG`, see register map below) that can be
-accessed by the CPU via normal load/store operations. The actual functionality of these register has to be
-defined by the hardware designer. Furthermore, the CFS provides two input/output conduits to implement custom
-on-chip or off-chip interfaces.
+The custom functions subsystem is a template module that allows to implement custom tightly-coupled co-processors
+or interfaces. It provides up to 64kB of address space for memory-mapped registers (`REG`, see register map below)
+that can be accessed by the CPU via normal load/store operations. The actual functionality is to be defined by the
+hardware designer. Furthermore, the CFS provides two input/output conduits to implement custom on-chip or off-chip
+interfaces.
 
-Just like any other externally-connected IP, logic implemented within the custom functions subsystem can operate
-_independently_ of the CPU providing true parallel processing capabilities. Potential use cases might include
-dedicated hardware accelerators for en-/decryption (AES), signal processing (FFT) or AI applications
-(CNNs) as well as custom IO systems like fast memory interfaces (DDR) and mass storage (SDIO), networking (CAN)
-real-time data transport (I2S) or just replication of existent NEORV32 peripherals.
+Logic implemented within the custom functions subsystem can operate _independently_ of the CPU providing true
+parallel processing capabilities. Potential use cases might include dedicated hardware accelerators for en-/decryption
+(e.g. AES), signal processing (e.g. FFT), AI applications (e.g. CNNs), custom IO controllers (e.g. SDIO),
+networking (e.g. CAN), real-time data transport (e.g. I2S) or just replication of existent NEORV32 peripherals
+(e.g. a second SPI controller).
 
 .Custom ISA Instructions
 [TIP]
@@ -63,10 +64,9 @@ int temp = (int)NEORV32_CFS->REG[20]; // read from CFS register 20
 
 **CFS Custom IOs**
 
-The CFS provides two unidirectional input and output conduits `cfs_in_i` and `cfs_out_o`. Both signals
-are 512 bit wide and are are directly propagated to the processor's top entity. These conduits can be used
-to implement application-specific interfaces like memory or peripheral connections. The actual use case of
-these signals has to be defined by the hardware designer.
+The CFS provides two unidirectional input and output conduits (`cfs_in_i` and `cfs_out_o`). Both signals
+are 256 bit wide and are are directly propagated to the processor's top entity. These conduits can be used
+to implement application-specific interfaces like memory or peripheral connections.
 
 
 **CFS Interrupt**

--- a/rtl/core/neorv32_cfs.vhd
+++ b/rtl/core/neorv32_cfs.vhd
@@ -1,6 +1,8 @@
 -- ================================================================================ --
 -- NEORV32 SoC - Custom Functions Subsystem (CFS)                                   --
 -- -------------------------------------------------------------------------------- --
+-- Use this module to implement custom memory-mapped co-processors or interfaces.   --
+-- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
 -- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
@@ -18,16 +20,22 @@ use neorv32.neorv32_package.all;
 entity neorv32_cfs is
   port (
     -- global control --
-    clk_i     : in  std_ulogic; -- global clock line
-    rstn_i    : in  std_ulogic; -- global reset line, low-active, async
-    -- CPU access --
-    bus_req_i : in  bus_req_t; -- bus request
-    bus_rsp_o : out bus_rsp_t; -- bus response
+    clk_i      : in  std_ulogic;                      -- global clock
+    rstn_i     : in  std_ulogic;                      -- global reset, low-active, async
+    -- CPU request --
+    req_addr_i : in  std_ulogic_vector(15 downto 0);  -- byte address (64kB address space)
+    req_data_i : in  std_ulogic_vector(31 downto 0);  -- write data
+    req_ben_i  : in  std_ulogic_vector(3 downto 0);   -- byte enable
+    req_stb_i  : in  std_ulogic;                      -- access request strobe
+    req_rw_i   : in  std_ulogic;                      -- 0=read, 1=write
+    -- CPU response --
+    rsp_data_o : out std_ulogic_vector(31 downto 0);  -- read data
+    rsp_ack_o  : out std_ulogic;                      -- access acknowledge
     -- CPU interrupt --
-    irq_o     : out std_ulogic; -- interrupt request
+    irq_o      : out std_ulogic;                      -- interrupt request, high-active
     -- external IO --
-    cfs_in_i  : in  std_ulogic_vector(255 downto 0); -- custom inputs conduit
-    cfs_out_o : out std_ulogic_vector(255 downto 0) -- custom outputs conduit
+    cfs_in_i   : in  std_ulogic_vector(255 downto 0); -- custom inputs conduit
+    cfs_out_o  : out std_ulogic_vector(255 downto 0)  -- custom outputs conduit
   );
 end entity;
 
@@ -58,56 +66,53 @@ begin
   -- -------------------------------------------------------------------------------------------
   -- The CFS provides up to 64kB of memory-mapped address space (16 address bits, byte-addressing) that can be used
   -- for custom memories and interface registers. According to the CPU's bus protocol, each read or write access has
-  -- to be acknowledged in the following cycle using the <bus_rsp_o.ack_o> signal (or even later if the module needs
+  -- to be acknowledged in the following cycle using the <rsp_ack_o> signal (or even later if the module needs
   -- additional time to complete the access). If no ACK is generated, the bus access will time out causing a bus access
-  -- fault exception.
+  -- fault exception (this can also be done intentionally to explicitly throw an access exception).
   --
   -- [EXAMPLE] Read and write access to the interface registers and bus transfer acknowledge. This example only four
   -- physical 32-bit read/write register (using the four lowest CFS address bits). The remaining addresses of the CFS
   -- are not associated with any physical registers - any access to those is simply ignored but still acknowledged;
-  -- read accesses will return zero. Only full-word write accesses are supported (and acknowledged) by this example.
-  -- Sub-word write accesses are ignored.
+  -- read accesses will return zero. Only full-word write accesses are supported by this example.
+  -- Sub-word write accesses are ignored but still acknowledged.
 
-  bus_access: process(rstn_i, clk_i)
+  host_access: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      cfs_reg_wr(0) <= (others => '0');
-      cfs_reg_wr(1) <= (others => '0');
-      cfs_reg_wr(2) <= (others => '0');
-      cfs_reg_wr(3) <= (others => '0');
-      bus_rsp_o     <= rsp_terminate_c;
+      cfs_reg_wr <= (others => (others => '0'));
+      rsp_data_o <= (others => '0');
+      rsp_ack_o  <= '0';
     elsif rising_edge(clk_i) then -- synchronous interface for read and write accesses
       -- transfer/access acknowledge --
-      bus_rsp_o.ack <= bus_req_i.stb; -- send ACK right after the access request
-      bus_rsp_o.err <= '0'; -- set high together with bus_rsp_o.ack if there is an access error
+      rsp_ack_o <= req_stb_i; -- send ACK right after the access request
 
       -- bus access --
-      bus_rsp_o.data <= (others => '0'); -- the output HAS TO BE ZERO if there is no actual (read) access
-      if (bus_req_i.stb = '1') then -- valid access cycle, STB is high for exactly one cycle
+      rsp_data_o <= (others => '0'); -- the output HAS TO BE ZERO if there is no actual (read) access
+      if (req_stb_i = '1') then -- valid access cycle, STB is high for exactly one cycle
 
         -- write access (word-wise) --
-        if (bus_req_i.rw = '1') then
-          if (bus_req_i.addr(15 downto 2) = "00000000000000") then -- 16-bit byte address = 14-bit word address
-            cfs_reg_wr(0) <= bus_req_i.data;
+        if (req_rw_i = '1') then
+          if (req_addr_i(15 downto 2) = "00000000000000") then -- 16-bit byte address = 14-bit word address
+            cfs_reg_wr(0) <= req_data_i;
           end if;
-          if (bus_req_i.addr(15 downto 2) = "00000000000001") then
-            cfs_reg_wr(1) <= bus_req_i.data;
+          if (req_addr_i(15 downto 2) = "00000000000001") then
+            cfs_reg_wr(1) <= req_data_i;
           end if;
-          if (bus_req_i.addr(15 downto 2) = "00000000000010") then
-            cfs_reg_wr(2) <= bus_req_i.data;
+          if (req_addr_i(15 downto 2) = "00000000000010") then
+            cfs_reg_wr(2) <= req_data_i;
           end if;
-          if (bus_req_i.addr(15 downto 2) = "00000000000011") then
-            cfs_reg_wr(3) <= bus_req_i.data;
+          if (req_addr_i(15 downto 2) = "00000000000011") then
+            cfs_reg_wr(3) <= req_data_i;
           end if;
 
         -- read access (word-wise) --
         else
-          case bus_req_i.addr(15 downto 2) is -- 16-bit byte-address = 14-bit word-address
-            when "00000000000000" => bus_rsp_o.data <= cfs_reg_rd(0);
-            when "00000000000001" => bus_rsp_o.data <= cfs_reg_rd(1);
-            when "00000000000010" => bus_rsp_o.data <= cfs_reg_rd(2);
-            when "00000000000011" => bus_rsp_o.data <= cfs_reg_rd(3);
-            when others           => bus_rsp_o.data <= (others => '0');
+          case req_addr_i(15 downto 2) is -- 16-bit byte-address = 14-bit word-address
+            when "00000000000000" => rsp_data_o <= cfs_reg_rd(0);
+            when "00000000000001" => rsp_data_o <= cfs_reg_rd(1);
+            when "00000000000010" => rsp_data_o <= cfs_reg_rd(2);
+            when "00000000000011" => rsp_data_o <= cfs_reg_rd(3);
+            when others           => rsp_data_o <= (others => '0');
           end case;
         end if;
 
@@ -120,9 +125,9 @@ begin
   -- This is where the actual functionality can be implemented. The logic below is just a very
   -- simple example that transforms data from an input register into data in an output register.
 
-  cfs_reg_rd(0) <= x"0000000" & "000" & or_reduce_f(cfs_reg_wr(0)); -- OR all bits
+  cfs_reg_rd(0) <= x"0000000" & "000" & or_reduce_f(cfs_reg_wr(0));  -- OR all bits
   cfs_reg_rd(1) <= x"0000000" & "000" & xor_reduce_f(cfs_reg_wr(1)); -- XOR all bits
-  cfs_reg_rd(2) <= bit_rev_f(cfs_reg_wr(2)); -- bit reversal
-  cfs_reg_rd(3) <= (others => '1');
+  cfs_reg_rd(2) <= bit_rev_f(cfs_reg_wr(2));                         -- bit reversal
+  cfs_reg_rd(3) <= cfs_reg_wr(3);                                    -- pass-through
 
 end architecture;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130301"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130302"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -1140,14 +1140,20 @@ begin
     if IO_CFS_EN generate
       neorv32_cfs_inst: entity neorv32.neorv32_cfs
       port map (
-        clk_i       => clk_i,
-        rstn_i      => rstn_sys,
-        bus_req_i   => iodev_req(IODEV_CFS),
-        bus_rsp_o   => iodev_rsp(IODEV_CFS),
-        irq_o       => firq(FIRQ_CFS),
-        cfs_in_i    => cfs_in_i,
-        cfs_out_o   => cfs_out_o
+        clk_i      => clk_i,
+        rstn_i     => rstn_sys,
+        req_addr_i => iodev_req(IODEV_CFS).addr(15 downto 0),
+        req_data_i => iodev_req(IODEV_CFS).data,
+        req_ben_i  => iodev_req(IODEV_CFS).ben,
+        req_stb_i  => iodev_req(IODEV_CFS).stb,
+        req_rw_i   => iodev_req(IODEV_CFS).rw,
+        rsp_data_o => iodev_rsp(IODEV_CFS).data,
+        rsp_ack_o  => iodev_rsp(IODEV_CFS).ack,
+        irq_o      => firq(FIRQ_CFS),
+        cfs_in_i   => cfs_in_i,
+        cfs_out_o  => cfs_out_o
       );
+      iodev_rsp(IODEV_CFS).err <= '0';
     end generate;
 
     neorv32_cfs_disabled:

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -346,7 +346,7 @@ begin
             if (or_reduce_f(rx.baudcnt) = '0') then -- bit done
               rx.baudcnt <= ctrl.baud;
               rx.bitcnt  <= std_ulogic_vector(unsigned(rx.bitcnt) - 1);
-              rx.sreg    <= rx.sync(2) & rx.sreg(rx.sreg'left downto 1);
+              rx.sreg    <= (rx.sync(2) and rx.sync(1)) & rx.sreg(rx.sreg'left downto 1);
             else
               rx.baudcnt <= std_ulogic_vector(unsigned(rx.baudcnt) - 1);
             end if;

--- a/rtl/core/neorv32_wdt.vhd
+++ b/rtl/core/neorv32_wdt.vhd
@@ -34,12 +34,12 @@ architecture neorv32_wdt_rtl of neorv32_wdt is
   constant reset_pwd_c : std_ulogic_vector(31 downto 0) := x"709d1ab3";
 
   -- Control register bits --
-  constant ctrl_enable_c     : natural :=  0; -- r/w: WDT enable
-  constant ctrl_lock_c       : natural :=  1; -- r/w: lock write access to control register when set
-  constant ctrl_rcause_lo_c  : natural :=  2; -- r/-: cause of last system reset, bit 0, LSB
-  constant ctrl_rcause_hi_c  : natural :=  3; -- r/-: cause of last system reset, bit 1, MSB
-  constant ctrl_timeout_lo_c : natural :=  8; -- r/w: timeout value, bit 0, LSB
-  constant ctrl_timeout_hi_c : natural := 31; -- r/w: timeout value, bit 23, MSB
+  constant ctrl_enable_c      : natural :=  0; -- r/w: WDT enable
+  constant ctrl_lock_c        : natural :=  1; -- r/w: lock write access to control register when set
+  constant ctrl_rcause_lsb_c  : natural :=  2; -- r/-: cause of last system reset, bit 0, LSB
+  constant ctrl_rcause_msb_c  : natural :=  3; -- r/-: cause of last system reset, bit 1, MSB
+  constant ctrl_timeout_lsb_c : natural :=  8; -- r/w: timeout value, bit 0, LSB
+  constant ctrl_timeout_msb_c : natural := 31; -- r/w: timeout value, bit 23, MSB
 
   -- control register --
   type ctrl_t is record
@@ -47,16 +47,17 @@ architecture neorv32_wdt_rtl of neorv32_wdt is
     lock    : std_ulogic;
     timeout : std_ulogic_vector(23 downto 0);
   end record;
-  signal ctrl : ctrl_t;
+  signal ctrl : ctrl_t; -- register set
 
+  -- misc --
   signal prsc_tick      : std_ulogic; -- prescaler clock generator
   signal cen            : std_ulogic; -- counter enable
   signal cnt            : std_ulogic_vector(23 downto 0); -- timeout counter
-  signal reset_cause    : std_ulogic_vector(1 downto 0); -- cause of last reset
-  signal hw_rst_timeout : std_ulogic; -- trigger reset because of timeout
-  signal hw_rst_access  : std_ulogic; -- trigger reset because of illegal access in strict mode
   signal reset_wdt      : std_ulogic; -- reset timeout counter ("feed the watch dog")
-  signal reset_force    : std_ulogic; -- trigger reset because of illegal access in strict mode (raw)
+  signal reset_force    : std_ulogic; -- illegal access
+  signal hw_rst_timeout : std_ulogic; -- trigger reset because of timeout
+  signal hw_rst_access  : std_ulogic; -- trigger reset because of illegal access if locked
+  signal reset_cause    : std_ulogic_vector(1 downto 0); -- cause of last reset
 
 begin
 
@@ -86,7 +87,7 @@ begin
             if (ctrl.lock = '0') then -- update configuration only if not locked
               ctrl.enable  <= bus_req_i.data(ctrl_enable_c);
               ctrl.lock    <= bus_req_i.data(ctrl_lock_c);
-              ctrl.timeout <= bus_req_i.data(ctrl_timeout_hi_c downto ctrl_timeout_lo_c);
+              ctrl.timeout <= bus_req_i.data(ctrl_timeout_msb_c downto ctrl_timeout_lsb_c);
             else -- write access attempt to locked CTRL register
               reset_force <= '1';
             end if;
@@ -98,10 +99,10 @@ begin
             end if;
           end if;
         else -- read access
-          bus_rsp_o.data(ctrl_enable_c)                              <= ctrl.enable;
-          bus_rsp_o.data(ctrl_lock_c)                                <= ctrl.lock;
-          bus_rsp_o.data(ctrl_rcause_hi_c downto ctrl_rcause_lo_c)   <= reset_cause;
-          bus_rsp_o.data(ctrl_timeout_hi_c downto ctrl_timeout_lo_c) <= ctrl.timeout;
+          bus_rsp_o.data(ctrl_enable_c)                                <= ctrl.enable;
+          bus_rsp_o.data(ctrl_lock_c)                                  <= ctrl.lock;
+          bus_rsp_o.data(ctrl_rcause_msb_c downto ctrl_rcause_lsb_c)   <= reset_cause;
+          bus_rsp_o.data(ctrl_timeout_msb_c downto ctrl_timeout_lsb_c) <= ctrl.timeout;
         end if;
       end if;
     end if;
@@ -134,15 +135,13 @@ begin
     if (rstn_sys_i = '0') then
       hw_rst_timeout <= '0';
       hw_rst_access  <= '0';
+      rstn_o         <= '1';
     elsif rising_edge(clk_i) then -- reset triggers are sticky until system reset
       hw_rst_timeout <= hw_rst_timeout or (ctrl.enable and cen and prsc_tick and (not or_reduce_f(cnt))); -- timeout
       hw_rst_access  <= hw_rst_access  or (ctrl.enable and ctrl.lock and reset_force); -- locked and incorrect password
+      rstn_o         <= not (hw_rst_timeout or hw_rst_access); -- system-wide reset
     end if;
-  end process reset_generator;
-
-  -- system-wide reset --
-  rstn_o <= not (hw_rst_timeout or hw_rst_access);
-
+  end process;
 
   -- Reset-Cause Indicator ------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------


### PR DESCRIPTION
* minor WDT rtl cleanups
* fix UART RX input spike filter
* ⚠️ simplify CFS bus interface: do not use custom types; propagate only relevant signals

```vhdl
entity neorv32_cfs is
  port (
    -- global control --
    clk_i      : in  std_ulogic;                      -- global clock
    rstn_i     : in  std_ulogic;                      -- global reset, low-active, async
    -- CPU request --
    req_addr_i : in  std_ulogic_vector(15 downto 0);  -- byte address (64kB address space)
    req_data_i : in  std_ulogic_vector(31 downto 0);  -- write data
    req_ben_i  : in  std_ulogic_vector(3 downto 0);   -- byte enable
    req_stb_i  : in  std_ulogic;                      -- access request strobe
    req_rw_i   : in  std_ulogic;                      -- 0=read, 1=write
    -- CPU response --
    rsp_data_o : out std_ulogic_vector(31 downto 0);  -- read data
    rsp_ack_o  : out std_ulogic;                      -- access acknowledge
    -- CPU interrupt --
    irq_o      : out std_ulogic;                      -- interrupt request, high-active
    -- external IO --
    cfs_in_i   : in  std_ulogic_vector(255 downto 0); -- custom inputs conduit
    cfs_out_o  : out std_ulogic_vector(255 downto 0)  -- custom outputs conduit
  );
end entity;
```