### PR TITLE
[ci] build documentation: install tools natively

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -30,9 +30,10 @@ jobs:
       - name: '📦 Install Doxygen'
         run: |
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends doxygen graphviz
+          sudo apt-get install --yes --no-install-recommends doxygen
 
       - name: '🛠️ Modify Doxyfile'
+        shell: bash
         run: |
           ls -al ./docs
           sed -i 's/$(PWD)\/../$(GITHUB_WORKSPACE)/g' ./docs/Doxyfile
@@ -47,7 +48,6 @@ jobs:
           path: doxygen_build/html
           if-no-files-found: error
 
-
   asciidoctor:
     runs-on: ubuntu-latest
     name: 'Datasheet & User Guide'
@@ -59,15 +59,16 @@ jobs:
       - name: '📦 Install Asciidoctor'
         run: |
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends build-essential graphviz ruby-full
+          sudo apt-get install --yes --no-install-recommends build-essential ruby-full ruby-dev nodejs npm
           sudo gem install --no-document asciidoctor asciidoctor-pdf asciidoctor-diagram rouge
+          sudo npm install --global wavedrom-cli
 
       - name: '🔎 Show Tool Versions'
         run: |
           ruby --version
           asciidoctor --version
           asciidoctor-pdf --version
-          dot --version
+          wavedrom-cli --version
 
       - name: '📚 Build Datasheet and User Guide'
         run: make -C docs all
@@ -78,7 +79,6 @@ jobs:
           name: NEORV32
           path: docs/public
           if-no-files-found: error
-
 
   deploy:
     if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/'))
@@ -108,8 +108,7 @@ jobs:
       - name: '📦 Deploy to GitHub Releases'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload nightly_release NEORV32-SITE-nightly.tar.gz pdf/NEORV32*nightly.pdf --clobber
+        run: gh release upload nightly_release NEORV32-SITE-nightly.tar.gz pdf/NEORV32*nightly.pdf --clobber
 
       - name: '🚀 Deploy to GitHub Pages'
         run: |

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -6,16 +6,17 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'sw/**'
       - '.github/workflows/Documentation.yml'
   pull_request:
     paths:
       - 'docs/**'
+      - 'sw/**'
       - '.github/workflows/Documentation.yml'
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pages: write
+  contents: read
 
 jobs:
 
@@ -38,8 +39,11 @@ jobs:
           ls -al ./docs
           sed -i 's/$(PWD)\/../$(GITHUB_WORKSPACE)/g' ./docs/Doxyfile
 
+      - name: '🔎 Show Tool Versions'
+        run: doxygen --version
+
       - name: '📚 Generate Doxygen Documentation'
-        run: doxygen ./docs/Doxyfile
+        run: make -C docs doxygen
 
       - name: '📤 Upload Artifact'
         uses: actions/upload-artifact@v7
@@ -56,11 +60,16 @@ jobs:
       - name: '🧰 Repository Checkout'
         uses: actions/checkout@v6
 
-      - name: '📦 Install Asciidoctor'
+      - name: '💎 Set Up Ruby'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0'
+
+      - name: '📦 Install Asciidoctor and Wavedrom'
         run: |
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends build-essential ruby-full ruby-dev nodejs npm
-          sudo gem install --no-document asciidoctor asciidoctor-pdf asciidoctor-diagram rouge
+          sudo apt-get install --yes --no-install-recommends nodejs npm
+          gem install --no-document asciidoctor asciidoctor-pdf asciidoctor-diagram rouge
           sudo npm install --global wavedrom-cli
 
       - name: '🔎 Show Tool Versions'

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -24,26 +24,28 @@ jobs:
     name: 'API Documentation'
 
     steps:
+      - name: '🧰 Repository Checkout'
+        uses: actions/checkout@v6
 
-    - name: '🧰 Repository Checkout'
-      uses: actions/checkout@v6
+      - name: '📦 Install Doxygen'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends doxygen graphviz
 
