### PR TITLE
[ocd,gptmr,pwm] further area optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 30.08.2026 | 1.13.5.4 | ocd, gptmr, pwm: area optimizations; remove reset from registers where it is not strictly necessary | [#1641](https://github.com/stnolting/neorv32/pull/1641) |
 | 29.08.2026 | 1.13.5.3 | :test_tube: use asynchronous bus read access for further IO devices | [#1640](https://github.com/stnolting/neorv32/pull/1640) |
 | 29.08.2026 | 1.13.5.2 | :test_tube: use asynchronous bus read access for serial IO devices | [#1638](https://github.com/stnolting/neorv32/pull/1638) |
 | 29.08.2026 | 1.13.5.1 | CPU: optimize set-on-less-than timing | [#1635](https://github.com/stnolting/neorv32/pull/1635) |

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -155,13 +155,13 @@ architecture neorv32_debug_dm_rtl of neorv32_debug_dm is
 
   -- Debug Core Interface --
   type dci_t is record
-    ack_hlt  : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU (re-)entered HALT state (single-shot)
-    req_res  : std_ulogic_vector(NUM_HARTS-1 downto 0); -- DM wants the CPU to resume when set
-    ack_res  : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU starts resuming when set (single-shot)
-    req_exe  : std_ulogic_vector(NUM_HARTS-1 downto 0); -- DM wants CPU to execute program buffer when set
-    ack_exe  : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU starts executing program buffer when set (single-shot)
-    ack_exc  : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU has detected an exception (single-shot)
-    data_reg : std_ulogic_vector(31 downto 0); -- memory-mapped data exchange register
+    ack_hlt : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU (re-)entered HALT state (single-shot)
+    req_res : std_ulogic_vector(NUM_HARTS-1 downto 0); -- DM wants the CPU to resume when set
+    ack_res : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU starts resuming when set (single-shot)
+    req_exe : std_ulogic_vector(NUM_HARTS-1 downto 0); -- DM wants CPU to execute program buffer when set
+    ack_exe : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU starts executing program buffer when set (single-shot)
+    ack_exc : std_ulogic_vector(NUM_HARTS-1 downto 0); -- CPU has detected an exception (single-shot)
+    data0   : std_ulogic_vector(31 downto 0); -- memory-mapped data exchange register
   end record;
   signal dci : dci_t;
 
@@ -211,15 +211,19 @@ begin
 
           -- debug module control --
           when addr_dmcontrol_c =>
-            dm_reg.halt_req  <= dmi_req_i.data(31);                                          -- haltreq
-            dm_reg.req_res   <= dmi_req_i.data(30) and (not dmi_req_i.data(31));             -- resumereq, ignore if halt request
-            dm_reg.reset_ack <= dmi_req_i.data(28);                                          -- ackhavereset
-            if (cmd_busy = '0') then dm_reg.hartsel <= dmi_req_i.data(18 downto 16); end if; -- hartsello, no update while CMD is executing
-            dm_reg.ndmreset  <= dmi_req_i.data(1);                                           -- ndmreset
+            dm_reg.halt_req  <= dmi_req_i.data(31);                              -- haltreq
+            dm_reg.req_res   <= dmi_req_i.data(30) and (not dmi_req_i.data(31)); -- resumereq, ignore if halt request
+            dm_reg.reset_ack <= dmi_req_i.data(28);                              -- ackhavereset
+            if (cmd_busy = '0') then
+              dm_reg.hartsel <= dmi_req_i.data(18 downto 16);                    -- hartsello, no update while CMD is executing
+            end if;
+            dm_reg.ndmreset  <= dmi_req_i.data(1);                               -- ndmreset
 
           -- write abstract command (only when idle and no error yet) --
           when addr_command_c =>
-            if (cmd_busy = '0') and (cmd_err = "000") then dm_reg.command <= dmi_req_i.data; end if;
+            if (cmd_busy = '0') and (cmd_err = "000") then
+              dm_reg.command <= dmi_req_i.data;
+            end if;
 
           -- write abstract command autoexec (only when idle) --
           when addr_abstractauto_c =>
@@ -230,15 +234,21 @@ begin
 
           -- acknowledge command error --
           when addr_abstractcs_c =>
-            if (dmi_req_i.data(10 downto 8) = "111") then dm_reg.clr_acc_err <= '1'; end if;
+            if (dmi_req_i.data(10 downto 8) = "111") then
+              dm_reg.clr_acc_err <= '1';
+            end if;
 
           -- write program buffer 0 (only when idle) --
           when addr_progbuf0_c =>
-            if (cmd_busy = '0') then dm_reg.progbuf(0) <= dmi_req_i.data; end if;
+            if (cmd_busy = '0') then
+              dm_reg.progbuf(0) <= dmi_req_i.data;
+            end if;
 
           -- write program buffer 1 (only when idle) --
           when addr_progbuf1_c =>
-            if (cmd_busy = '0') then dm_reg.progbuf(1) <= dmi_req_i.data; end if;
+            if (cmd_busy = '0') then
+              dm_reg.progbuf(1) <= dmi_req_i.data;
+            end if;
 
           -- undefined --
           when others =>
@@ -371,7 +381,7 @@ begin
         -- abstract data 0 --
         when addr_data0_c =>
           if (dmi_rden = '1') then
-            dmi_rsp_o.data <= dci.data_reg;
+            dmi_rsp_o.data <= dci.data0;
           end if;
 
         -- authentication data (can always be read) --
@@ -386,7 +396,7 @@ begin
 
         -- not implemented or read-only-zero --
         when others =>
-          null;
+          dmi_rsp_o.data <= (others => '0');
 
       end case;
     end if;
@@ -536,11 +546,11 @@ begin
       bus_rsp_o.err <= '0';
       -- data0 write access --
       if (dmi_wren = '1') and (dmi_req_i.addr = addr_data0_c) and (cmd_busy = '0') then -- DM write access
-        dci.data_reg <= dmi_req_i.data;
+        dci.data0 <= dmi_req_i.data;
       elsif (accen = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(7 downto 6) = dm_data_base_c(7 downto 6)) then -- CPU write access
         for i in 0 to 3 loop
           if (bus_req_i.ben(i) = '1') then
-            dci.data_reg(8*i+7 downto 8*i) <= bus_req_i.data(8*i+7 downto 8*i);
+            dci.data0(8*i+7 downto 8*i) <= bus_req_i.data(8*i+7 downto 8*i);
           end if;
         end loop;
       end if;

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -529,22 +529,25 @@ begin
   dci.req_exe <= hartselect when (cmd_state = CMD_START) else (others => '0');
 
 
-  -- Bus Access (from CPU) ------------------------------------------------------------------
+  -- CPU Interface --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o    <= rsp_terminate_c;
-      dci.data_reg <= (others => '0');
-      dci.ack_hlt  <= (others => '0');
-      dci.ack_res  <= (others => '0');
-      dci.ack_exe  <= (others => '0');
-      dci.ack_exc  <= (others => '0');
-    elsif rising_edge(clk_i) then
-      -- bus handshake --
-      bus_rsp_o.ack <= accen;
+      bus_rsp_o.ack <= '0';
       bus_rsp_o.err <= '0';
-      -- data0 write access --
+    elsif rising_edge(clk_i) then
+      bus_rsp_o.ack <= bus_req_i.stb;
+      bus_rsp_o.err <= bus_req_i.stb and (not bus_req_i.meta(2)); -- access error non-debug-mode access
+    end if;
+  end process;
+
+  -- data0 register --
+  data0_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      dci.data0 <= (others => '0');
+    elsif rising_edge(clk_i) then
       if (dmi_wren = '1') and (dmi_req_i.addr = addr_data0_c) and (cmd_busy = '0') then -- DM write access
         dci.data0 <= dmi_req_i.data;
       elsif (accen = '1') and (bus_req_i.rw = '1') and (bus_req_i.addr(7 downto 6) = dm_data_base_c(7 downto 6)) then -- CPU write access
@@ -554,8 +557,14 @@ begin
           end if;
         end loop;
       end if;
-      -- CPU status register write access; all flags auto-clear --
-      dci.ack_hlt <= (others => '0');
+    end if;
+  end process;
+
+  -- status register --
+  status_reg: process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      dci.ack_hlt <= (others => '0'); -- all flags auto-clear
       dci.ack_res <= (others => '0');
       dci.ack_exe <= (others => '0');
       dci.ack_exc <= (others => '0');
@@ -567,16 +576,22 @@ begin
           if (bus_req_i.ben(3) = '1') then dci.ack_exc(i) <= cpu_id_dec(i); end if; -- CPU has encountered an EXCEPTION
         end loop;
       end if;
-      -- CPU read access --
+    end if;
+  end process;
+
+  -- bus read access --
+  bus_read: process(clk_i)
+  begin
+    if rising_edge(clk_i) then
       bus_rsp_o.data <= (others => '0'); -- default
       if (accen = '1') and (bus_req_i.rw = '0') then
-        case bus_req_i.addr(7 downto 6) is -- module select
+        case bus_req_i.addr(7 downto 6) is
           when "00" => -- dm_code_base_c: code ROM
             bus_rsp_o.data <= code_rom_c(to_integer(unsigned(bus_req_i.addr(5 downto 2))));
           when "01" => -- dm_pbuf_base_c: program buffer
             bus_rsp_o.data <= cpu_progbuf(to_integer(unsigned(bus_req_i.addr(3 downto 2))));
           when "10" => -- dm_data_base_c: data buffer
-            bus_rsp_o.data <= dci.data_reg;
+            bus_rsp_o.data <= dci.data0;
           when others => -- dm_sreg_base_c: status register
             bus_rsp_o.data(1*8) <= or_reduce_f(dci.req_res and cpu_id_dec); -- DM requests CPU to resume
             bus_rsp_o.data(2*8) <= or_reduce_f(dci.req_exe and cpu_id_dec); -- DM requests CPU to execute program buffer

--- a/rtl/core/neorv32_debug_dm.vhd
+++ b/rtl/core/neorv32_debug_dm.vhd
@@ -300,12 +300,9 @@ begin
 
   -- Debug Module Interface - Read Access ---------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  dmi_read_access: process(rstn_i, clk_i)
+  dmi_read_access: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      dmi_rsp_o.ack  <= '0';
-      dmi_rsp_o.data <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       dmi_rsp_o.ack  <= or_reduce_f(dmi_req_i.op); -- always ACK any request
       dmi_rsp_o.data <= (others => '0');
       case dmi_req_i.addr is
@@ -398,14 +395,9 @@ begin
 
   -- Hart Status Controller -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  hart_status: process(rstn_i, clk_i)
+  hart_status: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      hart.halted     <= (others => '0');
-      hart.resume_req <= (others => '0');
-      hart.resume_ack <= (others => '0');
-      hart.reset      <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       for i in 0 to NUM_HARTS-1 loop
         -- halted ACK --
         if (dm_reg.ndmreset = '1') or (dm_reg.dmactive = '0') or (dci.ack_res(i) = '1') then
@@ -441,12 +433,9 @@ begin
 
   -- Command Execution Arbiter --------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  cmd_arbiter: process(rstn_i, clk_i)
+  cmd_arbiter: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      cmd_state <= CMD_IDLE;
-      cmd_err   <= (others => '0');
-    elsif rising_edge(clk_i) then
+    if rising_edge(clk_i) then
       if (dm_reg.ndmreset = '1') or (dm_reg.dmactive = '0') then -- hart/DM reset
         cmd_state <= CMD_IDLE;
         cmd_err   <= (others => '0');

--- a/rtl/core/neorv32_debug_dtm.vhd
+++ b/rtl/core/neorv32_debug_dtm.vhd
@@ -57,9 +57,7 @@ architecture neorv32_debug_dtm_rtl of neorv32_debug_dtm is
   -- JTAG tap --
   type state_t is (LOGIC_RESET, DR_SCAN, DR_CAPTURE, DR_SHIFT, DR_EXIT1, DR_PAUSE, DR_EXIT2, DR_UPDATE,
                       RUN_IDLE, IR_SCAN, IR_CAPTURE, IR_SHIFT, IR_EXIT1, IR_PAUSE, IR_EXIT2, IR_UPDATE);
-  signal state, state2 : state_t;
-
-  -- TAP registers --
+  signal state : state_t;
   signal ireg : std_ulogic_vector(4 downto 0);
   signal dreg : std_ulogic_vector(size_dmi_c-1 downto 0); -- max size (= dmi size)
 
@@ -93,10 +91,10 @@ begin
   tap_control: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      state2 <= LOGIC_RESET;
       state  <= LOGIC_RESET;
+      update <= '0';
     elsif rising_edge(clk_i) then
-      state2 <= state;
+      update <= '0';
       if (tck_rise = '1') then -- clock pulse (evaluate TMS on the rising edge of TCK)
         case state is -- JTAG state machine
           when LOGIC_RESET => if (tms = '0') then state <= RUN_IDLE;   else state <= LOGIC_RESET; end if;
@@ -117,13 +115,12 @@ begin
           when IR_UPDATE   => if (tms = '0') then state <= RUN_IDLE;   else state <= DR_SCAN;     end if;
           when others      => state <= LOGIC_RESET;
         end case;
+        if (state = DR_UPDATE) then -- register update pulse
+          update <= '1';
+        end if;
       end if;
     end if;
   end process;
-
-  -- DR_UPDATE edge detector --
-  update <= '1' when (state = DR_UPDATE) and (state2 /= DR_UPDATE) else '0';
-
 
   -- Tap Register Access --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_debug_dtm.vhd
+++ b/rtl/core/neorv32_debug_dtm.vhd
@@ -39,23 +39,22 @@ end entity;
 
 architecture neorv32_debug_dtm_rtl of neorv32_debug_dtm is
 
-  -- TAP data registers --
+  -- tap data registers --
   constant addr_idcode_c : std_ulogic_vector(4 downto 0) := "00001";
   constant addr_dtmcs_c  : std_ulogic_vector(4 downto 0) := "10000";
   constant addr_dmi_c    : std_ulogic_vector(4 downto 0) := "10001";
   constant addr_bypass_c : std_ulogic_vector(4 downto 0) := "11111";
-  --
   constant size_idcode_c : natural := 32;
   constant size_dtmcs_c  : natural := 32;
   constant size_dmi_c    : natural := 7+32+2; -- 7-bit address + 32-bit data + 2-bit operation/status
   constant size_bypass_c : natural := 1;
 
-  -- JTAG signal synchronizer --
+  -- JTAG synchronizer --
   signal tck_ff : std_ulogic_vector(2 downto 0);
   signal tdi_ff, tms_ff : std_ulogic_vector(1 downto 0);
   signal tck_rise, tck_fall, tdi, tms : std_ulogic;
 
-  -- TAP controller --
+  -- JTAG tap --
   type state_t is (LOGIC_RESET, DR_SCAN, DR_CAPTURE, DR_SHIFT, DR_EXIT1, DR_PAUSE, DR_EXIT2, DR_UPDATE,
                       RUN_IDLE, IR_SCAN, IR_CAPTURE, IR_SHIFT, IR_EXIT1, IR_PAUSE, IR_EXIT2, IR_UPDATE);
   signal state, state2 : state_t;
@@ -65,11 +64,8 @@ architecture neorv32_debug_dtm_rtl of neorv32_debug_dtm is
   signal dreg : std_ulogic_vector(size_dmi_c-1 downto 0); -- max size (= dmi size)
 
   -- misc --
-  signal update, dmihardreset, dmireset : std_ulogic;
-
-  -- debug module interface controller --
   signal dmi : dmi_req_t;
-  signal busy, err : std_ulogic;
+  signal update, dmihardreset, dmireset, busy, err : std_ulogic;
 
 begin
 
@@ -91,7 +87,6 @@ begin
   -- JTAG inputs --
   tms <= tms_ff(1);
   tdi <= tdi_ff(1);
-
 
   -- JTAG Tap Control FSM -------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -175,7 +170,6 @@ begin
   -- reset control; [NOTE] dreg bits are LSB-aligned --
   dmihardreset <= '1' when (update = '1') and (ireg = addr_dtmcs_c) and (dreg((dreg'left - (size_dtmcs_c-1)) + 17) = '1') else '0';
   dmireset     <= '1' when (update = '1') and (ireg = addr_dtmcs_c) and (dreg((dreg'left - (size_dtmcs_c-1)) + 16) = '1') else '0';
-
 
   -- Debug Module Interface -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_gptmr.vhd
+++ b/rtl/core/neorv32_gptmr.vhd
@@ -54,15 +54,33 @@ architecture neorv32_gptmr_rtl of neorv32_gptmr is
   signal acc_addr : std_ulogic_vector(1 downto 0);
   signal clkprsc : std_ulogic_vector(2 downto 0);
   signal enable, mode, irq : std_ulogic_vector(NUM_SLICES-1 downto 0);
+  signal clken : std_ulogic;
 
   -- slice wiring --
   type rdata_t is array (NUM_SLICES-1 downto 0) of std_ulogic_vector(31 downto 0);
   signal rdata : rdata_t;
   signal rdata_sum : std_ulogic_vector(31 downto 0);
   signal cs, trig : std_ulogic_vector(NUM_SLICES-1 downto 0);
-  signal clken : std_ulogic;
 
 begin
+
+  -- Bus Handshake --------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  bus_handshake: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      bus_rsp_o.ack <= '0';
+    elsif rising_edge(clk_i) then
+      bus_rsp_o.ack <= bus_req_i.stb;
+    end if;
+  end process;
+
+  -- no access errors supported --
+  bus_rsp_o.err <= '0';
+
+  -- access helper --
+  acc_addr <= bus_req_i.addr(7) & bus_req_i.addr(2);
+
 
   -- Configuration Registers ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -74,7 +92,7 @@ begin
       clkprsc <= (others => '0');
     elsif rising_edge(clk_i) then
       if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') then -- write access
-        -- control and status register 0 (CSR0) --
+        -- CSR0: control and status register 0 --
         if (acc_addr = "00") then
           if (bus_req_i.ben(1 downto 0) = "11") then -- low half: per-slice enable
             enable <= bus_req_i.data((NUM_SLICES-1)+0 downto 0);
@@ -83,7 +101,7 @@ begin
             mode <= bus_req_i.data((NUM_SLICES-1)+16 downto 16);
           end if;
         end if;
-        -- control and status register 1 (CSR1) --
+        -- CSR1: control and status register 1 --
         if (acc_addr = "01") then
           if (bus_req_i.ben(3 downto 2) = "11") then -- high half: clock prescaler
             clkprsc <= bus_req_i.data(18 downto 16);
@@ -92,9 +110,6 @@ begin
       end if;
     end if;
   end process;
-
-  -- access helper --
-  acc_addr <= bus_req_i.addr(7) & bus_req_i.addr(2);
 
   -- clock generator --
   clk_gen: process(clk_i)
@@ -105,15 +120,11 @@ begin
   end process;
 
 
-  -- Bus (Read) Access ----------------------------------------------------------------------
+  -- Bus Read Access ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_read: process(clk_i)
   begin
-    if (rstn_i = '0') then
-      bus_rsp_o <= rsp_terminate_c;
-    elsif rising_edge(clk_i) then
-      bus_rsp_o.ack  <= bus_req_i.stb;
-      bus_rsp_o.err  <= '0';
+    if rising_edge(clk_i) then
       bus_rsp_o.data <= (others => '0');
       if (bus_req_i.stb = '1') and (bus_req_i.rw = '0') then -- read access
         case acc_addr is

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130503"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130504"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_pwm.vhd
+++ b/rtl/core/neorv32_pwm.vhd
@@ -67,19 +67,28 @@ begin
 
   -- Bus Access -----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  bus_access: process(rstn_i, clk_i)
+  bus_handshake: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      bus_rsp_o <= rsp_terminate_c;
-      enable    <= (others => '0');
-      polarity  <= (others => '0');
-      clkprsc   <= (others => '0');
-      mode      <= (others => '0');
+      bus_rsp_o.ack <= '0';
     elsif rising_edge(clk_i) then
-      -- handshake --
       bus_rsp_o.ack <= bus_req_i.stb;
-      bus_rsp_o.err <= '0';
-      -- write access --
+    end if;
+  end process;
+  bus_rsp_o.err <= '0'; -- no access errors supported
+
+  -- access address helper --
+  addr <= bus_req_i.addr(7) & bus_req_i.addr(3 downto 2);
+
+  -- write access --
+  bus_write: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      enable   <= (others => '0');
+      polarity <= (others => '0');
+      clkprsc  <= (others => '0');
+      mode     <= (others => '0');
+    elsif rising_edge(clk_i) then
       if (bus_req_i.stb = '1') and (bus_req_i.rw = '1') then
         if (addr = "000") then
           enable <= bus_req_i.data(NUM_CHANNELS-1 downto 0);
@@ -94,22 +103,25 @@ begin
           mode <= bus_req_i.data(NUM_CHANNELS-1 downto 0);
         end if;
       end if;
-      -- read access --
+    end if;
+  end process;
+
+  -- read access --
+  bus_read: process(clk_i)
+  begin
+    if rising_edge(clk_i) then
       bus_rsp_o.data <= (others => '0');
       if (bus_req_i.stb = '1') and (bus_req_i.rw = '0') then
         case addr is
           when "000"  => bus_rsp_o.data(NUM_CHANNELS-1 downto 0) <= enable;
           when "001"  => bus_rsp_o.data(NUM_CHANNELS-1 downto 0) <= polarity;
-          when "010"  => bus_rsp_o.data(2 downto 0) <= clkprsc;
+          when "010"  => bus_rsp_o.data(2 downto 0)              <= clkprsc;
           when "011"  => bus_rsp_o.data(NUM_CHANNELS-1 downto 0) <= mode;
-          when others => bus_rsp_o.data <= rdata_sum;
+          when others => bus_rsp_o.data                          <= rdata_sum;
         end case;
       end if;
     end if;
   end process;
-
-  -- access address helper --
-  addr <= bus_req_i.addr(7) & bus_req_i.addr(3 downto 2);
 
   -- Channel Controllers --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------


### PR DESCRIPTION
* GPTMR + PWM: remove reset from data read-back register; Unlike #1638 and #1640, we are sticking with registered readback here (for now), since these can modules implement a large number of memory-mapped registers (depending on the configuration)
* OCD/DTM: simplify update-event detector
* OCD/DM: remove dedicated hardware reset from uncritical registers; minor code cleanups