### PR TITLE
[instret counter] only increment for actually retired instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 02.08.2026 | 1.13.3.7 | `instret` counter: only increment for actually retired instructions | [#1615](https://github.com/stnolting/neorv32/pull/1615) |
 | 02.08.2026 | 1.13.3.6 | minor rtl cleanups and optimizations | [#1614](https://github.com/stnolting/neorv32/pull/1614) |
 | 02.08.2026 | 1.13.3.5 | CPU register file area optimizations and cleanups | [#1613](https://github.com/stnolting/neorv32/pull/1613) |
 | 01.08.2026 | 1.13.3.4 | RVFI: extend `order` to 64-bit as required by the spec | [#1612](https://github.com/stnolting/neorv32/pull/1612) |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -568,12 +568,6 @@ All remaining register are hardwired to zero.
 :sectnums:
 ==== (Machine) Counter and Timer CSRs
 
-.Instruction Retired Counter Increment
-[NOTE]
-The `[m]instret[h]` counter always increments when a instruction enters the pipeline's execute stage no matter
-if this instruction is actually going to retire or if it causes an exception.
-
-
 [discrete]
 ===== **`cycle[h]`**
 
@@ -653,14 +647,15 @@ cycle (CPU not in <<_sleep_mode>>). These registers are read/write only for mach
 |             | `0xb82` (`minstreth`)
 | Reset value | `0x00000000_00000000`
 | ISA         | <<_zicsr_isa_extension,`Zicsr`>> & <<_zicntr_isa_extension,`Zicntr`>>
-| Description | If not halted via the <<_mcountinhibit>> CSR the `minstret[h]` CSRs will increment with every retired instruction.
+| Description | If not halted via the <<_mcountinhibit>> CSR the `minstret[h]` CSRs will increment with every **retired** instruction.
 These registers are read/write only for machine-mode software
 |=======================
 
 .Instruction Retiring
-[IMPORTANT]
-Note that **all** executed instruction do increment the `[m]instret[h]` counters even if they do not retire
-(e.g. if the instruction causes an exception).
+[NOTE]
+According to the RISC-V specification, instructions that trigger an asynchronous exception or
+are interrupted by a debug mode or an interrupt request are not considered "retired". Hence, these
+events are not counted by `[m]instret[h]`.
 
 
 <<<
@@ -704,15 +699,10 @@ events is observed (logical OR). Note that the counter will only increment by 1 
 | 5   | `HPMCNT_EVENT_WAIT_LSU` | r/w | memory/bus/cache/etc. delay/wait cycle while executing any load or store operation (caused by a data bus wait cycle))
 | 4   | `HPMCNT_EVENT_WAIT_ALU` | r/w | delay/wait cycle caused by a _multi-cycle_ <<_cpu_arithmetic_logic_unit>> operation (e.g. bit-serial shift)
 | 3   | `HPMCNT_EVENT_WAIT_DIS` | r/w | instruction dispatch wait cycle (wait for instruction prefetch-buffer refill); caused by a fence instruction, a control flow transfer or a instruction fetch bus wait cycle (e.g. cache miss)
-| 2   | `HPMCNT_EVENT_CI`       | r/w | executed 16-bit/compressed (<<_c_isa_extension>>) instruction
-| 1   | `HPMCNT_EVENT_IR`       | r/w | executed instruction (16-bit/compressed or 32-bit/uncompressed)
+| 2   | `HPMCNT_EVENT_CI`       | r/w | retired compressed instruction (<<_c_isa_extension>>)
+| 1   | `HPMCNT_EVENT_IR`       | r/w | retired instruction (16-bit/compressed or 32-bit/uncompressed)
 | 0   | `HPMCNT_EVENT_CY`       | r/w | active clock cycle (CPU not in <<_sleep_mode>>)
 |=======================
-
-.Instruction Retiring ("Retired == Executed")
-[IMPORTANT]
-The CPU HPM/counter logic treats all executed instruction as "retired" even if they raise an exception,
-are intercepted by an interrupt, trigger a privilege mode change or were not meant to retire (i.e. claimed by the RISC-V spec.).
 
 .Atomic Memory Access
 [NOTE]

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -166,6 +166,8 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
   signal cnt_event    : std_ulogic_vector(cnt_event_width_c-1 downto 0); -- counter events
   signal ebreak_trig  : std_ulogic; -- environment break exception trigger
   signal trap_env     : std_ulogic_vector(6 downto 0); -- environment call cause-value helper
+  signal retire_start : std_ulogic; -- start of instruction retire tracking
+  signal retired      : std_ulogic; -- tracked instruction has retired
 
 begin
 
@@ -546,6 +548,23 @@ begin
   cnt_event(cnt_event_delta_c)    <= '1' when (ctrl.if_reset = '1') and (exec.ir(6 downto 2) /= "00011") else '0'; -- control flow transfer
   cnt_event(cnt_event_load_c)     <= '1' when (ctrl.lsu_req = '1') and (ctrl.lsu_rd = '1')               else '0'; -- memory load
   cnt_event(cnt_event_store_c)    <= '1' when (ctrl.lsu_req = '1') and (ctrl.lsu_wr = '1')               else '0'; -- memory store
+
+  -- retire tacking --
+  retire_tracking: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      retire_start <= '0';
+    elsif rising_edge(clk_i) then
+      if (exec.state = S_DISPATCH) then -- instruction completed
+        retire_start <= '0';
+      elsif (exec.state = S_EXECUTE) then -- instruction started
+        retire_start <= '1';
+      end if;
+    end if;
+  end process;
+
+  -- instruction has retired: execution completed without any trap --
+  retired <= '1' when (retire_start = '1') and (exec.state = S_DISPATCH) and (env_pend = '0') and (exc_fire = '0') else '0';
 
 
   -- ****************************************************************************************************************************

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -540,8 +540,8 @@ begin
   -- Counter Events -------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   cnt_event(cnt_event_cy_c)       <= '0' when (exec.state = S_SLEEP)                                     else '1'; -- active cycle
-  cnt_event(cnt_event_ir_c)       <= '1' when (exec.state = S_EXECUTE)                                   else '0'; -- retired (=executed) instr.
-  cnt_event(cnt_event_ci_c)       <= '1' when (exec.state = S_EXECUTE) and (exec.ci = '1')               else '0'; -- executed compressed instr.
+  cnt_event(cnt_event_ir_c)       <= '1' when (retired = '1')                                            else '0'; -- retired instr.
+  cnt_event(cnt_event_ci_c)       <= '1' when (retired = '1') and (exec.ci = '1')                        else '0'; -- retired compressed instr.
   cnt_event(cnt_event_wait_dis_c) <= '1' when (exec.state = S_DISPATCH) and (frontend_i.valid = '0')     else '0'; -- instruction dispatch wait
   cnt_event(cnt_event_wait_alu_c) <= '1' when (exec.state = S_ALU_WAIT)                                  else '0'; -- multi-cycle ALU wait
   cnt_event(cnt_event_wait_lsu_c) <= '1' when (ctrl.lsu_req = '0') and (exec.state = S_MEM_RSP)          else '0'; -- load/store memory wait

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -528,6 +528,7 @@ begin
   ctrl_o.ir_opcode    <= exec.ir(instr_opcode_msb_c downto instr_opcode_lsb_c);
   ctrl_o.ir_rvc       <= exec.irc;
   -- status --
+  ctrl_o.cpu_exec     <= '1' when (exec.state = S_EXECUTE) else '0';
   ctrl_o.cpu_priv     <= csr.prv_level;
   ctrl_o.cpu_trap     <= env_enter;
   ctrl_o.cpu_sync_exc <= exc_fire;

--- a/rtl/core/neorv32_cpu_hwtrig.vhd
+++ b/rtl/core/neorv32_cpu_hwtrig.vhd
@@ -182,7 +182,7 @@ begin
     elsif rising_edge(clk_i) then
       for i in 0 to NUM_TRIGGERS-1 loop
         match(i) <= (not ctrl_i.cpu_debug) and (match(i) or -- keep active until we are in debug-mode
-                    (tdata1_exec(i)  and cmp_inst(i) and ctrl_i.cnt_event(cnt_event_ir_c))    or -- execute
+                    (tdata1_exec(i)  and cmp_inst(i) and ctrl_i.cpu_exec)                     or -- execute
                     (tdata1_store(i) and cmp_data(i) and ctrl_i.cnt_event(cnt_event_store_c)) or -- store
                     (tdata1_load(i)  and cmp_data(i) and ctrl_i.cnt_event(cnt_event_load_c)));   -- load
       end loop;

--- a/rtl/core/neorv32_cpu_trace.vhd
+++ b/rtl/core/neorv32_cpu_trace.vhd
@@ -62,11 +62,11 @@ begin
       arbiter.order <= (others => '0');
     elsif rising_edge(clk_i) then
       -- sampling control: start trace cycle when in EXECUTE state --
-      arbiter.state <= (arbiter.state or ctrl_i.cnt_event(cnt_event_ir_c)) and (not done);
+      arbiter.state <= (arbiter.state or ctrl_i.cpu_exec) and (not done);
       -- trap-entry detector: buffer trap entry until trace commit --
       arbiter.entry <= (arbiter.entry or ctrl_i.cpu_trap) and (not valid);
       -- delta detector: buffer delta trigger until we are back in EXECUTE stage --
-      arbiter.delta <= (arbiter.delta or ctrl_i.cnt_event(cnt_event_delta_c)) and (not ctrl_i.cnt_event(cnt_event_ir_c));
+      arbiter.delta <= (arbiter.delta or ctrl_i.cnt_event(cnt_event_delta_c)) and (not ctrl_i.cpu_exec);
       -- instruction counter --
       if (valid = '1') then
         arbiter.order <= std_ulogic_vector(unsigned(arbiter.order) + 1);
@@ -96,7 +96,7 @@ begin
       trace_buf.halt  <= not ctrl_i.cnt_event(cnt_event_cy_c);
       trace_buf.intr  <= arbiter.entry;
       trace_buf.ixl   <= "01"; -- XLEN = 32-bit
-      if (ctrl_i.cnt_event(cnt_event_ir_c) = '1') then
+      if (ctrl_i.cpu_exec = '1') then
         trace_buf.mode  <= ctrl_i.cpu_priv & ctrl_i.cpu_priv;
         trace_buf.debug <= ctrl_i.cpu_debug;
         trace_buf.compr <= ctrl_i.cnt_event(cnt_event_ci_c);

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130306"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130307"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -698,6 +698,7 @@ package neorv32_package is
     ir_opcode    : std_ulogic_vector(6 downto 0);  -- opcode bit field
     ir_rvc       : std_ulogic_vector(15 downto 0); -- compressed instruction word
     -- status --
+    cpu_exec     : std_ulogic;                     -- attempting to execute current instruction
     cpu_priv     : std_ulogic;                     -- effective privilege mode
     cpu_trap     : std_ulogic;                     -- set when CPU is entering trap
     cpu_sync_exc : std_ulogic;                     -- set when CPU encounters a synchronous exception
@@ -742,6 +743,7 @@ package neorv32_package is
     ir_funct12   => (others => '0'),
     ir_opcode    => (others => '0'),
     ir_rvc       => (others => '0'),
+    cpu_exec     => '0',
     cpu_priv     => '0',
     cpu_trap     => '0',
     cpu_sync_exc => '0',


### PR DESCRIPTION
Fixing #1610.

Do not increment `instret` if
* instruction causes a synchronous exception
* instruction gets interrupted by an interrupt request
* instruction gets interrupted by an debug request