### PR TITLE
[SoC] remove reset from registers where it is not strictly necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 08.08.2026 | 1.13.3.8 | remove reset from registers where it is not strictly necessary | [#1620](https://github.com/stnolting/neorv32/pull/1620) |
 | 02.08.2026 | 1.13.3.7 | `instret` counter: only increment for actually retired instructions | [#1615](https://github.com/stnolting/neorv32/pull/1615) |
 | 02.08.2026 | 1.13.3.6 | minor rtl cleanups and optimizations | [#1614](https://github.com/stnolting/neorv32/pull/1614) |
 | 02.08.2026 | 1.13.3.5 | CPU register file area optimizations and cleanups | [#1613](https://github.com/stnolting/neorv32/pull/1613) |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ and targets digital design / RISC-V beginners as well as experienced users.
 
 * :recycle: Looking for an **all-Verilog** version? Have a look at the [auto-conversion setup](rtl/verilog).
 * :mag: [Continuous integration](#project-status) to check for regressions.
+* :heavy_check_mark: Passes the official RISC-V [Architectural Certification Tests](https://github.com/stnolting/neorv32-riscv-act).
 * :open_file_folder: [Exemplary setups](https://github.com/stnolting/neorv32-setups) and
 [community projects](https://github.com/stnolting/neorv32-setups/blob/main/README.md#Community-Projects)
 targeting various FPGA boards and toolchains to get started.

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -127,6 +127,7 @@ The CPU does not support resolving unaligned memory access by the hardware. Any 
 unaligned memory access will raise an exception to allow a software-based emulation.
 See section <<_application_context_handling>> for more information.
 
+
 :sectnums:
 ==== CPU Front-End
 
@@ -139,6 +140,7 @@ to the CPU back-end for execution.
 The IPB allows the front-end to do "speculative" instruction fetches as it keeps fetching the next consecutive
 instruction all the time. This also allows to decouple instruction fetch and instruction execution so both stages
 can operate in parallel to increase performance.
+
 
 :sectnums:
 ==== CPU Back-End
@@ -153,6 +155,7 @@ The division into individual micro-operations not only allows for small hardware
 cycles (e.g., the ALU: for arithmetic/logical calculations and also for calculating the next program counter). It also
 allows for precise monitoring of execution and the generation of precise traps. Hence, the back-end also includes
 <<_control_and_status_registers_csrs>>, the<<_traps_exceptions_and_interrupts>> logic and the <<_cpu_debug_mode>> controller.
+
 
 :sectnums:
 ==== CPU Register File
@@ -436,6 +439,7 @@ can be implemented most efficiently for the target platform/technology. see sect
 |=======================
 
 
+:sectnums:
 ==== Sleep Mode
 
 The NEORV32 CPU provides a single sleep mode that can be entered to power-down the core reducing
@@ -450,6 +454,13 @@ source becomes _pending_ or if a debug session is started.
 When executed in debug-mode or during single-stepping, `wfi` will behave as simple `nop` without entering sleep mode.
 
 
+:sectnums:
+==== CPU Reset
+
+See <<_reset_implementation>>.
+
+
+:sectnums:
 ==== Full Virtualization
 
 Just like the RISC-V ISA, the NEORV32 aims to provide _maximum virtualization_ capabilities on CPU and SoC level to

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -394,14 +394,26 @@ of the following sources:
 [TIP]
 The actual reset cause can be determined via the <<_watchdog_timer_wdt>>.
 
-If any of these sources triggers a reset, the internal system-wide reset will be active for at least 4 clock cycles ensuring
-a valid reset of the entire processor. This system reset is asserted _asynchronoulsy_ if triggered by the external
-`rstn_i` signal and is asserted _synchronously_ if triggered by an internal reset source. However, the system reset is
-always de-asserted _synchronously_ at the next rising clock edge.
+If any of these sources triggers a reset, the internal system-wide reset will be active for at least 4 clock cycles
+ensuring a valid reset of the entire processor (reset sequencer VHDL module: `neorv32_sys_reset`). This system reset is
+asserted _asynchronoulsy_ if triggered by the external `rstn_i` signal and is asserted _synchronously_ if triggered by
+an internal reset source. However, the system reset is always de-asserted _synchronously_ at the next rising clock edge.
 
-Internally, **all registers** that are not meant for mapping to blockRAM (like the register file) do provide a dedicated and
-**low-active asynchronous** hardware reset. This asynchronous reset ensures that the entire processor logic is reset to a
-defined state even if the main clock is not operational yet.
+==== Reset Implementation
+
+Internally, only registers that require a defined and controlled processor startup are equipped with a dedicated,
+**low-active asynchronous** hardware reset. These include, in particular, state registers of FSMs, control and configuration
+registers, and registers of the control logic. The asynchronous reset sets these components to a defined initial state even
+when the main clock is not yet available.
+
+In contrast, registers whose contents are not relevant during or immediately after the reset do not have an explicit hardware
+reset. This applies, among other things, to memory structures, pipeline registers, data buffers, and synchronizers. The values
+contained therein may initially be undefined after the reset. However, reset control, status, and validity signals ensure that
+such values are not used before they have been replaced by valid data.
+
+The deliberate omission of reset logic reduces resource requirements and reset fan-out, improves timing characteristics, and
+facilitates the mapping of suitable memory structures to FPGA block RAM. As a result, the processor startup remains fully
+controlled without creating unnecessary reset structures in components that are purely for data storage.
 
 
 <<<

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -860,11 +860,9 @@ begin
 
   -- Data ALU -------------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  amo_alu: process(rstn_i, clk_i)
+  amo_alu: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      alu_res <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       case arbiter.cmd(2 downto 0) is
         when "000"  => alu_res <= arbiter.wdata; -- AMOSWAP.W
         when "001"  => alu_res <= std_ulogic_vector(unsigned(arbiter.rdata) + unsigned(arbiter.wdata)); -- AMOADD.W

--- a/rtl/core/neorv32_clint.vhd
+++ b/rtl/core/neorv32_clint.vhd
@@ -248,12 +248,9 @@ begin
 
   -- Interrupt Generator (comparator is split across two cycles) ----------------------------
   -- -------------------------------------------------------------------------------------------
-  irq_gen: process(rstn_i, clk_i)
+  irq_gen: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      cmp_lo_ge <= '0';
-      mti_o     <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       cmp_lo_ge <= cmp_lo_gt or cmp_lo_eq; -- low word greater-than or equal
       mti_o     <= cmp_hi_gt or (cmp_hi_eq and cmp_lo_ge);
     end if;

--- a/rtl/core/neorv32_debug_dtm.vhd
+++ b/rtl/core/neorv32_debug_dtm.vhd
@@ -75,13 +75,9 @@ begin
 
   -- JTAG Input Synchronizer ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  tap_synchronizer: process(rstn_i, clk_i)
+  tap_synchronizer: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      tck_ff <= (others => '0');
-      tdi_ff <= (others => '0');
-      tms_ff <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       tck_ff <= tck_ff(1 downto 0) & jtag_tck_i;
       tdi_ff <= tdi_ff(0) & jtag_tdi_i;
       tms_ff <= tms_ff(0) & jtag_tms_i;

--- a/rtl/core/neorv32_gpio.vhd
+++ b/rtl/core/neorv32_gpio.vhd
@@ -157,11 +157,9 @@ begin
   end generate;
 
   -- buffer pending interrupts until cleared or disabled --
-  irq_buffer: process(rstn_i, clk_i)
+  irq_buffer: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      irq_pend <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       irq_pend <= irq_en and ((irq_pend and irq_clrn) or irq_trig);
     end if;
   end process;

--- a/rtl/core/neorv32_gpio.vhd
+++ b/rtl/core/neorv32_gpio.vhd
@@ -117,12 +117,9 @@ begin
   end generate;
 
   -- input sampling --
-  input_stage: process(rstn_i, clk_i)
+  input_stage: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      port_in  <= (others => '0');
-      port_in2 <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       port_in  <= port_in_i(GPIO_NUM-1 downto 0);
       port_in2 <= port_in;
     end if;

--- a/rtl/core/neorv32_gptmr.vhd
+++ b/rtl/core/neorv32_gptmr.vhd
@@ -97,11 +97,9 @@ begin
   acc_addr <= bus_req_i.addr(7) & bus_req_i.addr(2);
 
   -- clock generator --
-  clk_gen: process(rstn_i, clk_i)
+  clk_gen: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      clken <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       clken <= clkgen_i(to_integer(unsigned(clkprsc)));
     end if;
   end process;

--- a/rtl/core/neorv32_gptmr.vhd
+++ b/rtl/core/neorv32_gptmr.vhd
@@ -172,11 +172,9 @@ begin
 
   -- Interrupt Generator --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  irq_generator: process(rstn_i, clk_i)
+  irq_generator: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      irq <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       for i in 0 to NUM_SLICES-1 loop
         if (enable(i) = '0') then
           irq(i) <= '0';

--- a/rtl/core/neorv32_neoled.vhd
+++ b/rtl/core/neorv32_neoled.vhd
@@ -159,11 +159,9 @@ begin
   tx_fifo.clr   <= not ctrl.enable;
 
   -- IRQ generator --
-  irq_generator: process(rstn_i, clk_i)
+  irq_generator: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      irq_o <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       irq_o <= ctrl.enable and (not tx_fifo.avail); -- IRQ if FIFO is empty
     end if;
   end process;

--- a/rtl/core/neorv32_onewire.vhd
+++ b/rtl/core/neorv32_onewire.vhd
@@ -224,11 +224,9 @@ begin
 
 
   -- IRQ if enabled and TX FIFO is empty and serial engine is idle --
-  irq_generator: process(rstn_i, clk_i)
+  irq_generator: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      irq_o <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       irq_o <= ctrl.enable and (not fifo.tx_avail) and (not busy);
     end if;
   end process;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130307"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130308"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_prim.vhd
+++ b/rtl/core/neorv32_prim.vhd
@@ -86,11 +86,9 @@ begin
     full  <= '1' when (r_pnt(AWIDTH) /= w_pnt(AWIDTH)) and (match = '1') else '0';
     empty <= '1' when (r_pnt(AWIDTH)  = w_pnt(AWIDTH)) and (match = '1') else '0';
     -- [important] 'avail' is synchronized to the read port --
-    status_reg: process(rstn_i, clk_i)
+    status_reg: process(clk_i)
     begin
-      if (rstn_i = '0') then
-        avail <= '0';
-      elsif rising_edge(clk_i) then
+      if rising_edge(clk_i) then
         avail <= not empty;
       end if;
     end process;

--- a/rtl/core/neorv32_pwm.vhd
+++ b/rtl/core/neorv32_pwm.vhd
@@ -138,11 +138,9 @@ begin
   end generate;
 
   -- clock generator --
-  clk_gen: process(rstn_i, clk_i)
+  clk_gen: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      clken <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       clken <= clkgen_i(to_integer(unsigned(clkprsc)));
     end if;
   end process;

--- a/rtl/core/neorv32_pwm.vhd
+++ b/rtl/core/neorv32_pwm.vhd
@@ -231,12 +231,9 @@ begin
 
   -- PWM Counter ----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  pwm_counter: process(rstn_i, clk_i)
+  pwm_counter: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      dir <= '0';
-      cnt <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       if (en_i = '0') then
         dir <= '0';
         cnt <= (others => '0');

--- a/rtl/core/neorv32_sdi.vhd
+++ b/rtl/core/neorv32_sdi.vhd
@@ -212,13 +212,9 @@ begin
 
   -- Input Synchronizer ---------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  synchronizer: process(rstn_i, clk_i)
+  synchronizer: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      sync_sck_ff <= (others => '0');
-      sync_csn_ff <= (others => '0');
-      sync_sdi_ff <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       sync_sck_ff <= sync_sck_ff(1 downto 0) & sdi_clk_i;
       sync_csn_ff <= sync_csn_ff(0) & sdi_csn_i;
       sync_sdi_ff <= sync_sdi_ff(0) & sdi_dat_i;

--- a/rtl/core/neorv32_sdi.vhd
+++ b/rtl/core/neorv32_sdi.vhd
@@ -199,11 +199,9 @@ begin
 
 
   -- interrupt generator --
-  irq_generator: process(rstn_i, clk_i)
+  irq_generator: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      irq_o <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       irq_o <= ctrl.enable and (
                (ctrl.irq_rx_nempty and      rx_fifo.avail) or -- RX FIFO not empty
                (ctrl.irq_rx_full   and (not rx_fifo.free)) or -- RX FIFO full

--- a/rtl/core/neorv32_slink.vhd
+++ b/rtl/core/neorv32_slink.vhd
@@ -226,11 +226,9 @@ begin
 
   -- Interrupt Generator --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  irq_gen: process(rstn_i, clk_i)
+  irq_gen: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      irq_o <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       irq_o <= ctrl.enable and (
                (ctrl.irq_rx_nempty and (    rx_fifo.avail)) or -- RX FIFO not empty
                (ctrl.irq_rx_full   and (not rx_fifo.free))  or -- RX FIFO full

--- a/rtl/core/neorv32_smc.vhd
+++ b/rtl/core/neorv32_smc.vhd
@@ -112,7 +112,6 @@ architecture neorv32_smc_rtl of neorv32_smc is
   component neorv32_smc_mac
   port (
     -- global control --
-    rstn_i      : in  std_ulogic;
     clk_i       : in  std_ulogic;
     -- configuration --
     cfg_en_i    : in  std_ulogic;
@@ -371,7 +370,6 @@ begin
   neorv32_smc_mac_inst: neorv32_smc_mac
   port map (
     -- global control --
-    rstn_i      => rstn_i,
     clk_i       => clk_i,
     -- configuration --
     cfg_en_i    => csr.enable,
@@ -442,7 +440,6 @@ use ieee.numeric_std.all;
 entity neorv32_smc_mac is
   port (
     -- global control --
-    rstn_i     : in  std_ulogic;                      -- global reset line, low-active, async
     clk_i      : in  std_ulogic;                      -- global clock line
     -- configuration --
     cfg_en_i    : in  std_ulogic;                     -- enable, reset when low
@@ -508,14 +505,9 @@ begin
 
   -- Access Arbiter Sync --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  arbiter_sync: process(rstn_i, clk_i)
+  arbiter_sync: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      mac.state <= S_INIT_0;
-      mac.isel  <= (others => '0');
-      mac.csn   <= (others => '1');
-      mac.rdata <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       mac <= mac_nxt;
       if (cfg_en_i = '0') then -- sync reset only for relevant signals
         mac.state <= S_INIT_0;

--- a/rtl/core/neorv32_spi.vhd
+++ b/rtl/core/neorv32_spi.vhd
@@ -316,12 +316,9 @@ begin
 
   -- SPI Clock Generator --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  clock_generator: process(rstn_i, clk_i)
+  clock_generator: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      spi_clk_en <= '0';
-      cdiv_cnt   <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       spi_clk_en <= '0'; -- default
       if (ctrl.enable = '0') then -- reset/disabled
         cdiv_cnt <= (others => '0');

--- a/rtl/core/neorv32_spi.vhd
+++ b/rtl/core/neorv32_spi.vhd
@@ -213,11 +213,9 @@ begin
 
 
   -- IRQ generator: IRQ if TX FIFO is empty and serial engine is idle --
-  irq_generator: process(rstn_i, clk_i)
+  irq_generator: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      irq_o <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       irq_o <= ctrl.enable and (not tx_fifo.avail) and (not busy);
     end if;
   end process;

--- a/rtl/core/neorv32_tracer.vhd
+++ b/rtl/core/neorv32_tracer.vhd
@@ -233,11 +233,9 @@ begin
   fifo.re    <= '1' when (discard = '1') or ((bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(3 downto 2) = "11")) else '0';
 
   -- discard oldest entry if overflowing --
-  fifo_overflow: process(rstn_i, clk_i)
+  fifo_overflow: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      discard <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       discard <= ctrl_en and arbiter.run and (not fifo.free);
     end if;
   end process;

--- a/rtl/core/neorv32_tracer.vhd
+++ b/rtl/core/neorv32_tracer.vhd
@@ -189,11 +189,9 @@ begin
 
   -- Interrupt Generator --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  irq_generator: process(rstn_i, clk_i)
+  irq_generator: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      irq_o <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       if (ctrl_en = '0') then
         irq_o <= '0';
       elsif (stop = '1') then -- trigger interrupt when reaching auto-stop-address

--- a/rtl/core/neorv32_trng.vhd
+++ b/rtl/core/neorv32_trng.vhd
@@ -169,11 +169,9 @@ begin
   fifo.re    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(2) = '1') else '0';
 
   -- interrupt generator --
-  irq_gen: process(rstn_i, clk_i)
+  irq_gen: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      irq_o <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       irq_o <= enable and (not fifo.free); -- FIFO full
     end if;
   end process;

--- a/rtl/core/neorv32_twd.vhd
+++ b/rtl/core/neorv32_twd.vhd
@@ -420,12 +420,9 @@ begin
 
   -- Communication State Monitor ------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  com_state_monitor: process(rstn_i, clk_i)
+  com_state_monitor: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      com_beg <= '0';
-      com_end <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       if (ctrl.enable = '0') then
         com_beg <= '0';
         com_end <= '0';

--- a/rtl/core/neorv32_twd.vhd
+++ b/rtl/core/neorv32_twd.vhd
@@ -264,13 +264,9 @@ begin
 
   -- Bus Sampling Logic ---------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  synchronizer: process(rstn_i, clk_i)
+  synchronizer: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      smp_valid    <= '0';
-      smp_sda_sreg <= (others => '0');
-      smp_scl_sreg <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       -- input register --
       smp_sda_sreg(0) <= to_stdulogic(to_bit(twd_sda_i)); -- "to_bit" to avoid hardware-vs-simulation mismatch
       smp_scl_sreg(0) <= to_stdulogic(to_bit(twd_scl_i));

--- a/rtl/core/neorv32_twd.vhd
+++ b/rtl/core/neorv32_twd.vhd
@@ -248,11 +248,9 @@ begin
 
   -- Interrupt Generator --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  irq_gen: process(rstn_i, clk_i)
+  irq_gen: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      irq_o <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       irq_o <= ctrl.enable and (
                (ctrl.irq_rx_avail and      rx_fifo.avail)  or -- RX FIFO not empty
                (ctrl.irq_rx_full  and (not rx_fifo.free))  or -- RX FIFO full

--- a/rtl/core/neorv32_twi.vhd
+++ b/rtl/core/neorv32_twi.vhd
@@ -213,11 +213,9 @@ begin
 
 
   -- IRQ if enabled and TX FIFO is empty and bus engine is idle --
-  irq_generator: process(rstn_i, clk_i)
+  irq_generator: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      irq_o <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       irq_o <= ctrl.enable and (not fifo.tx_avail) and (not busy);
     end if;
   end process;

--- a/rtl/core/neorv32_twi.vhd
+++ b/rtl/core/neorv32_twi.vhd
@@ -372,12 +372,9 @@ begin
 
   -- IO Control -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  input_synchronizer: process(rstn_i, clk_i)
+  input_synchronizer: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      sda_sync <= (others => '0');
-      scl_sync <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       sda_sync <= sda_sync(0) & to_stdulogic(to_bit(twi_sda_i)); -- "to_bit" to avoid HW-vs-sim mismatch
       scl_sync <= scl_sync(0) & to_stdulogic(to_bit(twi_scl_i));
     end if;

--- a/rtl/core/neorv32_twi.vhd
+++ b/rtl/core/neorv32_twi.vhd
@@ -223,12 +223,9 @@ begin
 
   -- TWI Clock Generator --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  clock_generator: process(rstn_i, clk_i)
+  clock_generator: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      clkgen_tick <= '0';
-      clkgen_cnt  <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       if (ctrl.enable = '0') then -- reset/disabled
         clkgen_tick <= '0';
         clkgen_cnt  <= (others => '0');
@@ -247,12 +244,9 @@ begin
   end process;
 
   -- generate four non-overlapping clock phases --
-  phase_generator: process(rstn_i, clk_i)
+  phase_generator: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      clkgen_phase_gen    <= (others => '0');
-      clkgen_phase_gen_ff <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       clkgen_phase_gen_ff <= clkgen_phase_gen;
       if (ctrl.enable = '0') or (busy = '0') then -- disabled or idle
         clkgen_phase_gen <= "0001"; -- start with a new phase

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -238,11 +238,9 @@ begin
 
   -- Interrupt Generator --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  irq_gen: process(rstn_i, clk_i)
+  irq_gen: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      irq_o <= '0';
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       irq_o <= ctrl.enable and (
                (ctrl.irq_tx_empty  and (not tx_fifo.avail)) or -- TX FIFO empty
                (ctrl.irq_tx_nfull  and tx_fifo.free)        or -- TX FIFO not full
@@ -263,7 +261,7 @@ begin
       tx.baudcnt <= (others => '0');
       tx.sync    <= (others => '0');
       tx.done    <= '0';
-      uart_txd_o        <= '1';
+      uart_txd_o <= '1';
     elsif rising_edge(clk_i) then
       if (uart_clk = '1') then
         tx.sync <= tx.sync(1 downto 0) & uart_ctsn_i; -- CTS synchronizer (and spike filter)


### PR DESCRIPTION
This PR extends #1609 (_remove reset from data path registers_) to the entire SoC:

* remove device's IRQ buffer reset (they have a synchronous reset via the module's "enable" flag)
* remove synchronizer reset (even with a reset these can have undefined values)
* remove clock gen async reset (they also have a sync reset via the module's enable flag)
* remove reset of FFs that have a sync reset (like the enable flag)