### PR TITLE
[serial IO] use asynchronous bus read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 29.08.2026 | 1.13.5.2 | :test_tube: use asynchronous bus read access for serial IO devices | [#1638](https://github.com/stnolting/neorv32/pull/1638) |
 | 29.08.2026 | 1.13.5.1 | CPU: optimize set-on-less-than timing | [#1635](https://github.com/stnolting/neorv32/pull/1635) |
 | 22.08.2026 | [**1.13.5**](https://github.com/stnolting/neorv32/releases/tag/v1.13.5) | :rocket: **New release** | |
 | 21.08.2026 | 1.13.4.9 | :bug: fix permanent CPU stall when accessing unmapped addresses (if XBUS is disabled) | [#1634](https://github.com/stnolting/neorv32/pull/1634) |

--- a/rtl/core/neorv32_neoled.vhd
+++ b/rtl/core/neorv32_neoled.vhd
@@ -52,6 +52,10 @@ architecture neorv32_neoled_rtl of neorv32_neoled is
   -- helpers --
   constant log2_fifo_size_c : natural := index_size_f(FIFO_DEPTH);
 
+  -- bus interface --
+  signal bus_ack, bus_rden : std_ulogic;
+  signal bus_rdata : std_ulogic_vector(31 downto 0);
+
   -- control register --
   type ctrl_t is record
     enable   : std_ulogic;
@@ -89,45 +93,60 @@ begin
 
   -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o     <= rsp_terminate_c;
+      bus_ack  <= '0';
+      bus_rden <= '0';
+    elsif rising_edge(clk_i) then
+      bus_ack  <= bus_req_i.stb;
+      bus_rden <= bus_req_i.stb and (not bus_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  bus_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
       ctrl.enable   <= '0';
       ctrl.clk_prsc <= (others => '0');
       ctrl.t_total  <= (others => '0');
       ctrl.t0_high  <= (others => '0');
       ctrl.t1_high  <= (others => '0');
     elsif rising_edge(clk_i) then
-      -- bus handshake --
-      bus_rsp_o.ack  <= bus_req_i.stb;
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      -- bus access --
-      if (bus_req_i.stb = '1') then
-        if (bus_req_i.rw = '1') then -- write access
-          if (bus_req_i.addr(2) = '0') then
-            ctrl.enable   <= bus_req_i.data(ctrl_en_c);
-            ctrl.clk_prsc <= bus_req_i.data(ctrl_clksel2_c downto ctrl_clksel0_c);
-            ctrl.t_total  <= bus_req_i.data(ctrl_t_tot4_c downto ctrl_t_tot0_c);
-            ctrl.t0_high  <= bus_req_i.data(ctrl_t_0h4_c downto ctrl_t_0h0_c);
-            ctrl.t1_high  <= bus_req_i.data(ctrl_t_1h4_c downto ctrl_t_1h0_c);
-          end if;
-        else -- read access
-          bus_rsp_o.data(ctrl_en_c)                            <= ctrl.enable;
-          bus_rsp_o.data(ctrl_clksel2_c downto ctrl_clksel0_c) <= ctrl.clk_prsc;
-          bus_rsp_o.data(ctrl_t_tot4_c downto ctrl_t_tot0_c)   <= ctrl.t_total;
-          bus_rsp_o.data(ctrl_t_0h4_c downto ctrl_t_0h0_c)     <= ctrl.t0_high;
-          bus_rsp_o.data(ctrl_t_1h4_c downto ctrl_t_1h0_c)     <= ctrl.t1_high;
-          --
-          bus_rsp_o.data(ctrl_fifo3_c downto ctrl_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
-          bus_rsp_o.data(ctrl_tx_empty_c)                  <= not tx_fifo.avail;
-          bus_rsp_o.data(ctrl_tx_full_c)                   <= not tx_fifo.free;
-          bus_rsp_o.data(ctrl_tx_busy_c)                   <= busy or tx_fifo.avail;
+      if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') then
+        if (bus_req_i.addr(2) = '0') then
+          ctrl.enable   <= bus_req_i.data(ctrl_en_c);
+          ctrl.clk_prsc <= bus_req_i.data(ctrl_clksel2_c downto ctrl_clksel0_c);
+          ctrl.t_total  <= bus_req_i.data(ctrl_t_tot4_c downto ctrl_t_tot0_c);
+          ctrl.t0_high  <= bus_req_i.data(ctrl_t_0h4_c downto ctrl_t_0h0_c);
+          ctrl.t1_high  <= bus_req_i.data(ctrl_t_1h4_c downto ctrl_t_1h0_c);
         end if;
       end if;
     end if;
   end process;
+
+  -- read access (asynchronous) --
+  bus_read: process(bus_rden, ctrl, tx_fifo, busy)
+  begin
+    bus_rdata <= (others => '0');
+    if (bus_rden = '1') then -- output gating
+      bus_rdata(ctrl_en_c)                            <= ctrl.enable;
+      bus_rdata(ctrl_clksel2_c downto ctrl_clksel0_c) <= ctrl.clk_prsc;
+      bus_rdata(ctrl_t_tot4_c downto ctrl_t_tot0_c)   <= ctrl.t_total;
+      bus_rdata(ctrl_t_0h4_c downto ctrl_t_0h0_c)     <= ctrl.t0_high;
+      bus_rdata(ctrl_t_1h4_c downto ctrl_t_1h0_c)     <= ctrl.t1_high;
+      bus_rdata(ctrl_fifo3_c downto ctrl_fifo0_c)     <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
+      bus_rdata(ctrl_tx_empty_c)                      <= not tx_fifo.avail;
+      bus_rdata(ctrl_tx_full_c)                       <= not tx_fifo.free;
+      bus_rdata(ctrl_tx_busy_c)                       <= busy or tx_fifo.avail;
+    end if;
+  end process;
+
+  -- bus response --
+  bus_rsp_o.ack  <= bus_ack;
+  bus_rsp_o.err  <= '0'; -- no access errors supported
+  bus_rsp_o.data <= bus_rdata;
 
 
   -- TX Buffer (FIFO) -----------------------------------------------------------------------

--- a/rtl/core/neorv32_onewire.vhd
+++ b/rtl/core/neorv32_onewire.vhd
@@ -34,7 +34,7 @@ end entity;
 architecture neorv32_onewire_rtl of neorv32_onewire is
 
   -- timing configuration (known-good, no need to change) --
-  -- absolute time in multiples of the base tick time t_base; see data sheet for more information about the t* timing values
+  -- absolute time in multiples of the base tick time t_base; see data sheet for more information
   constant t_write_one_c       : unsigned(6 downto 0) := to_unsigned( 1, 7); -- t0
   constant t_read_sample_c     : unsigned(6 downto 0) := to_unsigned( 2, 7); -- t1
   constant t_slot_end_c        : unsigned(6 downto 0) := to_unsigned( 7, 7); -- t2
@@ -74,6 +74,10 @@ architecture neorv32_onewire_rtl of neorv32_onewire is
 
   -- helpers --
   constant log2_fifo_size_c : natural := index_size_f(ONEWIRE_FIFO);
+
+  -- bus interface --
+  signal bus_ack, bus_rden : std_ulogic;
+  signal bus_rdata : std_ulogic_vector(31 downto 0);
 
   -- control register --
   type ctrl_t is record
@@ -120,48 +124,63 @@ architecture neorv32_onewire_rtl of neorv32_onewire is
 
 begin
 
-  -- Bus Access ---------------------------------------------------------------------------
+  -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o     <= rsp_terminate_c;
+      bus_ack  <= '0';
+      bus_rden <= '0';
+    elsif rising_edge(clk_i) then
+      bus_ack  <= bus_req_i.stb;
+      bus_rden <= bus_req_i.stb and (not bus_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  bus_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
       ctrl.enable   <= '0';
       ctrl.clk_prsc <= (others => '0');
       ctrl.clk_div  <= (others => '0');
       ctrl.clear    <= '0';
     elsif rising_edge(clk_i) then
-      -- bus handshake --
-      bus_rsp_o.ack  <= bus_req_i.stb;
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      -- control register write access --
-      ctrl.clear <= '0';
+      ctrl.clear <= '0'; -- default
       if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '0') then -- control register
         ctrl.enable   <= bus_req_i.data(ctrl_en_c);
         ctrl.clear    <= bus_req_i.data(ctrl_clear_c);
         ctrl.clk_prsc <= bus_req_i.data(ctrl_prsc1_c downto ctrl_prsc0_c);
         ctrl.clk_div  <= bus_req_i.data(ctrl_clkdiv7_c downto ctrl_clkdiv0_c);
       end if;
-      -- read access --
-      if (bus_req_i.stb = '1') and (bus_req_i.rw = '0') then
-        if (bus_req_i.addr(2) = '0') then -- control register
-          bus_rsp_o.data(ctrl_en_c)                                  <= ctrl.enable;
-          bus_rsp_o.data(ctrl_prsc1_c downto ctrl_prsc0_c)           <= ctrl.clk_prsc;
-          bus_rsp_o.data(ctrl_clkdiv7_c downto ctrl_clkdiv0_c)       <= ctrl.clk_div;
-          bus_rsp_o.data(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
-          bus_rsp_o.data(ctrl_tx_full_c)                             <= not fifo.tx_free;
-          bus_rsp_o.data(ctrl_rx_avail_c)                            <= fifo.rx_avail;
-          bus_rsp_o.data(ctrl_sense_c)                               <= serial.wire_in(1);
-          bus_rsp_o.data(ctrl_busy_c)                                <= fifo.tx_avail or busy;
-        else -- data register
-          bus_rsp_o.data(dcmd_msb_c downto dcmd_lsb_c) <= fifo.rx_rdata(7 downto 0);
-          bus_rsp_o.data(dcmd_pres_c)                  <= fifo.rx_rdata(8);
-        end if;
-      end if;
-
     end if;
   end process;
+
+  -- read access (asynchronous) --
+  bus_read: process(bus_rden, bus_req_i.addr, ctrl, fifo, serial, busy)
+  begin
+     bus_rdata <= (others => '0');
+     if (bus_rden = '1') then -- output gating
+       if (bus_req_i.addr(2) = '0') then -- control register
+         bus_rdata(ctrl_en_c)                                  <= ctrl.enable;
+         bus_rdata(ctrl_prsc1_c downto ctrl_prsc0_c)           <= ctrl.clk_prsc;
+         bus_rdata(ctrl_clkdiv7_c downto ctrl_clkdiv0_c)       <= ctrl.clk_div;
+         bus_rdata(ctrl_fifo_size3_c downto ctrl_fifo_size0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
+         bus_rdata(ctrl_tx_full_c)                             <= not fifo.tx_free;
+         bus_rdata(ctrl_rx_avail_c)                            <= fifo.rx_avail;
+         bus_rdata(ctrl_sense_c)                               <= serial.wire_in(1);
+         bus_rdata(ctrl_busy_c)                                <= fifo.tx_avail or busy;
+       else -- data register
+         bus_rdata(dcmd_msb_c downto dcmd_lsb_c) <= fifo.rx_rdata(7 downto 0);
+         bus_rdata(dcmd_pres_c)                  <= fifo.rx_rdata(8);
+       end if;
+     end if;
+  end process;
+
+  -- bus response --
+  bus_rsp_o.ack  <= bus_ack;
+  bus_rsp_o.err  <= '0'; -- no access errors supported
+  bus_rsp_o.data <= bus_rdata;
 
 
   -- Data FIFO ("Ring Buffer") --------------------------------------------------------------
@@ -189,8 +208,8 @@ begin
     avail_o => fifo.tx_avail
   );
 
-  fifo.tx_clr   <= '1' when (ctrl.enable = '0') or (ctrl.clear = '1') else '0';
-  fifo.tx_we    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '1') else '0';
+  fifo.tx_clr   <= (not ctrl.enable) or ctrl.clear;
+  fifo.tx_we    <= bus_req_i.stb and bus_req_i.rw and bus_req_i.addr(2);
   fifo.tx_wdata <= bus_req_i.data(dcmd_cmd_hi_c downto dcmd_cmd_lo_c) & bus_req_i.data(dcmd_msb_c downto dcmd_lsb_c);
   fifo.tx_re    <= '1' when (serial.state = "101") and (clk_tick = '1') else '0';
 
@@ -217,10 +236,10 @@ begin
     avail_o => fifo.rx_avail
   );
 
-  fifo.rx_clr   <= '1' when (ctrl.enable = '0') or (ctrl.clear = '1') else '0';
+  fifo.rx_clr   <= (not ctrl.enable) or ctrl.clear;
   fifo.rx_wdata <= serial.presence & serial.sreg;
   fifo.rx_we    <= serial.done;
-  fifo.rx_re    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(2) = '1') else '0';
+  fifo.rx_re    <= bus_rden and bus_req_i.addr(2);
 
 
   -- IRQ if enabled and TX FIFO is empty and serial engine is idle --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130501"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130502"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_sdi.vhd
+++ b/rtl/core/neorv32_sdi.vhd
@@ -56,6 +56,10 @@ architecture neorv32_sdi_rtl of neorv32_sdi is
   -- helpers --
   constant log2_fifo_size_c : natural := index_size_f(RTX_FIFO);
 
+  -- bus interface --
+  signal bus_ack, bus_rden : std_ulogic;
+  signal bus_rdata : std_ulogic_vector(31 downto 0);
+
   -- control register (see bit definitions above) --
   type ctrl_t is record
     enable, clr_rx, clr_tx, irq_rx_nempty, irq_rx_full, irq_tx_empty : std_ulogic;
@@ -90,10 +94,21 @@ begin
 
   -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o          <= rsp_terminate_c;
+      bus_ack  <= '0';
+      bus_rden <= '0';
+    elsif rising_edge(clk_i) then
+      bus_ack  <= bus_req_i.stb;
+      bus_rden <= bus_req_i.stb and (not bus_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  bus_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
       ctrl.enable        <= '0';
       ctrl.clr_rx        <= '0';
       ctrl.clr_tx        <= '0';
@@ -101,42 +116,47 @@ begin
       ctrl.irq_rx_full   <= '0';
       ctrl.irq_tx_empty  <= '0';
     elsif rising_edge(clk_i) then
-      -- bus handshake --
-      bus_rsp_o.ack  <= bus_req_i.stb;
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      -- read/write access --
       ctrl.clr_rx <= '0';
       ctrl.clr_tx <= '0';
-      if (bus_req_i.stb = '1') then
-        if (bus_req_i.rw = '1') then -- write access
-          if (bus_req_i.addr(2) = '0') then -- control register
-            ctrl.enable        <= bus_req_i.data(ctrl_en_c);
-            ctrl.clr_rx        <= bus_req_i.data(ctrl_clr_rx_c);
-            ctrl.clr_tx        <= bus_req_i.data(ctrl_clr_tx_c);
-            ctrl.irq_rx_nempty <= bus_req_i.data(ctrl_irq_rx_nempty_c);
-            ctrl.irq_rx_full   <= bus_req_i.data(ctrl_irq_rx_full_c);
-            ctrl.irq_tx_empty  <= bus_req_i.data(ctrl_irq_tx_empty_c);
-          end if;
-        else -- read access
-          if (bus_req_i.addr(2) = '0') then -- control register
-            bus_rsp_o.data(ctrl_en_c)                        <= ctrl.enable;
-            bus_rsp_o.data(ctrl_fifo3_c downto ctrl_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
-            bus_rsp_o.data(ctrl_irq_rx_nempty_c)             <= ctrl.irq_rx_nempty;
-            bus_rsp_o.data(ctrl_irq_rx_full_c)               <= ctrl.irq_rx_full;
-            bus_rsp_o.data(ctrl_irq_tx_empty_c)              <= ctrl.irq_tx_empty;
-            bus_rsp_o.data(ctrl_rx_empty_c)                  <= not rx_fifo.avail;
-            bus_rsp_o.data(ctrl_rx_full_c)                   <= not rx_fifo.free;
-            bus_rsp_o.data(ctrl_tx_empty_c)                  <= not tx_fifo.avail;
-            bus_rsp_o.data(ctrl_tx_full_c)                   <= not tx_fifo.free;
-            bus_rsp_o.data(ctrl_cs_active_c)                 <= not sync_csn;
-          else -- data register
-            bus_rsp_o.data(7 downto 0) <= rx_fifo.rdata;
-          end if;
+      if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') then
+        if (bus_req_i.addr(2) = '0') then -- control register
+          ctrl.enable        <= bus_req_i.data(ctrl_en_c);
+          ctrl.clr_rx        <= bus_req_i.data(ctrl_clr_rx_c);
+          ctrl.clr_tx        <= bus_req_i.data(ctrl_clr_tx_c);
+          ctrl.irq_rx_nempty <= bus_req_i.data(ctrl_irq_rx_nempty_c);
+          ctrl.irq_rx_full   <= bus_req_i.data(ctrl_irq_rx_full_c);
+          ctrl.irq_tx_empty  <= bus_req_i.data(ctrl_irq_tx_empty_c);
         end if;
       end if;
     end if;
   end process;
+
+  -- read access (asynchronous) --
+  bus_read: process(bus_rden, bus_req_i.addr, ctrl, rx_fifo, tx_fifo, sync_csn)
+  begin
+    bus_rdata <= (others => '0');
+    if (bus_rden = '1') then -- output gating
+      if (bus_req_i.addr(2) = '0') then -- control register
+        bus_rdata(ctrl_en_c)                        <= ctrl.enable;
+        bus_rdata(ctrl_fifo3_c downto ctrl_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
+        bus_rdata(ctrl_irq_rx_nempty_c)             <= ctrl.irq_rx_nempty;
+        bus_rdata(ctrl_irq_rx_full_c)               <= ctrl.irq_rx_full;
+        bus_rdata(ctrl_irq_tx_empty_c)              <= ctrl.irq_tx_empty;
+        bus_rdata(ctrl_rx_empty_c)                  <= not rx_fifo.avail;
+        bus_rdata(ctrl_rx_full_c)                   <= not rx_fifo.free;
+        bus_rdata(ctrl_tx_empty_c)                  <= not tx_fifo.avail;
+        bus_rdata(ctrl_tx_full_c)                   <= not tx_fifo.free;
+        bus_rdata(ctrl_cs_active_c)                 <= not sync_csn;
+      else -- data register
+        bus_rdata(7 downto 0) <= rx_fifo.rdata;
+      end if;
+    end if;
+  end process;
+
+  -- bus response --
+  bus_rsp_o.ack  <= bus_ack;
+  bus_rsp_o.err  <= '0'; -- no access errors supported
+  bus_rsp_o.data <= bus_rdata;
 
 
   -- Data FIFO ("Ring Buffer") --------------------------------------------------------------
@@ -166,7 +186,7 @@ begin
 
   tx_fifo.clr   <= (not ctrl.enable) or ctrl.clr_tx;
   tx_fifo.wdata <= bus_req_i.data(7 downto 0);
-  tx_fifo.we    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '1') else '0';
+  tx_fifo.we    <= bus_req_i.stb and bus_req_i.rw and bus_req_i.addr(2);
   tx_fifo.re    <= serial.done;
 
 
@@ -195,7 +215,7 @@ begin
   rx_fifo.clr   <= (not ctrl.enable) or ctrl.clr_rx;
   rx_fifo.wdata <= serial.sreg;
   rx_fifo.we    <= serial.done;
-  rx_fifo.re    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(2) = '1') else '0';
+  rx_fifo.re    <= bus_rden and bus_req_i.addr(2);
 
 
   -- interrupt generator --

--- a/rtl/core/neorv32_spi.vhd
+++ b/rtl/core/neorv32_spi.vhd
@@ -57,6 +57,10 @@ architecture neorv32_spi_rtl of neorv32_spi is
   -- helpers --
   constant log2_fifo_size_c : natural := index_size_f(IO_SPI_FIFO);
 
+  -- bus interface --
+  signal bus_ack, bus_rden : std_ulogic;
+  signal bus_rdata : std_ulogic_vector(31 downto 0);
+
   -- control register --
   type ctrl_t is record
     enable : std_ulogic;
@@ -106,51 +110,66 @@ begin
 
   -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o   <= rsp_terminate_c;
+      bus_ack  <= '0';
+      bus_rden <= '0';
+    elsif rising_edge(clk_i) then
+      bus_ack  <= bus_req_i.stb;
+      bus_rden <= bus_req_i.stb and (not bus_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  bus_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
       ctrl.enable <= '0';
       ctrl.cpha   <= '0';
       ctrl.cpol   <= '0';
       ctrl.prsc   <= (others => '0');
       ctrl.cdiv   <= (others => '0');
     elsif rising_edge(clk_i) then
-      -- bus handshake --
-      bus_rsp_o.ack  <= bus_req_i.stb;
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-
-      -- read/write access --
-      if (bus_req_i.stb = '1') then
-        if (bus_req_i.rw = '1') then -- write access
-          if (bus_req_i.addr(2) = '0') then -- control register
-            ctrl.enable <= bus_req_i.data(ctrl_en_c);
-            ctrl.cpha   <= bus_req_i.data(ctrl_cpha_c);
-            ctrl.cpol   <= bus_req_i.data(ctrl_cpol_c);
-            ctrl.prsc   <= bus_req_i.data(ctrl_prsc2_c downto ctrl_prsc0_c);
-            ctrl.cdiv   <= bus_req_i.data(ctrl_cdiv3_c downto ctrl_cdiv0_c);
-          end if;
-        else -- read access
-          if (bus_req_i.addr(2) = '0') then -- control register
-            bus_rsp_o.data(ctrl_en_c)                        <= ctrl.enable;
-            bus_rsp_o.data(ctrl_cpha_c)                      <= ctrl.cpha;
-            bus_rsp_o.data(ctrl_cpol_c)                      <= ctrl.cpol;
-            bus_rsp_o.data(ctrl_prsc2_c downto ctrl_prsc0_c) <= ctrl.prsc;
-            bus_rsp_o.data(ctrl_cdiv3_c downto ctrl_cdiv0_c) <= ctrl.cdiv;
-            bus_rsp_o.data(ctrl_rx_avail_c)                  <= rx_fifo.avail;
-            bus_rsp_o.data(ctrl_tx_empty_c)                  <= not tx_fifo.avail;
-            bus_rsp_o.data(ctrl_tx_full_c)                   <= not tx_fifo.free;
-            bus_rsp_o.data(ctrl_fifo3_c downto ctrl_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
-            bus_rsp_o.data(ctrl_cs_en_c)                     <= rtx_engine.cs_ctrl(3);
-            bus_rsp_o.data(ctrl_busy_c)                      <= busy or tx_fifo.avail;
-          else -- RX data
-            bus_rsp_o.data(7 downto 0) <= rx_fifo.rdata;
-          end if;
+      if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') then
+        if (bus_req_i.addr(2) = '0') then -- control register
+          ctrl.enable <= bus_req_i.data(ctrl_en_c);
+          ctrl.cpha   <= bus_req_i.data(ctrl_cpha_c);
+          ctrl.cpol   <= bus_req_i.data(ctrl_cpol_c);
+          ctrl.prsc   <= bus_req_i.data(ctrl_prsc2_c downto ctrl_prsc0_c);
+          ctrl.cdiv   <= bus_req_i.data(ctrl_cdiv3_c downto ctrl_cdiv0_c);
         end if;
       end if;
     end if;
   end process;
+
+  -- read access (asynchronous) --
+  bus_read: process(bus_rden, bus_req_i.addr, ctrl, rx_fifo, tx_fifo, rtx_engine, busy)
+  begin
+    bus_rdata <= (others => '0');
+    if (bus_rden = '1') then -- output gating
+      if (bus_req_i.addr(2) = '0') then -- control register
+        bus_rdata(ctrl_en_c)                        <= ctrl.enable;
+        bus_rdata(ctrl_cpha_c)                      <= ctrl.cpha;
+        bus_rdata(ctrl_cpol_c)                      <= ctrl.cpol;
+        bus_rdata(ctrl_prsc2_c downto ctrl_prsc0_c) <= ctrl.prsc;
+        bus_rdata(ctrl_cdiv3_c downto ctrl_cdiv0_c) <= ctrl.cdiv;
+        bus_rdata(ctrl_rx_avail_c)                  <= rx_fifo.avail;
+        bus_rdata(ctrl_tx_empty_c)                  <= not tx_fifo.avail;
+        bus_rdata(ctrl_tx_full_c)                   <= not tx_fifo.free;
+        bus_rdata(ctrl_fifo3_c downto ctrl_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
+        bus_rdata(ctrl_cs_en_c)                     <= rtx_engine.cs_ctrl(3);
+        bus_rdata(ctrl_busy_c)                      <= busy or tx_fifo.avail;
+      else -- RX data
+        bus_rdata(7 downto 0) <= rx_fifo.rdata;
+      end if;
+    end if;
+  end process;
+
+  -- bus response --
+  bus_rsp_o.ack  <= bus_ack;
+  bus_rsp_o.err  <= '0'; -- no access errors supported
+  bus_rsp_o.data <= bus_rdata;
 
 
   -- Data FIFO ("Ring Buffer") --------------------------------------------------------------
@@ -179,7 +198,7 @@ begin
   );
 
   tx_fifo.clear <= not ctrl.enable;
-  tx_fifo.we    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '1') else '0';
+  tx_fifo.we    <= bus_req_i.stb and bus_req_i.rw and bus_req_i.addr(2);
   tx_fifo.wdata <= bus_req_i.data(31) & bus_req_i.data(7 downto 0); -- command/data select & command/data byte
   tx_fifo.re    <= '1' when (rtx_engine.state = "100") else '0';
 
@@ -209,7 +228,7 @@ begin
   rx_fifo.clear <= not ctrl.enable;
   rx_fifo.wdata <= rtx_engine.sreg;
   rx_fifo.we    <= rtx_engine.done;
-  rx_fifo.re    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(2) = '1') else '0';
+  rx_fifo.re    <= bus_rden and bus_req_i.addr(2);
 
 
   -- IRQ generator: IRQ if TX FIFO is empty and serial engine is idle --

--- a/rtl/core/neorv32_twd.vhd
+++ b/rtl/core/neorv32_twd.vhd
@@ -64,12 +64,15 @@ architecture neorv32_twd_rtl of neorv32_twd is
   constant rx_size_c : natural := index_size_f(TWD_RX_FIFO);
   constant tx_size_c : natural := index_size_f(TWD_TX_FIFO);
 
-  -- access helpers --
-  signal acc_we, acc_re : std_ulogic;
+  -- bus interface --
+  signal bus_ack, bus_rden : std_ulogic;
+  signal bus_rdata : std_ulogic_vector(31 downto 0);
 
   -- control register --
   type ctrl_t is record
     enable       : std_ulogic;
+    clr_rx       : std_ulogic;
+    clr_tx       : std_ulogic;
     fsel         : std_ulogic;
     device_addr  : std_ulogic_vector(6 downto 0);
     irq_rx_avail : std_ulogic;
@@ -125,11 +128,24 @@ begin
 
   -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o         <= rsp_terminate_c;
+      bus_ack  <= '0';
+      bus_rden <= '0';
+    elsif rising_edge(clk_i) then
+      bus_ack  <= bus_req_i.stb;
+      bus_rden <= bus_req_i.stb and (not bus_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  bus_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
       ctrl.enable       <= '0';
+      ctrl.clr_rx       <= '0';
+      ctrl.clr_tx       <= '0';
       ctrl.fsel         <= '0';
       ctrl.device_addr  <= (others => '0');
       ctrl.irq_rx_avail <= '0';
@@ -139,13 +155,12 @@ begin
       ctrl.irq_com_beg  <= '0';
       ctrl.irq_com_end  <= '0';
     elsif rising_edge(clk_i) then
-      -- bus defaults --
-      bus_rsp_o.ack  <= bus_req_i.stb;
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      -- write access --
-      if (acc_we = '1') and (bus_req_i.addr(2) = '0') then -- control register
+      ctrl.clr_rx <= '0'; -- auto clear
+      ctrl.clr_tx <= '0'; -- auto clear
+      if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '0') then -- control register
         ctrl.enable       <= bus_req_i.data(ctrl_en_c);
+        ctrl.clr_rx       <= bus_req_i.data(ctrl_clr_rx_c);
+        ctrl.clr_tx       <= bus_req_i.data(ctrl_clr_tx_c);
         ctrl.fsel         <= bus_req_i.data(ctrl_fsel_c);
         ctrl.device_addr  <= bus_req_i.data(ctrl_addr6_c downto ctrl_addr0_c);
         ctrl.irq_rx_avail <= bus_req_i.data(ctrl_irq_rx_avail_c);
@@ -155,37 +170,43 @@ begin
         ctrl.irq_com_beg  <= bus_req_i.data(ctrl_irq_com_beg_c);
         ctrl.irq_com_end  <= bus_req_i.data(ctrl_irq_com_end_c);
       end if;
-      -- read access --
-      if (acc_re = '1') then
-        if (bus_req_i.addr(2) = '0') then -- control register
-          bus_rsp_o.data(ctrl_en_c)                              <= ctrl.enable;
-          bus_rsp_o.data(ctrl_fsel_c)                            <= ctrl.fsel;
-          bus_rsp_o.data(ctrl_addr6_c downto ctrl_addr0_c)       <= ctrl.device_addr;
-          bus_rsp_o.data(ctrl_irq_rx_avail_c)                    <= ctrl.irq_rx_avail;
-          bus_rsp_o.data(ctrl_irq_rx_full_c)                     <= ctrl.irq_rx_full;
-          bus_rsp_o.data(ctrl_irq_tx_empty_c)                    <= ctrl.irq_tx_empty;
-          bus_rsp_o.data(ctrl_irq_tx_nfull_c)                    <= ctrl.irq_tx_nfull;
-          bus_rsp_o.data(ctrl_irq_com_beg_c)                     <= ctrl.irq_com_beg;
-          bus_rsp_o.data(ctrl_irq_com_end_c)                     <= ctrl.irq_com_end;
-          bus_rsp_o.data(ctrl_rx_size3_c downto ctrl_rx_size0_c) <= std_ulogic_vector(to_unsigned(rx_size_c, 4));
-          bus_rsp_o.data(ctrl_tx_size3_c downto ctrl_tx_size0_c) <= std_ulogic_vector(to_unsigned(tx_size_c, 4));
-          bus_rsp_o.data(ctrl_rx_avail_c)                        <= rx_fifo.avail;
-          bus_rsp_o.data(ctrl_rx_full_c)                         <= not rx_fifo.free;
-          bus_rsp_o.data(ctrl_tx_empty_c)                        <= not tx_fifo.avail;
-          bus_rsp_o.data(ctrl_tx_full_c)                         <= not tx_fifo.free;
-          bus_rsp_o.data(ctrl_com_beg_c)                         <= com_beg;
-          bus_rsp_o.data(ctrl_com_end_c)                         <= com_end;
-          bus_rsp_o.data(ctrl_com_c)                             <= engine.com;
-        else -- RX data FIFO
-          bus_rsp_o.data(7 downto 0) <= rx_fifo.rdata;
-        end if;
+    end if;
+  end process;
+
+  -- read access (asynchronous) --
+  bus_read: process(bus_rden, bus_req_i.addr, ctrl, rx_fifo, tx_fifo, com_beg, com_end, engine)
+  begin
+    bus_rdata <= (others => '0');
+    if (bus_rden = '1') then -- output gating
+      if (bus_req_i.addr(2) = '0') then -- control register
+        bus_rdata(ctrl_en_c)                              <= ctrl.enable;
+        bus_rdata(ctrl_fsel_c)                            <= ctrl.fsel;
+        bus_rdata(ctrl_addr6_c downto ctrl_addr0_c)       <= ctrl.device_addr;
+        bus_rdata(ctrl_irq_rx_avail_c)                    <= ctrl.irq_rx_avail;
+        bus_rdata(ctrl_irq_rx_full_c)                     <= ctrl.irq_rx_full;
+        bus_rdata(ctrl_irq_tx_empty_c)                    <= ctrl.irq_tx_empty;
+        bus_rdata(ctrl_irq_tx_nfull_c)                    <= ctrl.irq_tx_nfull;
+        bus_rdata(ctrl_irq_com_beg_c)                     <= ctrl.irq_com_beg;
+        bus_rdata(ctrl_irq_com_end_c)                     <= ctrl.irq_com_end;
+        bus_rdata(ctrl_rx_size3_c downto ctrl_rx_size0_c) <= std_ulogic_vector(to_unsigned(rx_size_c, 4));
+        bus_rdata(ctrl_tx_size3_c downto ctrl_tx_size0_c) <= std_ulogic_vector(to_unsigned(tx_size_c, 4));
+        bus_rdata(ctrl_rx_avail_c)                        <= rx_fifo.avail;
+        bus_rdata(ctrl_rx_full_c)                         <= not rx_fifo.free;
+        bus_rdata(ctrl_tx_empty_c)                        <= not tx_fifo.avail;
+        bus_rdata(ctrl_tx_full_c)                         <= not tx_fifo.free;
+        bus_rdata(ctrl_com_beg_c)                         <= com_beg;
+        bus_rdata(ctrl_com_end_c)                         <= com_end;
+        bus_rdata(ctrl_com_c)                             <= engine.com;
+      else -- RX data FIFO
+        bus_rdata(7 downto 0) <= rx_fifo.rdata;
       end if;
     end if;
   end process;
 
-  -- access helpers --
-  acc_we <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '1') else '0';
-  acc_re <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') else '0';
+  -- bus response --
+  bus_rsp_o.ack  <= bus_ack;
+  bus_rsp_o.err  <= '0'; -- no access errors supported
+  bus_rsp_o.data <= bus_rdata;
 
 
   -- Data FIFOs -----------------------------------------------------------------------------
@@ -213,9 +234,9 @@ begin
     avail_o => tx_fifo.avail
   );
 
-  tx_fifo.clr   <= (not ctrl.enable) or (acc_we and (not bus_req_i.addr(2)) and bus_req_i.data(ctrl_clr_tx_c));
+  tx_fifo.clr   <= (not ctrl.enable) or ctrl.clr_tx;
   tx_fifo.wdata <= bus_req_i.data(7 downto 0);
-  tx_fifo.we    <= acc_we and bus_req_i.addr(2);
+  tx_fifo.we    <= bus_req_i.stb and bus_req_i.rw and bus_req_i.addr(2);
   tx_fifo.re    <= engine.tx_re;
 
   -- RX --
@@ -240,10 +261,10 @@ begin
     avail_o => rx_fifo.avail
   );
 
-  rx_fifo.clr   <= (not ctrl.enable) or (acc_we and (not bus_req_i.addr(2)) and bus_req_i.data(ctrl_clr_rx_c));
+  rx_fifo.clr   <= (not ctrl.enable) or ctrl.clr_rx;
   rx_fifo.wdata <= engine.sreg;
   rx_fifo.we    <= engine.rx_we;
-  rx_fifo.re    <= acc_re and bus_req_i.addr(2);
+  rx_fifo.re    <= bus_rden and bus_req_i.addr(2);
 
 
   -- Interrupt Generator --------------------------------------------------------------------
@@ -430,13 +451,15 @@ begin
         -- begin of communication --
         if (engine.state = S_RESP) and (smp_scl_fall = '1') then
           com_beg <= '1';
-        elsif (acc_we = '1') and (bus_req_i.addr(2) = '0') and (bus_req_i.data(ctrl_com_beg_c) = '1') then
+        elsif (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '0') and
+              (bus_req_i.data(ctrl_com_beg_c) = '1') then
           com_beg <= '0';
         end if;
         -- end of communication --
         if (engine.state = S_IDLE) and (engine.com = '1') then
           com_end <= '1';
-        elsif (acc_we = '1') and (bus_req_i.addr(2) = '0') and (bus_req_i.data(ctrl_com_end_c) = '1') then
+        elsif (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '0') and
+              (bus_req_i.data(ctrl_com_end_c) = '1') then
           com_end <= '0';
         end if;
       end if;

--- a/rtl/core/neorv32_twi.vhd
+++ b/rtl/core/neorv32_twi.vhd
@@ -62,6 +62,10 @@ architecture neorv32_twi_rtl of neorv32_twi is
   -- helpers --
   constant log2_fifo_size_c : natural := index_size_f(IO_TWI_FIFO);
 
+  -- bus interface --
+  signal bus_ack, bus_rden : std_ulogic;
+  signal bus_rdata : std_ulogic_vector(31 downto 0);
+
   -- control register --
   type ctrl_t is record
     enable : std_ulogic;
@@ -110,47 +114,63 @@ begin
 
   -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o   <= rsp_terminate_c;
+      bus_ack  <= '0';
+      bus_rden <= '0';
+    elsif rising_edge(clk_i) then
+      bus_ack  <= bus_req_i.stb;
+      bus_rden <= bus_req_i.stb and (not bus_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  bus_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
       ctrl.enable <= '0';
       ctrl.prsc   <= (others => '0');
       ctrl.cdiv   <= (others => '0');
       ctrl.clkstr <= '0';
     elsif rising_edge(clk_i) then
-      -- bus handshake defaults --
-      bus_rsp_o.ack  <= bus_req_i.stb;
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      -- read/write access --
-      if (bus_req_i.stb = '1') then
-        if (bus_req_i.rw = '1') then -- write access
-          if (bus_req_i.addr(2) = '0') then -- control register
-            ctrl.enable <= bus_req_i.data(ctrl_en_c);
-            ctrl.prsc   <= bus_req_i.data(ctrl_prsc2_c downto ctrl_prsc0_c);
-            ctrl.cdiv   <= bus_req_i.data(ctrl_cdiv3_c downto ctrl_cdiv0_c);
-            ctrl.clkstr <= bus_req_i.data(ctrl_clkstr_en_c);
-          end if;
-        else -- read access
-          if (bus_req_i.addr(2) = '0') then -- control register
-            bus_rsp_o.data(ctrl_en_c)                        <= ctrl.enable;
-            bus_rsp_o.data(ctrl_prsc2_c downto ctrl_prsc0_c) <= ctrl.prsc;
-            bus_rsp_o.data(ctrl_cdiv3_c downto ctrl_cdiv0_c) <= ctrl.cdiv;
-            bus_rsp_o.data(ctrl_clkstr_en_c)                 <= ctrl.clkstr;
-            bus_rsp_o.data(ctrl_fifo3_c downto ctrl_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
-            bus_rsp_o.data(ctrl_sense_scl_c)                 <= scl_sync(1);
-            bus_rsp_o.data(ctrl_sense_sda_c)                 <= sda_sync(1);
-            bus_rsp_o.data(ctrl_tx_full_c)                   <= not fifo.tx_free;
-            bus_rsp_o.data(ctrl_rx_avail_c)                  <= fifo.rx_avail;
-            bus_rsp_o.data(ctrl_busy_c)                      <= busy or fifo.tx_avail;
-          else -- RX data
-            bus_rsp_o.data(8 downto 0) <= fifo.rx_rdata; -- ACK + data
-          end if;
+      if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') then
+        if (bus_req_i.addr(2) = '0') then -- control register
+          ctrl.enable <= bus_req_i.data(ctrl_en_c);
+          ctrl.prsc   <= bus_req_i.data(ctrl_prsc2_c downto ctrl_prsc0_c);
+          ctrl.cdiv   <= bus_req_i.data(ctrl_cdiv3_c downto ctrl_cdiv0_c);
+          ctrl.clkstr <= bus_req_i.data(ctrl_clkstr_en_c);
         end if;
       end if;
     end if;
   end process;
+
+  -- read access (asynchronous) --
+  bus_read: process(bus_rden, bus_req_i.addr, ctrl, scl_sync, sda_sync, fifo, busy)
+  begin
+    bus_rdata <= (others => '0');
+    if (bus_rden = '1') then -- output gating
+      if (bus_req_i.addr(2) = '0') then -- control register
+        bus_rdata(ctrl_en_c)                        <= ctrl.enable;
+        bus_rdata(ctrl_prsc2_c downto ctrl_prsc0_c) <= ctrl.prsc;
+        bus_rdata(ctrl_cdiv3_c downto ctrl_cdiv0_c) <= ctrl.cdiv;
+        bus_rdata(ctrl_clkstr_en_c)                 <= ctrl.clkstr;
+        bus_rdata(ctrl_fifo3_c downto ctrl_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
+        bus_rdata(ctrl_sense_scl_c)                 <= scl_sync(1);
+        bus_rdata(ctrl_sense_sda_c)                 <= sda_sync(1);
+        bus_rdata(ctrl_tx_full_c)                   <= not fifo.tx_free;
+        bus_rdata(ctrl_rx_avail_c)                  <= fifo.rx_avail;
+        bus_rdata(ctrl_busy_c)                      <= busy or fifo.tx_avail;
+      else -- RX data
+        bus_rdata(8 downto 0) <= fifo.rx_rdata; -- ACK + data
+      end if;
+    end if;
+  end process;
+
+  -- bus response --
+  bus_rsp_o.ack  <= bus_ack;
+  bus_rsp_o.err  <= '0'; -- no access errors supported
+  bus_rsp_o.data <= bus_rdata;
 
 
   -- Data FIFOs ("Ring Buffer") -------------------------------------------------------------
@@ -180,7 +200,7 @@ begin
 
   fifo.tx_clear <= not ctrl.enable;
   fifo.tx_wdata <= bus_req_i.data(dcmd_cmd_hi_c downto dcmd_lsb_c);
-  fifo.tx_we    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '1') else '0';
+  fifo.tx_we    <= bus_req_i.stb and bus_req_i.rw and bus_req_i.addr(2);
   fifo.tx_re    <= engine.tx_re;
 
 
@@ -209,7 +229,7 @@ begin
   fifo.rx_clear <= not ctrl.enable;
   fifo.rx_wdata <= engine.sreg(0) & engine.sreg(8 downto 1); -- ACK + data
   fifo.rx_we    <= engine.rx_we;
-  fifo.rx_re    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(2) = '1') else '0';
+  fifo.rx_re    <= bus_rden and bus_req_i.addr(2);
 
 
   -- IRQ if enabled and TX FIFO is empty and bus engine is idle --

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -74,6 +74,10 @@ architecture neorv32_uart_rtl of neorv32_uart is
   constant log2_rx_fifo_c : natural := index_size_f(UART_RX_FIFO);
   constant log2_tx_fifo_c : natural := index_size_f(UART_TX_FIFO);
 
+  -- bus interface --
+  signal bus_ack, bus_rden : std_ulogic;
+  signal bus_rdata : std_ulogic_vector(31 downto 0);
+
   -- clock generator --
   signal uart_clk : std_ulogic;
 
@@ -115,10 +119,21 @@ begin
 
   -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o          <= rsp_terminate_c;
+      bus_ack  <= '0';
+      bus_rden <= '0';
+    elsif rising_edge(clk_i) then
+      bus_ack  <= bus_req_i.stb;
+      bus_rden <= bus_req_i.stb and (not bus_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  bus_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
       ctrl.enable        <= '0';
       ctrl.sim_mode      <= '0';
       ctrl.hwfc_en       <= '0';
@@ -129,52 +144,57 @@ begin
       ctrl.irq_tx_empty  <= '0';
       ctrl.irq_tx_nfull  <= '0';
     elsif rising_edge(clk_i) then
-      -- bus handshake --
-      bus_rsp_o.ack  <= bus_req_i.stb;
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      -- bus access --
-      if (bus_req_i.stb = '1') then
-        if (bus_req_i.rw = '1') then -- write access
-          if (bus_req_i.addr(2) = '0') then -- control register
-            ctrl.enable        <= bus_req_i.data(ctrl_en_c);
-            ctrl.sim_mode      <= bus_req_i.data(ctrl_sim_en_c) and bool_to_ulogic_f(is_simulation_c);
-            ctrl.hwfc_en       <= bus_req_i.data(ctrl_hwfc_en_c);
-            ctrl.prsc          <= bus_req_i.data(ctrl_prsc2_c downto ctrl_prsc0_c);
-            ctrl.baud          <= bus_req_i.data(ctrl_baud9_c downto ctrl_baud0_c);
-            ctrl.irq_rx_nempty <= bus_req_i.data(ctrl_irq_rx_nempty_c);
-            ctrl.irq_rx_full   <= bus_req_i.data(ctrl_irq_rx_full_c);
-            ctrl.irq_tx_empty  <= bus_req_i.data(ctrl_irq_tx_empty_c);
-            ctrl.irq_tx_nfull  <= bus_req_i.data(ctrl_irq_tx_nfull_c);
-          end if;
-        else -- read access
-          if (bus_req_i.addr(2) = '0') then -- control register
-            bus_rsp_o.data(ctrl_en_c)                        <= ctrl.enable;
-            bus_rsp_o.data(ctrl_sim_en_c)                    <= ctrl.sim_mode and bool_to_ulogic_f(is_simulation_c);
-            bus_rsp_o.data(ctrl_hwfc_en_c)                   <= ctrl.hwfc_en;
-            bus_rsp_o.data(ctrl_prsc2_c downto ctrl_prsc0_c) <= ctrl.prsc;
-            bus_rsp_o.data(ctrl_baud9_c downto ctrl_baud0_c) <= ctrl.baud;
-            bus_rsp_o.data(ctrl_rx_nempty_c)                 <= rx_fifo.avail;
-            bus_rsp_o.data(ctrl_rx_full_c)                   <= not rx_fifo.free;
-            bus_rsp_o.data(ctrl_tx_empty_c)                  <= not tx_fifo.avail;
-            bus_rsp_o.data(ctrl_tx_nfull_c)                  <= tx_fifo.free;
-            bus_rsp_o.data(ctrl_irq_rx_nempty_c)             <= ctrl.irq_rx_nempty;
-            bus_rsp_o.data(ctrl_irq_rx_full_c)               <= ctrl.irq_rx_full;
-            bus_rsp_o.data(ctrl_irq_tx_empty_c)              <= ctrl.irq_tx_empty;
-            bus_rsp_o.data(ctrl_irq_tx_nfull_c)              <= ctrl.irq_tx_nfull;
-            bus_rsp_o.data(ctrl_rx_over_c)                   <= rx_overrun;
-            bus_rsp_o.data(ctrl_tx_busy_c)                   <= tx.state(0) or tx_fifo.avail;
-          else -- data register
-            bus_rsp_o.data(data_rtx_msb_c     downto data_rtx_lsb_c)     <= rx_fifo.rdata;
-            bus_rsp_o.data(data_rx_fifo_msb_c downto data_rx_fifo_lsb_c) <= std_ulogic_vector(to_unsigned(log2_rx_fifo_c, 4));
-            bus_rsp_o.data(data_tx_fifo_msb_c downto data_tx_fifo_lsb_c) <= std_ulogic_vector(to_unsigned(log2_tx_fifo_c, 4));
-          end if;
+      if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') then
+        if (bus_req_i.addr(2) = '0') then -- control register
+          ctrl.enable        <= bus_req_i.data(ctrl_en_c);
+          ctrl.sim_mode      <= bus_req_i.data(ctrl_sim_en_c) and bool_to_ulogic_f(is_simulation_c);
+          ctrl.hwfc_en       <= bus_req_i.data(ctrl_hwfc_en_c);
+          ctrl.prsc          <= bus_req_i.data(ctrl_prsc2_c downto ctrl_prsc0_c);
+          ctrl.baud          <= bus_req_i.data(ctrl_baud9_c downto ctrl_baud0_c);
+          ctrl.irq_rx_nempty <= bus_req_i.data(ctrl_irq_rx_nempty_c);
+          ctrl.irq_rx_full   <= bus_req_i.data(ctrl_irq_rx_full_c);
+          ctrl.irq_tx_empty  <= bus_req_i.data(ctrl_irq_tx_empty_c);
+          ctrl.irq_tx_nfull  <= bus_req_i.data(ctrl_irq_tx_nfull_c);
         end if;
       end if;
     end if;
   end process;
 
-  -- UART clock enable --
+  -- read access (asynchronous) --
+  bus_read: process(bus_rden, bus_req_i.addr, ctrl, rx_fifo, tx_fifo, rx_overrun, tx)
+  begin
+    bus_rdata <= (others => '0');
+    if (bus_rden = '1') then -- output gating
+      if (bus_req_i.addr(2) = '0') then -- control register
+        bus_rdata(ctrl_en_c)                        <= ctrl.enable;
+        bus_rdata(ctrl_sim_en_c)                    <= ctrl.sim_mode and bool_to_ulogic_f(is_simulation_c);
+        bus_rdata(ctrl_hwfc_en_c)                   <= ctrl.hwfc_en;
+        bus_rdata(ctrl_prsc2_c downto ctrl_prsc0_c) <= ctrl.prsc;
+        bus_rdata(ctrl_baud9_c downto ctrl_baud0_c) <= ctrl.baud;
+        bus_rdata(ctrl_rx_nempty_c)                 <= rx_fifo.avail;
+        bus_rdata(ctrl_rx_full_c)                   <= not rx_fifo.free;
+        bus_rdata(ctrl_tx_empty_c)                  <= not tx_fifo.avail;
+        bus_rdata(ctrl_tx_nfull_c)                  <= tx_fifo.free;
+        bus_rdata(ctrl_irq_rx_nempty_c)             <= ctrl.irq_rx_nempty;
+        bus_rdata(ctrl_irq_rx_full_c)               <= ctrl.irq_rx_full;
+        bus_rdata(ctrl_irq_tx_empty_c)              <= ctrl.irq_tx_empty;
+        bus_rdata(ctrl_irq_tx_nfull_c)              <= ctrl.irq_tx_nfull;
+        bus_rdata(ctrl_rx_over_c)                   <= rx_overrun;
+        bus_rdata(ctrl_tx_busy_c)                   <= tx.state(0) or tx_fifo.avail;
+      else -- data register
+        bus_rdata(data_rtx_msb_c     downto data_rtx_lsb_c)     <= rx_fifo.rdata;
+        bus_rdata(data_rx_fifo_msb_c downto data_rx_fifo_lsb_c) <= std_ulogic_vector(to_unsigned(log2_rx_fifo_c, 4));
+        bus_rdata(data_tx_fifo_msb_c downto data_tx_fifo_lsb_c) <= std_ulogic_vector(to_unsigned(log2_tx_fifo_c, 4));
+      end if;
+    end if;
+  end process;
+
+  -- bus response --
+  bus_rsp_o.ack  <= bus_ack;
+  bus_rsp_o.err  <= '0'; -- no access errors supported
+  bus_rsp_o.data <= bus_rdata;
+
+  -- UART clock tick --
   uart_clk <= clkgen_i(to_integer(unsigned(ctrl.prsc)));
 
 
@@ -233,7 +253,7 @@ begin
   rx_fifo.clr   <= '1' when (ctrl.enable = '0') or (ctrl.sim_mode = '1') else '0';
   rx_fifo.wdata <= rx.sreg(7 downto 0);
   rx_fifo.we    <= rx.done;
-  rx_fifo.re    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(2) = '1') else '0';
+  rx_fifo.re    <= '1' when (bus_rden = '1') and (bus_req_i.addr(2) = '1') else '0';
 
 
   -- Interrupt Generator --------------------------------------------------------------------
@@ -374,7 +394,7 @@ begin
         rx_overrun <= '0';
       elsif (rx_fifo.we = '1') and (rx_fifo.free = '0') then -- writing to full FIFO
         rx_overrun <= '1';
-      elsif (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(2) = '0') then
+      elsif (bus_rden = '1') and (bus_req_i.addr(2) = '0') then
         rx_overrun <= '0'; -- clear on read of control register
       end if;
     end if;


### PR DESCRIPTION
The serial interfaces now use **asynchronous** bus read access. This not only saves 32 FFs per device, but also reduces the amount of logic required, because the read logic for all devices can be merged together.

This should not cause the timing to get worse. There is a central bus register that separates the bus between the core/memory and the I/O devices.

Most logical memory-mapped registers that can be read are driven by actual FF. This is not the case for status signals (e.g., FIFO status), which could actually cause timing issues.

This is still experimental. Asynchronous reading also changes the timing of side effects. But I think I've implemented it more or less correctly.