### PR TITLE
[cpu] minor updates, optimizations and RV-compliance fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
-| 09.08.2026 | 1.13.3.9 | minor CPU updates and optimizations | [#1621](https://github.com/stnolting/neorv32/pull/1621) |
+| 09.08.2026 | 1.13.3.9 | minor CPU updates, optimizations and RISC-V-compliance fixes | [#1621](https://github.com/stnolting/neorv32/pull/1621) |
 | 08.08.2026 | 1.13.3.8 | remove reset from registers where it is not strictly necessary | [#1620](https://github.com/stnolting/neorv32/pull/1620) |
 | 02.08.2026 | 1.13.3.7 | `instret` counter: only increment for actually retired instructions | [#1615](https://github.com/stnolting/neorv32/pull/1615) |
 | 02.08.2026 | 1.13.3.6 | minor rtl cleanups and optimizations | [#1614](https://github.com/stnolting/neorv32/pull/1614) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 09.08.2026 | 1.13.3.9 | minor CPU updates and optimizations | [#1621](https://github.com/stnolting/neorv32/pull/1621) |
 | 08.08.2026 | 1.13.3.8 | remove reset from registers where it is not strictly necessary | [#1620](https://github.com/stnolting/neorv32/pull/1620) |
 | 02.08.2026 | 1.13.3.7 | `instret` counter: only increment for actually retired instructions | [#1615](https://github.com/stnolting/neorv32/pull/1615) |
 | 02.08.2026 | 1.13.3.6 | minor rtl cleanups and optimizations | [#1614](https://github.com/stnolting/neorv32/pull/1614) |

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -769,10 +769,10 @@ counters are read-only. Any write access will raise an illegal instruction excep
 [options="header",grid="rows"]
 |=======================
 | Bit | Name [C] | R/W | Description
-| 15:3 | `CSR_MCOUNTINHIBIT_HPM3` : `CSR_MCOUNTINHIBIT_HPM15` | r/w | **HPMx**: Set to `1` to halt `[m]hpmcount*[h]`; hardwired to zero if `Zihpm` ISA extension is disabled
-| 2    | `CSR_MCOUNTINHIBIT_CY` | r/w | **CY**: Set to `1` to halt `[m]cycle[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
-| 1    | -                      | r/- | **TM**: Hardwired to zero as `time[h]` CSRs are not implemented
-| 0    | `CSR_MCOUNTINHIBIT_IR` | r/w | **IR**: Set to `1` to halt `[m]instret[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
+| 31:3 | `CSR_MCOUNTINHIBIT_HPM31` : `CSR_MCOUNTINHIBIT_HPM3` | r/w | **HPMx**: Set to `1` to halt `[m]hpmcount*[h]`; hardwired to zero if `Zihpm` ISA extension is disabled; only the lowest `HPM_NUM_CNTS` bits are implemented, the remaining bits are read-only zeo
+| 2    | `CSR_MCOUNTINHIBIT_CY`                               | r/w | **CY**: Set to `1` to halt `[m]cycle[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
+| 1    | -                                                    | r/- | **TM**: Hardwired to zero as `time[h]` CSRs are not implemented
+| 0    | `CSR_MCOUNTINHIBIT_IR`                               | r/w | **IR**: Set to `1` to halt `[m]instret[h]`; hardwired to zero if `Zicntr` ISA extension is disabled
 |=======================
 
 

--- a/docs/datasheet/cpu_csr.adoc
+++ b/docs/datasheet/cpu_csr.adoc
@@ -284,7 +284,8 @@ Machine-mode software can discover available `Z*` sub-extensions (like `Zicsr` o
 | 31:2 | r/w | **BASE**: in DIRECT mode = 4-byte-aligned base address of trap base handler, _all_ traps jump to `pc = BASE`;
 in VECTORED mode = 128-byte-aligned base address of trap vector table, interrupts cause a jump to `pc = BASE + 4 * mcause`
 and exceptions a jump to `pc = BASE`.
-| 1:0  | r/w | **MODE**: mode configuration, `00` = DIRECT, `01` = VECTORED; other encodings are _reserved_.
+| 1:0  | r/w | **MODE**: mode configuration, `00` = DIRECT, `01` = VECTORED; other encodings are _reserved_ and will fall back
+to DIRECT mode; the lowest address bits are hardwired to zero in VECTORED mode to enforce the according 128-byte-alignment
 |=======================
 
 

--- a/rtl/core/neorv32_cpu_alu_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_alu_bitmanip.vhd
@@ -231,10 +231,6 @@ begin
   begin
     if (rstn_i = '0') then
       state         <= S_IDLE;
-      rs1_reg       <= (others => '0');
-      rs2_reg       <= (others => '0');
-      sha_reg       <= (others => '0');
-      less_reg      <= '0';
       shifter_start <= '0';
       clmul_start   <= '0';
       valid         <= '0';
@@ -243,20 +239,11 @@ begin
       shifter_start <= '0';
       clmul_start   <= '0';
       valid         <= '0';
-
-      -- operand gating / buffering --
-      if (valid_cmd = '1') then
-        less_reg <= less_i;
-        rs1_reg  <= rs1_i;
-        rs2_reg  <= rs2_i;
-        sha_reg  <= shamt_i;
-      end if;
-
       -- fsm --
       case state is
 
-        when S_IDLE => -- wait for operation trigger
-        -- ------------------------------------------------------------
+        -- wait for operation trigger --
+        when S_IDLE =>
           if (valid_cmd = '1') then
             if (not FAST_SHIFT) and ((cmd(op_cz_c) or cmd(op_cpop_c) or cmd(op_rot_c)) = '1') then -- multi-cycle shift operation
               shifter_start <= '1';
@@ -270,18 +257,31 @@ begin
             end if;
           end if;
 
-        when S_START => -- one cycle delay to start iterative operation
-        -- ------------------------------------------------------------
+        -- one cycle delay to start iterative operation --
+        when S_START =>
           state <= S_BUSY;
 
-        when S_BUSY => -- wait for multi-cycle operation to finish
-        -- ------------------------------------------------------------
+        -- wait for multi-cycle operation to complete --
+        when S_BUSY =>
           if ((shifter_run = '0') and (clmul_run = '0')) or (ctrl_i.cpu_trap = '1') then -- abort on trap
             valid <= '1';
             state <= S_IDLE;
           end if;
 
       end case;
+    end if;
+  end process;
+
+  -- operand gating / buffering --
+  op_buf: process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      if (valid_cmd = '1') then
+        less_reg <= less_i;
+        rs1_reg  <= rs1_i;
+        rs2_reg  <= rs2_i;
+        sha_reg  <= shamt_i;
+      end if;
     end if;
   end process;
 

--- a/rtl/core/neorv32_cpu_alu_cfu.vhd
+++ b/rtl/core/neorv32_cpu_alu_cfu.vhd
@@ -39,8 +39,8 @@ architecture neorv32_cpu_alu_cfu_rtl of neorv32_cpu_alu_cfu is
   -- supported CFU opcodes --
   constant opcode_custom0_c : std_ulogic_vector(6 downto 0) := "0001011"; -- CUSTOM-0 opcode
   constant opcode_custom1_c : std_ulogic_vector(6 downto 0) := "0101011"; -- CUSTOM-1 opcode
-  constant opcode_op32_c    : std_ulogic_vector(6 downto 0) := "0011011"; -- OP-32 opcode
-  constant opcode_opimm32_c : std_ulogic_vector(6 downto 0) := "0111011"; -- OP-IMM-32 opcode
+  constant opcode_op32_c    : std_ulogic_vector(6 downto 0) := "0111011"; -- OP-32 opcode
+  constant opcode_opimm32_c : std_ulogic_vector(6 downto 0) := "0011011"; -- OP-IMM-32 opcode
 
   -- **********************************************************
   -- CFU Example: XTEA - Extended Tiny Encryption Algorithm

--- a/rtl/core/neorv32_cpu_alu_crypto.vhd
+++ b/rtl/core/neorv32_cpu_alu_crypto.vhd
@@ -241,20 +241,9 @@ begin
   control: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      rs1     <= (others => '0');
-      rs2     <= (others => '0');
-      funct12 <= (others => '0');
-      done    <= '0';
-      state   <= S_IDLE;
+      done  <= '0';
+      state <= S_IDLE;
     elsif rising_edge(clk_i) then
-      -- operand gating --
-      if (cmd_valid = '1') then
-        rs1     <= rs1_i;
-        rs2     <= rs2_i;
-        funct12 <= ctrl_i.ir_funct12;
-      end if;
-
-      -- FSM --
       done <= '0'; -- default
       case state is
 
@@ -273,7 +262,7 @@ begin
         when S_BUSY =>
           state <= S_DONE;
 
-        -- final step & enable output for one cycle --
+        -- final step & output enable --
         when S_DONE =>
           done  <= '1';
           state <= S_IDLE;
@@ -284,6 +273,18 @@ begin
 
   -- processing done (high one cycle before actual data output) --
   valid_o <= done;
+
+  -- operand gating / buffering --
+  op_buf: process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      if (cmd_valid = '1') then
+        rs1     <= rs1_i;
+        rs2     <= rs2_i;
+        funct12 <= ctrl_i.ir_funct12;
+      end if;
+    end if;
+  end process;
 
 
   -- Output Select --------------------------------------------------------------------------

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -739,8 +739,9 @@ begin
         if (exec.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = "010") then -- word-quantity only
           case exec.ir(instr_funct5_msb_c downto instr_funct5_lsb_c) is
             when "00001" | "00000" | "00100" | "01100" | "01000" | "10000" | "10100" | "11000" | "11100" => illegal_cmd <= not bool_to_ulogic_f(RISCV_ISA_Zaamo);
-            when "00010" | "00011" => illegal_cmd <= not bool_to_ulogic_f(RISCV_ISA_Zalrsc);
-            when others => illegal_cmd <= '1';
+            when "00010" => illegal_cmd <= (not bool_to_ulogic_f(RISCV_ISA_Zalrsc)) or or_reduce_f(exec.ir(instr_rs2_msb_c downto instr_rs2_lsb_c)); -- LR
+            when "00011" => illegal_cmd <= not bool_to_ulogic_f(RISCV_ISA_Zalrsc); -- SC
+            when others  => illegal_cmd <= '1';
           end case;
         end if;
 

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -549,7 +549,7 @@ begin
   cnt_event(cnt_event_load_c)     <= '1' when (ctrl.lsu_req = '1') and (ctrl.lsu_rd = '1')               else '0'; -- memory load
   cnt_event(cnt_event_store_c)    <= '1' when (ctrl.lsu_req = '1') and (ctrl.lsu_wr = '1')               else '0'; -- memory store
 
-  -- retire tacking --
+  -- retire tracking --
   retire_tracking: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
@@ -563,8 +563,8 @@ begin
     end if;
   end process;
 
-  -- instruction has retired: execution completed without any trap --
-  retired <= '1' when (retire_start = '1') and (exec.state = S_DISPATCH) and (env_pend = '0') and (exc_fire = '0') else '0';
+  -- instruction has retired: execution completed without any sync. exception --
+  retired <= '1' when (retire_start = '1') and (exec.state = S_DISPATCH) and (exc_fire = '0') else '0';
 
 
   -- ****************************************************************************************************************************

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -1057,8 +1057,12 @@ begin
             csr.mie_mei  <= csr_wdata(11);
             csr.mie_firq <= csr_wdata(31 downto 16);
 
-          when csr_mtvec_c => -- machine trap-handler base address
-            csr.mtvec <= csr_wdata(31 downto 2) & '0' & csr_wdata(0); -- base + mode (vectored/direct)
+          when csr_mtvec_c => -- machine trap-handler base + mode
+            if (csr_wdata(1 downto 0) = "01") then -- vectored mode
+              csr.mtvec <= csr_wdata(31 downto 7) & "00000" & "01";
+            else -- direct mode (fallback for reserved modes)
+              csr.mtvec <= csr_wdata(31 downto 2) & "00";
+            end if;
 
           when csr_mcounteren_c => -- machine counter access enable
             csr.mcounteren <= csr_wdata;

--- a/rtl/core/neorv32_cpu_counters.vhd
+++ b/rtl/core/neorv32_cpu_counters.vhd
@@ -106,11 +106,15 @@ begin
         inhibit(2) <= ctrl_i.csr_wdata(2); -- [m]instret[h]
       end if;
       -- hardware performance monitors --
-      if not ZIHPM_EN then
-        inhibit(31 downto 3) <= (others => '0');
-      elsif (inh_acc = '1') and (ctrl_i.csr_we = '1') then
-        inhibit(31 downto 3) <= ctrl_i.csr_wdata(31 downto 3); -- [m]hpmcounter3..31[h]
-      end if;
+      for i in 3 to 31 loop
+        if ZIHPM_EN and ((i-3) < HPM_NUM) then
+          if (inh_acc = '1') and (ctrl_i.csr_we = '1') then
+            inhibit(i) <= ctrl_i.csr_wdata(i); -- [m]hpmcounter3..31[h]
+          end if;
+        else
+          inhibit(i) <= '0'; -- unimplemented: read-only zero
+        end if;
+      end loop;
       -- unused --
       inhibit(1) <= '0';
     end if;

--- a/rtl/core/neorv32_cpu_counters.vhd
+++ b/rtl/core/neorv32_cpu_counters.vhd
@@ -60,7 +60,7 @@ architecture neorv32_cpu_counters_rtl of neorv32_cpu_counters is
   signal hpmcnt_rd : hpmcnt_t;
 
   -- global CSR read-backs --
-  signal rdata64, cycle_rd, time_q, time_rd, instret_rd, hpm_rd, inhibit_rd, pmf_rd : std_ulogic_vector(63 downto 0);
+  signal rdata64, cycle_rd, time_rd, instret_rd, hpm_rd, inhibit_rd, pmf_rd : std_ulogic_vector(63 downto 0);
 
 begin
 
@@ -211,13 +211,7 @@ begin
     );
 
     -- time[h] --
-    time_buf: process(clk_i)
-    begin
-      if rising_edge(clk_i) then
-        time_q <= mtime_i;
-      end if;
-    end process;
-    time_rd <= time_q when (cnt_re(1) = '1') else (others => '0');
+    time_rd <= mtime_i when (cnt_re(1) = '1') else (others => '0');
 
     -- [m]instret[h] --
     instret_inst: entity neorv32.neorv32_prim_cnt
@@ -240,7 +234,6 @@ begin
   base_disabled:
   if not ZICNTR_EN generate
     cycle_rd   <= (others => '0');
-    time_q     <= (others => '0');
     time_rd    <= (others => '0');
     instret_rd <= (others => '0');
   end generate;

--- a/rtl/core/neorv32_cpu_decompressor.vhd
+++ b/rtl/core/neorv32_cpu_decompressor.vhd
@@ -175,7 +175,7 @@ begin
               decoded(instr_imm12_msb_c  downto instr_imm12_lsb_c)  <= replicate_f(instr_i(12),3) & instr_i(4 downto 3) & instr_i(5) & instr_i(2) & instr_i(6) & x"0";
             elsif ZCMOP_EN and (instr_i(12 downto 11) = "00") and (instr_i(ci_rs2_5_msb_c downto ci_rs2_5_lsb_c) = "00000") then -- C.MOP
               decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_system_c;
-              decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= "100";
+              decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_zimop_c;
               decoded(instr_rs1_msb_c    downto instr_rs1_lsb_c)    <= "00000";
               decoded(instr_rd_msb_c     downto instr_rd_lsb_c)     <= "00000";
               decoded(instr_imm12_msb_c  downto instr_imm12_lsb_c)  <= "1000" & instr_i(10) & instr_i(9) & "0111" & instr_i(8) & '0';
@@ -207,6 +207,7 @@ begin
                 decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_alui_c;
                 decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_sr_c;
                 decoded(instr_rs2_msb_c    downto instr_rs2_lsb_c)    <= instr_i(6 downto 2); -- immediate
+                illegal                                               <= instr_i(12); -- shamt[5] == zero
               when "10" => -- C.ANDI
                 decoded(instr_opcode_msb_c downto instr_opcode_lsb_c) <= opcode_alui_c;
                 decoded(instr_funct3_msb_c downto instr_funct3_lsb_c) <= funct3_and_c;

--- a/rtl/core/neorv32_cpu_lsu.vhd
+++ b/rtl/core/neorv32_cpu_lsu.vhd
@@ -98,7 +98,6 @@ begin
   mem_do_reg: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      req.meta <= (others => '0');
       req.addr <= (others => '0');
       req.data <= (others => '0');
       req.ben  <= (others => '0');
@@ -106,7 +105,6 @@ begin
       misalign <= '0';
     elsif rising_edge(clk_i) then
       if (ctrl_i.lsu_mo_en = '1') then
-        req.meta <= std_ulogic_vector(to_unsigned(HART_ID, 2)) & ctrl_i.cpu_debug & ctrl_i.lsu_priv & '0';
         req.addr <= addr_i; -- memory address register
         case ctrl_i.ir_funct3(1 downto 0) is -- alignment + byte-enable
           when "00" => -- byte
@@ -134,6 +132,7 @@ begin
     end if;
   end process;
 
+  req.meta   <= std_ulogic_vector(to_unsigned(HART_ID, 2)) & ctrl_i.cpu_debug & ctrl_i.lsu_priv & '0';
   req.burst  <= '0'; -- only non-burst/single-accesses
   req.stb    <= ctrl_i.lsu_req and (not misalign) and (not pmp_fault_i); -- access request (all source signals are driven by registers)
   dbus_req_o <= req; -- output bus request

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130308"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130309"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 


### PR DESCRIPTION
* fix `OP-32` / `OP-IMM-32` opcode typo in CFU
* remove reset of operand buffers in `Zk*` and `Zb*` ISA extensions
* remove `time[h]` CSR register buffer
* detect `lr.w` with `rs2 != 0` as illegal
* implement only the `mcountinhibt` HPM bits that are actually configured
* `c.srli` and `c.srai` need to have shift_amount[4] == 0
* make lowest 7 bits of `mtvec` WARL (enforce alignment when using vectored mode)
* fix `instret` counting of instructions that retire during a pending interrupt request