-    - name: '🛠️ Modifying Doxyfile'
-      run: |
-        ls -al ./docs
-        sed -i 's/$(PWD)\/../$(GITHUB_WORKSPACE)/g' ./docs/Doxyfile
+      - name: '🛠️ Modify Doxyfile'
+        run: |
+          ls -al ./docs
+          sed -i 's/$(PWD)\/../$(GITHUB_WORKSPACE)/g' ./docs/Doxyfile
 
-    - name: '📚 Generate Doxygen Documentation'
-      uses: mattnotmitt/doxygen-action@v1.12.0
-      with:
-        working-directory: '.'
-        doxyfile-path: 'docs/Doxyfile'
+      - name: '📚 Generate Doxygen Documentation'
+        run: doxygen ./docs/Doxyfile
 
-    - name: '📤 Upload Artifact'
-      uses: actions/upload-artifact@v7
-      with:
-        name: NEORV32-Doxygen
-        path: doxygen_build/html
+      - name: '📤 Upload Artifact'
+        uses: actions/upload-artifact@v7
+        with:
+          name: NEORV32-Doxygen
+          path: doxygen_build/html
+          if-no-files-found: error
 
 
   asciidoctor:
@@ -51,20 +53,31 @@ jobs:
     name: 'Datasheet & User Guide'
 
     steps:
+      - name: '🧰 Repository Checkout'
+        uses: actions/checkout@v6
 
-    - name: '🧰 Repository Checkout'
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
+      - name: '📦 Install Asciidoctor'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommend build-essential graphviz ruby-full
+          sudo gem install --no-document asciidoctor asciidoctor-pdf asciidoctor-diagram rouge
 
-    - name: '📚 Build Datasheet and User Guide (PDF and HTML)'
-      run: make -C docs container
+      - name: '🔎 Show Tool Versions'
+        run: |
+          ruby --version
+          asciidoctor --version
+          asciidoctor-pdf --version
+          dot --version
 
-    - name: '📤 Upload Artifact: HTML'
-      uses: actions/upload-artifact@v7
-      with:
-        name: NEORV32
-        path: docs/public
+      - name: '📚 Build Datasheet and User Guide'
+        run: make -C docs all
+
+      - name: '📤 Upload Artifact: HTML and PDF'
+        uses: actions/upload-artifact@v7
+        with:
+          name: NEORV32
+          path: docs/public
+          if-no-files-found: error
 
 
   deploy:
@@ -76,40 +89,36 @@ jobs:
     name: 'Deploy to Releases and Pages'
 
     steps:
+      - name: '🧰 Repository Checkout'
+        uses: actions/checkout@v6
 
-    - name: '🧰 Repository Checkout'
-      uses: actions/checkout@v6
+      - name: '📥 Download Artifacts'
+        uses: actions/download-artifact@v8
 
-    - name: '📥 Download Artifacts'
-      uses: actions/download-artifact@v8
+      - name: '🛠️ Organize public subdir and create a tarball'
+        run: |
+          mv NEORV32 public
+          mv public/pdf ./
+          mv NEORV32-Doxygen public/sw
+          tar zvcf NEORV32-SITE-nightly.tar.gz -C public .
+          cd pdf
+          mv NEORV32.pdf NEORV32-nightly.pdf
+          mv NEORV32_UserGuide.pdf NEORV32_UserGuide-nightly.pdf
 
-    - name: '🛠️ Organize public subdir and create a tarball'
-      run: |
-        mv NEORV32 public
-        mv public/pdf ./
-        mv NEORV32-Doxygen public/sw
-        tar zvcf NEORV32-SITE-nightly.tar.gz -C public .
-        cd pdf
-        mv NEORV32.pdf NEORV32-nightly.pdf
-        mv NEORV32_UserGuide.pdf NEORV32_UserGuide-nightly.pdf
+      - name: '📦 Deploy to GitHub Releases'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload nightly_release NEORV32-SITE-nightly.tar.gz pdf/NEORV32*nightly.pdf --clobber
 
