### PR TITLE
Normalize bus/list array ranges to downto (ARY_MS_DRNG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 14.08.2026 | 1.13.4.3 | normalize bus/list array ranges to `x downto y` | [#1622](https://github.com/stnolting/neorv32/pull/1622) |
 | 14.08.2026 | 1.13.4.2 | bitmanip: simplify register enables | [#1626](https://github.com/stnolting/neorv32/pull/1626) |
 | 12.08.2026 | 1.13.4.1 | declare FIFO/SPRAM memory arrays per generate-branch to fix RAM extraction on Verific-based synthesis tools | [#1623](https://github.com/stnolting/neorv32/pull/1623) |
 | 10.08.2026 | [**1.13.4**](https://github.com/stnolting/neorv32/releases/tag/v1.13.4) | :rocket: **New release** | |

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -365,8 +365,8 @@ architecture neorv32_bus_gateway_rtl of neorv32_bus_gateway is
   constant tmo_cnt_size_c : natural := max_tmo_bit_f(port_tmo_bit_list_c);
 
   -- gateway ports combined as arrays --
-  type port_req_t is array (0 to 4) of bus_req_t;
-  type port_rsp_t is array (0 to 4) of bus_rsp_t;
+  type port_req_t is array (4 downto 0) of bus_req_t;
+  type port_rsp_t is array (4 downto 0) of bus_rsp_t;
   signal port_req : port_req_t;
   signal port_rsp : port_rsp_t;
 
@@ -628,8 +628,8 @@ architecture neorv32_bus_io_switch_rtl of neorv32_bus_io_switch is
   );
 
   -- device ports combined as arrays --
-  type dev_req_t is array (0 to num_devs_c-1) of bus_req_t;
-  type dev_rsp_t is array (0 to num_devs_c-1) of bus_rsp_t;
+  type dev_req_t is array (num_devs_c-1 downto 0) of bus_req_t;
+  type dev_rsp_t is array (num_devs_c-1 downto 0) of bus_rsp_t;
   signal dev_req : dev_req_t;
   signal dev_rsp : dev_rsp_t;
 

--- a/rtl/core/neorv32_cfs.vhd
+++ b/rtl/core/neorv32_cfs.vhd
@@ -42,7 +42,7 @@ end entity;
 architecture neorv32_cfs_rtl of neorv32_cfs is
 
   -- exemplary CFS interface registers --
-  type cfs_regs_t is array (0 to 3) of std_ulogic_vector(31 downto 0); -- implement 4 read/write registers
+  type cfs_regs_t is array (3 downto 0) of std_ulogic_vector(31 downto 0); -- implement 4 read/write registers
   signal cfs_reg_wr : cfs_regs_t; -- for WRITE accesses
   signal cfs_reg_rd : cfs_regs_t; -- for READ accesses
 

--- a/rtl/core/neorv32_clint.vhd
+++ b/rtl/core/neorv32_clint.vhd
@@ -59,7 +59,7 @@ architecture neorv32_clint_rtl of neorv32_clint is
   signal mtime_we : std_ulogic_vector(1 downto 0);
 
   -- mtimecmp access --
-  type mtimecmp_rwe_t is array (0 to NUM_HARTS-1) of std_ulogic_vector(1 downto 0);
+  type mtimecmp_rwe_t is array (NUM_HARTS-1 downto 0) of std_ulogic_vector(1 downto 0);
   signal mtimecmp_we : mtimecmp_rwe_t;
   signal mtimecmp_re : mtimecmp_rwe_t;
   signal mtimecmp_en : std_ulogic_vector(NUM_HARTS-1 downto 0);
@@ -68,7 +68,7 @@ architecture neorv32_clint_rtl of neorv32_clint is
   signal mswi_en, mswi : std_ulogic_vector(NUM_HARTS-1 downto 0);
 
   -- read-back --
-  type rb32_t is array (0 to NUM_HARTS-1) of std_ulogic_vector(31 downto 0);
+  type rb32_t is array (NUM_HARTS-1 downto 0) of std_ulogic_vector(31 downto 0);
   signal mtimecmp_rd : rb32_t;
   signal mswi_rd     : rb32_t;
   signal mtime       : std_ulogic_vector(63 downto 0);

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -83,7 +83,7 @@ architecture neorv32_cpu_alu_rtl of neorv32_cpu_alu is
   signal cmp : std_ulogic_vector(1 downto 0);
 
   -- co-processor interface --
-  type cp_data_t  is array (0 to 6) of std_ulogic_vector(31 downto 0);
+  type cp_data_t  is array (6 downto 0) of std_ulogic_vector(31 downto 0);
   signal cp_result : cp_data_t;
   signal cp_valid : std_ulogic_vector(6 downto 0);
   signal cfu_inst : std_ulogic_vector(31 downto 0);

--- a/rtl/core/neorv32_cpu_alu_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_alu_bitmanip.vhd
@@ -179,7 +179,7 @@ architecture neorv32_cpu_alu_bitmanip_rtl of neorv32_cpu_alu_bitmanip is
   signal bs_shift : std_ulogic_vector(4 downto 0);
 
   -- operation/intermediate results --
-  type res_t is array (0 to op_width_c-1) of std_ulogic_vector(31 downto 0);
+  type res_t is array (op_width_c-1 downto 0) of std_ulogic_vector(31 downto 0);
   signal res_int, res : res_t;
   signal xperm4_res, xperm8_res, adder_res, one_hot_res, zip_res, unzip_res, res_out : std_ulogic_vector(31 downto 0);
 

--- a/rtl/core/neorv32_cpu_alu_fpu.vhd
+++ b/rtl/core/neorv32_cpu_alu_fpu.vhd
@@ -145,8 +145,8 @@ architecture neorv32_cpu_alu_fpu_rtl of neorv32_cpu_alu_fpu is
   signal ctrl_engine : ctrl_engine_t;
 
   -- floating-point operands --
-  type op_data_t  is array (0 to 1) of std_ulogic_vector(31 downto 0);
-  type op_class_t is array (0 to 1) of std_ulogic_vector(9 downto 0);
+  type op_data_t  is array (1 downto 0) of std_ulogic_vector(31 downto 0);
+  type op_class_t is array (1 downto 0) of std_ulogic_vector(9 downto 0);
   type fpu_operands_t is record
     rs1       : std_ulogic_vector(31 downto 0);
     rs1_class : std_ulogic_vector(9 downto 0);

--- a/rtl/core/neorv32_cpu_counters.vhd
+++ b/rtl/core/neorv32_cpu_counters.vhd
@@ -44,7 +44,7 @@ end entity;
 architecture neorv32_cpu_counters_rtl of neorv32_cpu_counters is
 
   -- global access decoder --
-  type cnt_we_t is array (0 to 31) of std_ulogic_vector(1 downto 0);
+  type cnt_we_t is array (31 downto 0) of std_ulogic_vector(1 downto 0);
   signal cnt_we : cnt_we_t;
   signal cnt_acc, cfg_acc, inh_acc, pmf_acc : std_ulogic;
   signal sel, cnt_re, cfg_we, cfg_re : std_ulogic_vector(31 downto 0);

--- a/rtl/core/neorv32_cpu_frontend.vhd
+++ b/rtl/core/neorv32_cpu_frontend.vhd
@@ -79,7 +79,7 @@ architecture neorv32_cpu_frontend_rtl of neorv32_cpu_frontend is
   signal restart : std_ulogic;
 
   -- instruction prefetch buffer (FIFO) interface --
-  type ipb_data_t is array (0 to 1) of std_ulogic_vector(16 downto 0); -- bus_error & 16-bit instruction
+  type ipb_data_t is array (1 downto 0) of std_ulogic_vector(16 downto 0); -- bus_error & 16-bit instruction
   signal ipb_wdata, ipb_rdata : ipb_data_t;
   signal ipb_we,    ipb_re    : std_ulogic_vector(1 downto 0);
   signal ipb_free,  ipb_avail : std_ulogic_vector(1 downto 0);

--- a/rtl/core/neorv32_cpu_hwtrig.vhd
+++ b/rtl/core/neorv32_cpu_hwtrig.vhd
@@ -42,7 +42,7 @@ architecture neorv32_cpu_hwtrig_rtl of neorv32_cpu_hwtrig is
   constant log2_num_triggers_c : natural := index_size_f(NUM_TRIGGERS);
 
   -- match control CSRs: tdata1[tselect] and tdata2[tselect] --
-  type tdata2_t is array (0 to NUM_TRIGGERS-1) of std_ulogic_vector(31 downto 0);
+  type tdata2_t is array (NUM_TRIGGERS-1 downto 0) of std_ulogic_vector(31 downto 0);
   signal tdata2 : tdata2_t;
   signal tdata1, tdata1_rb, tdata2_rb, tinfo_rb : std_ulogic_vector(31 downto 0);
   signal tdata1_exec, tdata1_store, tdata1_load, tdata1_hit : std_ulogic_vector(NUM_TRIGGERS-1 downto 0);

--- a/rtl/core/neorv32_cpu_pmp.vhd
+++ b/rtl/core/neorv32_cpu_pmp.vhd
@@ -67,29 +67,29 @@ architecture neorv32_cpu_pmp_rtl of neorv32_cpu_pmp is
   constant mode_napot_c : std_ulogic_vector(1 downto 0) := "11"; -- naturally aligned power-of-two region (> 4 bytes)
 
   -- configuration CSRs --
-  type pmpcfg_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(7 downto 0);
+  type pmpcfg_t is array (NUM_REGIONS-1 downto 0) of std_ulogic_vector(7 downto 0);
   signal pmpcfg    : pmpcfg_t;
   signal pmpcfg_we : std_ulogic_vector(3 downto 0);
 
   -- address CSRs --
-  type pmpaddr_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(29 downto pmp_alsb_c);
+  type pmpaddr_t is array (NUM_REGIONS-1 downto 0) of std_ulogic_vector(29 downto pmp_alsb_c);
   signal pmpaddr    : pmpaddr_t;
   signal pmpaddr_we : std_ulogic_vector(15 downto 0);
 
   -- CSR read-back --
-  type csr_cfg_rd_t   is array (0 to 15) of std_ulogic_vector(7 downto 0);
-  type csr_cfg_rd32_t is array (0 to 03) of std_ulogic_vector(31 downto 0);
-  type csr_addr_rd_t  is array (0 to 15) of std_ulogic_vector(31 downto 0);
+  type csr_cfg_rd_t   is array (15 downto 0) of std_ulogic_vector(7 downto 0);
+  type csr_cfg_rd32_t is array (03 downto 0) of std_ulogic_vector(31 downto 0);
+  type csr_addr_rd_t  is array (15 downto 0) of std_ulogic_vector(31 downto 0);
   signal cfg_rd   : csr_cfg_rd_t;
   signal cfg_rd32 : csr_cfg_rd32_t;
   signal addr_rd  : csr_addr_rd_t;
 
   -- address mask (NA4/NAPOT) --
-  type addr_mask_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(31 downto pmp_lsb_c);
+  type addr_mask_t is array (NUM_REGIONS-1 downto 0) of std_ulogic_vector(31 downto pmp_lsb_c);
   signal addr_mask_napot, addr_mask : addr_mask_t;
 
   -- address comparators, region-match and permission check --
-  type cmp_t is array (0 to NUM_REGIONS-1) of std_ulogic_vector(1 downto 0); -- 0 = instruction fetch, 1 = data access
+  type cmp_t is array (NUM_REGIONS-1 downto 0) of std_ulogic_vector(1 downto 0); -- 0 = instruction fetch, 1 = data access
   signal cmp_na, cmp_ge, match : cmp_t;
   signal cmp_lt : std_ulogic_vector(1 downto 0); -- 0 = instruction fetch, 1 = data access
 

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -72,7 +72,7 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   -- ----------------------------------------------------------
 
   -- debug module DMI registers / access --
-  type progbuf_t is array (0 to 1) of std_ulogic_vector(31 downto 0);
+  type progbuf_t is array (1 downto 0) of std_ulogic_vector(31 downto 0);
   type dm_reg_t is record
     ndmreset        : std_ulogic;
     dmactive        : std_ulogic;
@@ -96,7 +96,7 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
   signal hart_avail : std_ulogic; -- selected hart is available
 
   -- CPU program buffer --
-  type cpu_progbuf_t is array (0 to 3) of std_ulogic_vector(31 downto 0);
+  type cpu_progbuf_t is array (3 downto 0) of std_ulogic_vector(31 downto 0);
   signal cpu_progbuf : cpu_progbuf_t;
 
   -- signed base address of data registers in memory/CSR space --

--- a/rtl/core/neorv32_gptmr.vhd
+++ b/rtl/core/neorv32_gptmr.vhd
@@ -56,7 +56,7 @@ architecture neorv32_gptmr_rtl of neorv32_gptmr is
   signal enable, mode, irq : std_ulogic_vector(NUM_SLICES-1 downto 0);
 
   -- slice wiring --
-  type rdata_t is array (0 to NUM_SLICES-1) of std_ulogic_vector(31 downto 0);
+  type rdata_t is array (NUM_SLICES-1 downto 0) of std_ulogic_vector(31 downto 0);
   signal rdata : rdata_t;
   signal rdata_sum : std_ulogic_vector(31 downto 0);
   signal cs, trig : std_ulogic_vector(NUM_SLICES-1 downto 0);

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130402"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130403"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_pwm.vhd
+++ b/rtl/core/neorv32_pwm.vhd
@@ -57,7 +57,7 @@ architecture neorv32_pwm_rtl of neorv32_pwm is
   signal clkprsc, addr : std_ulogic_vector(2 downto 0);
 
   -- wiring --
-  type rdata_t is array (0 to NUM_CHANNELS-1) of std_ulogic_vector(31 downto 0);
+  type rdata_t is array (NUM_CHANNELS-1 downto 0) of std_ulogic_vector(31 downto 0);
   signal rdata : rdata_t;
   signal rdata_sum : std_ulogic_vector(31 downto 0);
   signal cs, pwm : std_ulogic_vector(NUM_CHANNELS-1 downto 0);

--- a/rtl/core/neorv32_sysinfo.vhd
+++ b/rtl/core/neorv32_sysinfo.vhd
@@ -81,7 +81,7 @@ architecture neorv32_sysinfo_rtl of neorv32_sysinfo is
   constant log2_c_bsize_c   : natural := index_size_f(CACHE_BLOCK_SIZE);
 
   -- system information memory --
-  type sysinfo_t is array (0 to 3) of std_ulogic_vector(31 downto 0);
+  type sysinfo_t is array (3 downto 0) of std_ulogic_vector(31 downto 0);
   signal sysinfo : sysinfo_t;
 
 begin

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -342,15 +342,15 @@ architecture neorv32_top_rtl of neorv32_top is
   signal dci_haltreq : std_ulogic_vector(num_cores_c-1 downto 0);
 
   -- CPU trace interface --
-  type cpu_trace_t is array (0 to num_cores_c-1) of trace_port_t;
+  type cpu_trace_t is array (num_cores_c-1 downto 0) of trace_port_t;
   signal cpu_trace : cpu_trace_t;
 
   -- CPU memory ordering (cache synchronization) --
   signal cpu_i_fence, cpu_d_fence, icache_sync, dcache_sync : std_ulogic_vector(num_cores_c-1 downto 0);
 
   -- bus: CPU core complex --
-  type core_complex_req_t is array (0 to num_cores_c-1) of bus_req_t;
-  type core_complex_rsp_t is array (0 to num_cores_c-1) of bus_rsp_t;
+  type core_complex_req_t is array (num_cores_c-1 downto 0) of bus_req_t;
+  type core_complex_rsp_t is array (num_cores_c-1 downto 0) of bus_rsp_t;
   signal cpu_i_req, cpu_d_req, icache_req, dcache_req, core_req : core_complex_req_t;
   signal cpu_i_rsp, cpu_d_rsp, icache_rsp, dcache_rsp, core_rsp : core_complex_rsp_t;
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -342,15 +342,15 @@ architecture neorv32_top_rtl of neorv32_top is
   signal dci_haltreq : std_ulogic_vector(num_cores_c-1 downto 0);
 
   -- CPU trace interface --
-  type cpu_trace_t is array (num_cores_c-1 downto 0) of trace_port_t;
+  type cpu_trace_t is array (0 to num_cores_c-1) of trace_port_t;
   signal cpu_trace : cpu_trace_t;
 
   -- CPU memory ordering (cache synchronization) --
   signal cpu_i_fence, cpu_d_fence, icache_sync, dcache_sync : std_ulogic_vector(num_cores_c-1 downto 0);
 
   -- bus: CPU core complex --
-  type core_complex_req_t is array (num_cores_c-1 downto 0) of bus_req_t;
-  type core_complex_rsp_t is array (num_cores_c-1 downto 0) of bus_rsp_t;
+  type core_complex_req_t is array (0 to num_cores_c-1) of bus_req_t;
+  type core_complex_rsp_t is array (0 to num_cores_c-1) of bus_rsp_t;
   signal cpu_i_req, cpu_d_req, icache_req, dcache_req, core_req : core_complex_req_t;
   signal cpu_i_rsp, cpu_d_rsp, icache_rsp, dcache_rsp, core_rsp : core_complex_rsp_t;
 

--- a/rtl/system_integration/neorv32_litex_core_complex.vhd
+++ b/rtl/system_integration/neorv32_litex_core_complex.vhd
@@ -69,8 +69,8 @@ architecture neorv32_litex_core_complex_rtl of neorv32_litex_core_complex is
 
   -- configuration helpers --
   constant num_configs_c : natural := 5;    -- number of pre-defined configurations
-  type bool_t is array (0 to num_configs_c-1) of boolean;
-  type natural_t is array (0 to num_configs_c-1) of natural;
+  type bool_t is array (num_configs_c-1 downto 0) of boolean;
+  type natural_t is array (num_configs_c-1 downto 0) of natural;
   type configs_t is record
     riscv_c      : bool_t;
     riscv_m      : bool_t;

--- a/sim/xbus_gateway.vhd
+++ b/sim/xbus_gateway.vhd
@@ -57,8 +57,8 @@ architecture xbus_gateway_rtl of xbus_gateway is
   constant dev_size_list_c : dev_size_list_t := (DEV_0_SIZE, DEV_1_SIZE, DEV_2_SIZE, DEV_3_SIZE, DEV_4_SIZE, DEV_5_SIZE, DEV_6_SIZE, DEV_7_SIZE);
 
   -- device ports combined as arrays --
-  type dev_req_t is array (0 to num_devs_c-1) of xbus_req_t;
-  type dev_rsp_t is array (0 to num_devs_c-1) of xbus_rsp_t;
+  type dev_req_t is array (num_devs_c-1 downto 0) of xbus_req_t;
+  type dev_rsp_t is array (num_devs_c-1 downto 0) of xbus_rsp_t;
   signal dev_req : dev_req_t;
   signal dev_rsp : dev_rsp_t;
 


### PR DESCRIPTION
Following up on #1584, this normalizes the non-memory array declarations from ascending `(0 to N)` to descending `(N downto 0)` range direction to clear the Superlint ARY_MS_DRNG warnings.

Memory/ROM arrays (`rom_t`, `code_rom_t`, `key_mem_t`, etc.) are kept as `to` since, as you noted, that is fine for memory.

A few arrays use positional aggregate initialization (`port_bool_list_t`, `port_tmo_en_list_t`, `dev_en_list_t`, `inst_c`, `ID`, etc.) so I have left those as `to` for now to avoid reversing the element mapping. Easy to do a follow-up that migrates them to named association and flips them too if you want.

33 declarations across 17 files. No functional changes, same indices and access patterns throughout.