### PR TITLE
[bitmanip] simplify register enables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
-| 14.08.2026 | 1.13.4.2 | [bitmanip] simplify register enables | [#1626](https://github.com/stnolting/neorv32/pull/1626) |
+| 14.08.2026 | 1.13.4.2 | bitmanip: simplify register enables | [#1626](https://github.com/stnolting/neorv32/pull/1626) |
 | 12.08.2026 | 1.13.4.1 | declare FIFO/SPRAM memory arrays per generate-branch to fix RAM extraction on Verific-based synthesis tools | [#1623](https://github.com/stnolting/neorv32/pull/1623) |
 | 10.08.2026 | [**1.13.4**](https://github.com/stnolting/neorv32/releases/tag/v1.13.4) | :rocket: **New release** | |
 | 09.08.2026 | 1.13.3.9 | minor CPU updates, optimizations and RISC-V-compliance fixes | [#1621](https://github.com/stnolting/neorv32/pull/1621) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 14.08.2026 | 1.13.4.2 | [bitmanip] simplify register enables | [#1626](https://github.com/stnolting/neorv32/pull/1626) |
 | 12.08.2026 | 1.13.4.1 | declare FIFO/SPRAM memory arrays per generate-branch to fix RAM extraction on Verific-based synthesis tools | [#1623](https://github.com/stnolting/neorv32/pull/1623) |
 | 10.08.2026 | [**1.13.4**](https://github.com/stnolting/neorv32/releases/tag/v1.13.4) | :rocket: **New release** | |
 | 09.08.2026 | 1.13.3.9 | minor CPU updates, optimizations and RISC-V-compliance fixes | [#1621](https://github.com/stnolting/neorv32/pull/1621) |

--- a/rtl/core/neorv32_cpu_alu_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_alu_bitmanip.vhd
@@ -253,7 +253,6 @@ begin
               state       <= S_START;
             else
               valid <= '1';
-              state <= S_IDLE;
             end if;
           end if;
 
@@ -276,7 +275,7 @@ begin
   op_buf: process(clk_i)
   begin
     if rising_edge(clk_i) then
-      if (valid_cmd = '1') then
+      if (ctrl_i.alu_cp_alu = '1') then
         less_reg <= less_i;
         rs1_reg  <= rs1_i;
         rs2_reg  <= rs2_i;

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130401"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130402"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 


### PR DESCRIPTION
## Summary

This PR makes two small changes to the bit-manipulation unit's controller:

- capture `rs1`, `rs2`, `shamt`, and `less` on the common
  `ctrl_i.alu_cp_alu` dispatch trigger instead of the fully decoded
  `valid_cmd`; and
- remove the redundant `state <= S_IDLE` self-assignment for single-cycle
  operations.

## Motivation

The `or_reduce_f(cmd)` function-decode was part of the clock-enable cone for
the bit-manipulation unit's operand and FSM state registers.

At 500 MHz on a Zynq UltraScale+ RFSoC with a 2 ns clock constraint, the path
from `exec_reg[ir]` through instruction decode to approximately 70 register
clock enables was the final timing-violating cluster.

The operands are stable during the one-cycle ALU co-processor dispatch. The
bit-manipulation FSM only consumes the captured values when its own command
decode is valid, so capturing them for other ALU co-processor commands has no
behavioral effect. Likewise, omitting the explicit `S_IDLE` self-assignment
retains the current state through normal sequential semantics while reducing
the state register's load-enable logic.

There is no interface, behavior, or instruction-latency change.

With these changes, the previously failing register-enable paths have positive
timing slack at synthesis.

## Verification

- [x] Full maximum-ISA `processor_check` build and GHDL simulation
- [x] All enabled bit-manipulation extensions exercised: Zba, Zbb, Zbc, Zbs,
      Zbkb, Zbkc, and Zbkx
- [x] Processor check: 62/62 passed, 0 failed
- [x] `git diff --check`

Regression command:

```console
make RISCV_PREFIX=riscv32-unknown-elf- \
  USER_FLAGS+="-DUART0_SIM_MODE -DUART1_SIM_MODE" \
  clean_all info all sim-check
```

Closes #1617