-    # Tagged: create a pre-release or a release (semver)
-    # Untagged: update the assets of pre-release 'nightly_release'
-    - name: '📦 Deploy to GitHub-Releases'
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: |
-        gh release upload nightly_release NEORV32-SITE-nightly.tar.gz pdf/NEORV32*nightly.pdf --clobber
-
-    - name: '🚀 Deploy to GitHub-Pages'
-      run: |
-        cd public
-        git init
-        # use authenticated remote (GITHUB_TOKEN is available as a secret)
-        git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
-        touch .nojekyll
-        git add .
-        git config --local user.email "push@gha"
-        git config --local user.name "GHA"
-        git commit -am "update ${{ github.sha }}"
-        git push -u origin +HEAD:gh-pages --force
+      - name: '🚀 Deploy to GitHub Pages'
+        run: |
+          cd public
+          git init
+          git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          touch .nojekyll
+          git add .
+          git config --local user.email "push@gha"
+          git config --local user.name "GHA"
+          git commit -m "update ${{ github.sha }}"
+          git push -u origin +HEAD:gh-pages --force

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -59,7 +59,7 @@ jobs:
       - name: '📦 Install Asciidoctor'
         run: |
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommend build-essential graphviz ruby-full
+          sudo apt-get install --yes --no-install-recommends build-essential graphviz ruby-full
           sudo gem install --no-document asciidoctor asciidoctor-pdf asciidoctor-diagram rouge
 
       - name: '🔎 Show Tool Versions'

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: NEORV32-Doxygen
-          path: doxygen_build/html
+          path: docs/doxygen_build/html
           if-no-files-found: error
 
   asciidoctor:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,92 +1,125 @@
 .DEFAULT_GOAL := help
 
-PUBLIC_DIR = public
-PUBLIC_IMG_DIR = $(PUBLIC_DIR)/img
+PUBLIC_DIR := public
+PUBLIC_IMG_DIR := $(PUBLIC_DIR)/img
+PUBLIC_PDF_DIR := $(PUBLIC_DIR)/pdf
+PUBLIC_UG_DIR := $(PUBLIC_DIR)/ug
 
-DOXYGEN_IMG_DIR = doxygen_build/html/docs/figures
+DOXYGEN_BUILD_DIR := doxygen_build
+DOXYGEN_IMG_DIR := $(DOXYGEN_BUILD_DIR)/html/docs/figures
+
+.PHONY: all site pdf html ug-pdf ug-html doxygen
+.PHONY: public-images doxygen-images revnumber clean help
 
 all: pdf html ug-pdf ug-html
 
-# Public folder
+# Generate the revision number first and then build all AsciiDoc documents
+site: revnumber
+	$(MAKE) all
+
+# Output directories
 $(PUBLIC_DIR):
-	@mkdir -p $(PUBLIC_DIR)
-
-# Copy images for datasheet and ug html
-$(PUBLIC_IMG_DIR): $(PUBLIC_DIR)
 	@mkdir -p $@
