### PR TITLE
🐛 [axi bridge] full rework; add data buffering to handle back pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 05.09.2026 | 1.13.5.6 | :bug: rework AXI bridge; add data buffering support (to handle back pressure) | [#1645](https://github.com/stnolting/neorv32/pull/1645) |
 | 02.09.2026 | 1.13.5.5 | CLINT area optimizations | [#1642](https://github.com/stnolting/neorv32/pull/1642) |
 | 30.08.2026 | 1.13.5.4 | ocd, gptmr, pwm: area optimizations; remove reset from registers where it is not strictly necessary | [#1641](https://github.com/stnolting/neorv32/pull/1641) |
 | 29.08.2026 | 1.13.5.3 | :test_tube: use asynchronous bus read access for further IO devices | [#1640](https://github.com/stnolting/neorv32/pull/1640) |

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130505"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130506"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -211,10 +211,9 @@ proc setup_ip_gui {} {
 
   set group [add_group $page {External Bus Interface (XBUS / AXI4-MM Host)}]
   add_params $group {
-    { XBUS_EN          {Enable XBUS} }
-    { XBUS_REGSTAGE_EN {Add register stages}   {In/out register stages; relaxes timing, but will increase latency} {$XBUS_EN} }
-    { CACHE_BURSTS_EN  {Enable AXI bursts}     {For I-/D-cache accesses only}                                      {$XBUS_EN} }
-    { XBUS_TIMEOUT     {Access timeout window} {Should be a power of two; timeout disabled when zero}              {$XBUS_EN} }
+    { XBUS_EN          {Enable AXI/XBUS} }
+    { CACHE_BURSTS_EN  {Enable AXI bursts}     {For I-/D-cache accesses only}                         {$XBUS_EN} }
+    { XBUS_TIMEOUT     {Access timeout window} {Should be a power of two; timeout disabled when zero} {$XBUS_EN} }
   }
 
   set group [add_group $page {Stream Link Interface (SLINK / AXI4-Stream Source & Sink)}]

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -325,6 +325,7 @@ architecture neorv32_vivado_ip_rtl of neorv32_vivado_ip is
     xbus_we_i     : in  std_ulogic;
     xbus_sel_i    : in  std_ulogic_vector(3 downto 0);
     xbus_stb_i    : in  std_ulogic;
+    xbus_cyc_i    : in  std_ulogic;
     xbus_ack_o    : out std_ulogic;
     xbus_err_o    : out std_ulogic;
     xbus_dat_o    : out std_ulogic_vector(31 downto 0);
@@ -718,6 +719,7 @@ begin
       xbus_we_i     => xbus_req.we,
       xbus_sel_i    => xbus_req.sel,
       xbus_stb_i    => xbus_req.stb,
+      xbus_cyc_i    => xbus_req.cyc,
       xbus_ack_o    => xbus_rsp.ack,
       xbus_err_o    => xbus_rsp.err,
       xbus_dat_o    => xbus_rsp.data,

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -104,7 +104,6 @@ entity neorv32_vivado_ip is
     -- External Bus Interface (XBUS) --
     XBUS_EN               : boolean                        := false;
     XBUS_TIMEOUT          : natural                        := 2048;
-    XBUS_REGSTAGE_EN      : boolean                        := false;
     -- General-Purpose Input/Output Controller (GPIO) --
     IO_GPIO_EN            : boolean                        := false;
     IO_GPIO_IN_NUM        : natural range 1 to 32          := 1; -- variable-sized ports must be at least 0 downto 0; #974
@@ -476,7 +475,7 @@ begin
     -- External Bus Interface (XBUS) --
     XBUS_EN             => XBUS_EN,
     XBUS_TIMEOUT        => XBUS_TIMEOUT,
-    XBUS_REGSTAGE_EN    => XBUS_REGSTAGE_EN,
+    XBUS_REGSTAGE_EN    => true, -- to shorten critical path through AXI-bridge
     -- General-Purpose Input/Output Controller --
     IO_GPIO_NUM         => num_gpio_c,
     IO_GPIO_DIR_EN      => IO_GPIO_DIR_EN,

--- a/rtl/system_integration/xbus2axi4_bridge.vhd
+++ b/rtl/system_integration/xbus2axi4_bridge.vhd
@@ -31,9 +31,10 @@ entity xbus2axi4_bridge is
     xbus_we_i     : in  std_ulogic;
     xbus_sel_i    : in  std_ulogic_vector(3 downto 0);
     xbus_stb_i    : in  std_ulogic;
-    xbus_dat_o    : out std_ulogic_vector(31 downto 0);
+    xbus_cyc_i    : in  std_ulogic;
     xbus_ack_o    : out std_ulogic;
     xbus_err_o    : out std_ulogic;
+    xbus_dat_o    : out std_ulogic_vector(31 downto 0);
     -- AXI4 host write address channel --
     m_axi_awaddr  : out std_logic_vector(31 downto 0);
     m_axi_awlen   : out std_logic_vector(7 downto 0);

--- a/rtl/system_integration/xbus2axi4_bridge.vhd
+++ b/rtl/system_integration/xbus2axi4_bridge.vhd
@@ -1,7 +1,8 @@
 -- ================================================================================ --
--- NEORV32 SoC - XBUS to AXI4-Compatible Bridge                                     --
+-- NEORV32 SoC - Size-Optimized XBUS to AXI4-Compatible Bridge                      --
 -- -------------------------------------------------------------------------------- --
--- Supported transfers: Single Transfers + Incrementing Address Bursts.             --
+-- Supported transfers: Single Transfers and Incrementing Address Bursts.           --
+-- [TODO] Exclusive accesses do not check for EXOKAY.                               --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
@@ -74,105 +75,362 @@ end entity;
 
 architecture xbus2axi4_bridge_rtl of xbus2axi4_bridge is
 
+  -- determine FIFO address width --
+  function fifo_awidth_f(e : boolean; n : natural) return natural is
+  begin
+    if e then
+      for i in 0 to 10 loop
+        if (2**i >= n) then
+          return i;
+        end if;
+      end loop;
+      return 10; -- fallback
+    else
+      return 0; -- no bursts, use a single-entry FIFO
+    end if;
+  end function;
+
+  -- auto-configuration --
+  constant fifo_awidth_c : natural := fifo_awidth_f(BURST_EN, BURST_LEN/4);
   constant blen_c : std_ulogic_vector(7 downto 0) := std_ulogic_vector(to_unsigned((BURST_LEN/4)-1, 8));
-  signal arvalid, awvalid, wvalid, wb_ack, xbus_rd_ack, xbus_rd_err, xbus_wr_ack, xbus_wr_err : std_ulogic;
-  signal state : std_ulogic_vector(1 downto 0);
+
+  -- generic low-latency FIFO --
+  component xbus2axi4_bridge_fifo
+  generic (
+    AWIDTH : natural;
+    DWIDTH : natural
+  );
+  port (
+    clk_i   : in  std_ulogic;
+    rstn_i  : in  std_ulogic;
+    clear_i : in  std_ulogic;
+    wdata_i : in  std_ulogic_vector(DWIDTH-1 downto 0);
+    we_i    : in  std_ulogic;
+    free_o  : out std_ulogic;
+    re_i    : in  std_ulogic;
+    rdata_o : out std_ulogic_vector(DWIDTH-1 downto 0);
+    avail_o : out std_ulogic
+  );
+  end component;
+
+  -- FIFO interface --
+  type fifo_t is record
+    we,    re    : std_ulogic;
+    wdata, rdata : std_ulogic_vector(32 downto 0);
+    avail, clr   : std_ulogic;
+  end record;
+  signal fifo : fifo_t;
+
+  -- arbitration --
+  type state_t is (S_IDLE, S_SINGLE_READ, S_SINGLE_WRITE, S_BURST_READ, S_BURST_WRITE, S_BURST_END);
+  signal state : state_t;
+  signal busy, burst, rw, w_ack : std_ulogic;
+  signal arvalid, awvalid, xbus_rd_ack, xbus_rd_err, xbus_wr_ack, xbus_wr_err : std_ulogic;
+  signal address : std_ulogic_vector(31 downto 0);
 
 begin
 
-  -- AXI transfer arbiter --
-  arbiter: process(resetn, clk)
+  -- Address Channels -----------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  address_arbiter: process(resetn, clk)
   begin
     if (resetn = '0') then
       arvalid <= '0';
       awvalid <= '0';
-      wvalid  <= '0';
-      wb_ack  <= '0';
-      state   <= (others => '0');
+      address <= (others => '0');
     elsif rising_edge(clk) then
-      -- AXI handshake --
-      arvalid <= arvalid and std_ulogic(not m_axi_arready);
-      awvalid <= awvalid and std_ulogic(not m_axi_awready);
-      wvalid  <= wvalid  and std_ulogic(not m_axi_wready);
-      -- state machine --
-      wb_ack <= '0';
-      case state is
-
-        when "00" => -- idle; wait for access request
-        -- ------------------------------------------------------------
-          arvalid <= xbus_stb_i and (not xbus_we_i);
-          awvalid <= xbus_stb_i and xbus_we_i;
-          wvalid  <= xbus_stb_i and xbus_we_i;
-          if (xbus_stb_i = '1') then
-            if (xbus_cti_i = "000") then -- single transfer
-              state <= "01";
-            elsif BURST_EN and (xbus_cti_i = "010") then -- incrementing address burst
-              state <= '1' & xbus_we_i;
-            end if;
-          end if;
-
-        when "01" => -- single transfer in progress
-        -- ------------------------------------------------------------
-          if (m_axi_rvalid = '1') or (m_axi_bvalid = '1') then
-            state <= "00";
-          end if;
-
-        when "10" | "11" => -- burst transfer in progress
-        -- ------------------------------------------------------------
-          if (state(0) = '1') and BURST_EN then
-            if (wvalid = '1') or ((xbus_cti_i = "010") and (xbus_stb_i = '1')) then
-              wb_ack <= '1'; -- issue BURST_LEN-1 local ACKs during write-burst
-            end if;
-          end if;
-          if (xbus_cti_i = "000") or (BURST_EN = false) then
-            state <= "00";
-          end if;
-
-        when others => -- undefined
-        -- ------------------------------------------------------------
-          state <= "00";
-
-      end case;
+      if (busy = '0') then -- idle
+        arvalid <= '0';
+        awvalid <= '0';
+        if (xbus_cyc_i = '1') and (xbus_stb_i = '1') then -- mew access request
+          arvalid <= not xbus_we_i;
+          awvalid <= xbus_we_i;
+          address <= xbus_adr_i;
+        end if;
+      else
+        arvalid <= arvalid and std_ulogic(not m_axi_arready);
+        awvalid <= awvalid and std_ulogic(not m_axi_awready);
+      end if;
     end if;
   end process;
 
   -- AXI read address channel --
-  m_axi_araddr  <= std_logic_vector(xbus_adr_i);
-  m_axi_arlen   <= std_logic_vector(blen_c) when BURST_EN and (state(1) = '1') else (others => '0'); -- burst length
-  m_axi_arsize  <= "010"; -- 4 bytes per transfer
+  m_axi_araddr  <= std_logic_vector(address);
+  m_axi_arlen   <= std_logic_vector(blen_c) when BURST_EN and (burst = '1') else (others => '0'); -- burst length
+  m_axi_arsize  <= "010"; -- 4 bytes per beat
   m_axi_arburst <= "01"; -- incrementing bursts only
   m_axi_arcache <= "0011"; -- recommended by Vivado
   m_axi_arprot  <= std_logic_vector(xbus_tag_i);
   m_axi_arvalid <= std_logic(arvalid);
 
-  -- AXI read data channel --
-  m_axi_rready  <= '1'; -- always ready for read response
-  xbus_rd_ack   <= '1' when (m_axi_rvalid = '1') and (m_axi_rresp(1) = '0') else '0'; -- OKAY(00)/EXOKAY(01)
-  xbus_rd_err   <= '1' when (m_axi_rvalid = '1') and (m_axi_rresp(1) = '1') else '0'; -- SLVERR(10)/DECERR(11)
-  xbus_dat_o    <= std_ulogic_vector(m_axi_rdata);
-
   -- AXI write address channel --
-  m_axi_awaddr  <= std_logic_vector(xbus_adr_i);
-  m_axi_awlen   <= std_logic_vector(blen_c) when BURST_EN and (state(1) = '1') else (others => '0'); -- burst length
-  m_axi_awsize  <= "010"; -- 4 bytes per transfer
+  m_axi_awaddr  <= std_logic_vector(address);
+  m_axi_awlen   <= std_logic_vector(blen_c) when BURST_EN and (burst = '1') else (others => '0'); -- burst length
+  m_axi_awsize  <= "010"; -- 4 bytes per beat
   m_axi_awburst <= "01"; -- incrementing bursts only
   m_axi_awcache <= "0011"; -- recommended by Vivado
   m_axi_awprot  <= std_logic_vector(xbus_tag_i);
   m_axi_awvalid <= std_logic(awvalid);
 
+
+  -- Write Data Channel ---------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  data_buffer_inst: xbus2axi4_bridge_fifo
+  generic map (
+    AWIDTH => fifo_awidth_c,
+    DWIDTH => 33
+  )
+  port map (
+    -- global control --
+    clk_i   => clk,
+    rstn_i  => resetn,
+    clear_i => fifo.clr,
+    -- write port --
+    wdata_i => fifo.wdata,
+    we_i    => fifo.we,
+    free_o  => open,
+    -- read port --
+    re_i    => fifo.re,
+    rdata_o => fifo.rdata,
+    avail_o => fifo.avail
+  );
+
+  fifo.clr <= not xbus_cyc_i;
+  fifo.we  <= xbus_cyc_i and xbus_stb_i and xbus_we_i;
+  fifo.re  <= fifo.avail and std_ulogic(m_axi_wready);
+
+  fifo.wdata(32) <= '1' when (xbus_cti_i = "000") or (xbus_cti_i = "001") else '0'; -- last/only word of transfer
+  fifo.wdata(31 downto 0) <= xbus_dat_i;
+
   -- AXI write data channel --
-  m_axi_wdata   <= std_logic_vector(xbus_dat_i);
-  m_axi_wstrb   <= std_logic_vector(xbus_sel_i);
-  m_axi_wlast   <= '1' when (xbus_cti_i = "000") else '0'; -- last word of transfer
-  m_axi_wvalid  <= '1' when (wvalid = '1') or (BURST_EN and (state = "11") and (xbus_stb_i = '1')) else '0';
+  m_axi_wdata  <= std_logic_vector(fifo.rdata(31 downto 0));
+  m_axi_wstrb  <= std_logic_vector(xbus_sel_i);
+  m_axi_wlast  <= std_logic(fifo.rdata(32)); -- last word of transfer
+  m_axi_wvalid <= std_logic(fifo.avail);
+
+
+  -- Transfer Arbiter -----------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  access_arbiter: process(resetn, clk)
+  begin
+    if (resetn = '0') then
+      state <= S_IDLE;
+      w_ack <= '0';
+    elsif rising_edge(clk) then
+      w_ack <= '0'; -- default
+      case state is
+
+        when S_IDLE => -- idle, wait for access request
+        -- ------------------------------------------------------------
+          if (xbus_cyc_i = '1') and (xbus_stb_i = '1') then
+            if (xbus_cti_i = "000") or (xbus_cti_i = "001") then -- single transfer / AMO operation (RMW)
+              if (xbus_we_i = '0') then
+                state <= S_SINGLE_READ;
+              else
+                state <= S_SINGLE_WRITE;
+              end if;
+            elsif BURST_EN and (xbus_cti_i = "010") then -- incrementing address burst
+              if (xbus_we_i = '0') then
+                state <= S_BURST_READ;
+              else
+                w_ack <= '1'; -- ACK write-burst start request
+                state <= S_BURST_WRITE;
+              end if;
+            end if;
+          end if;
+
+        when S_SINGLE_READ => -- single read in progress
+        -- ------------------------------------------------------------
+          if (m_axi_rvalid = '1') then
+            state <= S_IDLE;
+          end if;
+
+        when S_SINGLE_WRITE => -- single write in progress
+        -- ------------------------------------------------------------
+          if (m_axi_bvalid = '1') then
+            state <= S_IDLE;
+          end if;
+
+        when S_BURST_READ => -- read burst in progress
+        -- ------------------------------------------------------------
+          if (m_axi_rvalid = '1') and (m_axi_rlast = '1') then
+            state <= S_BURST_END;
+          end if;
+
+        when S_BURST_WRITE => -- write burst in progress
+        -- ------------------------------------------------------------
+          if (xbus_cyc_i = '1') and (xbus_stb_i = '1') and (xbus_cti_i = "010") then
+            w_ack <= '1'; -- issue (BURST_LEN/4)-1 local ACKs
+          end if;
+          if (m_axi_bvalid = '1') then -- this will also issue the remaining last ACK
+            state <= S_BURST_END;
+          end if;
+
+        when S_BURST_END => -- wait for host-side burst completion
+        -- ------------------------------------------------------------
+          if (xbus_cti_i = "000") then
+            state <= S_IDLE;
+          end if;
+
+        when others => -- undefined
+        -- ------------------------------------------------------------
+          state <= S_IDLE;
+
+      end case;
+    end if;
+  end process;
+
+  -- state decoder --
+  busy  <= '0' when (state = S_IDLE) else '1';
+  burst <= '1' when (state = S_BURST_READ)   or (state = S_BURST_WRITE) else '0';
+  rw    <= '1' when (state = S_SINGLE_WRITE) or (state = S_BURST_WRITE) else '0';
+
+  -- AXI read data channel --
+  m_axi_rready <= '1' when (busy = '1') and (rw = '0') else '0'; -- always ready when doing read accesses
+  xbus_rd_ack  <= '1' when (m_axi_rvalid = '1') and (m_axi_rresp(1) = '0') else '0'; -- OKAY(00)/EXOKAY(01)
+  xbus_rd_err  <= '1' when (m_axi_rvalid = '1') and (m_axi_rresp(1) = '1') else '0'; -- SLVERR(10)/DECERR(11)
+  xbus_dat_o   <= std_ulogic_vector(m_axi_rdata);
 
   -- AXI write response channel --
-  m_axi_bready  <= '1'; -- always ready for write response
-  xbus_wr_ack   <= '1' when (m_axi_bvalid = '1') and (m_axi_bresp(1) = '0') else '0'; -- OKAY(00)/EXOKAY(01)
-  xbus_wr_err   <= '1' when (m_axi_bvalid = '1') and (m_axi_bresp(1) = '1') else '0'; -- SLVERR(10)/DECERR(11)
+  m_axi_bready <= '1' when (busy = '1') and (rw = '1') else '0'; -- always ready when doing write accesses
+  xbus_wr_ack  <= '1' when (m_axi_bvalid = '1') and (m_axi_bresp(1) = '0') else '0'; -- OKAY(00)/EXOKAY(01)
+  xbus_wr_err  <= '1' when (m_axi_bvalid = '1') and (m_axi_bresp(1) = '1') else '0'; -- SLVERR(10)/DECERR(11)
 
   -- XBUS response --
-  xbus_ack_o    <= '1' when BURST_EN and (wb_ack = '1') else (xbus_rd_ack or xbus_wr_ack);
-  xbus_err_o    <= '0' when BURST_EN and (wb_ack = '1') else (xbus_rd_err or xbus_wr_err);
+  xbus_ack_o <= '1' when BURST_EN and (w_ack = '1') else (xbus_rd_ack or xbus_wr_ack);
+  xbus_err_o <= '0' when BURST_EN and (w_ack = '1') else (xbus_rd_err or xbus_wr_err);
+
+end architecture;
+
+
+-- ================================================================================ --
+-- NEORV32 SoC - XBUS to AXI4-Compatible Bridge - Generic Low-Latency FIFO          --
+-- -------------------------------------------------------------------------------- --
+-- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
+-- Copyright (c) NEORV32 contributors.                                              --
+-- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
+-- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
+-- SPDX-License-Identifier: BSD-3-Clause                                            --
+-- ================================================================================ --
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity xbus2axi4_bridge_fifo is
+  generic (
+    AWIDTH : natural; -- address width
+    DWIDTH : natural  -- data width
+  );
+  port (
+    -- global control --
+    clk_i   : in  std_ulogic; -- clock, rising edge
+    rstn_i  : in  std_ulogic; -- async reset, low-active
+    clear_i : in  std_ulogic; -- sync reset, high-active
+    -- write port --
+    wdata_i : in  std_ulogic_vector(DWIDTH-1 downto 0); -- write data
+    we_i    : in  std_ulogic; -- write enable
+    free_o  : out std_ulogic; -- at least one entry is free when set
+    -- read port --
+    re_i    : in  std_ulogic; -- read enable
+    rdata_o : out std_ulogic_vector(DWIDTH-1 downto 0); -- read data
+    avail_o : out std_ulogic  -- data available when set
+  );
+end entity;
+
+architecture xbus2axi4_bridge_fifo_rtl of xbus2axi4_bridge_fifo is
+
+  type ipb_t is array (0 to (2**AWIDTH)-1) of std_ulogic_vector(DWIDTH-1 downto 0);
+  signal w_pnt, r_pnt : std_ulogic_vector(AWIDTH downto 0);
+  signal match, empty, full, re, we : std_ulogic;
+
+begin
+
+  -- Pointers -------------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  pointer_reg: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      w_pnt <= (others => '0');
+      r_pnt <= (others => '0');
+    elsif rising_edge(clk_i) then
+      if (clear_i = '1') then
+        w_pnt <= (others => '0');
+      elsif (we = '1') then
+        w_pnt <= std_ulogic_vector(unsigned(w_pnt) + 1);
+      end if;
+      if (clear_i = '1') then
+        r_pnt <= (others => '0');
+      elsif (re = '1') then
+        r_pnt <= std_ulogic_vector(unsigned(r_pnt) + 1);
+      end if;
+    end if;
+  end process pointer_reg;
+
+  -- access control --
+  re <= re_i and (not empty); -- read only if data available
+  we <= we_i and (not full);  -- write only if free space available
+
+
+  -- Status ---------------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  -- more than 1 FIFO entry --
+  status_large:
+  if (AWIDTH > 0) generate
+    match <= '1' when (r_pnt(AWIDTH-1 downto 0) = w_pnt(AWIDTH-1 downto 0)) else '0';
+    full  <= '1' when (r_pnt(AWIDTH) /= w_pnt(AWIDTH)) and (match = '1') else '0';
+    empty <= '1' when (r_pnt(AWIDTH)  = w_pnt(AWIDTH)) and (match = '1') else '0';
+  end generate;
+
+  -- just 1 FIFO entry --
+  status_small:
+  if (AWIDTH = 0) generate
+    match <= '1' when (r_pnt(0) = w_pnt(0)) else '0';
+    full  <= not match;
+    empty <= match;
+  end generate;
+
+  -- status output --
+  free_o  <= not full;
+  avail_o <= not empty;
+
+
+  -- Memory ---------------------------------------------------------------------------------
+  -- -------------------------------------------------------------------------------------------
+  -- more than 1 FIFO entry --
+  memory_large:
+  if (AWIDTH > 0) generate
+    signal ipb : ipb_t;
+  begin
+    -- simple dual-port RAM --
+    mem_write: process(clk_i)
+    begin
+      if rising_edge(clk_i) then
+        if (we = '1') then
+          ipb(to_integer(unsigned(w_pnt(AWIDTH-1 downto 0)))) <= wdata_i;
+        end if;
+      end if;
+    end process mem_write;
+    -- asynchronous read --
+    rdata_o <= ipb(to_integer(unsigned(r_pnt(AWIDTH-1 downto 0))));
+  end generate;
+
+  -- just 1 FIFO entry --
+  memory_small:
+  if (AWIDTH = 0) generate
+    signal ipb : ipb_t;
+  begin
+    -- single register --
+    mem_write: process(clk_i)
+    begin
+      if rising_edge(clk_i) then
+        if (we = '1') then
+          ipb(0) <= wdata_i;
+        end if;
+      end if;
+    end process mem_write;
+    -- asynchronous read --
+    rdata_o <= ipb(0);
+  end generate;
 
 end architecture;


### PR DESCRIPTION
The current XBUS-to-AXI bridge works well for single accesses. However, problems can arise with bursts. For example, write bursts cannot be paused, which means the bridge cannot handle back pressure.

This pull request is a complete redesign of the AXI bridge. Among other things, it now features data buffering (FIFO).

I have tested the bridge using AMD Vivado: high bus utilization using AXI Traffic Generator IP and protocol verification using the AXI Protocol Checker IP. Anyway, it would be great if someone else could test the bridge in their own design.