### PR TITLE
sw/floating_point_test: fix unreachable special values and use signaling NaN

### DIFF
--- a/sw/example/floating_point_test/main.c
+++ b/sw/example/floating_point_test/main.c
@@ -1018,7 +1018,7 @@ uint32_t get_test_vector(void) {
   // generate special value "every" ~256th time this function is called
   if ((neorv32_aux_xorshift32() & 0xff) == 0xff) {
 
-    switch((neorv32_aux_xorshift32() >> 10) & 0x3) { // random decision which special value we are taking
+    switch((neorv32_aux_xorshift32() >> 10) & 0x7) { // random decision which special value we are taking
       case  0: tmp.float_value  = +INFINITY; break;
       case  1: tmp.float_value  = -INFINITY; break;
       case  2: tmp.float_value  = +0.0f; break;
@@ -1026,7 +1026,7 @@ uint32_t get_test_vector(void) {
       case  4: tmp.binary_value = 0x7fffffff; break;
       case  5: tmp.binary_value = 0xffffffff; break;
       case  6: tmp.float_value  = NAN; break;
-      case  7: tmp.float_value  = NAN; break; // FIXME signaling_NAN?
+      case  7: tmp.binary_value = FLOAT32_SNAN; break;
       default: tmp.float_value  = NAN; break;
     }
   }


### PR DESCRIPTION
### Description

This PR fixes two issues in the `floating_point_test` application that prevented complete IEEE-754 special value coverage.

1. **Unreachable special value cases**

The special value selection in `get_test_vector()` used the mask `& 0x3`, which limited the generated values to the range 0-3. As a result, cases 4-7 were unreachable and several predefined corner cases were never tested.

The mask has been changed to `& 0x7` so all eight special value cases can be selected.

2. **Signaling NaN test case**

Case 7 previously contained:

```c
case 7: tmp.float_value = NAN; break; // FIXME signaling_NAN?