### PR TITLE
[alu] optimize set-on-less-than timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 29.08.2026 | 1.13.5.1 | CPU: optimize set-on-less-than timing | [#1635](https://github.com/stnolting/neorv32/pull/1635) |
 | 22.08.2026 | [**1.13.5**](https://github.com/stnolting/neorv32/releases/tag/v1.13.5) | :rocket: **New release** | |
 | 21.08.2026 | 1.13.4.9 | :bug: fix permanent CPU stall when accessing unmapped addresses (if XBUS is disabled) | [#1634](https://github.com/stnolting/neorv32/pull/1634) |
 | 21.08.2026 | 1.13.4.8 | convert remaining list arrays to `downto` (named-association aggregates) | [#1632](https://github.com/stnolting/neorv32/pull/1632) |

--- a/rtl/core/neorv32_cpu_alu.vhd
+++ b/rtl/core/neorv32_cpu_alu.vhd
@@ -78,7 +78,7 @@ architecture neorv32_cpu_alu_rtl of neorv32_cpu_alu is
   end function;
 
   -- ALU core --
-  signal cmp_rs1, cmp_rs2, opa, opb, addsub, cp_res : std_ulogic_vector(31 downto 0);
+  signal cmp_rs1, cmp_rs2, opa, opb, slt_opb, addsub, cp_res : std_ulogic_vector(31 downto 0);
   signal cmp_eq, cmp_lt, slt : std_ulogic;
 
   -- co-processor interface --
@@ -132,10 +132,11 @@ begin
   opb <= ctrl_i.alu_imm when (ctrl_i.alu_opb_mux = '1') else rs2_i;
 
   -- adder/subtractor
-  addsub <= std_ulogic_vector(unsigned(opa) - unsigned(opb)) when (ctrl_i.alu_sub = '1') else
-            std_ulogic_vector(unsigned(opa) + unsigned(opb));
-  add_o  <= addsub; -- direct output
-  slt    <= addsub(31) when (opa(31) = opb(31)) else opa(31) when (ctrl_i.alu_unsigned = '0') else opb(31);
+  addsub  <= std_ulogic_vector(unsigned(opa) - unsigned(opb)) when (ctrl_i.alu_sub = '1') else
+             std_ulogic_vector(unsigned(opa) + unsigned(opb));
+  add_o   <= addsub; -- direct output
+  slt_opb <= (opb(31) xnor ctrl_i.alu_unsigned) & opb(30 downto 0);
+  slt     <= '1' when unsigned(cmp_rs1) < unsigned(slt_opb) else '0';
 
   -- **************************************************************************************************************************
   -- Co-Processors

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130500"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130501"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 


### PR DESCRIPTION
## Summary

Replace the set-on-less-than result derived from the adder/subtractor MSB with a dedicated magnitude comparator.

The selected ALU operands are sign-bit biased before an unsigned comparison:

- signed `SLT`/`SLTI` invert the operand sign bits;
- unsigned `SLTU`/`SLTIU` preserve the operand sign bits;
- using `opa` and `opb` preserves register and immediate operand selection.

This does not change the CPU state machine, instruction latency, register-file architecture, or ISA behavior.

## Motivation

The previous implementation reused the adder/subtractor result and corrected its sign afterward. In a 500 MHz AMD UltraScale+ integration, this created 31 identical paths from the registered second operand through the full carry chain and ALU result selection to register-file bit 0.

The dedicated comparator maps the reported path to the comparator carry output and removes the adder-result sign-correction path from set-on-less-than writeback.

## Timing results

Vivado 2026.1 synthesis for `xczu48dr-ffvg1517-2` at 500 MHz:

| Metric | Before | After |
|---|---:|---:|
| WNS | -0.037 ns | +0.046 ns |
| TNS | -1.147 ns | 0.000 ns |
| Violating endpoints | 31 | 0 |
| Former SLT path delay | 1.882 ns | 1.310 ns |
| LUTs | 4,201 | 4,258 |
| CARRY8 | 70 | 72 |

For the former worst path, carry depth fell from four `CARRY8` cells to two and post-carry logic fell from four LUT levels to two.

# NEORV32 timing census

This census contains the endpoints whose destination is below the NEORV32 CPU hierarchy:

```text
u_impl_inst/scheduler_uc_inst/cpu_inst/
```

It was extracted from the uncapped Vivado 2026.1 synthesis report for `xczu48dr-ffvg1517-2` with a 2.000 ns clock requirement. Paths are classified by destination hierarchy, even when their startpoint is outside the CPU, such as program-BRAM-to-frontend paths. It would be nice to clear paths below +0.2 WNS and even better those below +.4 WNS for real margin at 500 MHz. My application outputs words using the stream interfaces for scheduling.

## Endpoint census

The NEORV32 hierarchy contains 6,620 timed endpoints.

| Slack bin | Paths | Cumulative |
|---|---:|---:|
| < 0.000 ns | 0 | 0 |
| 0.000–0.100 ns | 23 | 23 |
| 0.100–0.200 ns | 83 | 106 |
| 0.200–0.300 ns | 52 | 158 |
| 0.300–0.400 ns | 59 | 217 |
| 0.400–0.500 ns | 1,824 | 2,041 |
| 0.500–0.600 ns | 361 | 2,402 |
| 0.600–0.700 ns | 213 | 2,615 |
| 0.700–0.800 ns | 124 | 2,739 |
| 0.800–1.000 ns | 872 | 3,611 |
| >= 1.000 ns | 3,009 | 6,620 |

## Endpoints below +0.100 ns

| Paths | Slack | Family |
|---:|---:|---|
| 3 | +0.046 ns | `exec_reg[ir][26]` to bit-manipulation `FSM_onehot_state_reg[0:2]/CE` |
| 10 | +0.063 ns | `ctrl_reg[csr_addr][10]` to `csr_rdata_reg[6,10,18,19,21,25-29]/D` |
| 6 | +0.074 ns | `ctrl_reg[csr_addr][10]` to `csr_rdata_reg[16,17,20,22,24,30]/D` |
| 4 | +0.081 ns | `ctrl_reg[csr_addr][10]` to `csr_rdata_reg[4,7,23,31]/D` |

The NEORV32 WNS is therefore +0.046 ns. It belongs to three bit-manipulation FSM enable paths, not to SLT/SLTU.

## Endpoints below +0.200 ns

| Paths | Slack range | Family |
|---:|---:|---|
| 3 | +0.046 ns | Bit-manipulation FSM enables |
| 30 | +0.063 to +0.125 ns | CSR address decode to CSR read-data registers |
| 4 | +0.117 ns | Instruction decode to execution-state CEs |
| 27 | +0.132 to +0.196 ns | DSP multiplier-result recombination |
| 36 | +0.134 to +0.163 ns | Program BRAM to frontend prefetch storage |
| 3 | +0.154 ns | Register-file `rs2` to frontend fetch-state CEs |
| 3 | +0.194 ns | Bit-manipulation result registers |

## Destination attribution below +0.800 ns

| NEORV32 block | Paths |
|---|---:|
| Register file | 1,984 |
| CPU control | 328 |
| ALU | 308 |
| LSU | 69 |
| Frontend | 50 |
| **Total** | **2,739** |

## Verification

- [x] NEORV32 `processor_check` GHDL simulation: 62/62 passed, 0 failed
- [x] NEORV32 `hello_world` GHDL simulation: expected `Hello world! :)` output
- [x] The tested processor image contains `SLTI`, `SLTIU`, and `SLTU` instructions
- [x] `git diff --check`

Tests used the repository workflow with `RISCV_PREFIX=riscv32-unknown-elf-`.
