### PR TITLE
minor rtl edits and optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 12.08.2026 | 1.13.4.2 | minor rtl edits and optimizations | [#1624](https://github.com/stnolting/neorv32/pull/1624) |
 | 12.08.2026 | 1.13.4.1 | declare FIFO/SPRAM memory arrays per generate-branch to fix RAM extraction on Verific-based synthesis tools | [#1623](https://github.com/stnolting/neorv32/pull/1623) |
 | 10.08.2026 | [**1.13.4**](https://github.com/stnolting/neorv32/releases/tag/v1.13.4) | :rocket: **New release** | |
 | 09.08.2026 | 1.13.3.9 | minor CPU updates, optimizations and RISC-V-compliance fixes | [#1621](https://github.com/stnolting/neorv32/pull/1621) |

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -374,8 +374,9 @@ architecture neorv32_bus_gateway_rtl of neorv32_bus_gateway is
   signal int_rsp : bus_rsp_t;
 
   -- bus monitor --
+  type state_t is (S_IDLE, S_BUSY, S_ERROR);
   type keeper_t is record
-    state : std_ulogic_vector(1 downto 0);
+    state : state_t;
     lock  : std_ulogic;
     sel   : std_ulogic_vector(4 downto 0);
     cnt   : std_ulogic_vector(tmo_cnt_size_c downto 0);
@@ -438,23 +439,23 @@ begin
   bus_monitor: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      keeper.state <= (others => '0');
+      keeper.state <= S_IDLE;
       keeper.lock  <= '0';
       keeper.sel   <= (others => '0');
       keeper.cnt   <= (others => '0');
     elsif rising_edge(clk_i) then
       case keeper.state is
 
-        when "00" => -- idle, waiting for new access request
+        when S_IDLE => -- idle, waiting for new access request
         -- ------------------------------------------------------------
           keeper.lock <= req_i.lock;
           keeper.sel  <= port_sel;
           keeper.cnt  <= (others => '0');
           if (req_i.stb = '1') then
-            keeper.state <= "01";
+            keeper.state <= S_BUSY;
           end if;
 
-        when "01" => -- busy, transfer in progress
+        when S_BUSY => -- busy, transfer in progress
         -- ------------------------------------------------------------
           -- timeout counter --
           if (int_rsp.ack = '1') then -- reset for each burst element
@@ -464,19 +465,19 @@ begin
           end if;
           -- bus status --
           if (tmo_fire = '1') then -- timeout
-            keeper.state <= "11";
+            keeper.state <= S_ERROR;
           elsif (keeper.lock = '1') then -- locked / burst transfer
             if (req_i.lock = '0') then
-              keeper.state <= "00";
+              keeper.state <= S_IDLE;
             end if;
           elsif (int_rsp.ack = '1') then -- end of single transfer
-            keeper.state <= "00";
+            keeper.state <= S_IDLE;
           end if;
 
-        when others => -- return error response until end of (locked) transfer
+        when S_ERROR => -- return error response until end of (locked) transfer
         -- ------------------------------------------------------------
           if (keeper.lock = '0') or (req_i.lock = '0') then
-            keeper.state <= "00";
+            keeper.state <= S_IDLE;
           end if;
 
       end case;
@@ -491,8 +492,8 @@ begin
   tmo_fire <= or_reduce_f(tmo_bits and keeper.sel);
 
   -- bus keeper error --
-  bus_err <= keeper.state(1); -- send error to host
-  term_o  <= keeper.state(1); -- terminate pending (external) bus access
+  bus_err <= '1' when (keeper.state = S_ERROR) else '0'; -- send error to host
+  term_o  <= '1' when (keeper.state = S_ERROR) else '0'; -- terminate pending (external) bus access
 
   -- external timeout notification --
   assert (X_TMO > 0) report "[NEORV32] External bus timeout disabled! Can cause permanent system stall!" severity warning;

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -219,14 +219,27 @@ begin
   -- -------------------------------------------------------------------------------------------
   response_reg_enabled:
   if RSP_REG_EN generate
-    response_reg: process(rstn_i, clk_i)
+
+    -- signals that DO require a defined reset (access control signals) --
+    response_reg_reset: process(rstn_i, clk_i)
     begin
       if (rstn_i = '0') then
-        host_rsp_o <= rsp_terminate_c;
+        host_rsp_o.ack <= '0';
+        host_rsp_o.err <= '0';
       elsif rising_edge(clk_i) then
-        host_rsp_o <= device_rsp_i;
+        host_rsp_o.ack <= device_rsp_i.ack;
+        host_rsp_o.err <= device_rsp_i.err;
       end if;
     end process;
+
+    -- signals that do not need a defined reset --
+    response_reg_noreset: process(clk_i)
+    begin
+      if rising_edge(clk_i) then
+        host_rsp_o.data <= device_rsp_i.data;
+      end if;
+    end process;
+
   end generate;
 
   response_reg_disabled:

--- a/rtl/core/neorv32_bus.vhd
+++ b/rtl/core/neorv32_bus.vhd
@@ -431,8 +431,8 @@ begin
 
   -- host response --
   rsp_o.data <= int_rsp.data;
-  rsp_o.ack  <= int_rsp.ack or bus_err;
-  rsp_o.err  <= int_rsp.err or bus_err;
+  rsp_o.ack  <= '0' when (keeper.state = S_IDLE) else (int_rsp.ack or bus_err); -- filter spurious response
+  rsp_o.err  <= '0' when (keeper.state = S_IDLE) else (int_rsp.err or bus_err); -- filter spurious response
 
   -- Bus Monitor (aka "the KEEPER") ---------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -392,11 +392,10 @@ begin
           when opcode_fence_c =>
             if (exec.ir(instr_funct3_lsb_c) = '1') then -- fence.i
               ctrl_nxt.if_fence <= '1'; -- instruction fence
-              exec_nxt.state    <= S_RESTART; -- reset instruction fetch & IPB via branch to next-PC
             else -- fence
               ctrl_nxt.lsu_fence <= or_reduce_f(exec.ir(31 downto 24)); -- data fence if pred/succ != 0; execute as NOP otherwise
-              exec_nxt.state     <= S_DISPATCH;
             end if;
+            exec_nxt.state <= S_RESTART; -- reset instruction fetch & IPB via branch to next-PC (only required for fence.i)
 
           -- FPU: floating-point operations --
           when opcode_fpu_c =>

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -290,9 +290,10 @@ begin
           exec_nxt.irc   <= frontend_i.i16; -- original instruction word
           exec_nxt.pc    <= exec.pc2(31 downto 1) & '0';
           exec_nxt.state <= S_EXECUTE; -- start executing new instruction
-          if (frontend_i.i32(instr_opcode_msb_c downto instr_opcode_lsb_c+2) = opcode_system_c(6 downto 2)) then
-            ctrl_nxt.csr_addr <= frontend_i.i32(instr_imm12_msb_c downto instr_imm12_lsb_c); -- reduce switching activity on csr_addr net
-          end if;
+        end if;
+        -- buffer CSR address for SYSTEM instructions to reduce switching activity on csr_addr net --
+        if (frontend_i.i32(instr_opcode_msb_c downto instr_opcode_lsb_c+2) = opcode_system_c(6 downto 2)) then
+          ctrl_nxt.csr_addr <= frontend_i.i32(instr_imm12_msb_c downto instr_imm12_lsb_c);
         end if;
 
       when S_TRAP_ENTER => -- enter trap environment and jump to trap vector

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,6 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130402"; -- hardware version
   constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130404"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130401"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130402"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_sysinfo.vhd
+++ b/rtl/core/neorv32_sysinfo.vhd
@@ -84,6 +84,9 @@ architecture neorv32_sysinfo_rtl of neorv32_sysinfo is
   type sysinfo_t is array (0 to 3) of std_ulogic_vector(31 downto 0);
   signal sysinfo : sysinfo_t;
 
+  -- bus access --
+  signal ack, err : std_ulogic;
+
 begin
 
   -- SYSINFO(0): Processor Clock Frequency --------------------------------------------------
@@ -157,17 +160,22 @@ begin
   bus_response: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o <= rsp_terminate_c;
+      ack <= '0';
+      err <= '0';
     elsif rising_edge(clk_i) then
-      bus_rsp_o <= rsp_terminate_c; -- default
+      ack <= '0';
+      err <= '0';
       if (bus_req_i.stb = '1') then
-        bus_rsp_o.data <= sysinfo(to_integer(unsigned(bus_req_i.addr(3 downto 2))));
-        bus_rsp_o.ack  <= '1';
+        ack <= '1';
         if (bus_req_i.rw = '1') and (bus_req_i.addr(3 downto 2) /= "00") then
-          bus_rsp_o.err <= '1'; -- error if write access to any address other than zero
+          err <= '1'; -- error if write access to any address other than zero
         end if;
       end if;
     end if;
   end process;
+
+  bus_rsp_o.ack  <= ack;
+  bus_rsp_o.err  <= err;
+  bus_rsp_o.data <= sysinfo(to_integer(unsigned(bus_req_i.addr(3 downto 2)))) when (ack = '1') else (others => '0');
 
 end architecture;


### PR DESCRIPTION
* bus monitor: use generic state encoding
* bus monitor: add spurious response filtering
* bus register: remove response data reset
* sysinfo: use async read access
* control: simplify CSR address buffer logic
* control: simplify `fence` next-state logic