### PR TITLE
Fix typo in README about GHDL

### DIFF
--- a/sim/README.md
+++ b/sim/README.md
@@ -1,5 +1,5 @@
 ## Simulation Sources
 
-Default testbench, helper modules and GDHL simulation scripts.
+Default testbench, helper modules and GHDL simulation scripts.
 
 :books: See [UG: Simulating the Processor](https://stnolting.github.io/neorv32/ug/#_simulating_the_processor).


### PR DESCRIPTION
Fixing Typo GDHL to GHDL