-	cp -vr figures/* $@
 
-# Copy images for doxygen
+$(PUBLIC_IMG_DIR): | $(PUBLIC_DIR)
+	@mkdir -p $@
+
+$(PUBLIC_PDF_DIR): | $(PUBLIC_DIR)
+	@mkdir -p $@
+
+$(PUBLIC_UG_DIR): | $(PUBLIC_DIR)
+	@mkdir -p $@
+
 $(DOXYGEN_IMG_DIR):
 	@mkdir -p $@
-	cp -vr figures/* $@
+
+# Copy images for datasheet and user guide
+public-images: $(PUBLIC_IMG_DIR)
+	cp -a figures/. $(PUBLIC_IMG_DIR)/
+
+# Copy images required by Doxygen
+doxygen-images: $(DOXYGEN_IMG_DIR)
+	cp -a figures/. $(DOXYGEN_IMG_DIR)/
 
 # Generate PDF datasheet
-pdf: $(PUBLIC_DIR)
-	[ -f revnumber.txt ] && REVNUMBER='-a revnumber='"$$(cat revnumber.txt)" || unset REVNUMBER; \
-	asciidoctor-pdf $$REVNUMBER \
+pdf: $(PUBLIC_PDF_DIR)
+	@set -eu; \
+	if [ -f revnumber.txt ]; then \
+	  set -- -a "revnumber=$$(cat revnumber.txt)"; \
+	else \
+	  set --; \
+	fi; \
+	asciidoctor-pdf "$$@" \
 	  -a allow-uri-read \
 	  -a pdf-theme=neorv32-theme.yml \
 	  -r asciidoctor-diagram \
 	  datasheet/main.adoc \
-	  --out-file $(PUBLIC_DIR)/pdf/NEORV32.pdf
+	  --out-file $(PUBLIC_PDF_DIR)/NEORV32.pdf
 
 # Generate HTML datasheet
-html: $(PUBLIC_IMG_DIR) $(PUBLIC_DIR)
-	[ -f revnumber.txt ] && REVNUMBER='-a revnumber='"$$(cat revnumber.txt)" || unset REVNUMBER; \
-	asciidoctor $$REVNUMBER \
+html: public-images
+	@set -eu; \
+	if [ -f revnumber.txt ]; then \
+	  set -- -a "revnumber=$$(cat revnumber.txt)"; \
+	else \
+	  set --; \
+	fi; \
+	asciidoctor "$$@" \
 	  -r asciidoctor-diagram \
 	  datasheet/index.adoc \
 	  --out-file $(PUBLIC_DIR)/index.html
 
 # Generate PDF user guide
-ug-pdf: $(PUBLIC_DIR)
-	[ -f revnumber.txt ] && REVNUMBER='-a revnumber='"$$(cat revnumber.txt)" || unset REVNUMBER; \
-	asciidoctor-pdf $$REVNUMBER \
+ug-pdf: $(PUBLIC_PDF_DIR)
+	@set -eu; \
+	if [ -f revnumber.txt ]; then \
+	  set -- -a "revnumber=$$(cat revnumber.txt)"; \
+	else \
+	  set --; \
+	fi; \
+	asciidoctor-pdf "$$@" \
 	  -a allow-uri-read \
 	  -a pdf-theme=neorv32-theme.yml \
 	  -r asciidoctor-diagram \
 	  userguide/main.adoc \
-	  --out-file $(PUBLIC_DIR)/pdf/NEORV32_UserGuide.pdf
+	  --out-file $(PUBLIC_PDF_DIR)/NEORV32_UserGuide.pdf
 
 # Generate HTML user guide
-ug-html: $(PUBLIC_IMG_DIR) $(PUBLIC_DIR)
-	[ -f revnumber.txt ] && REVNUMBER='-a revnumber='"$$(cat revnumber.txt)" || unset REVNUMBER; \
-	asciidoctor $$REVNUMBER \
+ug-html: public-images $(PUBLIC_UG_DIR)
+	@set -eu; \
+	if [ -f revnumber.txt ]; then \
+	  set -- -a "revnumber=$$(cat revnumber.txt)"; \
+	else \
+	  set --; \
+	fi; \
+	asciidoctor "$$@" \
 	  -r asciidoctor-diagram \
 	  userguide/index.adoc \
-	  --out-file $(PUBLIC_DIR)/ug/index.html
+	  --out-file $(PUBLIC_UG_DIR)/index.html
 
-# Generate DOXYGEN software documentation
-doxygen: $(DOXYGEN_IMG_DIR)
+# Generate Doxygen software documentation
+doxygen: doxygen-images
 	doxygen Doxyfile
 
-# Generate revnumber.txt for overriding the revnumber attribute in 'pdf' and/or 'html'
+# Generate revnumber.txt without modifying local Git tags
 revnumber:
-	if [ `git tag -l | grep nightly_release` ]; then git tag -d nightly_release; fi
 	git describe --long --tags | sed 's#\([^-]*-g\)#r\1#;' > revnumber.txt
 	cat revnumber.txt
 
-# Build 'pdf' and 'html' in an 'asciidoctor-wavedrom' container
-container: revnumber
-	docker run --rm -v /$(shell pwd)://documents/ btdi/asciidoctor make all
-
 clean:
-	@rm -rf $(PUBLIC_IMG_DIR)
 	@rm -rf $(PUBLIC_DIR)
-	@rm -rf doxygen_build
+	@rm -rf $(DOXYGEN_BUILD_DIR)
 	@rm -f revnumber.txt
 
-# Help
 help:
 	@echo "Targets:"
-	@echo " all       - build datasheet and user guide as pdf and HTML file"
+	@echo " all       - build datasheet and user guide as PDF and HTML"
+	@echo " site      - generate revnumber.txt and build all AsciiDoc documents"
+	@echo " pdf       - build datasheet PDF"
+	@echo " html      - build datasheet HTML"
+	@echo " ug-pdf    - build user guide PDF"
+	@echo " ug-html   - build user guide HTML"
+	@echo " doxygen   - build Doxygen software documentation"
+	@echo " revnumber - generate revnumber.txt from the current Git revision"
+	@echo " clean     - delete generated files and directories"
 	@echo " help      - show this text"
-	@echo " pdf       - build datasheet as pdf file (public/pdf/NEORV32.pdf)"
-	@echo " html      - build datasheet as HTML page (public/index.html)"
-	@echo " ug-pdf    - build user guide as pdf file (public/pdf/NEORV32_UserGuide.pdf)"
-	@echo " ug-html   - build user guide as HTML page (public/ug/index.html)"
-	@echo " doxygen   - build software documentation as HTML page (doxygen_build/html/index.html)"
-	@echo " revnumber - for overriding the revnumber attribute in 'pdf' and/or 'html'"
-	@echo " container - Build 'pdf' and 'html' in an 'asciidoctor-wavedrom' container"
-	@echo " clean     - delete output files and directories"

--- a/docs/userguide/building_the_documentation.adoc
+++ b/docs/userguide/building_the_documentation.adoc
@@ -12,20 +12,20 @@ or as PDF documents.
 Pre-rendered PDFs are available online as nightly pre-releases: https://github.com/stnolting/neorv32/releases/tag/nightly_release
 The HTML-based documentation is also available online at the project's https://stnolting.github.io/neorv32/[GitHub Page].
 
-The makefile provides a help target to show all available build options and their according outputs.
+The makefile provides a help target to show all available build options:
 
 [source,bash]
 ----
 neorv32/docs$ make help
+Targets:
+ all       - build datasheet and user guide as PDF and HTML
+ site      - generate revnumber.txt and build all AsciiDoc documents
+ pdf       - build datasheet PDF
+ html      - build datasheet HTML
+ ug-pdf    - build user guide PDF
+ ug-html   - build user guide HTML
+ doxygen   - build Doxygen software documentation
+ revnumber - generate revnumber.txt from the current Git revision
+ clean     - delete generated files and directories
+ help      - show this text
 ----
-
-.Example: Generate HTML documentation (data sheet) using `asciidoctor`
-[source,bash]
-----
-neorv32/docs$ make html
-----
-
-.Using Containers for Building
-[TIP]
-If you don't have `asciidoctor` / `asciidoctor-pdf` installed, you can still generate all the documentation using
-a _docker container_ via `make container`.


### PR DESCRIPTION
Trying to fix #1618.

Do not use any containers or pre-defined GH actions for setting up the tools.
