### PR TITLE
[io] implement async bus read access for further IO modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 29.08.2026 | 1.13.5.3 | :test_tube: use asynchronous bus read access for further IO devices | [#1640](https://github.com/stnolting/neorv32/pull/1640) |
 | 29.08.2026 | 1.13.5.2 | :test_tube: use asynchronous bus read access for serial IO devices | [#1638](https://github.com/stnolting/neorv32/pull/1638) |
 | 29.08.2026 | 1.13.5.1 | CPU: optimize set-on-less-than timing | [#1635](https://github.com/stnolting/neorv32/pull/1635) |
 | 22.08.2026 | [**1.13.5**](https://github.com/stnolting/neorv32/releases/tag/v1.13.5) | :rocket: **New release** | |

--- a/rtl/core/neorv32_dma.vhd
+++ b/rtl/core/neorv32_dma.vhd
@@ -75,6 +75,10 @@ architecture neorv32_dma_rtl of neorv32_dma is
     return res_v;
   end function;
 
+  -- host bus interface --
+  signal bus_ack, bus_rden : std_ulogic;
+  signal bus_rdata : std_ulogic_vector(31 downto 0);
+
   -- control and status register --
   type ctrl_t is record
     enable, start, err, done : std_ulogic;
@@ -119,44 +123,61 @@ begin
 
   -- Control and Status Register ------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  ctrl_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o   <= rsp_terminate_c;
+      bus_ack  <= '0';
+      bus_rden <= '0';
+    elsif rising_edge(clk_i) then
+      bus_ack  <= bus_req_i.stb;
+      bus_rden <= bus_req_i.stb and (not bus_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  ctrl_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
       ctrl.enable <= '0';
       ctrl.start  <= '0';
       ctrl.err    <= '0';
       ctrl.done   <= '0';
     elsif rising_edge(clk_i) then
-      -- bus handshake --
-      bus_rsp_o.ack  <= bus_req_i.stb;
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
       -- defaults --
       ctrl.start <= '0';
       ctrl.err   <= ctrl.enable and (ctrl.err  or engine.err);
       ctrl.done  <= ctrl.enable and (ctrl.done or engine.done);
-      -- bus access --
-      if (bus_req_i.stb = '1') and (bus_req_i.addr(2) = '0') then
-        if (bus_req_i.rw = '1') then -- write access
-          ctrl.enable <= bus_req_i.data(ctrl_en_c);
-          ctrl.start  <= bus_req_i.data(ctrl_start_c);
-          if (bus_req_i.data(ctrl_start_c) = '1') or (bus_req_i.data(ctrl_ack_c) = '1') then -- write 1 to clear
-            ctrl.err  <= '0';
-            ctrl.done <= '0';
-          end if;
-        else -- read access
-          bus_rsp_o.data(ctrl_en_c)     <= ctrl.enable;
-          bus_rsp_o.data(ctrl_fifo3_c downto ctrl_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
-          bus_rsp_o.data(ctrl_dempty_c) <= not fifo.avail;
-          bus_rsp_o.data(ctrl_dfull_c)  <= not fifo.free;
-          bus_rsp_o.data(ctrl_error_c)  <= ctrl.err;
-          bus_rsp_o.data(ctrl_done_c)   <= ctrl.done;
-          bus_rsp_o.data(ctrl_busy_c)   <= engine.run;
+      -- write access --
+      if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '0') then
+        ctrl.enable <= bus_req_i.data(ctrl_en_c);
+        ctrl.start  <= bus_req_i.data(ctrl_start_c);
+        if (bus_req_i.data(ctrl_start_c) = '1') or (bus_req_i.data(ctrl_ack_c) = '1') then -- write 1 to clear
+          ctrl.err  <= '0';
+          ctrl.done <= '0';
         end if;
       end if;
     end if;
   end process;
+
+  -- read access (asynchronous) --
+  ctrl_read: process(bus_rden, bus_req_i.addr, ctrl, fifo, engine)
+  begin
+    bus_rdata <= (others => '0');
+    if (bus_rden = '1') and (bus_req_i.addr(2) = '0') then -- output gating
+      bus_rdata(ctrl_en_c)                        <= ctrl.enable;
+      bus_rdata(ctrl_fifo3_c downto ctrl_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
+      bus_rdata(ctrl_dempty_c)                    <= not fifo.avail;
+      bus_rdata(ctrl_dfull_c)                     <= not fifo.free;
+      bus_rdata(ctrl_error_c)                     <= ctrl.err;
+      bus_rdata(ctrl_done_c)                      <= ctrl.done;
+      bus_rdata(ctrl_busy_c)                      <= engine.run;
+    end if;
+  end process;
+
+  -- bus response --
+  bus_rsp_o.ack  <= bus_ack;
+  bus_rsp_o.err  <= '0'; -- no access errors supported
+  bus_rsp_o.data <= bus_rdata;
 
   -- transfer-done interrupt --
   irq_o <= ctrl.done;

--- a/rtl/core/neorv32_gpio.vhd
+++ b/rtl/core/neorv32_gpio.vhd
@@ -37,37 +37,48 @@ architecture neorv32_gpio_rtl of neorv32_gpio is
   constant addr_in_c  : std_ulogic_vector(2 downto 0) := "000"; -- r/-: input port
   constant addr_out_c : std_ulogic_vector(2 downto 0) := "001"; -- r/w: output port
   constant addr_dir_c : std_ulogic_vector(2 downto 0) := "010"; -- r/w: direction control
+--constant addr_???_c : std_ulogic_vector(2 downto 0) := "011"; -- r/-: reserved
   constant addr_tt_c  : std_ulogic_vector(2 downto 0) := "100"; -- r/w: trigger type (level/edge)
   constant addr_tp_c  : std_ulogic_vector(2 downto 0) := "101"; -- r/w: trigger polarity (high/low or rising/falling)
   constant addr_ie_c  : std_ulogic_vector(2 downto 0) := "110"; -- r/w: interrupt enable
   constant addr_ip_c  : std_ulogic_vector(2 downto 0) := "111"; -- r/c: interrupt pending
 
+  -- bus interface --
+  signal bus_ack, bus_rden : std_ulogic;
+  signal bus_rdata : std_ulogic_vector(31 downto 0);
+
   -- interface registers --
   signal port_in, port_out, port_dir, irq_typ, irq_pol, irq_en, irq_clrn : std_ulogic_vector(GPIO_NUM-1 downto 0);
 
-  -- interrupt generator --
+  -- synchronizer and interrupt logic --
   signal port_in2, irq_trig, irq_pend : std_ulogic_vector(GPIO_NUM-1 downto 0);
 
 begin
 
   -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o <= rsp_terminate_c;
-      port_out  <= (others => '0');
-      irq_typ   <= (others => '0');
-      irq_pol   <= (others => '0');
-      irq_en    <= (others => '0');
-      irq_clrn  <= (others => '0');
+      bus_ack  <= '0';
+      bus_rden <= '0';
     elsif rising_edge(clk_i) then
-      -- defaults --
-      bus_rsp_o.ack  <= bus_req_i.stb;
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      irq_clrn       <= (others => '1');
-      -- write access --
+      bus_ack  <= bus_req_i.stb;
+      bus_rden <= bus_req_i.stb and (not bus_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  bus_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      port_out <= (others => '0');
+      irq_typ  <= (others => '0');
+      irq_pol  <= (others => '0');
+      irq_en   <= (others => '0');
+      irq_clrn <= (others => '0');
+    elsif rising_edge(clk_i) then
+      irq_clrn <= (others => '1'); -- default
       if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') then
         case bus_req_i.addr(4 downto 2) is
           when addr_out_c => port_out <= bus_req_i.data(GPIO_NUM-1 downto 0); -- output port
@@ -78,21 +89,31 @@ begin
           when others     => null;
         end case;
       end if;
-      -- read access --
-      if (bus_req_i.stb = '1') and (bus_req_i.rw = '0') then
-        case bus_req_i.addr(4 downto 2) is
-          when addr_in_c  => bus_rsp_o.data(GPIO_NUM-1 downto 0) <= port_in;  -- input port
-          when addr_out_c => bus_rsp_o.data(GPIO_NUM-1 downto 0) <= port_out; -- output port
-          when addr_dir_c => bus_rsp_o.data(GPIO_NUM-1 downto 0) <= port_dir; -- direction control
-          when addr_tt_c  => bus_rsp_o.data(GPIO_NUM-1 downto 0) <= irq_typ;  -- trigger type
-          when addr_tp_c  => bus_rsp_o.data(GPIO_NUM-1 downto 0) <= irq_pol;  -- trigger polarity
-          when addr_ie_c  => bus_rsp_o.data(GPIO_NUM-1 downto 0) <= irq_en;   -- interrupt enable
-          when addr_ip_c  => bus_rsp_o.data(GPIO_NUM-1 downto 0) <= irq_pend; -- interrupt pending
-          when others     => bus_rsp_o.data(GPIO_NUM-1 downto 0) <= (others => '0');
-        end case;
-      end if;
     end if;
   end process;
+
+  -- read access (asynchronous) --
+  bus_read: process(bus_rden, bus_req_i.addr, port_in2, port_out, port_dir, irq_typ, irq_pol, irq_en, irq_pend)
+  begin
+    bus_rdata <= (others => '0');
+    if (bus_rden = '1') then -- output gating
+      case bus_req_i.addr(4 downto 2) is
+        when addr_in_c  => bus_rdata(GPIO_NUM-1 downto 0) <= port_in2; -- input port
+        when addr_out_c => bus_rdata(GPIO_NUM-1 downto 0) <= port_out; -- output port
+        when addr_dir_c => bus_rdata(GPIO_NUM-1 downto 0) <= port_dir; -- direction control
+        when addr_tt_c  => bus_rdata(GPIO_NUM-1 downto 0) <= irq_typ;  -- trigger type
+        when addr_tp_c  => bus_rdata(GPIO_NUM-1 downto 0) <= irq_pol;  -- trigger polarity
+        when addr_ie_c  => bus_rdata(GPIO_NUM-1 downto 0) <= irq_en;   -- interrupt enable
+        when addr_ip_c  => bus_rdata(GPIO_NUM-1 downto 0) <= irq_pend; -- interrupt pending
+        when others     => bus_rdata(GPIO_NUM-1 downto 0) <= (others => '0');
+      end case;
+    end if;
+  end process;
+
+  -- bus response --
+  bus_rsp_o.ack  <= bus_ack;
+  bus_rsp_o.err  <= '0'; -- no access errors supported
+  bus_rsp_o.data <= bus_rdata;
 
 
   -- Port IO --------------------------------------------------------------------------------
@@ -139,13 +160,13 @@ begin
   -- -------------------------------------------------------------------------------------------
   irq_trigger_gen:
   for i in 0 to GPIO_NUM-1 generate
-    irq_trigger: process(port_in, port_in2, irq_typ, irq_pol)
+    irq_trigger: process(irq_typ, irq_pol, port_in, port_in2)
       variable sel_v : std_ulogic_vector(1 downto 0);
     begin
       sel_v := irq_typ(i) & irq_pol(i);
       case sel_v is
-        when "00"   => irq_trig(i) <= not port_in(i); -- low-level
-        when "01"   => irq_trig(i) <= port_in(i); -- high-level
+        when "00"   => irq_trig(i) <= not port_in2(i); -- low-level
+        when "01"   => irq_trig(i) <= port_in2(i); -- high-level
         when "10"   => irq_trig(i) <= (not port_in(i)) and port_in2(i); -- falling-edge
         when "11"   => irq_trig(i) <= port_in(i) and (not port_in2(i)); -- rising-edge
         when others => irq_trig(i) <= '0';

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130502"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130503"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_slink.vhd
+++ b/rtl/core/neorv32_slink.vhd
@@ -67,6 +67,10 @@ architecture neorv32_slink_rtl of neorv32_slink is
   constant log2_rx_fifo_c : natural := index_size_f(SLINK_RX_FIFO);
   constant log2_tx_fifo_c : natural := index_size_f(SLINK_TX_FIFO);
 
+  -- bus interface --
+  signal bus_ack, bus_rden : std_ulogic;
+  signal bus_rdata : std_ulogic_vector(31 downto 0);
+
   -- control register --
   type ctrl_t is record
     enable, irq_rx_nempty, irq_rx_full, irq_tx_empty, irq_tx_nfull : std_ulogic;
@@ -91,10 +95,21 @@ begin
 
   -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o          <= rsp_terminate_c;
+      bus_ack  <= '0';
+      bus_rden <= '0';
+    elsif rising_edge(clk_i) then
+      bus_ack  <= bus_req_i.stb;
+      bus_rden <= bus_req_i.stb and (not bus_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  bus_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
       ctrl.enable        <= '0';
       ctrl.irq_rx_nempty <= '0';
       ctrl.irq_rx_full   <= '0';
@@ -102,49 +117,54 @@ begin
       ctrl.irq_tx_nfull  <= '0';
       tx_route           <= (others => '0');
     elsif rising_edge(clk_i) then
-      -- bus handshake --
-      bus_rsp_o.ack  <= bus_req_i.stb;
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      -- bus access --
-      if (bus_req_i.stb = '1') then
-        if (bus_req_i.rw = '1') then -- write access
-          -- control register --
-          if (bus_req_i.addr(3 downto 2) = "00") then
-            ctrl.enable        <= bus_req_i.data(ctrl_en_c);
-            ctrl.irq_rx_nempty <= bus_req_i.data(ctrl_irq_rx_nempty_c);
-            ctrl.irq_rx_full   <= bus_req_i.data(ctrl_irq_rx_full_c);
-            ctrl.irq_tx_empty  <= bus_req_i.data(ctrl_irq_tx_empty_c);
-            ctrl.irq_tx_nfull  <= bus_req_i.data(ctrl_irq_tx_nfull_c);
-          end if;
-          -- routing information --
-          if (bus_req_i.addr(3 downto 2) = "01") then
-            tx_route <= bus_req_i.data(3 downto 0);
-          end if;
-        else -- read access
-          case bus_req_i.addr(3 downto 2) is
-            when "00" => -- control register
-              bus_rsp_o.data(ctrl_en_c)                              <= ctrl.enable;
-              bus_rsp_o.data(ctrl_rx_empty_c)                        <= not rx_fifo.avail;
-              bus_rsp_o.data(ctrl_rx_full_c)                         <= not rx_fifo.free;
-              bus_rsp_o.data(ctrl_tx_empty_c)                        <= not tx_fifo.avail;
-              bus_rsp_o.data(ctrl_tx_full_c)                         <= not tx_fifo.free;
-              bus_rsp_o.data(ctrl_rx_last_c)                         <= rx_last;
-              bus_rsp_o.data(ctrl_irq_rx_nempty_c)                   <= ctrl.irq_rx_nempty;
-              bus_rsp_o.data(ctrl_irq_rx_full_c)                     <= ctrl.irq_rx_full;
-              bus_rsp_o.data(ctrl_irq_tx_empty_c)                    <= ctrl.irq_tx_empty;
-              bus_rsp_o.data(ctrl_irq_tx_nfull_c)                    <= ctrl.irq_tx_nfull;
-              bus_rsp_o.data(ctrl_rx_fifo3_c downto ctrl_rx_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_rx_fifo_c, 4));
-              bus_rsp_o.data(ctrl_tx_fifo3_c downto ctrl_tx_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_tx_fifo_c, 4));
-            when "01" => -- routing information
-              bus_rsp_o.data(3 downto 0) <= rx_route;
-            when others => -- RX data
-              bus_rsp_o.data <= rx_fifo.rdata(31 downto 0);
-          end case;
+      if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') then
+        -- control register --
+        if (bus_req_i.addr(3 downto 2) = "00") then
+          ctrl.enable        <= bus_req_i.data(ctrl_en_c);
+          ctrl.irq_rx_nempty <= bus_req_i.data(ctrl_irq_rx_nempty_c);
+          ctrl.irq_rx_full   <= bus_req_i.data(ctrl_irq_rx_full_c);
+          ctrl.irq_tx_empty  <= bus_req_i.data(ctrl_irq_tx_empty_c);
+          ctrl.irq_tx_nfull  <= bus_req_i.data(ctrl_irq_tx_nfull_c);
+        end if;
+        -- routing information --
+        if (bus_req_i.addr(3 downto 2) = "01") then
+          tx_route <= bus_req_i.data(3 downto 0);
         end if;
       end if;
     end if;
   end process;
+
+  -- read access (asynchronous) --
+  bus_read: process(bus_rden, bus_req_i.addr, ctrl, rx_fifo, tx_fifo, rx_last, rx_route)
+  begin
+    bus_rdata <= (others => '0');
+    if (bus_rden = '1') then -- output gating
+      case bus_req_i.addr(3 downto 2) is
+        when "00" => -- control register
+          bus_rdata(ctrl_en_c)                              <= ctrl.enable;
+          bus_rdata(ctrl_rx_empty_c)                        <= not rx_fifo.avail;
+          bus_rdata(ctrl_rx_full_c)                         <= not rx_fifo.free;
+          bus_rdata(ctrl_tx_empty_c)                        <= not tx_fifo.avail;
+          bus_rdata(ctrl_tx_full_c)                         <= not tx_fifo.free;
+          bus_rdata(ctrl_rx_last_c)                         <= rx_last;
+          bus_rdata(ctrl_irq_rx_nempty_c)                   <= ctrl.irq_rx_nempty;
+          bus_rdata(ctrl_irq_rx_full_c)                     <= ctrl.irq_rx_full;
+          bus_rdata(ctrl_irq_tx_empty_c)                    <= ctrl.irq_tx_empty;
+          bus_rdata(ctrl_irq_tx_nfull_c)                    <= ctrl.irq_tx_nfull;
+          bus_rdata(ctrl_rx_fifo3_c downto ctrl_rx_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_rx_fifo_c, 4));
+          bus_rdata(ctrl_tx_fifo3_c downto ctrl_tx_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_tx_fifo_c, 4));
+        when "01" => -- routing information
+          bus_rdata(3 downto 0) <= rx_route;
+        when others => -- RX data
+          bus_rdata <= rx_fifo.rdata(31 downto 0);
+      end case;
+    end if;
+  end process;
+
+  -- bus response --
+  bus_rsp_o.ack  <= bus_ack;
+  bus_rsp_o.err  <= '0'; -- no access errors supported
+  bus_rsp_o.data <= bus_rdata;
 
 
   -- RX Data FIFO ---------------------------------------------------------------------------
@@ -171,7 +191,7 @@ begin
   );
 
   rx_fifo.clr      <= not ctrl.enable;
-  rx_fifo.re       <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(3) = '1') else '0';
+  rx_fifo.re       <= bus_rden and bus_req_i.addr(3);
   rx_fifo.we       <= slink_rx_valid_i;
   rx_fifo.wdata    <= slink_rx_last_i & slink_rx_src_i & slink_rx_data_i;
   slink_rx_ready_o <= rx_fifo.free and ctrl.enable;
@@ -215,7 +235,7 @@ begin
   );
 
   tx_fifo.clr      <= not ctrl.enable;
-  tx_fifo.we       <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(3) = '1') else '0';
+  tx_fifo.we       <= bus_req_i.stb and bus_req_i.rw and bus_req_i.addr(3);
   tx_fifo.wdata    <= bus_req_i.addr(2) & tx_route & bus_req_i.data; -- last-flag is set implicitly via access address
   tx_fifo.re       <= slink_tx_ready_i;
   slink_tx_data_o  <= tx_fifo.rdata(31 downto 0);

