### PR TITLE
[cpu] remove reset from data path registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 01.08.2026 | 1.13.3.3 | :test_tube: remove dedicated reset logic from CPU data path FFs | [#1609](https://github.com/stnolting/neorv32/pull/1609) |
 | 26.07.2026 | 1.13.3.2 | minor rtl edits and cleanups; :warning: simplify CFS bus interface | [#1606](https://github.com/stnolting/neorv32/pull/1606) |
 | 24.07.2026 | 1.13.3.1 | :bug: fix PMP `pmpaddr*[31:30]` bits: must be read-only and zero | [#1605](https://github.com/stnolting/neorv32/pull/1605) |
 | 24.07.2026 | [**1.13.3**](https://github.com/stnolting/neorv32/releases/tag/v1.13.3) | :rocket: **New release** | |

--- a/docs/datasheet/overview.adoc
+++ b/docs/datasheet/overview.adoc
@@ -301,7 +301,9 @@ neorv32/rtl$ envsubst < file_list_cpu.f > file_list.f <2>
 * The entire processor, including the CPU core, is written in platform-/technology-independent VHDL.
 The code makes minimal use of VHDL 2008 features in order to remain compatible with older EDA tools.
 * A specific VHDL library `neorv32` is used for all sources.
-* All registers / flip-flops provide an _asynchronous_ reset (see <<_processor_reset>>).
+* All registers in the control path use an asynchronous reset. The registers in the data path do not
+have a dedicated reset if their state is gated by a "valid" signal. This allows using of smaller FFs
+and relaxes the reset routing.
 * The entire setup uses a single clock domain. External "clock" signals are synchronized into this
 clock domain using 2-stage shift registers.
 * A single package/library file (`neorv32_package.vhd`) is used to provide global definitions and auxiliary functions.

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -213,7 +213,7 @@ begin
     -- ISA configuration checks --
     assert not (RISCV_ISA_Zcb and (not RISCV_ISA_C)) report
       "[NEORV32] CPU ISA: Zcb requires C!" severity error;
-    assert not (RISCV_ISA_Zcmop and (not RISCV_ISA_C) and (not RISCV_ISA_Zimop)) report
+    assert not (RISCV_ISA_Zcmop and ((not RISCV_ISA_C) or (not RISCV_ISA_Zimop))) report
       "[NEORV32] CPU ISA: Zcmop requires C and Zimop!" severity error;
 
   end generate;

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -333,7 +333,6 @@ begin
     port map (
       -- global control --
       clk_i   => clk_i,        -- global clock, rising edge
-      rstn_i  => rstn_i,       -- global reset, low-active, async
       ctrl_i  => ctrl_i,       -- main control bus
       -- data input --
       rs1_i   => rs1_i,        -- register source 1

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -62,15 +62,19 @@ end entity;
 architecture neorv32_cpu_alu_rtl of neorv32_cpu_alu is
 
   -- Zibi ISA extension: compare with immediate --
-  function zibi_cmp_f(sel : std_ulogic_vector(4 downto 0); cmp : std_ulogic_vector) return std_ulogic is
+  function zibi_cmp_f(sel : std_ulogic_vector(4 downto 0); cmp : std_ulogic_vector(31 downto 0)) return std_ulogic is
     variable imm_v : std_ulogic_vector(31 downto 0);
   begin
     if (sel = "00000") then
-      imm_v := (others => '1');
+      imm_v := (others => '1'); -- minus 1
     else
-      imm_v := replicate_f('0', 27) & sel;
+      imm_v := x"000000" & "000" & sel;
     end if;
-    return bool_to_ulogic_f(imm_v = cmp);
+    if (imm_v = cmp) then
+      return '1';
+    else
+      return '0';
+    end if;
   end function;
 
   -- wiring --

--- a/rtl/core/neorv32_cpu_alu_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_alu_bitmanip.vhd
@@ -146,8 +146,8 @@ architecture neorv32_cpu_alu_bitmanip_rtl of neorv32_cpu_alu_bitmanip is
   constant op_width_c  : natural := 22;
 
   -- controller --
-  type ctrl_state_t is (S_IDLE, S_START, S_BUSY);
-  signal ctrl_state : ctrl_state_t;
+  type state_t is (S_IDLE, S_START, S_BUSY);
+  signal state      : state_t;
   signal valid_cmd  : std_ulogic;
   signal cmd        : std_ulogic_vector(op_width_c-1 downto 0);
   signal valid      : std_ulogic;
@@ -230,7 +230,7 @@ begin
   controller: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      ctrl_state    <= S_IDLE;
+      state         <= S_IDLE;
       rs1_reg       <= (others => '0');
       rs2_reg       <= (others => '0');
       sha_reg       <= (others => '0');
@@ -253,32 +253,32 @@ begin
       end if;
 
       -- fsm --
-      case ctrl_state is
+      case state is
 
         when S_IDLE => -- wait for operation trigger
         -- ------------------------------------------------------------
           if (valid_cmd = '1') then
             if (not FAST_SHIFT) and ((cmd(op_cz_c) or cmd(op_cpop_c) or cmd(op_rot_c)) = '1') then -- multi-cycle shift operation
               shifter_start <= '1';
-              ctrl_state    <= S_START;
+              state         <= S_START;
             elsif (cmd(op_clmul_c) = '1') or (cmd(op_clmulr_c) = '1') then -- multi-cycle carry-less multiplication operation
               clmul_start <= '1';
-              ctrl_state  <= S_START;
+              state       <= S_START;
             else
-              valid      <= '1';
-              ctrl_state <= S_IDLE;
+              valid <= '1';
+              state <= S_IDLE;
             end if;
           end if;
 
         when S_START => -- one cycle delay to start iterative operation
         -- ------------------------------------------------------------
-          ctrl_state <= S_BUSY;
+          state <= S_BUSY;
 
         when S_BUSY => -- wait for multi-cycle operation to finish
         -- ------------------------------------------------------------
           if ((shifter_run = '0') and (clmul_run = '0')) or (ctrl_i.cpu_trap = '1') then -- abort on trap
-            valid      <= '1';
-            ctrl_state <= S_IDLE;
+            valid <= '1';
+            state <= S_IDLE;
           end if;
 
       end case;
@@ -418,7 +418,7 @@ begin
       elsif rising_edge(clk_i) then
         if (clmul_start = '1') then -- start new multiplication
           clmul_cnt <= std_ulogic_vector(to_unsigned(32, clmul_cnt'length));
-          clmul_res <= replicate_f('0', 32) & rs1_reg;
+          clmul_res <= x"00000000" & rs1_reg;
         elsif (clmul_run = '1') then -- operation in progress
           clmul_cnt     <= std_ulogic_vector(unsigned(clmul_cnt) - 1);
           clmul_res(63) <= '0'; -- always zero

--- a/rtl/core/neorv32_cpu_alu_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_alu_bitmanip.vhd
@@ -588,11 +588,9 @@ begin
   end process;
 
   -- output gate --
-  output_gate: process(rstn_i, clk_i)
+  output_gate: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      res_o <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       res_o <= (others => '0');
       if (valid = '1') then
         res_o <= res;

--- a/rtl/core/neorv32_cpu_alu_cond.vhd
+++ b/rtl/core/neorv32_cpu_alu_cond.vhd
@@ -18,7 +18,6 @@ entity neorv32_cpu_alu_cond is
   port (
     -- global control --
     clk_i   : in  std_ulogic; -- global clock, rising edge
-    rstn_i  : in  std_ulogic; -- global reset, low-active, async
     ctrl_i  : in  ctrl_bus_t; -- main control bus
     -- data input --
     rs1_i   : in  std_ulogic_vector(31 downto 0); -- rf source 1
@@ -40,7 +39,6 @@ begin
   valid_cmd <= '1' when (ctrl_i.alu_cp_alu = '1') and
     (ctrl_i.ir_opcode(5) = '1') and (ctrl_i.ir_funct3(2) = '1') and
     (ctrl_i.ir_funct3(0) = '1') and (ctrl_i.ir_funct12(11 downto 5) = "0000111") else '0';
-
 
   -- Conditional Output ---------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_cpu_alu_cond.vhd
+++ b/rtl/core/neorv32_cpu_alu_cond.vhd
@@ -44,11 +44,9 @@ begin
 
   -- Conditional Output ---------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  cond_out: process(rstn_i, clk_i)
+  cond_out: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      res_o <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       if (valid_cmd = '1') and (condition = '1') then -- unit triggered and move-condition is true
         res_o <= rs1_i;
       else

--- a/rtl/core/neorv32_cpu_alu_crypto.vhd
+++ b/rtl/core/neorv32_cpu_alu_crypto.vhd
@@ -247,7 +247,7 @@ begin
       done    <= '0';
       state   <= S_IDLE;
     elsif rising_edge(clk_i) then
-      -- operand gating / buffer --
+      -- operand gating --
       if (cmd_valid = '1') then
         rs1     <= rs1_i;
         rs2     <= rs2_i;

--- a/rtl/core/neorv32_cpu_alu_crypto.vhd
+++ b/rtl/core/neorv32_cpu_alu_crypto.vhd
@@ -283,11 +283,9 @@ begin
 
   -- Output Select --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  result: process(rstn_i, clk_i)
+  result: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      res_o <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       res_o <= (others => '0'); -- default
       if (done = '1') then
         if ((funct12(9 downto 8) = "10") and (funct12(5) = '1')) or
@@ -402,11 +400,9 @@ begin
     end process;
 
     -- mix columns --
-    aes_mix_columns: process(rstn_i, clk_i)
+    aes_mix_columns: process(clk_i)
     begin
-      if (rstn_i = '0') then
-        aes_mix1 <= (others => '0');
-      elsif rising_edge(clk_i) then
+      if rising_edge(clk_i) then
         if (aes_dec = '1') then -- decrypt
           aes_mix1(31 downto 24) <= gfmul_f(aes_so, x"b");
           aes_mix1(23 downto 16) <= gfmul_f(aes_so, x"d");
@@ -452,11 +448,9 @@ begin
     sm4_so2 <= x"000000" & sm4_so1;
 
     -- round update: encrypt/decrypt or key schedule --
-    sm4_round: process(rstn_i, clk_i)
+    sm4_round: process(clk_i)
     begin
-      if (rstn_i = '0') then
-        sm4_rnd <= (others => '0');
-      elsif rising_edge(clk_i) then
+      if rising_edge(clk_i) then
         if (funct12(6) = '0') then -- encrypt/decrypt
           sm4_rnd <= sm4_so2 xor lsl_f(sm4_so2, 8) xor lsl_f(sm4_so2, 2) xor lsl_f(sm4_so2, 18) xor
                                  lsl_f((sm4_so2 and x"0000003F"), 26) xor lsl_f((sm4_so2 and x"000000C0"), 10);

--- a/rtl/core/neorv32_cpu_alu_fpu.vhd
+++ b/rtl/core/neorv32_cpu_alu_fpu.vhd
@@ -812,7 +812,6 @@ begin
   port map (
     -- global control --
     clk_i    => clk_i,
-    rstn_i   => rstn_i,
     -- data path --
     en_i     => multiplier.start,
     opa_i    => multiplier.opa,

--- a/rtl/core/neorv32_cpu_alu_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_alu_muldiv.vhd
@@ -182,7 +182,6 @@ begin
     )
     port map (
       clk_i    => clk_i,
-      rstn_i   => rstn_i,
       en_i     => mul_start,
       opa_i    => rs1_i,
       opa_sn_i => rs1_signed,

--- a/rtl/core/neorv32_cpu_alu_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_alu_muldiv.vhd
@@ -200,11 +200,9 @@ begin
   if not FAST_MUL_EN generate
 
     -- shift-and-add algorithm --
-    multiplier_core: process(rstn_i, clk_i)
+    multiplier_core: process(clk_i)
     begin
-      if (rstn_i = '0') then
-        mul_res <= (others => '0');
-      elsif rising_edge(clk_i) then
+      if rising_edge(clk_i) then
         if (mul_start = '1') then -- start new multiplication
           mul_res(63 downto 32) <= (others => '0');
           mul_res(31 downto 0)  <= rs1_i;
@@ -242,14 +240,9 @@ begin
   if DIVISION_EN generate
 
     -- unsigned restoring division algorithm --
-    divider_core: process(rstn_i, clk_i)
+    divider_core: process(clk_i)
     begin
-      if (rstn_i = '0') then
-        div_divi <= (others => '0');
-        div_quot <= (others => '0');
-        div_rema <= (others => '0');
-        div_sign <= '0';
-      elsif rising_edge(clk_i) then
+      if rising_edge(clk_i) then
         if (div_start = '1') then -- start new division
           div_divi <= abs32_f(rs2_i, rs2_signed);
           div_quot <= abs32_f(rs1_i, rs1_signed);

--- a/rtl/core/neorv32_cpu_alu_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_alu_muldiv.vhd
@@ -70,21 +70,21 @@ architecture neorv32_cpu_alu_muldiv_rtl of neorv32_cpu_alu_muldiv is
   -- controller --
   type state_t is (S_IDLE, S_BUSY, S_PIPE, S_DONE);
   type ctrl_t is record
-    state  : state_t;
-    cnt    : std_ulogic_vector(4 downto 0);
-    out_en : std_ulogic;
+    state : state_t;
+    cnt   : std_ulogic_vector(4 downto 0);
+    oe    : std_ulogic;
   end record;
   signal ctrl : ctrl_t; -- FSM
   signal rs1_signed, rs2_signed : std_ulogic;
 
   -- divider core --
   signal div_start : std_ulogic;
-  signal div_divi  : std_ulogic_vector(31 downto 0);
-  signal div_quot  : std_ulogic_vector(31 downto 0);
-  signal div_rema  : std_ulogic_vector(31 downto 0);
-  signal div_sign  : std_ulogic;
+  signal div_opb   : std_ulogic_vector(31 downto 0);
+  signal div_quo   : std_ulogic_vector(31 downto 0);
+  signal div_rem   : std_ulogic_vector(31 downto 0);
+  signal div_sgn   : std_ulogic;
   signal div_sub   : std_ulogic_vector(32 downto 0);
-  signal div_res_u : std_ulogic_vector(31 downto 0);
+  signal div_ures  : std_ulogic_vector(31 downto 0);
   signal div_res   : std_ulogic_vector(31 downto 0);
 
   -- multiplier core --
@@ -106,13 +106,13 @@ begin
   control: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      ctrl.state  <= S_IDLE;
-      ctrl.cnt    <= (others => '0');
-      ctrl.out_en <= '0';
+      ctrl.state <= S_IDLE;
+      ctrl.cnt   <= (others => '0');
+      ctrl.oe    <= '0';
     elsif rising_edge(clk_i) then
       -- defaults --
-      ctrl.out_en <= '0';
-      ctrl.cnt    <= std_ulogic_vector(to_unsigned(30, 5)); -- cycle counter initialization
+      ctrl.oe  <= '0';
+      ctrl.cnt <= std_ulogic_vector(to_unsigned(30, 5)); -- cycle counter initialization
 
       -- fsm --
       case ctrl.state is
@@ -150,8 +150,8 @@ begin
 
         when S_DONE => -- S_DONE: final step / enable output for one cycle
         -- ------------------------------------------------------------
-          ctrl.out_en <= '1';
-          ctrl.state  <= S_IDLE;
+          ctrl.oe    <= '1';
+          ctrl.state <= S_IDLE;
 
       end case;
     end if;
@@ -243,44 +243,44 @@ begin
     begin
       if rising_edge(clk_i) then
         if (div_start = '1') then -- start new division
-          div_divi <= abs32_f(rs2_i, rs2_signed);
-          div_quot <= abs32_f(rs1_i, rs1_signed);
-          div_rema <= (others => '0');
+          div_opb <= abs32_f(rs2_i, rs2_signed);
+          div_quo <= abs32_f(rs1_i, rs1_signed);
+          div_rem <= (others => '0');
           case ctrl_i.ir_funct3(1 downto 0) is -- check for result's sign compensation
-            when "00"   => div_sign <= or_reduce_f(rs2_i) and (rs1_i(rs1_i'left) xor rs2_i(rs2_i'left)); -- signed div
-            when "10"   => div_sign <= rs1_i(rs1_i'left); -- signed rem
-            when others => div_sign <= '0';
+            when "00"   => div_sgn <= or_reduce_f(rs2_i) and (rs1_i(rs1_i'left) xor rs2_i(rs2_i'left)); -- signed div
+            when "10"   => div_sgn <= rs1_i(rs1_i'left); -- signed rem
+            when others => div_sgn <= '0';
           end case;
         elsif (ctrl.state = S_BUSY) or (ctrl.state = S_DONE) then -- running?
-          div_quot <= div_quot(30 downto 0) & (not div_sub(32));
+          div_quo <= div_quo(30 downto 0) & (not div_sub(32));
           if (div_sub(32) = '0') then
-            div_rema <= div_sub(31 downto 0);
+            div_rem <= div_sub(31 downto 0);
           else -- underflow: restore
-            div_rema <= div_rema(30 downto 0) & div_quot(31);
+            div_rem <= div_rem(30 downto 0) & div_quo(31);
           end if;
         end if;
       end if;
     end process;
 
     -- do another subtraction (and shift) --
-    div_sub <= std_ulogic_vector(unsigned('0' & div_rema(30 downto 0) & div_quot(31)) - unsigned('0' & div_divi));
+    div_sub <= std_ulogic_vector(unsigned('0' & div_rem(30 downto 0) & div_quo(31)) - unsigned('0' & div_opb));
 
     -- result select and sign compensation --
-    div_res_u <= div_quot when (ctrl_i.ir_funct3(2 downto 1) = op_div_c(2 downto 1)) else div_rema;
-    div_res   <= std_ulogic_vector(0 - unsigned(div_res_u)) when (div_sign = '1') else div_res_u;
+    div_ures <= div_quo when (ctrl_i.ir_funct3(2 downto 1) = op_div_c(2 downto 1)) else div_rem;
+    div_res  <= std_ulogic_vector(0 - unsigned(div_ures)) when (div_sgn = '1') else div_ures;
 
   end generate;
 
   -- no divider --
   divider_core_serial_none:
   if not DIVISION_EN generate
-    div_divi  <= (others => '0');
-    div_quot  <= (others => '0');
-    div_rema  <= (others => '0');
-    div_sign  <= '0';
-    div_sub   <= (others => '0');
-    div_res_u <= (others => '0');
-    div_res   <= (others => '0');
+    div_opb  <= (others => '0');
+    div_quo  <= (others => '0');
+    div_rem  <= (others => '0');
+    div_sgn  <= '0';
+    div_sub  <= (others => '0');
+    div_ures <= (others => '0');
+    div_res  <= (others => '0');
   end generate;
 
 
@@ -289,7 +289,7 @@ begin
   operation_result: process(ctrl, ctrl_i.ir_funct3, mul_res, div_res)
   begin
     res_o <= (others => '0');
-    if (ctrl.out_en = '1') then
+    if (ctrl.oe = '1') then
       case ctrl_i.ir_funct3 is
         when op_mul_c =>
           res_o <= mul_res(31 downto 0);

--- a/rtl/core/neorv32_cpu_alu_shifter.vhd
+++ b/rtl/core/neorv32_cpu_alu_shifter.vhd
@@ -41,7 +41,7 @@ architecture neorv32_cpu_alu_shifter_rtl of neorv32_cpu_alu_shifter is
   -- instruction decode --
   signal valid_cmd : std_ulogic;
 
-  -- shifter --
+  -- shifter core --
   signal busy, sgn, done, oe : std_ulogic;
   signal cnt  : std_ulogic_vector(4 downto 0);
   signal sreg : std_ulogic_vector(31 downto 0);
@@ -64,31 +64,35 @@ begin
   serial_shifter:
   if not FAST_SHIFT_EN generate
 
-    shifter: process(rstn_i, clk_i)
+    -- iteration control --
+    serial_ctrl: process(rstn_i, clk_i)
     begin
       if (rstn_i = '0') then
         busy <= '0';
         oe   <= '0';
-        cnt  <= (others => '0');
-        sreg <= (others => '0');
       elsif rising_edge(clk_i) then
-        -- arbitration --
         if (valid_cmd = '1') then
           busy <= '1';
         elsif (done = '1') or (ctrl_i.cpu_trap = '1') then -- abort on trap
           busy <= '0';
         end if;
         oe <= busy and done;
-        -- shift register --
-        if (valid_cmd = '1') then -- trigger new operation
+      end if;
+    end process;
+
+    -- shift register --
+    serial_data: process(clk_i)
+    begin
+      if rising_edge(clk_i) then
+        if (valid_cmd = '1') then
           cnt  <= shamt_i;
           sreg <= rs1_i;
-        elsif (or_reduce_f(cnt) = '1') then -- operation in progress
+        elsif (busy = '1') and (or_reduce_f(cnt) = '1') then -- operation in progress
           cnt <= std_ulogic_vector(unsigned(cnt) - 1);
           if (ctrl_i.ir_funct3(2) = '0') then -- shift left logical
-            sreg <= sreg(sreg'left-1 downto 0) & '0';
+            sreg <= sreg(30 downto 0) & '0';
           else -- shift right (arithmetical)
-            sreg <= (sreg(sreg'left) and ctrl_i.ir_funct12(10)) & sreg(sreg'left downto 1);
+            sreg <= (sreg(31) and ctrl_i.ir_funct12(10)) & sreg(31 downto 1);
           end if;
         end if;
       end if;

--- a/rtl/core/neorv32_cpu_alu_shifter.vhd
+++ b/rtl/core/neorv32_cpu_alu_shifter.vhd
@@ -122,14 +122,20 @@ begin
     end generate;
 
     -- register layer --
-    pipe_reg: process(rstn_i, clk_i)
+    pipe_reg: process(clk_i)
+    begin
+      if rising_edge(clk_i) then
+        sreg <= lvl(5);
+      end if;
+    end process;
+
+    -- output control --
+    oe_reg: process(rstn_i, clk_i)
     begin
       if (rstn_i = '0') then
-        oe   <= '0';
-        sreg <= (others => '0');
+        oe <= '0';
       elsif rising_edge(clk_i) then
-        oe   <= valid_cmd;
-        sreg <= lvl(5);
+        oe <= valid_cmd;
       end if;
     end process;
 

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1171,11 +1171,9 @@ begin
 
   -- CSR Read Access ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  csr_read_access: process(rstn_i, clk_i)
+  csr_read_access: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      csr_rdata <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       csr_rdata <= (others => '0'); -- output all-zero if there is no CSR read operation
       if (ctrl.csr_re = '1') then
         case ctrl.csr_addr is

--- a/rtl/core/neorv32_cpu_counters.vhd
+++ b/rtl/core/neorv32_cpu_counters.vhd
@@ -112,7 +112,7 @@ begin
         inhibit(31 downto 3) <= ctrl_i.csr_wdata(31 downto 3); -- [m]hpmcounter3..31[h]
       end if;
       -- unused --
-      inhibit(1) <= '0'; -- [m]time[h] not implemented
+      inhibit(1) <= '0';
     end if;
   end process;
 

--- a/rtl/core/neorv32_cpu_counters.vhd
+++ b/rtl/core/neorv32_cpu_counters.vhd
@@ -211,11 +211,9 @@ begin
     );
 
     -- time[h] --
-    mtime: process(rstn_i, clk_i)
+    time_buf: process(clk_i)
     begin
-      if (rstn_i = '0') then
-        time_q <= (others => '0');
-      elsif rising_edge(clk_i) then
+      if rising_edge(clk_i) then
         time_q <= mtime_i;
       end if;
     end process;

--- a/rtl/core/neorv32_cpu_lsu.vhd
+++ b/rtl/core/neorv32_cpu_lsu.vhd
@@ -142,11 +142,9 @@ begin
 
   -- Response -------------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  mem_di_reg: process(rstn_i, clk_i)
+  mem_di_reg: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      rdata_o <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       rdata_o <= (others => '0'); -- output zero if there is no pending memory request
       if (ctrl_i.lsu_mi_en = '1') then
         case ctrl_i.ir_funct3(1 downto 0) is

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -253,12 +253,10 @@ begin
       addr_mask_napot(r)(i) <= addr_mask_napot(r)(i-1) or (not pmpaddr(r)(i-3));
     end generate;
 
-    -- NAPOT address mask select --
-    addr_masking: process(rstn_i, clk_i)
+    -- NAPOT address mask buffer --
+    addr_masking: process(clk_i)
     begin
-      if (rstn_i = '0') then
-        addr_mask(r) <= (others => '0');
-      elsif rising_edge(clk_i) then
+      if rising_edge(clk_i) then
         if NAP_EN then
           if (pmpcfg(r)(cfg_al_c) = '1') then -- NAPOT
             addr_mask(r) <= addr_mask_napot(r);

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130302"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130303"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_prim.vhd
+++ b/rtl/core/neorv32_prim.vhd
@@ -263,7 +263,6 @@ entity neorv32_prim_mul is
   port (
     -- global control --
     clk_i    : in  std_ulogic;                              -- clock, rising edge
-    rstn_i   : in  std_ulogic;                              -- reset, low-active, async
     -- data path --
     en_i     : in  std_ulogic;                              -- enable input operand registers
     opa_i    : in  std_ulogic_vector(DWIDTH-1 downto 0);    -- operand A
@@ -284,12 +283,9 @@ begin
 
   -- Input Registers ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  in_reg: process(rstn_i, clk_i)
+  in_reg: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      opa <= (others => '0');
-      opb <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       if (en_i = '1') then
         opa <= signed((opa_i(opa_i'left) and opa_sn_i) & opa_i);
         opb <= signed((opb_i(opb_i'left) and opb_sn_i) & opb_i);

--- a/rtl/core/neorv32_prim.vhd
+++ b/rtl/core/neorv32_prim.vhd
@@ -118,7 +118,7 @@ begin
     memory_core: process(clk_i) -- simple dual-port RAM
     begin
       if rising_edge(clk_i) then
-        if (we = '1') and (clear_i = '0') then
+        if (we = '1') then
           fifo(to_integer(unsigned(w_pnt(AWIDTH-1 downto 0)))) <= wdata_i;
         end if;
         rdata <= fifo(to_integer(unsigned(r_pnt(AWIDTH-1 downto 0))));
@@ -129,12 +129,10 @@ begin
   -- just 1 FIFO entry --
   memory_small:
   if (AWIDTH = 0) generate
-    memory_core: process(rstn_i, clk_i) -- single register
+    memory_core: process(clk_i) -- single register
     begin
-      if (rstn_i = '0') then
-        fifo(0) <= (others => '0');
-      elsif rising_edge(clk_i) then
-        if (we = '1') and (clear_i = '0') then
+      if rising_edge(clk_i) then
+        if (we = '1') then
           fifo(0) <= wdata_i;
         end if;
       end if;

--- a/rtl/verilog/ip/neorv32_cfs.v
+++ b/rtl/verilog/ip/neorv32_cfs.v
@@ -1,0 +1,136 @@
+// ================================================================================ //
+// NEORV32 SoC - Custom Functions Subsystem (CFS)                                   //
+// -------------------------------------------------------------------------------- //
+// The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
+// Copyright (c) NEORV32 contributors.                                              //
+// Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  //
+// Licensed under the BSD-3-Clause license, see LICENSE for details.                //
+// SPDX-License-Identifier: BSD-3-Clause                                            //
+// ================================================================================ //
+
+module neorv32_cfs (
+  // global control
+  input  wire        clk_i,      // global clock
+  input  wire        rstn_i,     // global reset, low-active, async
+  // CPU request
+  input  wire [15:0] req_addr_i, // byte address (64kB address space)
+  input  wire [31:0] req_data_i, // write data
+  input  wire [3:0]  req_ben_i,  // byte enable
+  input  wire        req_stb_i,  // access request strobe
+  input  wire        req_rw_i,   // 0=read, 1=write
+  // CPU response
+  output wire [31:0] rsp_data_o, // read data
+  output wire        rsp_ack_o,  // access acknowledge
+  // CPU interrupt
+  output wire        irq_o,      // interrupt request, high-active
+  // external IO
+  input  wire [255:0] cfs_in_i,  // custom inputs conduit
+  output wire [255:0] cfs_out_o  // custom outputs conduit
+);
+
+  // exemplary CFS interface registers
+  reg  [31:0] cfs_reg_wr [0:3]; // for WRITE accesses (4 read/write registers)
+  wire [31:0] cfs_reg_rd [0:3]; // for READ accesses
+
+  // CFS IOs --------------------------------------------------------------------------------
+  // -------------------------------------------------------------------------------------------
+  // By default, the CFS provides two IO ports (cfs_in_i and cfs_out_o) that are available at the processor's top entity.
+  // These are intended as "conduits" to propagate custom CFS signals between the CFS and the processor top entity.
+
+  assign cfs_out_o = 256'b0; // not used for this minimal example
+
+  // Interrupt ------------------------------------------------------------------------------
+  // -------------------------------------------------------------------------------------------
+  // The CFS features a single interrupt signal, which is connected to the CPU's "fast interrupt" channel 1 (FIRQ1).
+  // The according CPU interrupt becomes pending as long as <irq_o> is high.
+
+  assign irq_o = 1'b0; // not used for this minimal example
+
+  // Read/Write Access ----------------------------------------------------------------------
+  // -------------------------------------------------------------------------------------------
+  // The CFS provides up to 64kB of memory-mapped address space (16 address bits, byte-addressing) that can be used
+  // for custom memories and interface registers. According to the CPU's bus protocol, each read or write access has
+  // to be acknowledged in the following cycle using the <rsp_ack_o> signal (or even later if the module needs
+  // additional time to complete the access). If no ACK is generated, the bus access will time out causing a bus access
+  // fault exception (this can also be done intentionally to explicitly throw an access exception).
+  //
+  // [EXAMPLE] Read and write access to the interface registers and bus transfer acknowledge. This example only four
+  // physical 32-bit read/write register (using the four lowest CFS address bits). The remaining addresses of the CFS
+  // are not associated with any physical registers - any access to those is simply ignored but still acknowledged;
+  // read accesses will return zero. Only full-word write accesses are supported by this example.
+  // Sub-word write accesses are ignored but still acknowledged.
+
+  reg [31:0] rsp_data;
+  reg rsp_ack;
+
+  always @(posedge clk_i or negedge rstn_i) begin
+    if (rstn_i == 1'b0) begin
+      cfs_reg_wr[0] <= 32'b0;
+      cfs_reg_wr[1] <= 32'b0;
+      cfs_reg_wr[2] <= 32'b0;
+      cfs_reg_wr[3] <= 32'b0;
+      rsp_data      <= 32'b0;
+      rsp_ack       <= 1'b0;
+    end else begin // synchronous interface for read and write accesses
+      // transfer/access acknowledge
+      rsp_ack <= req_stb_i; // send ACK right after the access request
+
+      // bus access
+      rsp_data <= 32'b0; // the output HAS TO BE ZERO if there is no actual (read) access
+      if (req_stb_i == 1'b1) begin // valid access cycle, STB is high for exactly one cycle
+
+        // write access (word-wise)
+        if (req_rw_i == 1'b1) begin
+          if (req_addr_i[15:2] == 14'b00000000000000) begin // 16-bit byte address = 14-bit word address
+            cfs_reg_wr[0] <= req_data_i;
+          end
+          if (req_addr_i[15:2] == 14'b00000000000001) begin
+            cfs_reg_wr[1] <= req_data_i;
+          end
+          if (req_addr_i[15:2] == 14'b00000000000010) begin
+            cfs_reg_wr[2] <= req_data_i;
+          end
+          if (req_addr_i[15:2] == 14'b00000000000011) begin
+            cfs_reg_wr[3] <= req_data_i;
+          end
+
+        // read access (word-wise)
+        end else begin
+          case (req_addr_i[15:2]) // 16-bit byte-address = 14-bit word-address
+            14'b00000000000000: begin rsp_data <= cfs_reg_rd[0]; end
+            14'b00000000000001: begin rsp_data <= cfs_reg_rd[1]; end
+            14'b00000000000010: begin rsp_data <= cfs_reg_rd[2]; end
+            14'b00000000000011: begin rsp_data <= cfs_reg_rd[3]; end
+            default:            begin rsp_data <= 32'b0;         end
+          endcase
+        end
+
+      end
+    end
+  end
+
+  assign rsp_data_o = rsp_data;
+  assign rsp_ack_o  = rsp_ack;
+
+  // CFS Function Core ----------------------------------------------------------------------
+  // -------------------------------------------------------------------------------------------
+  // This is where the actual functionality can be implemented. The logic below is just a very
+  // simple example that transforms data from an input register into data in an output register.
+
+  // bit reversal helper
+  function [31:0] bit_rev_f;
+    input [31:0] data;
+    integer i;
+    begin
+      for (i=0; i<32; i=i+1) begin
+        bit_rev_f[i] = data[31-i];
+      end
+    end
+  endfunction
+
+  assign cfs_reg_rd[0] = {28'h0000000, 3'b000, (|cfs_reg_wr[0])}; // OR all bits
+  assign cfs_reg_rd[1] = {28'h0000000, 3'b000, (^cfs_reg_wr[1])}; // XOR all bits
+  assign cfs_reg_rd[2] = bit_rev_f(cfs_reg_wr[2]);                // bit reversal
+  assign cfs_reg_rd[3] = cfs_reg_wr[3];                           // pass-through
+
+endmodule

--- a/rtl/verilog/ip/neorv32_cpu_alu_cfu.v
+++ b/rtl/verilog/ip/neorv32_cpu_alu_cfu.v
@@ -1,0 +1,164 @@
+// ================================================================================ //
+// NEORV32 CPU - ALU Custom (RISC-V Instructions) Functions Unit (CFU)              //
+// -------------------------------------------------------------------------------- //
+// The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              //
+// Copyright (c) NEORV32 contributors.                                              //
+// Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  //
+// Licensed under the BSD-3-Clause license, see LICENSE for details.                //
+// SPDX-License-Identifier: BSD-3-Clause                                            //
+// ================================================================================ //
+
+module neorv32_cpu_alu_cfu (
+  // global control
+  input  wire        clk_i,    // global clock, rising edge
+  input  wire        rstn_i,   // global reset, low-active, async
+  // request
+  input  wire        start_i,  // start trigger, single-shot
+  input  wire [31:0] inst_i,   // full instruction word
+  input  wire [31:0] rs1_i,    // register source operand 1
+  input  wire [31:0] rs2_i,    // register source operand 2
+  // response
+  output wire [31:0] result_o, // operation result
+  output wire        valid_o   // operation done; result valid
+);
+
+  // supported CFU opcodes
+  localparam [6:0] opcode_custom0_c = 7'b0001011; // CUSTOM-0 opcode
+  localparam [6:0] opcode_custom1_c = 7'b0101011; // CUSTOM-1 opcode
+  localparam [6:0] opcode_op32_c    = 7'b0011011; // OP-32 opcode
+  localparam [6:0] opcode_opimm32_c = 7'b0111011; // OP-IMM-32 opcode
+
+  // **********************************************************
+  // CFU Example: XTEA - Extended Tiny Encryption Algorithm
+  // **********************************************************
+
+  // instruction types (opcode field)
+  localparam [6:0] xtea_r_type_c = opcode_custom0_c; // XTEA R-type instructions
+  localparam [6:0] xtea_i_type_c = opcode_custom1_c; // XTEA I-type instructions
+
+  // instruction identifiers (funct3 bit-field)
+  localparam [2:0] xtea_enc_v0_c = 3'b000;
+  localparam [2:0] xtea_enc_v1_c = 3'b001;
+  localparam [2:0] xtea_dec_v0_c = 3'b010;
+  localparam [2:0] xtea_dec_v1_c = 3'b011;
+  localparam [2:0] xtea_init_c   = 3'b100;
+
+  // instruction decoder
+  wire start; // start valid CFU instruction
+  wire itype; // XTEA instruction type (0 = r-type, 1 = i-type)
+  wire  [2:0] funct3; // i-type/r-type function select
+  wire [11:0] imm12; // i-type immediate
+
+  // round-key update
+  localparam [31:0] xtea_delta_c = 32'h9e3779b9;
+
+  // key storage (accessed via special r4-type instructions)
+  reg [31:0] key_mem [0:3];
+
+  // processing state
+  reg [1:0]  xtea_done; // multi-cycle done shift register; 2 stages = 2 cycles latency
+  reg [31:0] xtea_opa; // input operand a
+  reg [31:0] xtea_opb; // input operand b
+  reg [31:0] xtea_sum; // round key buffer
+  reg [31:0] xtea_res; // operation results
+
+  // helpers
+  wire [31:0] tmp_a, tmp_b, tmp_x, tmp_y, tmp_z, tmp_r;
+  reg [31:0] result;
+  reg valid;
+
+  // XTEA Instruction Decode ----------------------------------------------------------------
+  // -------------------------------------------------------------------------------------------
+  assign start  = ((inst_i[6:0] == xtea_r_type_c) || (inst_i[6:0] == xtea_i_type_c)) ? start_i : 1'b0; // valid instruction?
+  assign itype  = (inst_i[6:0] == xtea_r_type_c) ? 1'b0 : 1'b1; // XTEA r-type or i-type?
+  assign funct3 = inst_i[14:12]; // type function select
+  assign imm12  = inst_i[31:20]; // i-type 12-bit immediate
+
+  // XTEA Processing Core ------------------------------------------------------------------
+  // -------------------------------------------------------------------------------------------
+  always @(posedge clk_i or negedge rstn_i) begin
+    if (rstn_i == 1'b0) begin
+      xtea_done  <= 2'b00;
+      xtea_opa   <= 32'b0;
+      xtea_opb   <= 32'b0;
+      xtea_sum   <= 32'b0;
+      key_mem[0] <= 32'b0;
+      key_mem[1] <= 32'b0;
+      key_mem[2] <= 32'b0;
+      key_mem[3] <= 32'b0;
+    end else begin
+      // "operation-done" shift register: module has 2 cycles latency
+      xtea_done[0] <= 1'b0;      // default: no operation trigger
+      xtea_done[1] <= xtea_done[0];  // arbitration shift register
+
+      // trigger new operation
+      if (start == 1'b1) begin
+        if (itype == 1'b0) begin // R-type for computational instructions
+          xtea_opa     <= rs1_i; // buffer input operand rs1
+          xtea_opb     <= rs2_i; // buffer input operand rs2
+          xtea_done[0] <= 1'b1;  // start data processing
+        end else begin // I-type is used for key access instructions
+          if (funct3[0] == 1'b1) begin // key write-enable
+            key_mem[imm12[1:0]] <= rs1_i; // write key data at imm12(1:0)
+          end
+        end
+      end
+
+      // data processing
+      if (xtea_done[0] == 1'b1) begin // second-stage execution trigger
+        // update "sum" round key --
+        if (funct3[2] == 1'b1) begin // initialize
+          xtea_sum <= xtea_opa; // set initial round key
+        end else if (funct3[1:0] == xtea_enc_v0_c[1:0]) begin // encrypt v0
+          xtea_sum <= xtea_sum + xtea_delta_c;
+        end else if (funct3[1:0] == xtea_dec_v1_c[1:0]) begin // decrypt v1
+          xtea_sum <= xtea_sum - xtea_delta_c;
+        end
+        // process "v" operands
+        if (funct3[1] == 1'b0) begin// encrypt
+          xtea_res <= tmp_b + tmp_r;
+        end else begin // decrypt
+          xtea_res <= tmp_b - tmp_r;
+        end
+      end
+    end
+  end
+
+  // helpers
+  assign tmp_a = (funct3[0] == 1'b0) ? xtea_opb : xtea_opa; // v1 / v0 select
+  assign tmp_b = (funct3[0] == 1'b0) ? xtea_opa : xtea_opb; // v0 / v1 select
+  assign tmp_x = (funct3[0] == 1'b0) ? {xtea_opb[27:0], 4'b0000} : {xtea_opa[27:0], 4'b0000};   // v << 4
+  assign tmp_y = (funct3[0] == 1'b0) ? {5'b00000, xtea_opb[31:5]} : {5'b00000, xtea_opa[31:5]}; // v >> 5
+  assign tmp_z = (funct3[0] == 1'b0) ? key_mem[xtea_sum[1:0]]    // key[sum & 3]
+                                     : key_mem[xtea_sum[12:11]]; // key[(sum >> 11) & 3]
+  assign tmp_r = ((tmp_x ^ tmp_y) + tmp_a) ^ (xtea_sum + tmp_z);
+
+  // Function Result Select -----------------------------------------------------------------
+  // -------------------------------------------------------------------------------------------
+  always @(*) begin
+    // no need for a register stage here; the CFU output is registered inside the ALU module anyway
+    if (itype == 1'b0) begin // R-type instructions; function select via "funct3"
+      case (funct3) // just check "funct3" here
+        xtea_enc_v0_c, xtea_enc_v1_c, xtea_dec_v0_c, xtea_dec_v1_c: begin // encryption/decryption
+          result = xtea_res; // processing result
+          valid  = xtea_done[1]; // multi-cycle processing done when set
+        end
+        xtea_init_c: begin // xtea initialization
+          result = 32'b0; // just output zero
+          valid  = 1'b1;  // pure-combinatorial, so we are done "immediately"
+        end
+        default: begin // all unspecified operations
+          result = 32'b0; // no logic implemented
+          valid  = 1'b0;  // this will cause an illegal instruction exception
+        end
+      endcase
+    end else begin // I-type instructions; used for key access
+      result = key_mem[imm12[1:0]];
+      valid  = 1'b1; // pure-combinatorial, so we are done "immediately"
+    end
+  end
+
+  assign result_o = result;
+  assign valid_o  = valid;
+
+endmodule


### PR DESCRIPTION
All registers in the control path use an asynchronous reset. However, many registers in the data path now do not have a dedicated reset any more if their state is gated by a valid signal (and is therefore architecturally invisible while it is still undefined).

Without a dedicated reset, smaller FFs can be used (ASIC-only). In addition, the complexity of the reset network and its routing is simplified.

This is experimental.