### PR TITLE
[prim] declare FIFO/SPRAM memory arrays per generate-branch to fix RAM extraction on Verific-based synthesis tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 12.08.2026 | 1.13.4.1 | declare FIFO/SPRAM memory arrays per generate-branch to fix RAM extraction on Verific-based synthesis tools | [#1623](https://github.com/stnolting/neorv32/pull/1623) |
 | 10.08.2026 | [**1.13.4**](https://github.com/stnolting/neorv32/releases/tag/v1.13.4) | :rocket: **New release** | |
 | 09.08.2026 | 1.13.3.9 | minor CPU updates, optimizations and RISC-V-compliance fixes | [#1621](https://github.com/stnolting/neorv32/pull/1621) |
 | 08.08.2026 | 1.13.3.8 | remove reset from registers where it is not strictly necessary | [#1620](https://github.com/stnolting/neorv32/pull/1620) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130400"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130401"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_prim.vhd
+++ b/rtl/core/neorv32_prim.vhd
@@ -45,9 +45,9 @@ end entity;
 
 architecture neorv32_prim_fifo_rtl of neorv32_prim_fifo is
 
-  -- memory core --
+  -- memory core; the actual RAM signal is declared per generate-branch as a shared
+  -- architecture-scope signal would defeat RAM extraction on some synthesis tools --
   type ram_t is array ((2**AWIDTH)-1 downto 0) of std_ulogic_vector(DWIDTH-1 downto 0);
-  signal fifo : ram_t;
 
   -- local signals --
   signal rdata : std_ulogic_vector(DWIDTH-1 downto 0);
@@ -113,6 +113,8 @@ begin
   -- more than 1 FIFO entry --
   memory_large:
   if (AWIDTH > 0) generate
+    signal fifo : ram_t;
+  begin
     memory_core: process(clk_i) -- simple dual-port RAM
     begin
       if rising_edge(clk_i) then
@@ -127,6 +129,8 @@ begin
   -- just 1 FIFO entry --
   memory_small:
   if (AWIDTH = 0) generate
+    signal fifo : ram_t;
+  begin
     memory_core: process(clk_i) -- single register
     begin
       if rising_edge(clk_i) then
@@ -181,8 +185,9 @@ end entity;
 
 architecture neorv32_prim_spram_rtl of neorv32_prim_spram is
 
+  -- memory core; the actual RAM signal is declared per generate-branch as a shared
+  -- architecture-scope signal would defeat RAM extraction on some synthesis tools --
   type ram_t is array ((2**AWIDTH)-1 downto 0) of std_ulogic_vector(DWIDTH-1 downto 0);
-  signal spram : ram_t;
   signal rdata : std_ulogic_vector(DWIDTH-1 downto 0);
 
 begin
@@ -191,6 +196,8 @@ begin
   -- -------------------------------------------------------------------------------------------
   memory_large:
   if (AWIDTH > 0) generate
+    signal spram : ram_t;
+  begin
     memory_core: process(clk_i)
     begin
       if rising_edge(clk_i) then
@@ -207,6 +214,8 @@ begin
   -- single entry only --
   memory_small:
   if (AWIDTH = 0) generate
+    signal spram : ram_t;
+  begin
     memory_core: process(clk_i)
     begin
       if rising_edge(clk_i) then


### PR DESCRIPTION
While porting a NEORV32-based design to an Efinix Titanium (Efinity 2026.1), I
found that the processor's FIFO and SPRAM storage was being implemented in
discrete registers instead of block RAM, blowing up utilization.

The problem: in `neorv32_prim_fifo` and `neorv32_prim_spram` the memory array is
declared at architecture scope but driven from two mutually exclusive
`memory_large` / `memory_small` generate branches. Verific-based synthesis
front-ends (Efinity, and likely other tools using Verific elaboration) see a
signal with multiple processes driving it and don't map it to RAM — the
mutual exclusivity of the generate conditions is not considered.

My proposed fix: let's declare the array inside each generate branch instead. Since exactly one
branch is elaborated, this functions the same way and all tools see that only a single process
drives signals.

With this change Efinity extracts the FIFO/SPRAM memories to block RAM properly;
Xilinx/Microchip flows are unaffected (verified no change in inference there).
There's no functional change — things elaborate and the design boots and runs
identically in simulation.