--- a/rtl/core/neorv32_smc.vhd
+++ b/rtl/core/neorv32_smc.vhd
@@ -88,6 +88,10 @@ architecture neorv32_smc_rtl of neorv32_smc is
   end record;
   signal csr : csr_t; -- register set
 
+  -- control interface --
+  signal ctrl_ack, ctrl_rden : std_ulogic;
+  signal ctrl_rdata : std_ulogic_vector(31 downto 0);
+
   -- data memory access --
   signal acc_req, acc_bank : std_ulogic;
   signal acc_fail : std_ulogic_vector(31 downto 0);
@@ -174,10 +178,21 @@ begin
 
   -- Control and Status Registers -----------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  csr_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      ctrl_rsp_o <= rsp_terminate_c;
+      ctrl_ack  <= '0';
+      ctrl_rden <= '0';
+    elsif rising_edge(clk_i) then
+      ctrl_ack  <= ctrl_req_i.stb;
+      ctrl_rden <= ctrl_req_i.stb and (not ctrl_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  csr_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
       csr.enable <= '0';
       csr.ioen   <= '0';
       csr.dual   <= '0';
@@ -188,11 +203,6 @@ begin
       csr.cmd_wr <= (others => '0');
       csr.icmd   <= (others => '0');
     elsif rising_edge(clk_i) then
-      -- defaults --
-      ctrl_rsp_o.ack  <= ctrl_req_i.stb;
-      ctrl_rsp_o.err  <= '0';
-      ctrl_rsp_o.data <= (others => '0');
-      -- write access --
       if (ctrl_req_i.stb = '1') and (ctrl_req_i.rw = '1') then
         if (ctrl_req_i.addr(2) = '0') then -- CSR0
           csr.enable <= ctrl_req_i.data(csr0_enable_c);
@@ -207,25 +217,35 @@ begin
           csr.icmd <= ctrl_req_i.data(23 downto 0);
         end if;
       end if;
-      -- read access --
-      if (ctrl_req_i.stb = '1') and (ctrl_req_i.rw = '0') then
-        if (ctrl_req_i.addr(2) = '0') then -- CSR0
-          ctrl_rsp_o.data(csr0_enable_c)                            <= csr.enable;
-          ctrl_rsp_o.data(csr0_ioen_c)                              <= csr.ioen;
-          ctrl_rsp_o.data(csr0_dual_c)                              <= csr.dual;
-          ctrl_rsp_o.data(csr0_busy_c)                              <= busy;
-          ctrl_rsp_o.data(csr0_msize_msb_c downto csr0_msize_lsb_c) <= csr.msize;
-          ctrl_rsp_o.data(csr0_cdiv_msb_c  downto csr0_cdiv_lsb_c)  <= csr.cdiv;
-          ctrl_rsp_o.data(csr0_rwait_msb_c downto csr0_rwait_lsb_c) <= csr.rwait;
-          ctrl_rsp_o.data(csr0_rcmd_msb_c  downto csr0_rcmd_lsb_c)  <= csr.cmd_rd;
-          ctrl_rsp_o.data(csr0_wcmd_msb_c  downto csr0_wcmd_lsb_c)  <= csr.cmd_wr;
-        else -- CSR1
-          ctrl_rsp_o.data(23 downto 0)  <= csr.icmd;
-          ctrl_rsp_o.data(31 downto 28) <= MEM_BASE(31 downto 28);
-        end if;
+    end if;
+  end process;
+
+  -- read access (asynchronous) --
+  csr_read: process(ctrl_rden, ctrl_req_i.addr, csr, busy)
+  begin
+    ctrl_rdata <= (others => '0');
+    if (ctrl_rden = '1') then -- output gating
+      if (ctrl_req_i.addr(2) = '0') then -- CSR0
+        ctrl_rdata(csr0_enable_c)                            <= csr.enable;
+        ctrl_rdata(csr0_ioen_c)                              <= csr.ioen;
+        ctrl_rdata(csr0_dual_c)                              <= csr.dual;
+        ctrl_rdata(csr0_busy_c)                              <= busy;
+        ctrl_rdata(csr0_msize_msb_c downto csr0_msize_lsb_c) <= csr.msize;
+        ctrl_rdata(csr0_cdiv_msb_c  downto csr0_cdiv_lsb_c)  <= csr.cdiv;
+        ctrl_rdata(csr0_rwait_msb_c downto csr0_rwait_lsb_c) <= csr.rwait;
+        ctrl_rdata(csr0_rcmd_msb_c  downto csr0_rcmd_lsb_c)  <= csr.cmd_rd;
+        ctrl_rdata(csr0_wcmd_msb_c  downto csr0_wcmd_lsb_c)  <= csr.cmd_wr;
+      else -- CSR1
+        ctrl_rdata(23 downto 0)  <= csr.icmd;
+        ctrl_rdata(31 downto 28) <= MEM_BASE(31 downto 28);
       end if;
     end if;
   end process;
+
+  -- bus response --
+  ctrl_rsp_o.ack  <= ctrl_ack;
+  ctrl_rsp_o.err  <= '0'; -- no access errors supported
+  ctrl_rsp_o.data <= ctrl_rdata;
 
   -- SMC is in charge of interface IOs --
   smc_ioen_o <= csr.ioen;

--- a/rtl/core/neorv32_tracer.vhd
+++ b/rtl/core/neorv32_tracer.vhd
@@ -50,6 +50,10 @@ architecture neorv32_tracer_rtl of neorv32_tracer is
   -- helpers --
   constant log2_fifo_size_c : natural := index_size_f(TRACE_DEPTH);
 
+  -- bus interface --
+  signal bus_ack, bus_rden : std_ulogic;
+  signal bus_rdata : std_ulogic_vector(31 downto 0);
+
   -- control registers --
   signal ctrl_en, ctrl_hsel, ctrl_start, ctrl_stop, ctrl_iclr : std_ulogic;
   signal stop_addr : std_ulogic_vector(30 downto 0);
@@ -84,10 +88,21 @@ begin
 
   -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o  <= rsp_terminate_c;
+      bus_ack  <= '0';
+      bus_rden <= '0';
+    elsif rising_edge(clk_i) then
+      bus_ack  <= bus_req_i.stb;
+      bus_rden <= bus_req_i.stb and (not bus_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  bus_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
       ctrl_en    <= '0';
       ctrl_hsel  <= '0';
       ctrl_start <= '0';
@@ -95,10 +110,6 @@ begin
       ctrl_iclr  <= '0';
       stop_addr  <= (others => '0');
     elsif rising_edge(clk_i) then
-      -- bus handshake --
-      bus_rsp_o.ack <= bus_req_i.stb;
-      bus_rsp_o.err <= '0';
-      -- write access --
       ctrl_start <= '0';
       ctrl_stop  <= '0';
       ctrl_iclr  <= '0';
@@ -114,26 +125,35 @@ begin
           stop_addr <= bus_req_i.data(31 downto 1);
         end if;
       end if;
-      -- read access --
-      bus_rsp_o.data <= (others => '0');
-      if (bus_req_i.stb = '1') and (bus_req_i.rw = '0') then
-        case bus_req_i.addr(3 downto 2) is
-          when "00" => -- control register
-            bus_rsp_o.data(ctrl_enable_c) <= ctrl_en;
-            bus_rsp_o.data(ctrl_hsel_c)   <= ctrl_hsel and bool_to_ulogic_f(DUAL_CORE_EN);
-            bus_rsp_o.data(ctrl_run_c)    <= arbiter.run;
-            bus_rsp_o.data(ctrl_avail_c)  <= fifo.avail;
-            bus_rsp_o.data(data_tbm_msb_c downto data_tbm_lsb_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
-          when "01" => -- stop-address register
-            bus_rsp_o.data <= stop_addr & '0';
-          when "10" => -- trace data: source
-            bus_rsp_o.data <= fifo.rdata(31 downto 0);
-          when others => -- trace data: destination
-            bus_rsp_o.data <= fifo.rdata(63 downto 32);
-        end case;
-      end if;
     end if;
   end process;
+
+  -- read access (asynchronous) --
+  bus_read: process(bus_rden, bus_req_i.addr, ctrl_en, ctrl_hsel, arbiter.run, fifo, stop_addr)
+  begin
+    bus_rdata <= (others => '0');
+    if (bus_rden = '1') then -- output gating
+      case bus_req_i.addr(3 downto 2) is
+        when "00" => -- control register
+          bus_rdata(ctrl_enable_c) <= ctrl_en;
+          bus_rdata(ctrl_hsel_c)   <= ctrl_hsel and bool_to_ulogic_f(DUAL_CORE_EN);
+          bus_rdata(ctrl_run_c)    <= arbiter.run;
+          bus_rdata(ctrl_avail_c)  <= fifo.avail;
+          bus_rdata(data_tbm_msb_c downto data_tbm_lsb_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
+        when "01" => -- stop-address register
+          bus_rdata <= stop_addr & '0';
+        when "10" => -- trace data: source
+          bus_rdata <= fifo.rdata(31 downto 0);
+        when others => -- trace data: destination
+          bus_rdata <= fifo.rdata(63 downto 32);
+      end case;
+    end if;
+  end process;
+
+  -- bus response --
+  bus_rsp_o.ack  <= bus_ack;
+  bus_rsp_o.err  <= '0'; -- no access errors supported
+  bus_rsp_o.data <= bus_rdata;
 
   -- trace source select (CPU0 or CPU1) --
   trace_src <= trace0_i when (ctrl_hsel = '0') or (DUAL_CORE_EN = false) else trace1_i;
@@ -230,7 +250,7 @@ begin
   fifo.clear <= not ctrl_en;
   fifo.we    <= push;
   fifo.wdata <= arbiter.dst & arbiter.src;
-  fifo.re    <= '1' when (discard = '1') or ((bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(3 downto 2) = "11")) else '0';
+  fifo.re    <= '1' when (discard = '1') or ((bus_rden = '1') and (bus_req_i.addr(3 downto 2) = "11")) else '0';
 
   -- discard oldest entry if overflowing --
   fifo_overflow: process(clk_i)

--- a/rtl/core/neorv32_trng.vhd
+++ b/rtl/core/neorv32_trng.vhd
@@ -72,6 +72,10 @@ architecture neorv32_trng_rtl of neorv32_trng is
     );
   end component;
 
+  -- bus interface --
+  signal bus_ack, bus_rden : std_ulogic;
+  signal bus_rdata : std_ulogic_vector(31 downto 0);
+
   -- control register --
   signal enable, fifo_clr : std_ulogic;
 
@@ -88,41 +92,56 @@ begin
 
   -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o <= rsp_terminate_c;
-      enable    <= '0';
-      fifo_clr  <= '0';
+      bus_ack  <= '0';
+      bus_rden <= '0';
     elsif rising_edge(clk_i) then
-      -- bus handshake --
-      bus_rsp_o.ack  <= bus_req_i.stb;
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      -- write access --
+      bus_ack  <= bus_req_i.stb;
+      bus_rden <= bus_req_i.stb and (not bus_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  bus_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      enable   <= '0';
       fifo_clr <= '0';
+    elsif rising_edge(clk_i) then
+      fifo_clr <= '0'; -- default
       if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(2) = '0') then -- control register
         enable   <= bus_req_i.data(ctrl_en_c);
         fifo_clr <= bus_req_i.data(ctrl_fifo_clr_c);
       end if;
-      -- read access --
-      if (bus_req_i.stb = '1') and (bus_req_i.rw = '0') then
-        if (bus_req_i.addr(2) = '0') then -- control register
-          bus_rsp_o.data(ctrl_en_c)                         <= enable;
-          bus_rsp_o.data(ctrl_fifo_clr_c)                   <= '0';
-          bus_rsp_o.data(ctrl_sim_mode_c)                   <= bool_to_ulogic_f(is_simulation_c);
-          bus_rsp_o.data(ctrl_avail_c)                      <= fifo.avail;
-          bus_rsp_o.data(ctrl_fifo3_c  downto ctrl_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
-          bus_rsp_o.data(ctrl_nbit3_c  downto ctrl_nbit0_c) <= std_ulogic_vector(to_unsigned(log2_rbit_c, 4));
-          bus_rsp_o.data(ctrl_nro7_c   downto ctrl_nro0_c)  <= std_ulogic_vector(to_unsigned(NUM_RO, 8));
-          bus_rsp_o.data(ctrl_ninv11_c downto ctrl_ninv0_c) <= std_ulogic_vector(to_unsigned(num_inv_start_c, 12));
-        else -- data register
-          bus_rsp_o.data(7 downto 0) <= fifo.rdata;
-        end if;
+    end if;
+  end process;
+
+  -- read access (asynchronous) --
+  bus_read: process(bus_rden, bus_req_i.addr, enable, fifo)
+  begin
+    bus_rdata <= (others => '0');
+    if (bus_rden = '1') then -- output gating
+      if (bus_req_i.addr(2) = '0') then -- control register
+        bus_rdata(ctrl_en_c)                         <= enable;
+        bus_rdata(ctrl_fifo_clr_c)                   <= '0';
+        bus_rdata(ctrl_sim_mode_c)                   <= bool_to_ulogic_f(is_simulation_c);
+        bus_rdata(ctrl_avail_c)                      <= fifo.avail;
+        bus_rdata(ctrl_fifo3_c  downto ctrl_fifo0_c) <= std_ulogic_vector(to_unsigned(log2_fifo_size_c, 4));
+        bus_rdata(ctrl_nbit3_c  downto ctrl_nbit0_c) <= std_ulogic_vector(to_unsigned(log2_rbit_c, 4));
+        bus_rdata(ctrl_nro7_c   downto ctrl_nro0_c)  <= std_ulogic_vector(to_unsigned(NUM_RO, 8));
+        bus_rdata(ctrl_ninv11_c downto ctrl_ninv0_c) <= std_ulogic_vector(to_unsigned(num_inv_start_c, 12));
+      else -- data register
+        bus_rdata(7 downto 0) <= fifo.rdata;
       end if;
     end if;
   end process;
 
+  -- bus response --
+  bus_rsp_o.ack  <= bus_ack;
+  bus_rsp_o.err  <= '0'; -- no access errors supported
+  bus_rsp_o.data <= bus_rdata;
 
   -- neoTRNG True Random Number Generator ---------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -140,7 +159,6 @@ begin
     valid_o  => fifo.we,
     data_o   => fifo.wdata
   );
-
 
   -- Random Number Buffer --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -165,8 +183,8 @@ begin
     avail_o => fifo.avail
   );
 
-  fifo.clear <= '1' when (enable = '0') or (fifo_clr = '1') else '0';
-  fifo.re    <= '1' when (bus_req_i.stb = '1') and (bus_req_i.rw = '0') and (bus_req_i.addr(2) = '1') else '0';
+  fifo.clear <= (not enable) or fifo_clr;
+  fifo.re    <= bus_rden and bus_req_i.addr(2);
 
   -- interrupt generator --
   irq_gen: process(clk_i)

--- a/rtl/core/neorv32_wdt.vhd
+++ b/rtl/core/neorv32_wdt.vhd
@@ -52,6 +52,9 @@ architecture neorv32_wdt_rtl of neorv32_wdt is
   signal ctrl : ctrl_t; -- register set
 
   -- misc --
+  signal bus_ack        : std_ulogic; -- access acknowledge
+  signal bus_rden       : std_ulogic; -- bus read access
+  signal bus_rdata      : std_ulogic_vector(31 downto 0); -- bus read data
   signal prsc_tick      : std_ulogic; -- prescaler clock generator
   signal cen            : std_ulogic; -- counter enable
   signal cnt            : std_ulogic_vector(23 downto 0); -- timeout counter
@@ -63,50 +66,65 @@ begin
 
   -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_sys_i, clk_i)
+  bus_handshake: process(rstn_sys_i, clk_i)
   begin
     if (rstn_sys_i = '0') then
-      bus_rsp_o    <= rsp_terminate_c;
-      ctrl.enable  <= '0'; -- disable WDT after reset
-      ctrl.lock    <= '0'; -- unlock after reset
-      ctrl.timeout <= (others => '0');
-      reset_wdt    <= '0';
-      reset_force  <= '0';
+      bus_ack  <= '0';
+      bus_rden <= '0';
     elsif rising_edge(clk_i) then
-      -- bus handshake --
-      bus_rsp_o.ack  <= bus_req_i.stb;
-      bus_rsp_o.err  <= '0';
-      bus_rsp_o.data <= (others => '0');
-      -- defaults --
-      reset_wdt   <= '0';
-      reset_force <= '0';
-      -- bus access --
-      if (bus_req_i.stb = '1') then
-        if (bus_req_i.rw = '1') then -- write access
-          if (bus_req_i.addr(2) = '0') then -- control register
-            if (ctrl.lock = '0') then -- update configuration only if not locked
-              ctrl.enable  <= bus_req_i.data(ctrl_enable_c);
-              ctrl.lock    <= bus_req_i.data(ctrl_lock_c);
-              ctrl.timeout <= bus_req_i.data(ctrl_timeout_msb_c downto ctrl_timeout_lsb_c);
-            else -- write access attempt to locked CTRL register
-              reset_force <= '1';
-            end if;
-          else -- reset timeout counter - password check
-            if (bus_req_i.data(31 downto 0) = reset_pwd_c) then
-              reset_wdt <= '1'; -- correct; reset watchdog
-            else
-              reset_force <= '1'; -- incorrect; trigger system reset
-            end if;
+      bus_ack  <= bus_req_i.stb;
+      bus_rden <= bus_req_i.stb and (not bus_req_i.rw);
+    end if;
+  end process;
+
+  -- write access --
+  bus_write: process(rstn_sys_i, clk_i)
+  begin
+    if (rstn_sys_i = '0') then
+      ctrl.enable   <= '0'; -- disable WDT after reset
+      ctrl.lock     <= '0'; -- unlock after reset
+      ctrl.timeout  <= (others => '0');
+      ctrl.rst_time <= '0';
+      ctrl.rst_trig <= '0';
+    elsif rising_edge(clk_i) then
+      ctrl.rst_time <= '0'; -- default
+      ctrl.rst_trig <= '0'; -- default
+      if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') then
+        if (bus_req_i.addr(2) = '0') then -- control register
+          if (ctrl.lock = '0') then -- update configuration only if not locked
+            ctrl.enable  <= bus_req_i.data(ctrl_enable_c);
+            ctrl.lock    <= bus_req_i.data(ctrl_lock_c);
+            ctrl.timeout <= bus_req_i.data(ctrl_timeout_msb_c downto ctrl_timeout_lsb_c);
+          else -- write access attempt to locked CTRL register
+            ctrl.rst_trig <= '1';
           end if;
-        else -- read access
-          bus_rsp_o.data(ctrl_enable_c)                                <= ctrl.enable;
-          bus_rsp_o.data(ctrl_lock_c)                                  <= ctrl.lock;
-          bus_rsp_o.data(ctrl_rcause_msb_c downto ctrl_rcause_lsb_c)   <= reset_cause;
-          bus_rsp_o.data(ctrl_timeout_msb_c downto ctrl_timeout_lsb_c) <= ctrl.timeout;
+        else -- reset timeout counter - password check
+          if (bus_req_i.data(31 downto 0) = reset_pwd_c) then
+            ctrl.rst_time <= '1'; -- correct: reset timer
+          else
+            ctrl.rst_trig <= '1'; -- incorrect: trigger system reset
+          end if;
         end if;
       end if;
     end if;
   end process;
+
+  -- read access (asynchronous) --
+  bus_read: process(bus_rden, ctrl, reset_cause)
+  begin
+    bus_rdata <= (others => '0');
+    if (bus_rden = '1') then -- output gating
+      bus_rdata(ctrl_enable_c)                                <= ctrl.enable;
+      bus_rdata(ctrl_lock_c)                                  <= ctrl.lock;
+      bus_rdata(ctrl_rcause_msb_c  downto ctrl_rcause_lsb_c)  <= reset_cause;
+      bus_rdata(ctrl_timeout_msb_c downto ctrl_timeout_lsb_c) <= ctrl.timeout;
+    end if;
+  end process;
+
+  -- bus response --
+  bus_rsp_o.ack  <= bus_ack;
+  bus_rsp_o.err  <= '0'; -- no access errors supported
+  bus_rsp_o.data <= bus_rdata;
 
   -- Timeout Counter ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_wdt.vhd
+++ b/rtl/core/neorv32_wdt.vhd
@@ -17,14 +17,14 @@ use neorv32.neorv32_package.all;
 
 entity neorv32_wdt is
   port (
-    clk_i       : in  std_ulogic;                    -- global clock line
-    rstn_ext_i  : in  std_ulogic;                    -- external reset, low-active
-    rstn_dbg_i  : in  std_ulogic;                    -- debugger reset, low-active
-    rstn_sys_i  : in  std_ulogic;                    -- system reset, low-active
-    bus_req_i   : in  bus_req_t;                     -- bus request
-    bus_rsp_o   : out bus_rsp_t;                     -- bus response
-    clkgen_i    : in  std_ulogic_vector(7 downto 0); -- prescaled clock enables
-    rstn_o      : out std_ulogic                     -- timeout reset, low_active, sync
+    clk_i      : in  std_ulogic;                    -- global clock line
+    rstn_ext_i : in  std_ulogic;                    -- external reset, low-active
+    rstn_dbg_i : in  std_ulogic;                    -- debugger reset, low-active
+    rstn_sys_i : in  std_ulogic;                    -- system reset, low-active
+    bus_req_i  : in  bus_req_t;                     -- bus request
+    bus_rsp_o  : out bus_rsp_t;                     -- bus response
+    clkgen_i   : in  std_ulogic_vector(7 downto 0); -- prescaled clock enables
+    rstn_o     : out std_ulogic                     -- timeout reset, low_active, sync
   );
 end entity;
 
@@ -43,9 +43,11 @@ architecture neorv32_wdt_rtl of neorv32_wdt is
 
   -- control register --
   type ctrl_t is record
-    enable  : std_ulogic;
-    lock    : std_ulogic;
-    timeout : std_ulogic_vector(23 downto 0);
+    enable   : std_ulogic;
+    lock     : std_ulogic;
+    timeout  : std_ulogic_vector(23 downto 0);
+    rst_time : std_ulogic; -- reset timeout counter
+    rst_trig : std_ulogic; -- trigger system reset
   end record;
   signal ctrl : ctrl_t; -- register set
 
@@ -53,8 +55,6 @@ architecture neorv32_wdt_rtl of neorv32_wdt is
   signal prsc_tick      : std_ulogic; -- prescaler clock generator
   signal cen            : std_ulogic; -- counter enable
   signal cnt            : std_ulogic_vector(23 downto 0); -- timeout counter
-  signal reset_wdt      : std_ulogic; -- reset timeout counter ("feed the watch dog")
-  signal reset_force    : std_ulogic; -- illegal access
   signal hw_rst_timeout : std_ulogic; -- trigger reset because of timeout
   signal hw_rst_access  : std_ulogic; -- trigger reset because of illegal access if locked
   signal reset_cause    : std_ulogic_vector(1 downto 0); -- cause of last reset
@@ -117,7 +117,7 @@ begin
       cnt <= (others => '0');
     elsif rising_edge(clk_i) then
       cen <= ctrl.enable; -- delay start by 1 cycle to make sure cnt is initialized by ctrl.timeout
-      if (cen = '0') or (ctrl.enable = '0') or (reset_wdt = '1') then -- watchdog disabled or reset
+      if (cen = '0') or (ctrl.enable = '0') or (ctrl.rst_time = '1') then -- watchdog disabled or reset
         cnt <= ctrl.timeout;
       elsif (prsc_tick = '1') then
         cnt <= std_ulogic_vector(unsigned(cnt) - 1);
@@ -138,7 +138,7 @@ begin
       rstn_o         <= '1';
     elsif rising_edge(clk_i) then -- reset triggers are sticky until system reset
       hw_rst_timeout <= hw_rst_timeout or (ctrl.enable and cen and prsc_tick and (not or_reduce_f(cnt))); -- timeout
-      hw_rst_access  <= hw_rst_access  or (ctrl.enable and ctrl.lock and reset_force); -- locked and incorrect password
+      hw_rst_access  <= hw_rst_access  or (ctrl.enable and ctrl.lock and ctrl.rst_trig); -- locked and incorrect password
       rstn_o         <= not (hw_rst_timeout or hw_rst_access); -- system-wide reset
     end if;
   end process;


### PR DESCRIPTION
This PR builds on #1638 and extends the concept of asynchronous bus access to additional I/O modules.

> The serial interfaces now use asynchronous bus read access. This not only saves 32 FFs per device, but also reduces the amount of logic required, because the read logic for all devices can be merged together.

> This should not cause the timing to get worse. There is a central bus register that separates the bus between the core/memory and the I/O devices.

> Most logical memory-mapped registers that can be read are driven by actual FF. This is not the case for status signals (e.g., FIFO status), which could actually cause timing issues.