### PR TITLE
[regfile] optimizations and cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 02.08.2026 | 1.13.3.5 | CPU register file area optimizations and cleanups | [#1613](https://github.com/stnolting/neorv32/pull/1613) |
 | 01.08.2026 | 1.13.3.4 | RVFI: extend `order` to 64-bit as required by the spec | [#1612](https://github.com/stnolting/neorv32/pull/1612) |
 | 01.08.2026 | 1.13.3.3 | :test_tube: remove dedicated reset logic from CPU data path FFs | [#1609](https://github.com/stnolting/neorv32/pull/1609) |
 | 26.07.2026 | 1.13.3.2 | minor rtl edits and cleanups; :warning: simplify CFS bus interface | [#1606](https://github.com/stnolting/neorv32/pull/1606) |

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -399,19 +399,24 @@ begin
   -- -------------------------------------------------------------------------------------------
   neorv32_cpu_regfile_inst: entity neorv32.neorv32_cpu_regfile
   generic map (
-    DWIDTH   => 32,             -- data width
-    AWIDTH   => rf_awidth_c,    -- address width
-    ARCH_SEL => CPU_RF_ARCH_SEL -- architecture style select
+    AWIDTH  => rf_awidth_c,    -- address width
+    ARCHSEL => CPU_RF_ARCH_SEL -- architecture style select
   )
   port map (
     -- global control --
-    clk_i  => clk_i,    -- global clock, rising edge
-    rstn_i => rstn_i,   -- global reset, low-active, async
-    ctrl_i => ctrl,     -- main control bus
-    -- operands --
-    rd_i   => rf_wdata, -- destination operand rd
-    rs1_o  => rs1,      -- source operand rs1
-    rs2_o  => rs2       -- source operand rs2
+    clk_i      => clk_i,
+    rstn_i     => rstn_i,
+    zero_i     => ctrl.rf_zero,
+    -- write port (rd) --
+    rd_we_i    => ctrl.rf_wb_en,
+    rd_addr_i  => ctrl.rf_rd,
+    rd_data_i  => rf_wdata,
+    -- read port 1 (rs1) --
+    rs1_addr_i => ctrl.rf_rs1,
+    rs1_data_o => rs1,
+    -- read port 1 (rs2) --
+    rs2_addr_i => ctrl.rf_rs2,
+    rs2_data_o => rs2
   );
 
   -- all buses are zero unless there is an according operation --

--- a/rtl/core/neorv32_cpu_regfile.vhd
+++ b/rtl/core/neorv32_cpu_regfile.vhd
@@ -1,15 +1,14 @@
 -- ================================================================================ --
 -- NEORV32 CPU - Data Register File                                                 --
 -- -------------------------------------------------------------------------------- --
--- The architecture style of the register file is selected by the ARCH_SEL generic: --
+-- The architecture style of the register file is selected by the ARCHSEL generic:  --
 -- 0: Register-based SRAM with sync. read (e.g. to map to FPGA block RAM)           --
 -- 1: Register-based SRAM with async. read (e.g. to map to FPGA distributed RAM)    --
 -- 2: Register-based with full hardware reset                                       --
 -- 3: Latch-based (e.g. for ASIC implementation)                                    --
 --                                                                                  --
 -- [NOTE] Read-during-write behavior of the register file's memory core is          --
---        irrelevant as read and write accesses are mutually exclusive and          --
---        will never occur at the same time.                                        --
+--        irrelevant as read and write accesses are mutually exclusive.             --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
@@ -53,11 +52,11 @@ architecture neorv32_cpu_regfile_rtl of neorv32_cpu_regfile is
   -- access logic --
   signal rf_we  : std_ulogic;
   signal addr   : std_ulogic_vector(4 downto 0);
-  signal wdata  : std_ulogic_vector(DWIDTH-1 downto 0);
+  signal wdata  : std_ulogic_vector(31 downto 0);
   signal onehot : std_ulogic_vector((2**AWIDTH)-1 downto 1);
 
   -- memory core --
-  type   regfile_t is array ((2**AWIDTH)-1 downto 0) of std_ulogic_vector(DWIDTH-1 downto 0);
+  type   regfile_t is array ((2**AWIDTH)-1 downto 0) of std_ulogic_vector(31 downto 0);
   signal regfile : regfile_t;
 
 begin
@@ -65,23 +64,23 @@ begin
   -- Architecture Style 0: Register-Based SRAM with Synchronous Read ------------------------
   -- -------------------------------------------------------------------------------------------
   arch_sram_sync:
-  if (ARCH_SEL = 0) generate
+  if (ARCHSEL = 0) generate
 
     -- Register zero (x0) is just another physical register that has to be initialized by the CPU control.
     -- Writes to x0 are inhibited unless the control forces a write (writing zero) to re-initialize x0.
-    rf_we <= (ctrl_i.rf_wb_en and or_reduce_f(ctrl_i.rf_rd(AWIDTH-1 downto 0))) or ctrl_i.rf_zero;
-    addr  <= (others => '0') when (ctrl_i.rf_zero  = '1') else -- force rd = zero
-             ctrl_i.rf_rd    when (ctrl_i.rf_wb_en = '1') else ctrl_i.rf_rs1; -- multiplexed rd/rs1
+    rf_we <= (rd_we_i and or_reduce_f(rd_addr_i(AWIDTH-1 downto 0))) or zero_i;
+    addr  <= (others => '0') when (zero_i  = '1') else -- force rd = zero
+             rd_addr_i       when (rd_we_i = '1') else rs1_addr_i; -- multiplexed rd/rs1
 
     -- synchronous write & read (SDPRAM) --
     rf_access: process(clk_i)
     begin
       if rising_edge(clk_i) then
         if (rf_we = '1') then
-          regfile(to_integer(unsigned(addr(AWIDTH-1 downto 0)))) <= rd_i;
+          regfile(to_integer(unsigned(addr(AWIDTH-1 downto 0)))) <= rd_data_i;
         end if;
-        rs1_o <= regfile(to_integer(unsigned(addr(AWIDTH-1 downto 0))));
-        rs2_o <= regfile(to_integer(unsigned(ctrl_i.rf_rs2(AWIDTH-1 downto 0))));
+        rs1_data_o <= regfile(to_integer(unsigned(addr(AWIDTH-1 downto 0))));
+        rs2_data_o <= regfile(to_integer(unsigned(rs2_addr_i(AWIDTH-1 downto 0))));
       end if;
     end process;
 
@@ -95,17 +94,17 @@ begin
   -- Architecture Style 1: Register-Based SRAM with Asynchronous Read -----------------------
   -- -------------------------------------------------------------------------------------------
   arch_sram_async:
-  if (ARCH_SEL = 1) generate
+  if (ARCHSEL = 1) generate
 
     -- multiplexed rd/rs1 address to map to SDPRAM --
-    addr <= ctrl_i.rf_rd when (ctrl_i.rf_wb_en = '1') else ctrl_i.rf_rs1;
+    addr <= rd_addr_i when (rd_we_i = '1') else rs1_addr_i;
 
     -- synchronous write --
     rf_write: process(clk_i)
     begin
       if rising_edge(clk_i) then
-        if (ctrl_i.rf_wb_en = '1') then
-          regfile(to_integer(unsigned(addr(AWIDTH-1 downto 0)))) <= rd_i;
+        if (rd_we_i = '1') then
+          regfile(to_integer(unsigned(addr(AWIDTH-1 downto 0)))) <= rd_data_i;
         end if;
       end if;
     end process;
@@ -120,12 +119,12 @@ begin
         if (ctrl_i.rf_rs1 = "00000") then -- reading x0
           rs1_o <= (others => '0');
         else
-          rs1_o <= regfile(to_integer(unsigned(addr(AWIDTH-1 downto 0))));
+          rs1_data_o <= regfile(to_integer(unsigned(addr(AWIDTH-1 downto 0))));
         end if;
-        if (ctrl_i.rf_rs2 = "00000") then -- reading x0
-          rs2_o <= (others => '0');
+        if (rs2_addr_i = "00000") then -- reading x0
+          rs2_data_o <= (others => '0');
         else
-          rs2_o <= regfile(to_integer(unsigned(ctrl_i.rf_rs2(AWIDTH-1 downto 0))));
+          rs2_data_o <= regfile(to_integer(unsigned(rs2_addr_i(AWIDTH-1 downto 0))));
         end if;
       end if;
     end process;
@@ -141,12 +140,12 @@ begin
   -- Architecture Style 2: Register-Based with Hardware Reset -------------------------------
   -- -------------------------------------------------------------------------------------------
   arch_reg:
-  if (ARCH_SEL = 2) generate
+  if (ARCHSEL = 2) generate
 
     -- write select --
     onehot_gen:
     for i in 1 to (2**AWIDTH)-1 generate
-      onehot(i) <= ctrl_i.rf_wb_en when (unsigned(ctrl_i.rf_rd(AWIDTH-1 downto 0)) = to_unsigned(i, AWIDTH)) else '0';
+      onehot(i) <= rd_we_i when (unsigned(rd_addr_i(AWIDTH-1 downto 0)) = to_unsigned(i, AWIDTH)) else '0';
     end generate;
 
     -- individual registers --
@@ -158,7 +157,7 @@ begin
           regfile(i) <= (others => '0');
         elsif rising_edge(clk_i) then
           if (onehot(i) = '1') then
-            regfile(i) <= rd_i;
+            regfile(i) <= rd_data_i;
           end if;
         end if;
       end process;
@@ -169,8 +168,8 @@ begin
     rf_read: process(clk_i)
     begin
       if rising_edge(clk_i) then
-        rs1_o <= regfile(to_integer(unsigned(ctrl_i.rf_rs1(AWIDTH-1 downto 0))));
-        rs2_o <= regfile(to_integer(unsigned(ctrl_i.rf_rs2(AWIDTH-1 downto 0))));
+        rs1_data_o <= regfile(to_integer(unsigned(rs1_addr_i(AWIDTH-1 downto 0))));
+        rs2_data_o <= regfile(to_integer(unsigned(rs2_addr_i(AWIDTH-1 downto 0))));
       end if;
     end process;
 
@@ -185,7 +184,7 @@ begin
   -- Architecture Style 3: Latch-Based ------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   arch_latch:
-  if (ARCH_SEL = 3) generate
+  if (ARCHSEL = 3) generate
 
     -- write buffer --
     rf_write: process(rstn_i, clk_i)
@@ -219,15 +218,14 @@ begin
     rf_read: process(clk_i)
     begin
       if rising_edge(clk_i) then
-        rs1_o <= regfile(to_integer(unsigned(ctrl_i.rf_rs1(AWIDTH-1 downto 0))));
-        rs2_o <= regfile(to_integer(unsigned(ctrl_i.rf_rs2(AWIDTH-1 downto 0))));
+        rs1_data_o <= regfile(to_integer(unsigned(rs1_addr_i(AWIDTH-1 downto 0))));
+        rs2_data_o <= regfile(to_integer(unsigned(rs2_addr_i(AWIDTH-1 downto 0))));
       end if;
     end process;
 
     -- unused --
     rf_we <= '0';
-    addr  <= (others => '0');
 
   end generate;
 
-end Architecture;
+end architecture;

--- a/rtl/core/neorv32_cpu_regfile.vhd
+++ b/rtl/core/neorv32_cpu_regfile.vhd
@@ -27,19 +27,24 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_regfile is
   generic (
-    DWIDTH   : natural;             -- data width
-    AWIDTH   : natural;             -- address width
-    ARCH_SEL : natural range 0 to 3 -- architecture style select
+    AWIDTH  : natural range 4 to 5; -- address width
+    ARCHSEL : natural range 0 to 3  -- architecture style select
   );
   port (
     -- global control --
-    clk_i  : in  std_ulogic; -- global clock, rising edge
-    rstn_i : in  std_ulogic; -- global reset, low-active, async
-    ctrl_i : in  ctrl_bus_t; -- main control bus
-    -- operands --
-    rd_i   : in  std_ulogic_vector(DWIDTH-1 downto 0); -- destination data rd
-    rs1_o  : out std_ulogic_vector(DWIDTH-1 downto 0); -- source data rs1
-    rs2_o  : out std_ulogic_vector(DWIDTH-1 downto 0)  -- source data rs2
+    clk_i      : in  std_ulogic; -- global clock, rising edge
+    rstn_i     : in  std_ulogic; -- global reset, low-active, async
+    zero_i     : in  std_ulogic; -- force write to x0 (for SRAM memory only)
+    -- write port (rd) --
+    rd_we_i    : in  std_ulogic;                     -- write-enable
+    rd_addr_i  : in  std_ulogic_vector(4 downto 0);  -- address
+    rd_data_i  : in  std_ulogic_vector(31 downto 0); -- write data
+    -- read port 1 (rs1) --
+    rs1_addr_i : in  std_ulogic_vector(4 downto 0);  -- address
+    rs1_data_o : out std_ulogic_vector(31 downto 0); -- read data
+    -- read port 1 (rs2) --
+    rs2_addr_i : in  std_ulogic_vector(4 downto 0);  -- address
+    rs2_data_o : out std_ulogic_vector(31 downto 0)  -- read data
   );
 end entity;
 

--- a/rtl/core/neorv32_cpu_regfile.vhd
+++ b/rtl/core/neorv32_cpu_regfile.vhd
@@ -110,14 +110,11 @@ begin
     end process;
 
     -- asynchronous read + zero-insertion + output-register --
-    rf_read: process(rstn_i, clk_i)
+    rf_read: process(clk_i)
     begin
-      if (rstn_i = '0') then
-        rs1_o <= (others => '0');
-        rs2_o <= (others => '0');
-      elsif rising_edge(clk_i) then
-        if (ctrl_i.rf_rs1 = "00000") then -- reading x0
-          rs1_o <= (others => '0');
+      if rising_edge(clk_i) then
+        if (rs1_addr_i = "00000") then -- reading x0
+          rs1_data_o <= (others => '0');
         else
           rs1_data_o <= regfile(to_integer(unsigned(addr(AWIDTH-1 downto 0))));
         end if;
@@ -148,7 +145,7 @@ begin
       onehot(i) <= rd_we_i when (unsigned(rd_addr_i(AWIDTH-1 downto 0)) = to_unsigned(i, AWIDTH)) else '0';
     end generate;
 
-    -- individual registers --
+    -- individual registers with reset --
     regfile_gen:
     for i in 1 to (2**AWIDTH)-1 generate
       rf_write: process(rstn_i, clk_i)

--- a/rtl/core/neorv32_cpu_regfile.vhd
+++ b/rtl/core/neorv32_cpu_regfile.vhd
@@ -184,30 +184,37 @@ begin
   if (ARCHSEL = 3) generate
 
     -- write buffer --
-    rf_write: process(rstn_i, clk_i)
+    rf_write_buf: process(clk_i)
     begin
-      if (rstn_i = '0') then
-        wdata  <= (others => '0');
-        onehot <= (others => '0');
-      elsif rising_edge(clk_i) then
-        -- input register --
-        if (ctrl_i.rf_wb_en = '1') then
-          wdata <= rd_i;
+      if rising_edge(clk_i) then
+        -- data input register --
+        if (rd_we_i = '1') then
+          wdata <= rd_data_i;
         end if;
-        -- one-hot decoder --
-        onehot <= (others => '0');
-        for i in 1 to (2**AWIDTH)-1 loop
-          if (unsigned(ctrl_i.rf_rd(AWIDTH-1 downto 0)) = to_unsigned(i, AWIDTH)) then
-            onehot(i) <= ctrl_i.rf_wb_en;
-          end if;
-        end loop;
+        -- write-address buffer --
+        if (rd_we_i = '1') then
+          addr <= rd_addr_i;
+        else
+          addr <= (others => '0');
+        end if;
       end if;
     end process;
+
+    -- write select --
+    onehot_gen:
+    for i in 1 to (2**AWIDTH)-1 generate
+      onehot(i) <= '1' when (unsigned(addr(AWIDTH-1 downto 0)) = to_unsigned(i, AWIDTH)) else '0';
+    end generate;
 
     -- individual latches (transparent when clock is LOW) --
     regfile_gen:
     for i in 1 to (2**AWIDTH)-1 generate
-      regfile(i) <= wdata when (clk_i = '0') and (onehot(i) = '1') else regfile(i);
+      rf_write: process(clk_i, onehot, wdata)
+      begin
+        if (clk_i = '0') and (onehot(i) = '1') then
+          regfile(i) <= wdata;
+        end if;
+      end process;
     end generate;
     regfile(0) <= (others => '0'); -- x0 is hardwired to zero
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130304"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130305"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 


### PR DESCRIPTION
* use a simple types for interface only
  * to allow an easy repalcement by Verilog IP
* remove reset from data path registers
* optimize size of latch-based register file style