### PR TITLE
[cpu] generalize fast multiplier pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 14.08.2026 | 1.13.4.5 | CPU: generalize fast multiplier pipeline | [#1625](https://github.com/stnolting/neorv32/pull/1625) |
 | 14.08.2026 | 1.13.4.4 | minor rtl edits and optimizations | [#1624](https://github.com/stnolting/neorv32/pull/1624) |
 | 14.08.2026 | 1.13.4.3 | normalize bus/list array ranges to `x downto y` | [#1622](https://github.com/stnolting/neorv32/pull/1622) |
 | 14.08.2026 | 1.13.4.2 | bitmanip: simplify register enables | [#1626](https://github.com/stnolting/neorv32/pull/1626) |

--- a/docs/datasheet/cpu.adoc
+++ b/docs/datasheet/cpu.adoc
@@ -388,18 +388,20 @@ result bit in every cycle. Multiplication operations always require 32 clock cyc
 
 {empty} +
 [discrete]
-===== **`CPU_FAST_MUL_REG`**
+===== **`CPU_FAST_MUL_REGS`**
 
 [cols="<1,<8"]
 [frame="topbot",grid="none"]
 |=======================
-| Name        | Fast multiplier pipeline register
-| Type        | `boolean`
-| Default     | `false` (disabled)
-| Description | Only effective together with <<_cpu_fast_mul_en>>. When **enabled** a pipeline register is added to the fast
-multiplier so the synthesis tool can retime it into the DSP cascade that is inferred when the DSP blocks are narrower than the
-operands, shortening the critical path. Costs one extra latency cycle per multiplication (`T_mul_latency` = 2).
-|             | When **disabled** the fast multiplier is bit-identical to before. Wide-DSP targets (e.g. Xilinx UltraScale+) do not need this.
+| Name        | Fast multiplier register stages
+| Type        | `natural` (1..3)
+| Default     | 1
+| Description | Only effective together with <<_cpu_fast_mul_en>>. This option selects the number of register stages in the fast
+multiplier. The multiplier result is valid `CPU_FAST_MUL_REGS + 1` cycles after the operation trigger, including input operand capture;
+`T_mul_latency` equals `CPU_FAST_MUL_REGS`.
+|             | A value of 1 uses a single inferred multiplier stage. A value of 2 adds an output register that synthesis may retime
+into a DSP cascade. A value of 3 decomposes the product into four half-word multiplications with explicitly registered partial
+products, partial sums, and final result. This provides deterministic pipeline boundaries and avoids multi-DSP multiplier cascades.
 |=======================
 
 

--- a/docs/datasheet/cpu_isa.adoc
+++ b/docs/datasheet/cpu_isa.adoc
@@ -92,7 +92,7 @@ uncached accesses via the <<_processor_external_bus_interface_xbus>> may have ad
 2 for accessing the default processor-internal peripherals; +
 uncached accesses via the <<_processor_external_bus_interface_xbus>> may have additional wait states; +
 branches to an unaligned address require additional `2 x T_inst_latency` cycles
-| `T_mul_latency` | 1 if <<_cpu_fast_mul_en>> is `true` (2 if <<_cpu_fast_mul_reg>> is also `true`); 32 otherwise
+| `T_mul_latency` | <<_cpu_fast_mul_regs>> if <<_cpu_fast_mul_en>> is `true`; 32 otherwise
 | `T_cust_latency` | latency is defined by the custom <<_custom_functions_unit_cfu>> logic; +
 however, the minimum is 1 and the maximum is 512
 | `T_cache_sync` | cycles required to clear/flush the CPU cache(s) (D$ and/or I$); +

--- a/docs/datasheet/soc.adoc
+++ b/docs/datasheet/soc.adoc
@@ -117,7 +117,7 @@ can be determined via the <<_system_configuration_information_memory_sysinfo, SY
 4+^| **<<_cpu_tuning_options>>**
 | `CPU_CONSTT_BR_EN`    | boolean   | false         | Implement constant-time branches (same execution times for taken and not-taken branches).
 | `CPU_FAST_MUL_EN`     | boolean   | false         | Implement fast but large full-parallel multipliers (trying to infer DSP blocks); see section <<_cpu_arithmetic_logic_unit>>.
-| `CPU_FAST_MUL_REG`    | boolean   | false         | Add a pipeline register to the fast multiplier (requires `CPU_FAST_MUL_EN`); see section <<_cpu_arithmetic_logic_unit>>.
+| `CPU_FAST_MUL_REGS`   | natural   | 1             | Number of register stages for the fast multiplier (1..3; requires `CPU_FAST_MUL_EN`); see section <<_cpu_arithmetic_logic_unit>>.
 | `CPU_FAST_SHIFT_EN`   | boolean   | false         | Implement fast but large full-parallel barrel shifters; see section <<_cpu_arithmetic_logic_unit>>.
 | `CPU_RF_ARCH_SEL`     | natural   | 0             | CPU register file implementation style select; see section <<_cpu_register_file>>.
 4+^| **Physical Memory Protection (<<_smpmp_isa_extension>>)**

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -63,7 +63,7 @@ entity neorv32_cpu is
     CPU_TRACE_EN        : boolean                        := false;       -- enable CPU execution trace generator
     CPU_CONSTT_BR_EN    : boolean                        := false;       -- constant-time branches
     CPU_FAST_MUL_EN     : boolean                        := false;       -- use DSPs for M extension's multiplier
-    CPU_FAST_MUL_REG    : boolean                        := false;       -- add a pipeline register to the fast multiplier (needs CPU_FAST_MUL_EN)
+    CPU_FAST_MUL_REGS   : natural range 1 to 3           := 1;           -- number of fast multiplier register stages (needs CPU_FAST_MUL_EN)
     CPU_FAST_SHIFT_EN   : boolean                        := false;       -- use barrel shifter for shift operations
     CPU_RF_ARCH_SEL     : natural range 0 to 3           := 0;           -- register file implementation style select
     -- Physical Memory Protection (PMP) --
@@ -202,7 +202,7 @@ begin
       sel_string_f(CPU_TRACE_EN,                 "trace ",              "") &
       sel_string_f(CPU_CONSTT_BR_EN,             "constt_br ",          "") &
       sel_string_f(CPU_FAST_MUL_EN,              "fast_mul ",           "") &
-      sel_string_f(CPU_FAST_MUL_REG,             "fast_mul_reg ",       "") &
+      "fast_mul_regs=" & natural'image(CPU_FAST_MUL_REGS) & " " &
       sel_string_f(CPU_FAST_SHIFT_EN,            "fast_shift ",         "") &
       sel_string_f(boolean(CPU_RF_ARCH_SEL = 0), "rf_arch=sram_sync ",  "") &
       sel_string_f(boolean(CPU_RF_ARCH_SEL = 1), "rf_arch=sram_async ", "") &
@@ -447,9 +447,9 @@ begin
     RISCV_ISA_Zmmul  => RISCV_ISA_Zmmul,  -- multiply-only M sub-extension
     RISCV_ISA_Xcfu   => RISCV_ISA_Xcfu,   -- custom (instr.) functions unit
     -- Tuning Options --
-    FAST_MUL_EN      => CPU_FAST_MUL_EN,  -- use DSPs for M extension's multiplier
-    FAST_MUL_REG     => CPU_FAST_MUL_REG, -- add a pipeline register to the fast multiplier
-    FAST_SHIFT_EN    => CPU_FAST_SHIFT_EN -- use barrel shifter for shift operations
+    FAST_MUL_EN      => CPU_FAST_MUL_EN,   -- use DSPs for M extension's multiplier
+    FAST_MUL_REGS    => CPU_FAST_MUL_REGS, -- number of fast multiplier register stages
+    FAST_SHIFT_EN    => CPU_FAST_SHIFT_EN  -- use barrel shifter for shift operations
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -428,24 +428,24 @@ begin
   neorv32_cpu_alu_inst: entity neorv32.neorv32_cpu_alu
   generic map (
     -- RISC-V ISA Extensions --
-    RISCV_ISA_M      => RISCV_ISA_M,      -- mul/div extension
-    RISCV_ISA_Zba    => RISCV_ISA_Zba,    -- address-generation instruction
-    RISCV_ISA_Zbb    => RISCV_ISA_Zbb,    -- basic bit-manipulation instruction
-    RISCV_ISA_Zbc    => RISCV_ISA_Zbc,    -- carry-less multiplication instructions
-    RISCV_ISA_Zbkb   => RISCV_ISA_Zbkb,   -- bit-manipulation instructions for cryptography
-    RISCV_ISA_Zbkc   => RISCV_ISA_Zbkc,   -- carry-less multiplication instructions
-    RISCV_ISA_Zbkx   => RISCV_ISA_Zbkx,   -- cryptography crossbar permutation extension
-    RISCV_ISA_Zbs    => RISCV_ISA_Zbs,    -- single-bit instructions
-    RISCV_ISA_Zfinx  => RISCV_ISA_Zfinx,  -- 32-bit floating-point extension
-    RISCV_ISA_Zibi   => RISCV_ISA_Zibi,   -- branch with immediate
-    RISCV_ISA_Zicond => RISCV_ISA_Zicond, -- integer conditional operations
-    RISCV_ISA_Zknd   => RISCV_ISA_Zknd,   -- cryptography NIST AES decryption extension
-    RISCV_ISA_Zkne   => RISCV_ISA_Zkne,   -- cryptography NIST AES encryption extension
-    RISCV_ISA_Zknh   => RISCV_ISA_Zknh,   -- cryptography NIST hash extension
-    RISCV_ISA_Zksed  => RISCV_ISA_Zksed,  -- ShangMi block cipher extension
-    RISCV_ISA_Zksh   => RISCV_ISA_Zksh,   -- ShangMi hash extension
-    RISCV_ISA_Zmmul  => RISCV_ISA_Zmmul,  -- multiply-only M sub-extension
-    RISCV_ISA_Xcfu   => RISCV_ISA_Xcfu,   -- custom (instr.) functions unit
+    RISCV_ISA_M      => RISCV_ISA_M,       -- mul/div extension
+    RISCV_ISA_Zba    => RISCV_ISA_Zba,     -- address-generation instruction
+    RISCV_ISA_Zbb    => RISCV_ISA_Zbb,     -- basic bit-manipulation instruction
+    RISCV_ISA_Zbc    => RISCV_ISA_Zbc,     -- carry-less multiplication instructions
+    RISCV_ISA_Zbkb   => RISCV_ISA_Zbkb,    -- bit-manipulation instructions for cryptography
+    RISCV_ISA_Zbkc   => RISCV_ISA_Zbkc,    -- carry-less multiplication instructions
+    RISCV_ISA_Zbkx   => RISCV_ISA_Zbkx,    -- cryptography crossbar permutation extension
+    RISCV_ISA_Zbs    => RISCV_ISA_Zbs,     -- single-bit instructions
+    RISCV_ISA_Zfinx  => RISCV_ISA_Zfinx,   -- 32-bit floating-point extension
+    RISCV_ISA_Zibi   => RISCV_ISA_Zibi,    -- branch with immediate
+    RISCV_ISA_Zicond => RISCV_ISA_Zicond,  -- integer conditional operations
+    RISCV_ISA_Zknd   => RISCV_ISA_Zknd,    -- cryptography NIST AES decryption extension
+    RISCV_ISA_Zkne   => RISCV_ISA_Zkne,    -- cryptography NIST AES encryption extension
+    RISCV_ISA_Zknh   => RISCV_ISA_Zknh,    -- cryptography NIST hash extension
+    RISCV_ISA_Zksed  => RISCV_ISA_Zksed,   -- ShangMi block cipher extension
+    RISCV_ISA_Zksh   => RISCV_ISA_Zksh,    -- ShangMi hash extension
+    RISCV_ISA_Zmmul  => RISCV_ISA_Zmmul,   -- multiply-only M sub-extension
+    RISCV_ISA_Xcfu   => RISCV_ISA_Xcfu,    -- custom (instr.) functions unit
     -- Tuning Options --
     FAST_MUL_EN      => CPU_FAST_MUL_EN,   -- use DSPs for M extension's multiplier
     FAST_MUL_REGS    => CPU_FAST_MUL_REGS, -- number of fast multiplier register stages

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -37,9 +37,9 @@ entity neorv32_cpu_alu is
     RISCV_ISA_Zmmul  : boolean; -- multiply-only M sub-extension
     RISCV_ISA_Xcfu   : boolean; -- custom (instr.) functions unit
     -- Tuning Options --
-    FAST_MUL_EN      : boolean; -- use DSPs for M extension's multiplier
-    FAST_MUL_REG     : boolean; -- add a pipeline register to the fast multiplier
-    FAST_SHIFT_EN    : boolean  -- use barrel shifter for shift operations
+    FAST_MUL_EN      : boolean;              -- use DSPs for M extension's multiplier
+    FAST_MUL_REGS    : natural range 1 to 3; -- number of fast multiplier register stages
+    FAST_SHIFT_EN    : boolean               -- use barrel shifter for shift operations
   );
   port (
     -- global control --
@@ -172,9 +172,9 @@ begin
   if RISCV_ISA_M or RISCV_ISA_Zmmul generate
     neorv32_cpu_alu_muldiv_inst: entity neorv32.neorv32_cpu_alu_muldiv
     generic map (
-      FAST_MUL_EN  => FAST_MUL_EN,  -- use DSPs for faster multiplication
-      FAST_MUL_REG => FAST_MUL_REG, -- add a pipeline register to the fast multiplier
-      DIVISION_EN  => RISCV_ISA_M   -- implement divider hardware
+      FAST_MUL_EN   => FAST_MUL_EN,   -- use DSPs for faster multiplication
+      FAST_MUL_REGS => FAST_MUL_REGS, -- number of fast multiplier register stages
+      DIVISION_EN   => RISCV_ISA_M    -- implement divider hardware
     )
     port map (
       -- global control --

--- a/rtl/core/neorv32_cpu_alu_muldiv.vhd
+++ b/rtl/core/neorv32_cpu_alu_muldiv.vhd
@@ -22,9 +22,9 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_cpu_alu_muldiv is
   generic (
-    FAST_MUL_EN  : boolean; -- use DSPs for faster multiplication
-    FAST_MUL_REG : boolean; -- add a pipeline register to the fast multiplier (needs FAST_MUL_EN)
-    DIVISION_EN  : boolean  -- implement divider hardware
+    FAST_MUL_EN   : boolean;              -- use DSPs for faster multiplication
+    FAST_MUL_REGS : natural range 1 to 3; -- number of fast multiplier register stages (needs FAST_MUL_EN)
+    DIVISION_EN   : boolean               -- implement divider hardware
   );
   port (
     -- global control --
@@ -63,6 +63,9 @@ architecture neorv32_cpu_alu_muldiv_rtl of neorv32_cpu_alu_muldiv is
   constant op_divu_c   : std_ulogic_vector(2 downto 0) := "101";
   constant op_rem_c    : std_ulogic_vector(2 downto 0) := "110";
   constant op_remu_c   : std_ulogic_vector(2 downto 0) := "111";
+
+  -- clock cycles from fast-multiplier operand capture to result
+  constant mul_latency_c : natural := FAST_MUL_REGS + 1;
 
   -- instruction decode --
   signal valid_cmd : std_ulogic;
@@ -121,7 +124,8 @@ begin
         -- ------------------------------------------------------------
           if (valid_cmd = '1') then -- trigger new operation
             if (ctrl_i.ir_funct3(2) = '0') and FAST_MUL_EN then -- is fast multiplication?
-              if FAST_MUL_REG then -- pipelined product needs one more cycle
+              if (FAST_MUL_REGS > 1) then -- wait for the pipelined product
+                ctrl.cnt   <= std_ulogic_vector(to_unsigned(mul_latency_c - 3, ctrl.cnt'length));
                 ctrl.state <= S_PIPE;
               else
                 ctrl.state <= S_DONE;
@@ -138,9 +142,12 @@ begin
             ctrl.state <= S_DONE;
           end if;
 
-        when S_PIPE => -- extra cycle for the fast multiplier's pipeline register
+        when S_PIPE => -- wait for fast-multiplier pipeline
         -- ------------------------------------------------------------
-          ctrl.state <= S_DONE;
+          ctrl.cnt <= std_ulogic_vector(unsigned(ctrl.cnt) - 1);
+          if (or_reduce_f(ctrl.cnt) = '0') then
+            ctrl.state <= S_DONE;
+          end if;
 
         when S_DONE => -- S_DONE: final step / enable output for one cycle
         -- ------------------------------------------------------------
@@ -172,7 +179,7 @@ begin
     multiplier_inst: entity neorv32.neorv32_prim_mul
     generic map (
       DWIDTH   => 32,
-      PIPELINE => FAST_MUL_REG
+      NUM_REGS => FAST_MUL_REGS
     )
     port map (
       clk_i  => clk_i,

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130404"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130405"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -943,7 +943,7 @@ package neorv32_package is
     -- Tuning Options --
     CPU_CONSTT_BR_EN    : boolean                        := false;
     CPU_FAST_MUL_EN     : boolean                        := false;
-    CPU_FAST_MUL_REG    : boolean                        := false;
+    CPU_FAST_MUL_REGS   : natural range 1 to 3           := 1;
     CPU_FAST_SHIFT_EN   : boolean                        := false;
     CPU_RF_ARCH_SEL     : natural range 0 to 3           := 0;
     -- Physical Memory Protection (PMP) --

--- a/rtl/core/neorv32_prim.vhd
+++ b/rtl/core/neorv32_prim.vhd
@@ -249,7 +249,9 @@ end architecture;
 
 
 -- ================================================================================ --
--- NEORV32 Primitives - Generic 2-Cycle Signed/Unsigned Integer Multiplier (MUL)    --
+-- NEORV32 Primitives - Generic Signed/Unsigned Integer Multiplier (MUL)            --
+-- -------------------------------------------------------------------------------- --
+-- The result is valid NUM_REGS+1 cycles after en_i.                                --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
@@ -264,8 +266,8 @@ use ieee.numeric_std.all;
 
 entity neorv32_prim_mul is
   generic (
-    DWIDTH   : natural;         -- operand width
-    PIPELINE : boolean := false -- add a second (output) register stage
+    DWIDTH   : natural;                   -- operand width
+    NUM_REGS : natural range 1 to 3 := 1  -- number of multiplier register stages
   );
   port (
     -- global control --
@@ -282,8 +284,8 @@ end entity;
 
 architecture neorv32_prim_mul_rtl of neorv32_prim_mul is
 
-  signal opa, opb  : signed(DWIDTH downto 0);
-  signal res, res2 : signed((2*DWIDTH)+1 downto 0);
+  signal opa, opb : signed(DWIDTH downto 0);
+  signal res      : signed((2*DWIDTH)+1 downto 0);
 
 begin
 
@@ -299,37 +301,80 @@ begin
     end if;
   end process;
 
-  -- Output Register ------------------------------------------------------------------------
+  -- Multiplier -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  out_reg: process(clk_i)
-  begin
-    if rising_edge(clk_i) then -- no reset to improve DSP mapping
-      res <= opa * opb;
-    end if;
-  end process;
-
-  -- Optional Pipeline Register -------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  -- Second register layer, giving synthesis a register to retime into a DSP
-  -- cascade (needed when DSP blocks are narrower than the operands). Shortens
-  -- the critical path at the cost of one latency cycle (handled by the caller).
-  pipe_true:
-  if PIPELINE generate
-    pipe_reg: process(clk_i)
+  one_reg:
+  if (NUM_REGS = 1) generate
+    mul_reg: process(clk_i)
     begin
-      if rising_edge(clk_i) then -- no reset to improve DSP mapping
-        res2 <= res;
+      if rising_edge(clk_i) then -- no reset to improve multiplier mapping
+        res <= opa * opb;
       end if;
     end process;
   end generate;
 
-  pipe_false:
-  if not PIPELINE generate
-    res2 <= res;
+  two_regs:
+  if (NUM_REGS = 2) generate
+    signal mul_res : signed((2*DWIDTH)+1 downto 0);
+  begin
+    mul_reg: process(clk_i)
+    begin
+      if rising_edge(clk_i) then -- no reset to improve multiplier mapping
+        mul_res <= opa * opb;
+      end if;
+    end process;
+
+    result_reg: process(clk_i)
+    begin
+      if rising_edge(clk_i) then -- no reset to improve multiplier mapping
+        res <= mul_res;
+      end if;
+    end process;
+  end generate;
+
+  three_regs:
+  if (NUM_REGS = 3) generate
+    constant lo_width_c : natural := DWIDTH / 2;
+    constant hi_width_c : natural := (DWIDTH + 1) - lo_width_c;
+    constant pp_width_c : natural := 2 * hi_width_c;
+    constant pr_width_c : natural := (2 * DWIDTH) + 2;
+
+    signal q_ll, q_lh, q_hl, q_hh : signed(pp_width_c-1 downto 0);
+    signal q_sum_lo, q_sum_hi     : signed(pr_width_c-1 downto 0);
+  begin
+    partial_product_reg: process(clk_i)
+    begin
+      if rising_edge(clk_i) then -- no reset to improve multiplier mapping
+        q_ll <= resize(signed('0' & std_ulogic_vector(opa(lo_width_c-1 downto 0))) *
+                       signed('0' & std_ulogic_vector(opb(lo_width_c-1 downto 0))), pp_width_c);
+        q_lh <= resize(signed('0' & std_ulogic_vector(opa(lo_width_c-1 downto 0))) *
+                       resize(opb(opb'left downto lo_width_c), hi_width_c), pp_width_c);
+        q_hl <= resize(resize(opa(opa'left downto lo_width_c), hi_width_c) *
+                       signed('0' & std_ulogic_vector(opb(lo_width_c-1 downto 0))), pp_width_c);
+        q_hh <= resize(resize(opa(opa'left downto lo_width_c), hi_width_c) *
+                       resize(opb(opb'left downto lo_width_c), hi_width_c), pp_width_c);
+      end if;
+    end process;
+
+    partial_sum_reg: process(clk_i)
+    begin
+      if rising_edge(clk_i) then -- no reset to improve multiplier mapping
+        q_sum_lo <= resize(q_ll, pr_width_c) + shift_left(resize(q_lh, pr_width_c), lo_width_c);
+        q_sum_hi <= shift_left(resize(q_hl, pr_width_c), lo_width_c) +
+                    shift_left(resize(q_hh, pr_width_c), 2*lo_width_c);
+      end if;
+    end process;
+
+    result_reg: process(clk_i)
+    begin
+      if rising_edge(clk_i) then -- no reset to improve multiplier mapping
+        res <= q_sum_lo + q_sum_hi;
+      end if;
+    end process;
   end generate;
 
   -- result --
-  res_o <= std_ulogic_vector(res2((2*DWIDTH)-1 downto 0));
+  res_o <= std_ulogic_vector(res((2*DWIDTH)-1 downto 0));
 
 end architecture;
 

--- a/rtl/core/neorv32_top.vhd
+++ b/rtl/core/neorv32_top.vhd
@@ -69,7 +69,7 @@ entity neorv32_top is
     -- Tuning Options --
     CPU_CONSTT_BR_EN    : boolean                        := false;         -- enable constant-time branches
     CPU_FAST_MUL_EN     : boolean                        := false;         -- use DSPs for M extension's multiplier
-    CPU_FAST_MUL_REG    : boolean                        := false;         -- add a pipeline register to the fast multiplier (needs CPU_FAST_MUL_EN)
+    CPU_FAST_MUL_REGS   : natural range 1 to 3           := 1;             -- number of fast multiplier register stages (needs CPU_FAST_MUL_EN)
     CPU_FAST_SHIFT_EN   : boolean                        := false;         -- use barrel shifter for shift operations
     CPU_RF_ARCH_SEL     : natural range 0 to 3           := 0;             -- register file implementation style select
 
@@ -589,7 +589,7 @@ begin
       CPU_TRACE_EN        => trace_en_c,
       CPU_CONSTT_BR_EN    => CPU_CONSTT_BR_EN,
       CPU_FAST_MUL_EN     => CPU_FAST_MUL_EN,
-      CPU_FAST_MUL_REG    => CPU_FAST_MUL_REG,
+      CPU_FAST_MUL_REGS   => CPU_FAST_MUL_REGS,
       CPU_FAST_SHIFT_EN   => CPU_FAST_SHIFT_EN,
       CPU_RF_ARCH_SEL     => CPU_RF_ARCH_SEL,
       -- Physical Memory Protection (PMP) --

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -310,10 +310,12 @@ proc setup_ip_gui {} {
   add_params $group {
     { CPU_CONSTT_BR_EN  {Constant-time branches} {Identical execution times for taken and not-taken branches} }
     { CPU_FAST_MUL_EN   {DSP-based multiplier}   {Use DSP block instead of bit-serial multipliers} }
-    { CPU_FAST_MUL_REG  {Multiplier register}    {Add a pipeline register to the DSP-based multiplier to improve timing closure} }
+    { CPU_FAST_MUL_REGS {Multiplier registers}   {Number of multiplier register stages (1..3)} }
     { CPU_FAST_SHIFT_EN {Barrel shifter}         {Use full-parallel shifters instead of of bit-serial shifters} }
     { CPU_RF_ARCH_SEL   {Register file style}    {Select implementation style of CPU register file} }
   }
+  set_property value_validation_range_minimum 1 [ipx::get_user_parameters CPU_FAST_MUL_REGS -of_objects [ipx::current_core]]
+  set_property value_validation_range_maximum 3 [ipx::get_user_parameters CPU_FAST_MUL_REGS -of_objects [ipx::current_core]]
   set_property widget {comboBox} [ipgui::get_guiparamspec -name "CPU_RF_ARCH_SEL" -component [ipx::current_core] ]
   set_property value_validation_type pairs [ipx::get_user_parameters CPU_RF_ARCH_SEL -of_objects [ipx::current_core]]
   set_property value_validation_pairs {{Block RAM} 0 {Distributed RAM} 1 {FFs with reset} 2 {Latches} 3} [ipx::get_user_parameters CPU_RF_ARCH_SEL -of_objects [ipx::current_core]]

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -314,8 +314,6 @@ proc setup_ip_gui {} {
     { CPU_FAST_SHIFT_EN {Barrel shifter}         {Use full-parallel shifters instead of of bit-serial shifters} }
     { CPU_RF_ARCH_SEL   {Register file style}    {Select implementation style of CPU register file} }
   }
-  set_property value_validation_range_minimum 1 [ipx::get_user_parameters CPU_FAST_MUL_REGS -of_objects [ipx::current_core]]
-  set_property value_validation_range_maximum 3 [ipx::get_user_parameters CPU_FAST_MUL_REGS -of_objects [ipx::current_core]]
   set_property widget {comboBox} [ipgui::get_guiparamspec -name "CPU_RF_ARCH_SEL" -component [ipx::current_core] ]
   set_property value_validation_type pairs [ipx::get_user_parameters CPU_RF_ARCH_SEL -of_objects [ipx::current_core]]
   set_property value_validation_pairs {{Block RAM} 0 {Distributed RAM} 1 {FFs with reset} 2 {Latches} 3} [ipx::get_user_parameters CPU_RF_ARCH_SEL -of_objects [ipx::current_core]]

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -69,7 +69,7 @@ entity neorv32_vivado_ip is
     -- Tuning Options --
     CPU_CONSTT_BR_EN      : boolean                        := false;
     CPU_FAST_MUL_EN       : boolean                        := false;
-    CPU_FAST_MUL_REG      : boolean                        := false;
+    CPU_FAST_MUL_REGS     : natural range 1 to 3           := 1;
     CPU_FAST_SHIFT_EN     : boolean                        := false;
     CPU_RF_ARCH_SEL       : natural range 0 to 3           := 1; -- map to distributed RAM
     -- Physical Memory Protection (PMP) --
@@ -442,7 +442,7 @@ begin
     -- Extension Options --
     CPU_CONSTT_BR_EN    => CPU_CONSTT_BR_EN,
     CPU_FAST_MUL_EN     => CPU_FAST_MUL_EN,
-    CPU_FAST_MUL_REG    => CPU_FAST_MUL_REG,
+    CPU_FAST_MUL_REGS   => CPU_FAST_MUL_REGS,
     CPU_FAST_SHIFT_EN   => CPU_FAST_SHIFT_EN,
     CPU_RF_ARCH_SEL     => CPU_RF_ARCH_SEL,
     -- Physical Memory Protection --

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -58,7 +58,7 @@ entity neorv32_tb is
     RISCV_ISA_Xcfu    : boolean                        := true;        -- custom (instr.) functions unit
     CPU_CONSTT_BR_EN  : boolean                        := false;       -- constant-time branches
     CPU_FAST_MUL_EN   : boolean                        := true;        -- use DSPs for M extension's multiplier
-    CPU_FAST_MUL_REG  : boolean                        := false;       -- add a pipeline register to the fast multiplier (override with nvc -g)
+    CPU_FAST_MUL_REGS : natural range 1 to 3           := 1;           -- number of fast multiplier register stages (override with nvc -g)
     CPU_FAST_SHIFT_EN : boolean                        := true;        -- use barrel shifter for shift operations
     CPU_RF_ARCH_SEL   : natural range 0 to 3           := 0;           -- register file implementation style select
     IMEM_EN           : boolean                        := true;        -- implement processor-internal instruction memory
@@ -299,7 +299,7 @@ begin
     -- Extension Options --
     CPU_CONSTT_BR_EN    => CPU_CONSTT_BR_EN,
     CPU_FAST_MUL_EN     => CPU_FAST_MUL_EN,
-    CPU_FAST_MUL_REG    => CPU_FAST_MUL_REG,
+    CPU_FAST_MUL_REGS   => CPU_FAST_MUL_REGS,
     CPU_FAST_SHIFT_EN   => CPU_FAST_SHIFT_EN,
     CPU_RF_ARCH_SEL     => CPU_RF_ARCH_SEL,
     -- Physical Memory Protection (PMP) --

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -58,7 +58,7 @@ entity neorv32_tb is
     RISCV_ISA_Xcfu    : boolean                        := true;        -- custom (instr.) functions unit
     CPU_CONSTT_BR_EN  : boolean                        := false;       -- constant-time branches
     CPU_FAST_MUL_EN   : boolean                        := true;        -- use DSPs for M extension's multiplier
-    CPU_FAST_MUL_REGS : natural range 1 to 3           := 1;           -- number of fast multiplier register stages (override with nvc -g)
+    CPU_FAST_MUL_REGS : natural range 1 to 3           := 1;           -- number of fast multiplier register stages
     CPU_FAST_SHIFT_EN : boolean                        := true;        -- use barrel shifter for shift operations
     CPU_RF_ARCH_SEL   : natural range 0 to 3           := 0;           -- register file implementation style select
     IMEM_EN           : boolean                        := true;        -- implement processor-internal instruction memory


### PR DESCRIPTION
## Background

This builds on #1391, which centralized multiplication in
`neorv32_prim_mul`, and #1603, which introduced `CPU_FAST_MUL_REG`.

The existing optional output register relies on synthesis retiming it into a
multi-DSP multiplier. This works well in some toolchains, but mapping and timing
remain vendor-dependent when native DSP blocks are narrower than the 33x33
signed product.

As discussed, this PR generalizes the boolean register option and adds an
explicitly pipelined implementation that avoids multi-DSP multiplier cascades.

## Summary

`CPU_FAST_MUL_REG` is replaced by:

```vhdl
CPU_FAST_MUL_REGS : natural range 1 to 3 := 1
```

The configurations are:

| `CPU_FAST_MUL_REGS` | Implementation | Primitive latency |
|:-------------------:|----------------|:-----------------:|
| `1` | Original inferred multiplier | 2 cycles |
| `2` | Original multiplier plus output register (`CPU_FAST_MUL_REG`) | 3 cycles |
| `3` | Explicit half-word partial-product pipeline | 4 cycles |

Thus, existing configurations map as follows:

- `CPU_FAST_MUL_REG = false` -> `CPU_FAST_MUL_REGS = 1`
- `CPU_FAST_MUL_REG = true` -> `CPU_FAST_MUL_REGS = 2`

The new three-register implementation uses:

```text
registered operands
  -> four registered half x half partial products
  -> two registered partial sums
  -> registered final sum
```

For `DWIDTH = 32`, each partial product is at most 17x17 signed. This fits one
native multiplier block on the mainstream FPGA families targeted here, avoiding
tool-dependent composition and retiming across multiple DSP blocks.

The data-path registers remain reset-free and CE-free, except for the
enable-controlled operand registers.

## Controller changes

`neorv32_cpu_alu_muldiv` derives the fast-multiplier latency from the selected
register count:

```vhdl
constant mul_latency_c : natural := FAST_MUL_REGS + 1;
```

The existing cycle counter handles the additional wait cycles without adding
more FSM states.

The documented ISA timing is:

```text
T_mul_latency = CPU_FAST_MUL_REGS
```

when `CPU_FAST_MUL_EN` is enabled.

## Latency contract

I also considered moving the latency contract into either:

- a shared package function; or
- a `done_o` strobe generated by `neorv32_prim_mul`.

Neither seemed worth the additional machinery in this change.

A package function would only wrap the simple `NUM_REGS + 1` relationship while
still requiring each consumer to implement its own scheduling. It would also
couple the otherwise generic primitive more closely to the NEORV32 package.

A primitive completion strobe would require validity state and reset handling.
More importantly, the integer M unit currently provides a one-cycle look-ahead
`valid_o`, whereas a natural multiplier `done_o` would indicate that the result
is valid in the current cycle. Adopting it cleanly would therefore require a
wider ALU handshake refactor or could add another multiplication cycle.

The latency remains documented at the primitive interface and derived locally
by the controller. The FPU continues to use the default one-register
configuration (`DWIDTH = 24`) and is unaffected.

## Integration and documentation

The renamed generic and its 1..3 range are propagated through:

- the CPU and processor top entities;
- the package component declaration;
- the simulation testbench;
- the Vivado IP wrapper and GUI; and
- the CPU, SoC, and ISA timing documentation.

## Verification

Completed locally:

- [x] Full GHDL compilation and elaboration
- [x] Full-system elaboration with `CPU_FAST_MUL_REGS = 1`, `2`, and `3`
- [x] Directed primitive tests for:
  - zero operands
  - `0x80000000 * 0x80000000`
  - negative signed x unsigned multiplication
  - `0xffffffff * 0xffffffff` unsigned
  - signed boundary combinations
- [x] 1,000 randomized reference cross-checks covering all signedness combinations
- [x] All three register configurations checked against the same plain signed-product reference
- [x] Controller result and completion timing checked for `MUL`, `MULH`, `MULHSU`, and `MULHU`
- [x] 10 ms full-system GHDL simulation with `CPU_FAST_MUL_REGS = 3`
- [x] `git diff --check`

Still outstanding / useful upstream testing:

- [x] RISC-V ACT tests for the M extension
- [ ] Post-route timing confirmation
- [x] Intel synthesis results
- [x] Lattice/Synplify synthesis results
- [ ] Microchip synthesis results

The focused primitive and controller checks used temporary local GHDL
testbenches and are not added to this PR.

## Synthesis evidence

On an AMD Zynq UltraScale+ RFSoC (`xczu48dr`, speed grade `-2`) with a 2.0 ns
clock constraint, Vivado absorbed each partial product into a DSP multiplier
register without attributes.

All multiplier paths had positive synthesis timing slack. The remaining
core-internal violations were in the prefetch-buffer-to-decode path, around
-0.3 ns, rather than in the multiplier.

The Intel, Microchip, and Lattice portability argument is currently structural:
each partial product fits one native multiplier block and no DSP post-adder
cascade is required. Measurements from those toolchains would still be very
valuable.