### PR TITLE
test: add GPIO input loopback verification to processor_check

### DIFF
--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1578,10 +1578,20 @@ int main() {
 
   if (neorv32_gpio_available()) {
     neorv32_cpu_csr_write(CSR_MCAUSE, trap_never_c);
+
+    uint32_t gpio_pattern = 0b0101;
+    uint32_t gpio_mask = 0x0000000F;
+
     cnt_test++;
 
     gpio_trap_handler_ack = 0;
-    neorv32_gpio_port_set(0b0101);
+    neorv32_gpio_port_set(gpio_pattern);
+
+    // Test GPIO input readback via simulation loopback
+    neorv32_aux_delay_ms(neorv32_sysinfo_get_clk(), 1);
+    if ((neorv32_gpio_port_get() & gpio_mask) != gpio_pattern) {
+      test_fail();
+    }
 
     // install GPIO input trap handler and enable GPIO IRQ source
     neorv32_rte_handler_install(GPIO_TRAP_CODE, gpio_trap_handler);

--- a/sw/example/processor_check/main.c
+++ b/sw/example/processor_check/main.c
@@ -1579,19 +1579,26 @@ int main() {
   if (neorv32_gpio_available()) {
     neorv32_cpu_csr_write(CSR_MCAUSE, trap_never_c);
 
-    uint32_t gpio_pattern = 0b0101;
-    uint32_t gpio_mask = 0x0000000F;
+    uint32_t gpio_pattern = 0xAAAA5555;
+    uint32_t gpio_dir     = 0xFFFF0000; // upper 16 bits output, lower 16 bits input
+    int dir_test_err      = 0;
 
     cnt_test++;
 
     gpio_trap_handler_ack = 0;
+    neorv32_gpio_dir_set(gpio_dir);
     neorv32_gpio_port_set(gpio_pattern);
 
-    // Test GPIO input readback via simulation loopback
+    // test GPIO input readback via simulation loopback
     neorv32_aux_delay_ms(neorv32_sysinfo_get_clk(), 1);
-    if ((neorv32_gpio_port_get() & gpio_mask) != gpio_pattern) {
-      test_fail();
+    // output-configured pins read back pattern, input-configured pins read 0/L (simulation pull-down)
+    if (neorv32_gpio_port_get() != (gpio_pattern & gpio_dir)) {
+      dir_test_err = 1;
     }
+
+    // restore all pins as outputs and set pattern for the interrupt test
+    neorv32_gpio_dir_set(-1);
+    neorv32_gpio_port_set(gpio_pattern);
 
     // install GPIO input trap handler and enable GPIO IRQ source
     neorv32_rte_handler_install(GPIO_TRAP_CODE, gpio_trap_handler);
@@ -1616,8 +1623,9 @@ int main() {
 
     neorv32_cpu_csr_write(CSR_MIE, 0);
 
-    if ((neorv32_cpu_csr_read(CSR_MCAUSE) ==GPIO_TRAP_CODE) && // GPIO IRQ
-        (gpio_trap_handler_ack == 0x0000000f)) { // input 0..3 all fired
+    if ((neorv32_cpu_csr_read(CSR_MCAUSE) == GPIO_TRAP_CODE) && // GPIO IRQ
+        (gpio_trap_handler_ack == 0x0000000f) &&                // input 0..3 all fired
+        (dir_test_err == 0)) {                                  // input/output readback test passed
       test_ok();
     }
     else {


### PR DESCRIPTION
### Description

This PR improves GPIO verification coverage in the processor_check test suite.

The existing tests verify GPIO interrupt behavior, but the GPIO input read path was not explicitly checked.

This change adds a GPIO output-to-input loopback readback test using the existing simulation environment.

### Motivation

The default NEORV32 simulation connects GPIO outputs back to inputs. This allows verification that values written through the GPIO output interface are correctly sampled through the GPIO input interface.

This improves confidence in the GPIO peripheral verification without changing any RTL or software interfaces.

### Testing

- Built processor_check using the RISC-V GCC toolchain
- Executed the NEORV32 GHDL simulation flow
- Verified that the complete processor_check simulation passes successfully