### PR TITLE
minor rtl edits and cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ mimpid = 0x01040312 -> Version 01.04.03.12 -> v1.4.3.12
 
 | Date | Version | Comment | Ticket |
 |:----:|:-------:|:--------|:------:|
+| 09.09.2026 | 1.13.5.7 | minor rtl edits and cleanups | [#1647](https://github.com/stnolting/neorv32/pull/1647) |
 | 05.09.2026 | 1.13.5.6 | :bug: rework AXI bridge; add data buffering support (to handle back pressure) | [#1645](https://github.com/stnolting/neorv32/pull/1645) |
 | 02.09.2026 | 1.13.5.5 | CLINT area optimizations | [#1642](https://github.com/stnolting/neorv32/pull/1642) |
 | 30.08.2026 | 1.13.5.4 | ocd, gptmr, pwm: area optimizations; remove reset from registers where it is not strictly necessary | [#1641](https://github.com/stnolting/neorv32/pull/1641) |

--- a/rtl/core/neorv32_cpu_alu_cond.vhd
+++ b/rtl/core/neorv32_cpu_alu_cond.vhd
@@ -34,14 +34,12 @@ architecture neorv32_cpu_alu_cond_rtl of neorv32_cpu_alu_cond is
 
 begin
 
-  -- Valid Instruction? ---------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
+  -- valid instruction? --
   valid_cmd <= '1' when (ctrl_i.alu_cp_alu = '1') and
     (ctrl_i.ir_opcode(5) = '1') and (ctrl_i.ir_funct3(2) = '1') and
     (ctrl_i.ir_funct3(0) = '1') and (ctrl_i.ir_funct12(11 downto 5) = "0000111") else '0';
 
-  -- Conditional Output ---------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
+  -- conditional output --
   cond_out: process(clk_i)
   begin
     if rising_edge(clk_i) then

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -81,7 +81,7 @@ entity neorv32_cpu_control is
     xcsr_rdata_i  : in  std_ulogic_vector(31 downto 0); -- external CSR read data
     -- interrupts --
     irq_dbg_i     : in  std_ulogic;                     -- debug mode (halt) request
-    irq_machine_i : in  std_ulogic_vector(2 downto 0);  -- RISC-V interrupt
+    irq_machine_i : in  std_ulogic_vector(2 downto 0);  -- RISC-V interrupts
     irq_fast_i    : in  std_ulogic_vector(15 downto 0); -- fast interrupts
     -- load/store unit interface --
     lsu_wait_i    : in  std_ulogic;                     -- wait for data bus
@@ -177,7 +177,7 @@ begin
 
   -- Branch Condition Check -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  branch_check: process(exec, alu_cmp_i)
+  branch_check: process(exec.ir, alu_cmp_i)
   begin
     if (exec.ir(instr_opcode_lsb_c+2) = '0') then -- conditional branch
       if (exec.ir(instr_funct3_msb_c) = '0') then -- beq / bne
@@ -202,7 +202,7 @@ begin
       exec.irc   <= (others => '0');
       exec.ci    <= '0';
       exec.pc    <= BOOT_ADDR(31 downto 2) & "00"; -- 32-bit-aligned boot address
-      exec.pc2   <= BOOT_ADDR(31 downto 2) & "00"; -- 32-bit-aligned boot address
+      exec.pc2   <= BOOT_ADDR(31 downto 2) & "00";
     elsif rising_edge(clk_i) then
       ctrl <= ctrl_nxt;
       exec <= exec_nxt;
@@ -577,9 +577,9 @@ begin
   -- -------------------------------------------------------------------------------------------
   csr_check: process(ctrl, exec, csr, debug_ctrl)
   begin
-    -- ------------------------------------------------------------
+    -- --------------------------------------------------------------------
     -- Available at all
-    -- ------------------------------------------------------------
+    -- --------------------------------------------------------------------
     case ctrl.csr_addr is
 
       -- floating-point-unit CSRs --
@@ -669,9 +669,9 @@ begin
 
     end case;
 
-    -- ------------------------------------------------------------
+    -- --------------------------------------------------------------------
     -- R/W capabilities
-    -- ------------------------------------------------------------
+    -- --------------------------------------------------------------------
     if (ctrl.csr_addr(11 downto 10) = "11") and -- CSR is read-only
        ((exec.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_csrrw_c)  or -- will always write to CSR
         (exec.ir(instr_funct3_msb_c downto instr_funct3_lsb_c) = funct3_csrrwi_c) or -- will always write to CSR
@@ -681,9 +681,9 @@ begin
       csr_valid(1) <= '1'; -- access granted
     end if;
 
-    -- ------------------------------------------------------------
+    -- --------------------------------------------------------------------
     -- Privilege level
-    -- ------------------------------------------------------------
+    -- --------------------------------------------------------------------
     if (ctrl.csr_addr(11 downto 4) = csr_dcsr_c(11 downto 4)) and -- debug-mode-only CSR?
        RISCV_ISA_Sdext and (debug_ctrl.run = '0') then -- debug-mode implemented and not running?
       csr_valid(0) <= '0'; -- invalid access
@@ -874,7 +874,7 @@ begin
 
   -- any system interrupt? --
   irq_fire(0) <= '1' when
-    ((exec.state = S_EXECUTE) or (exec.state = S_SLEEP)) and -- trigger system IRQ only in S_EXECUTE state or in sleep mode
+    ((exec.state = S_EXECUTE) or (exec.state = S_SLEEP)) and -- trigger system IRQ only in S_EXECUTE state or when in sleep mode
     (or_reduce_f(irq_buf(irq_firq_15_c downto irq_msi_irq_c)) = '1') and -- pending system IRQ
     ((csr.mstatus_mie = '1') or (csr.prv_level = priv_mode_u_c)) and -- IRQ only when in M-mode and MIE=1 OR when in U-mode
     (debug_ctrl.run = '0') and (csr.dcsr_step = '0') else '0'; -- no system IRQs when in debug-mode / during single-stepping
@@ -1040,9 +1040,9 @@ begin
       csr.dscratch0    <= (others => '0');
     elsif rising_edge(clk_i) then
 
-      -- ********************************************************************************
+      -- --------------------------------------------------------------------
       -- Software CSR access
-      -- ********************************************************************************
+      -- --------------------------------------------------------------------
       if (ctrl.csr_we = '1') then
         case ctrl.csr_addr is
 
@@ -1098,9 +1098,9 @@ begin
 
         end case;
 
-      -- ********************************************************************************
+      -- --------------------------------------------------------------------
       -- Hardware CSR access: trap enter
-      -- ********************************************************************************
+      -- --------------------------------------------------------------------
       elsif (env_enter = '1') then
         if (debug_ctrl.run = '0') then -- no CSR update when in debug-mode
           if RISCV_ISA_Sdext and (ecause(5) = '1') then -- trap to debug-mode
@@ -1135,9 +1135,9 @@ begin
           end if;
         end if;
 
-      -- ********************************************************************************
+      -- --------------------------------------------------------------------
       -- Hardware CSR access: trap exit
-      -- ********************************************************************************
+      -- --------------------------------------------------------------------
       elsif (env_exit = '1') then
         if RISCV_ISA_Sdext and (debug_ctrl.run = '1') then -- return from debug-mode
           csr.prv_level <= csr.dcsr_prv;
@@ -1155,9 +1155,9 @@ begin
         end if;
       end if;
 
-      -- ********************************************************************************
+      -- --------------------------------------------------------------------
       -- Override: terminate unavailable registers and bits
-      -- ********************************************************************************
+      -- --------------------------------------------------------------------
       -- no base counters --
       if not RISCV_ISA_Zicntr then
         csr.mcounteren(2 downto 0) <= (others => '0');

--- a/rtl/core/neorv32_cpu_frontend.vhd
+++ b/rtl/core/neorv32_cpu_frontend.vhd
@@ -48,20 +48,6 @@ architecture neorv32_cpu_frontend_rtl of neorv32_cpu_frontend is
   -- heart ID --
   constant hid_c : std_ulogic_vector(1 downto 0) := std_ulogic_vector(to_unsigned(HART_ID, 2));
 
-  -- instruction prefetch buffer --
-  component neorv32_cpu_frontend_ipb
-  port (
-    clk_i   : in  std_ulogic;
-    clear_i : in  std_ulogic;
-    wdata_i : in  std_ulogic_vector(16 downto 0);
-    we_i    : in  std_ulogic;
-    free_o  : out std_ulogic;
-    re_i    : in  std_ulogic;
-    rdata_o : out std_ulogic_vector(16 downto 0);
-    avail_o : out std_ulogic
-  );
-  end component;
-
   -- instruction fetch engine --
   type state_t is (S_RESTART, S_REQUEST, S_PENDING);
   type fetch_t is record
@@ -171,10 +157,17 @@ begin
   -- -------------------------------------------------------------------------------------------
   prefetch_buffer:
   for i in 0 to 1 generate
-    ipb_inst: neorv32_cpu_frontend_ipb
+    ipb_inst: entity neorv32.neorv32_prim_fifo
+    generic map (
+      AWIDTH  => 1,
+      DWIDTH  => 17,
+      OUTGATE => false,
+      ASYNCRD => true
+    )
     port map (
       -- global control --
       clk_i   => clk_i,
+      rstn_i  => rstn_i,
       clear_i => restart,
       -- write port --
       wdata_i => ipb_wdata(i),
@@ -283,94 +276,5 @@ begin
     frontend_o.compr <= '0';
     frontend_o.fault <= ipb_rdata(0)(16);
   end generate;
-
-end architecture;
-
-
--- ================================================================================ --
--- NEORV32 CPU - Instruction Prefetch Buffer (FIFO)                                 --
--- -------------------------------------------------------------------------------- --
--- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
--- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
--- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
--- SPDX-License-Identifier: BSD-3-Clause                                            --
--- ================================================================================ --
-
-library ieee;
-use ieee.std_logic_1164.all;
-use ieee.numeric_std.all;
-
-library neorv32;
-use neorv32.neorv32_package.all;
-
-entity neorv32_cpu_frontend_ipb is
-  port (
-    -- global control --
-    clk_i   : in  std_ulogic; -- clock, rising edge
-    clear_i : in  std_ulogic; -- sync reset, high-active
-    -- write port --
-    wdata_i : in  std_ulogic_vector(16 downto 0); -- write data
-    we_i    : in  std_ulogic; -- write enable
-    free_o  : out std_ulogic; -- at least one entry is free when set
-    -- read port --
-    re_i    : in  std_ulogic; -- read enable
-    rdata_o : out std_ulogic_vector(16 downto 0); -- read data
-    avail_o : out std_ulogic  -- data available when set
-  );
-end entity;
-
-architecture neorv32_cpu_frontend_ipb_rtl of neorv32_cpu_frontend_ipb is
-
-  -- IPB depth --
-  constant awidth_c : natural := 1; -- 1 address bit = 2 entries
-
-  -- pointers and status --
-  signal w_pnt, r_pnt : std_ulogic_vector(awidth_c downto 0);
-  signal match : std_ulogic;
-
-  -- memory core --
-  type ipb_t is array (0 to (2**awidth_c)-1) of std_ulogic_vector(16 downto 0);
-  signal ipb : ipb_t;
-
-begin
-
-  -- Pointers -------------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  pointer_reg: process(clk_i)
-  begin
-    if rising_edge(clk_i) then
-      if (clear_i = '1') then
-        w_pnt <= (others => '0');
-        r_pnt <= (others => '0');
-      else
-        if (we_i = '1') then
-          w_pnt <= std_ulogic_vector(unsigned(w_pnt) + 1);
-        end if;
-        if (re_i = '1') then
-          r_pnt <= std_ulogic_vector(unsigned(r_pnt) + 1);
-        end if;
-      end if;
-    end if;
-  end process;
-
-  -- status --
-  match   <= '1' when (r_pnt(awidth_c-1 downto 0) = w_pnt(awidth_c-1 downto 0)) else '0';
-  free_o  <= '0' when (r_pnt(awidth_c) /= w_pnt(awidth_c)) and (match = '1') else '1';
-  avail_o <= '0' when (r_pnt(awidth_c)  = w_pnt(awidth_c)) and (match = '1') else '1';
-
-  -- Memory Core ----------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  mem_write: process(clk_i)
-  begin
-    if rising_edge(clk_i) then
-      if (we_i = '1') then
-        ipb(to_integer(unsigned(w_pnt(awidth_c-1 downto 0)))) <= wdata_i;
-      end if;
-    end if;
-  end process;
-
-  -- asynchronous read --
-  rdata_o <= ipb(to_integer(unsigned(r_pnt(awidth_c-1 downto 0))));
 
 end architecture;

--- a/rtl/core/neorv32_dma.vhd
+++ b/rtl/core/neorv32_dma.vhd
@@ -189,7 +189,8 @@ begin
   generic map (
     AWIDTH  => log2_fifo_size_c,
     DWIDTH  => 32,
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_neoled.vhd
+++ b/rtl/core/neorv32_neoled.vhd
@@ -155,7 +155,8 @@ begin
   generic map (
     AWIDTH  => log2_fifo_size_c,
     DWIDTH  => 34,
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_onewire.vhd
+++ b/rtl/core/neorv32_onewire.vhd
@@ -191,7 +191,8 @@ begin
   generic map (
     AWIDTH  => log2_fifo_size_c,
     DWIDTH  => 10, -- 2-bit command + 8-bit data
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --
@@ -219,7 +220,8 @@ begin
   generic map (
     AWIDTH  => log2_fifo_size_c,
     DWIDTH  => 9, -- 1-bit presence status + 8-bit data
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_package.vhd
+++ b/rtl/core/neorv32_package.vhd
@@ -20,7 +20,7 @@ package neorv32_package is
 
   -- Architecture Constants -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130506"; -- hardware version
+  constant hw_version_c  : std_ulogic_vector(31 downto 0) := x"01130507"; -- hardware version
   constant int_bus_tmo_c : natural := 16; -- internal bus timeout window; has to be a power of two
   constant alu_cp_tmo_c  : natural := 9;  -- log2 of max ALU co-processor execution cycles
 

--- a/rtl/core/neorv32_prim.vhd
+++ b/rtl/core/neorv32_prim.vhd
@@ -2,13 +2,8 @@
 -- NEORV32 Primitives - Generic Single-Clock FIFO (FIFO)                            --
 -- -------------------------------------------------------------------------------- --
 -- The FIFO operates in "first-word-fall-through" (FWFT) mode: the first written    --
--- word appears directly at the output (after the synchronous-read delay) without   --
--- any explicit read access.                                                        --
---                                                                                  --
--- [IMPORTANT] The status signals "free space left" (free_o) and "data available"   --
--- (avail_o) are synchronized to the according port:                                --
--- - free_o  -> write port                                                          --
--- - avail_o -> read port                                                           --
+-- word appears directly at the output (after the optional synchronous-read delay)  --
+-- without any explicit read access.                                                --
 -- -------------------------------------------------------------------------------- --
 -- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
 -- Copyright (c) NEORV32 contributors.                                              --
@@ -25,7 +20,8 @@ entity neorv32_prim_fifo is
   generic (
     AWIDTH  : natural; -- address width (= log2(number of FIFO entries))
     DWIDTH  : natural; -- size of data elements in FIFO
-    OUTGATE : boolean  -- true = output zero if no data available
+    OUTGATE : boolean; -- true = output zero if no data available
+    ASYNCRD : boolean  -- true = asynchronous read, false = synchronous read
   );
   port (
     -- global control --
@@ -85,13 +81,24 @@ begin
     match <= '1' when (r_pnt(AWIDTH-1 downto 0) = w_pnt(AWIDTH-1 downto 0)) else '0';
     full  <= '1' when (r_pnt(AWIDTH) /= w_pnt(AWIDTH)) and (match = '1') else '0';
     empty <= '1' when (r_pnt(AWIDTH)  = w_pnt(AWIDTH)) and (match = '1') else '0';
-    -- [IMPORTANT] 'avail' is synchronized to the read port --
-    status_reg: process(clk_i)
-    begin
-      if rising_edge(clk_i) then
-        avail <= not empty;
-      end if;
-    end process;
+
+    -- synchronous read: "avail" is synchronized to the read port --
+    status_large_sync_read:
+    if not ASYNCRD generate
+      avail_reg: process(clk_i)
+      begin
+        if rising_edge(clk_i) then
+          avail <= not empty;
+        end if;
+      end process;
+    end generate;
+
+    -- asynchronous read --
+    status_large_async_read:
+    if ASYNCRD generate
+      avail <= not empty;
+    end generate;
+
   end generate;
 
   -- just 1 FIFO entry --
@@ -99,7 +106,7 @@ begin
   if (AWIDTH = 0) generate
     match <= '1' when (r_pnt(0) = w_pnt(0)) else '0';
     full  <= not match;
-    empty <= match;
+    empty <= not full;
     avail <= not empty;
   end generate;
 
@@ -113,17 +120,39 @@ begin
   -- more than 1 FIFO entry --
   memory_large:
   if (AWIDTH > 0) generate
-    signal fifo : ram_t;
-  begin
-    memory_core: process(clk_i) -- simple dual-port RAM
+
+    -- memory with synchronous read --
+    memory_large_sync_read:
+    if not ASYNCRD generate
+      signal fifo : ram_t;
     begin
-      if rising_edge(clk_i) then
-        if (we = '1') then
-          fifo(to_integer(unsigned(w_pnt(AWIDTH-1 downto 0)))) <= wdata_i;
+      memory_core: process(clk_i) -- simple dual-port RAM
+      begin
+        if rising_edge(clk_i) then
+          if (we = '1') then
+            fifo(to_integer(unsigned(w_pnt(AWIDTH-1 downto 0)))) <= wdata_i;
+          end if;
+          rdata <= fifo(to_integer(unsigned(r_pnt(AWIDTH-1 downto 0))));
         end if;
-        rdata <= fifo(to_integer(unsigned(r_pnt(AWIDTH-1 downto 0))));
-      end if;
-    end process;
+      end process;
+    end generate;
+
+    -- memory with asynchronous read --
+    memory_large_async_read:
+    if ASYNCRD generate
+      signal fifo : ram_t;
+    begin
+      memory_core: process(clk_i) -- simple dual-port RAM
+      begin
+        if rising_edge(clk_i) then
+          if (we = '1') then
+            fifo(to_integer(unsigned(w_pnt(AWIDTH-1 downto 0)))) <= wdata_i;
+          end if;
+        end if;
+      end process;
+      rdata <= fifo(to_integer(unsigned(r_pnt(AWIDTH-1 downto 0))));
+    end generate;
+
   end generate;
 
   -- just 1 FIFO entry --

--- a/rtl/core/neorv32_sdi.vhd
+++ b/rtl/core/neorv32_sdi.vhd
@@ -167,7 +167,8 @@ begin
   generic map (
     AWIDTH  => log2_fifo_size_c,
     DWIDTH  => 8,
-    OUTGATE => true -- send zero if no TX data available
+    OUTGATE => true, -- send zero if no TX data available
+    ASYNCRD => false
   )
   port map (
     -- global control --
@@ -195,7 +196,8 @@ begin
   generic map (
     AWIDTH  => log2_fifo_size_c,
     DWIDTH  => 8,
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_slink.vhd
+++ b/rtl/core/neorv32_slink.vhd
@@ -173,7 +173,8 @@ begin
   generic map (
     AWIDTH  => log2_rx_fifo_c,
     DWIDTH  => 1+4+32, -- last + routing + data
-    OUTGATE => false   -- no output gate required
+    OUTGATE => false, -- no output gate required
+    ASYNCRD => false
   )
   port map (
     -- global control --
@@ -217,7 +218,8 @@ begin
   generic map (
     AWIDTH  => log2_tx_fifo_c,
     DWIDTH  => 1+4+32, -- last + routing + data
-    OUTGATE => false   -- no output gate required
+    OUTGATE => false, -- no output gate required
+    ASYNCRD => false
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_smc.vhd
+++ b/rtl/core/neorv32_smc.vhd
@@ -707,8 +707,6 @@ architecture neorv32_smc_phy_rtl of neorv32_smc_phy is
   signal sreg  : std_ulogic_vector(31 downto 0); -- input/output shift register
   signal cdiv  : std_ulogic_vector(2 downto 0);  -- clock divider
   signal bcnt  : std_ulogic_vector(5 downto 0);  -- bit counter
-  signal sck   : std_ulogic;                     -- serial clock
-  signal sdi   : std_ulogic;                     -- input sample register
 
 begin
 
@@ -721,18 +719,16 @@ begin
       sreg  <= (others => '0');
       cdiv  <= (others => '0');
       bcnt  <= (others => '0');
-      sck   <= '0';
-      sdi   <= '0';
+      sck_o <= '0';
     elsif rising_edge(clk_i) then
-      sdi <= sdi_i; -- input synchronizer
       case state is
 
         when S_IDLE => -- wait for request and sample configuration
         -- ------------------------------------------------------------
-          sck  <= '0'; -- clock mode 0: low when idle
-          cdiv <= cdiv_i; -- reload clock counter
-          bcnt <= nbits_i;
-          sreg <= txd_i;
+          sck_o <= '0'; -- clock mode 0: low when idle
+          cdiv  <= cdiv_i; -- reload clock counter
+          bcnt  <= nbits_i;
+          sreg  <= txd_i;
           if (en_i = '1') and (start_i = '1') then
             state <= S_RTX_0;
           end if;
@@ -742,7 +738,7 @@ begin
           if (en_i = '0') then -- shutdown
             state <= S_IDLE;
           elsif (cdiv = "000") then -- end of phase
-            sck   <= '1'; -- rising edge
+            sck_o <= '1'; -- rising edge
             cdiv  <= cdiv_i; -- reload clock counter
             bcnt  <= std_ulogic_vector(unsigned(bcnt) - 1);
             state <= S_RTX_1;
@@ -755,9 +751,9 @@ begin
           if (en_i = '0') then -- shutdown
             state <= S_IDLE;
           elsif (cdiv = "000") then -- end of phase
-            sck  <= '0'; -- falling edge
-            cdiv <= cdiv_i; -- reload clock counter
-            sreg <= sreg(30 downto 0) & sdi; -- set & sample at falling edge
+            sck_o <= '0'; -- falling edge
+            cdiv  <= cdiv_i; -- reload clock counter
+            sreg  <= sreg(30 downto 0) & sdi_i; -- set & sample at falling edge
             if (bcnt = "000000") then
               state <= S_IDLE;
             else
@@ -777,8 +773,7 @@ begin
   -- RX data --
   rxd_o <= sreg;
 
-  -- serial output --
-  sck_o <= sck;
+  -- serial output (MSB-first) --
   sdo_o <= sreg(31);
 
 end architecture;

--- a/rtl/core/neorv32_smc.vhd
+++ b/rtl/core/neorv32_smc.vhd
@@ -278,7 +278,8 @@ begin
   generic map (
     AWIDTH  => log2_fifo_size_c,
     DWIDTH  => 32,
-    OUTGATE => true -- output zero if no write data available (i.e. for read accesses)
+    OUTGATE => true, -- output zero if no write data available (i.e. for read accesses)
+    ASYNCRD => false
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_smc.vhd
+++ b/rtl/core/neorv32_smc.vhd
@@ -631,7 +631,7 @@ begin
       when S_WAIT => -- wait for access to complete
       -- ------------------------------------------------------------
         mac_nxt.csn <= bcsn; -- memory enabled
-        phy_nbits_o <= "000010"; -- 2 clock ticks as inter-access delay
+        phy_nbits_o <= "000001"; -- 1 clock tick as inter-access delay
         if (phy_busy_i = '0') then
           if (cmd_rw_i = '0') then
             mac_nxt.rdata <= phy_data_i; -- sample RX data

--- a/rtl/core/neorv32_spi.vhd
+++ b/rtl/core/neorv32_spi.vhd
@@ -180,7 +180,8 @@ begin
   generic map (
     AWIDTH  => log2_fifo_size_c,
     DWIDTH  => 9,
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --
@@ -208,7 +209,8 @@ begin
   generic map (
     AWIDTH  => log2_fifo_size_c,
     DWIDTH  => 8,
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_tracer.vhd
+++ b/rtl/core/neorv32_tracer.vhd
@@ -229,7 +229,8 @@ begin
   generic map (
     AWIDTH  => log2_fifo_size_c,
     DWIDTH  => 2*32,
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_trng.vhd
+++ b/rtl/core/neorv32_trng.vhd
@@ -166,7 +166,8 @@ begin
   generic map (
     AWIDTH  => log2_fifo_size_c,
     DWIDTH  => 8,
-    OUTGATE => true -- output zero if no data available
+    OUTGATE => true, -- output zero if no data available
+    ASYNCRD => false
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_twd.vhd
+++ b/rtl/core/neorv32_twd.vhd
@@ -217,7 +217,8 @@ begin
   generic map (
     AWIDTH  => tx_size_c,
     DWIDTH  => 8,
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --
@@ -244,7 +245,8 @@ begin
   generic map (
     AWIDTH  => rx_size_c,
     DWIDTH  => 8,
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_twi.vhd
+++ b/rtl/core/neorv32_twi.vhd
@@ -181,7 +181,8 @@ begin
   generic map (
     AWIDTH  => log2_fifo_size_c,
     DWIDTH  => 11, -- command, host-ACK, data
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --
@@ -209,7 +210,8 @@ begin
   generic map (
     AWIDTH  => log2_fifo_size_c,
     DWIDTH  => 9, -- ACK + data
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --

--- a/rtl/core/neorv32_uart.vhd
+++ b/rtl/core/neorv32_uart.vhd
@@ -204,7 +204,8 @@ begin
   generic map (
     AWIDTH  => log2_tx_fifo_c,
     DWIDTH  => 8,
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --
@@ -233,7 +234,8 @@ begin
   generic map (
     AWIDTH  => log2_rx_fifo_c,
     DWIDTH  => 8,
-    OUTGATE => false
+    OUTGATE => false,
+    ASYNCRD => false
   )
   port map (
     -- global control --

--- a/rtl/system_integration/neorv32_vivado_ip.tcl
+++ b/rtl/system_integration/neorv32_vivado_ip.tcl
@@ -48,14 +48,15 @@ set_property INCREMENTAL false [get_filesets sim_1]
 # read and process NEORV32 SoC file list
 set file_list_file [read [open "$neorv32_home/rtl/file_list_core.f" r]]
 set file_list [string map [list {$NEORV32_HOME} $neorv32_home] $file_list_file]
+
+# IP top module and AXI4 bridge
+lappend file_list "$neorv32_home/rtl/system_integration/xbus2axi4_bridge.vhd"
+lappend file_list "$neorv32_home/rtl/system_integration/$ip_top.vhd"
+
 puts "NEORV32 source files:"
 puts $file_list
 add_files $file_list
 set_property library neorv32 [get_files $file_list]
-
-# IP top module and AXI4 bridge
-add_file $neorv32_home/rtl/system_integration/xbus2axi4_bridge.vhd
-add_file $neorv32_home/rtl/system_integration/$ip_top.vhd
 set_property top $ip_top [current_fileset]
 
 update_compile_order -fileset sources_1

--- a/rtl/system_integration/neorv32_vivado_ip.vhd
+++ b/rtl/system_integration/neorv32_vivado_ip.vhd
@@ -307,65 +307,6 @@ architecture neorv32_vivado_ip_rtl of neorv32_vivado_ip is
   constant max_gpio_c  : natural := sel_natural_f(boolean(IO_GPIO_IN_NUM > IO_GPIO_OUT_NUM), IO_GPIO_IN_NUM, IO_GPIO_OUT_NUM);
   constant num_gpio_c  : natural := sel_natural_f(IO_GPIO_EN, max_gpio_c, 0);
 
-  -- AXI4 bridge --
-  component xbus2axi4_bridge
-  generic (
-    BURST_EN  : boolean; -- enable burst transfers
-    BURST_LEN : natural range 4 to 1024 -- bytes per burst, has to be a multiple of 4
-  );
-  port (
-    -- Global control
-    clk           : in  std_logic;
-    resetn        : in  std_logic;
-    -- XBUS device interface --
-    xbus_adr_i    : in  std_ulogic_vector(31 downto 0);
-    xbus_dat_i    : in  std_ulogic_vector(31 downto 0);
-    xbus_cti_i    : in  std_ulogic_vector(2 downto 0);
-    xbus_tag_i    : in  std_ulogic_vector(2 downto 0);
-    xbus_we_i     : in  std_ulogic;
-    xbus_sel_i    : in  std_ulogic_vector(3 downto 0);
-    xbus_stb_i    : in  std_ulogic;
-    xbus_cyc_i    : in  std_ulogic;
-    xbus_ack_o    : out std_ulogic;
-    xbus_err_o    : out std_ulogic;
-    xbus_dat_o    : out std_ulogic_vector(31 downto 0);
-    -- AXI4 host write address channel --
-    m_axi_awaddr  : out std_logic_vector(31 downto 0);
-    m_axi_awlen   : out std_logic_vector(7 downto 0);
-    m_axi_awsize  : out std_logic_vector(2 downto 0);
-    m_axi_awburst : out std_logic_vector(1 downto 0);
-    m_axi_awcache : out std_logic_vector(3 downto 0);
-    m_axi_awprot  : out std_logic_vector(2 downto 0);
-    m_axi_awvalid : out std_logic;
-    m_axi_awready : in  std_logic;
-    -- AXI4 host write data channel --
-    m_axi_wdata   : out std_logic_vector(31 downto 0);
-    m_axi_wstrb   : out std_logic_vector(3 downto 0);
-    m_axi_wlast   : out std_logic;
-    m_axi_wvalid  : out std_logic;
-    m_axi_wready  : in  std_logic;
-    -- AXI4 host read address channel --
-    m_axi_araddr  : out std_logic_vector(31 downto 0);
-    m_axi_arlen   : out std_logic_vector(7 downto 0);
-    m_axi_arsize  : out std_logic_vector(2 downto 0);
-    m_axi_arburst : out std_logic_vector(1 downto 0);
-    m_axi_arcache : out std_logic_vector(3 downto 0);
-    m_axi_arprot  : out std_logic_vector(2 downto 0);
-    m_axi_arvalid : out std_logic;
-    m_axi_arready : in  std_logic;
-    -- AXI4 host read data channel --
-    m_axi_rdata   : in  std_logic_vector(31 downto 0);
-    m_axi_rresp   : in  std_logic_vector(1 downto 0);
-    m_axi_rlast   : in  std_logic;
-    m_axi_rvalid  : in  std_logic;
-    m_axi_rready  : out std_logic;
-    -- AXI4 host write response channel --
-    m_axi_bresp   : in  std_logic_vector(1 downto 0);
-    m_axi_bvalid  : in  std_logic;
-    m_axi_bready  : out std_logic
-  );
-  end component;
-
   -- type conversion --
   signal rstn_ocd, rstn_wdt : std_ulogic;
   signal jtag_tdo_aux : std_ulogic;
@@ -388,7 +329,7 @@ architecture neorv32_vivado_ip_rtl of neorv32_vivado_ip is
   -- constrained-size ports --
   signal gpio_dir_o_aux, gpio_o_aux, gpio_i_aux, pwm_o_aux : std_ulogic_vector(31 downto 0);
 
-  -- internal xbus --
+  -- internal XBUS --
   signal xbus_req : xbus_req_t;
   signal xbus_rsp : xbus_rsp_t;
 
@@ -396,7 +337,7 @@ begin
 
   -- The Core Of The Problem ----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  neorv32_top_inst: neorv32_top
+  neorv32_top_inst: entity neorv32.neorv32_top
   generic map (
     -- General --
     CLOCK_FREQUENCY     => CLOCK_FREQUENCY,
@@ -622,50 +563,35 @@ begin
     irq_mei_i      => std_ulogic(irq_mei_i)
   );
 
-
-  -- Type Conversion (Outputs) --------------------------------------------------------------
+  -- Output Type Conversion -----------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  ocd_resetn <= std_logic(rstn_ocd);
-  wdt_resetn <= std_logic(rstn_wdt);
-
-  jtag_tdo_o <= std_logic(jtag_tdo_aux);
-
+  ocd_resetn     <= std_logic(rstn_ocd);
+  wdt_resetn     <= std_logic(rstn_wdt);
+  jtag_tdo_o     <= std_logic(jtag_tdo_aux);
   s1_axis_tready <= std_logic(s1_axis_tready_aux);
   s0_axis_tdata  <= std_logic_vector(s0_axis_tdata_aux);
   s0_axis_tdest  <= std_logic_vector(s0_axis_tdest_aux);
   s0_axis_tvalid <= std_logic(s0_axis_tvalid_aux);
   s0_axis_tlast  <= std_logic(s0_axis_tlast_aux);
-
-  uart0_txd_o  <= std_logic(uart0_txd_aux);
-  uart0_rtsn_o <= std_logic(uart0_rtsn_aux);
-
-  uart1_txd_o  <= std_logic(uart1_txd_aux);
-  uart1_rtsn_o <= std_logic(uart1_rtsn_aux);
-
-  spi_clk_o <= std_logic(spi_clk_aux);
-  spi_dat_o <= std_logic(spi_do_aux);
-  spi_csn_o <= std_logic_vector(spi_csn_aux);
-
-  sdi_dat_o <= std_logic(sdi_do_aux);
-
-  twi_sda_o <= std_logic(twi_sda_o_aux);
-  twi_scl_o <= std_logic(twi_scl_o_aux);
-
-  twd_sda_o <= std_logic(twd_sda_o_aux);
-
-  onewire_o <= std_logic(onewire_o_aux);
-
-  cfs_out_o <= std_logic_vector(cfs_out_aux);
-
-  neoled_o <= std_logic(neoled_aux);
-
-  mtime_time_o <= std_logic_vector(mtime_time_aux);
-
-  smc_ioen_o <= std_logic(smc_ioen_aux);
-  smc_sck_o  <= std_logic(smc_sck_aux);
-  smc_csn_o  <= std_logic_vector(smc_csn_aux);
-  smc_sdo_o  <= std_logic(smc_sdo_aux);
-
+  uart0_txd_o    <= std_logic(uart0_txd_aux);
+  uart0_rtsn_o   <= std_logic(uart0_rtsn_aux);
+  uart1_txd_o    <= std_logic(uart1_txd_aux);
+  uart1_rtsn_o   <= std_logic(uart1_rtsn_aux);
+  spi_clk_o      <= std_logic(spi_clk_aux);
+  spi_dat_o      <= std_logic(spi_do_aux);
+  spi_csn_o      <= std_logic_vector(spi_csn_aux);
+  sdi_dat_o      <= std_logic(sdi_do_aux);
+  twi_sda_o      <= std_logic(twi_sda_o_aux);
+  twi_scl_o      <= std_logic(twi_scl_o_aux);
+  twd_sda_o      <= std_logic(twd_sda_o_aux);
+  onewire_o      <= std_logic(onewire_o_aux);
+  cfs_out_o      <= std_logic_vector(cfs_out_aux);
+  neoled_o       <= std_logic(neoled_aux);
+  mtime_time_o   <= std_logic_vector(mtime_time_aux);
+  smc_ioen_o     <= std_logic(smc_ioen_aux);
+  smc_sck_o      <= std_logic(smc_sck_aux);
+  smc_csn_o      <= std_logic_vector(smc_csn_aux);
+  smc_sdo_o      <= std_logic(smc_sdo_aux);
 
   -- Mapping for Constrained-Size Ports -----------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -697,12 +623,11 @@ begin
     pwm_o(i) <= std_logic(pwm_o_aux(i));
   end generate;
 
-
   -- XBUS-to-AXI4 Bridge --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   axi4_bridge:
   if XBUS_EN generate
-    axi4_bridge_inst: xbus2axi4_bridge
+    axi4_bridge_inst: entity neorv32.xbus2axi4_bridge
     generic map (
       BURST_EN  => burst_en_c,
       BURST_LEN => CACHE_BLOCK_SIZE
@@ -712,17 +637,8 @@ begin
       clk           => clk,
       resetn        => resetn,
       -- XBUS device interface --
-      xbus_adr_i    => xbus_req.addr,
-      xbus_dat_i    => xbus_req.data,
-      xbus_cti_i    => xbus_req.cti,
-      xbus_tag_i    => xbus_req.tag,
-      xbus_we_i     => xbus_req.we,
-      xbus_sel_i    => xbus_req.sel,
-      xbus_stb_i    => xbus_req.stb,
-      xbus_cyc_i    => xbus_req.cyc,
-      xbus_ack_o    => xbus_rsp.ack,
-      xbus_err_o    => xbus_rsp.err,
-      xbus_dat_o    => xbus_rsp.data,
+      xbus_req_i    => xbus_req,
+      xbus_rsp_o    => xbus_rsp,
       -- AXI4 host write address channel --
       m_axi_awaddr  => m_axi_awaddr,
       m_axi_awlen   => m_axi_awlen ,

--- a/rtl/system_integration/xbus2axi4_bridge.vhd
+++ b/rtl/system_integration/xbus2axi4_bridge.vhd
@@ -94,25 +94,6 @@ architecture xbus2axi4_bridge_rtl of xbus2axi4_bridge is
   constant fifo_awidth_c : natural := fifo_awidth_f(BURST_EN, BURST_LEN/4);
   constant blen_c : std_ulogic_vector(7 downto 0) := std_ulogic_vector(to_unsigned((BURST_LEN/4)-1, 8));
 
-  -- generic low-latency FIFO --
-  component xbus2axi4_bridge_fifo
-  generic (
-    AWIDTH : natural;
-    DWIDTH : natural
-  );
-  port (
-    clk_i   : in  std_ulogic;
-    rstn_i  : in  std_ulogic;
-    clear_i : in  std_ulogic;
-    wdata_i : in  std_ulogic_vector(DWIDTH-1 downto 0);
-    we_i    : in  std_ulogic;
-    free_o  : out std_ulogic;
-    re_i    : in  std_ulogic;
-    rdata_o : out std_ulogic_vector(DWIDTH-1 downto 0);
-    avail_o : out std_ulogic
-  );
-  end component;
-
   -- FIFO interface --
   type fifo_t is record
     we,    re    : std_ulogic;
@@ -175,10 +156,12 @@ begin
 
   -- Write Data Channel ---------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  data_buffer_inst: xbus2axi4_bridge_fifo
+  data_buffer_inst: entity neorv32.neorv32_prim_fifo
   generic map (
-    AWIDTH => fifo_awidth_c,
-    DWIDTH => 33
+    AWIDTH  => fifo_awidth_c,
+    DWIDTH  => 33,
+    OUTGATE => false,
+    ASYNCRD => true
   )
   port map (
     -- global control --
@@ -297,140 +280,8 @@ begin
   xbus_wr_err  <= '1' when (m_axi_bvalid = '1') and (m_axi_bresp(1) = '1') else '0'; -- SLVERR(10)/DECERR(11)
 
   -- XBUS response --
-  xbus_ack_o <= '1' when BURST_EN and (w_ack = '1') else (xbus_rd_ack or xbus_wr_ack);
-  xbus_err_o <= '0' when BURST_EN and (w_ack = '1') else (xbus_rd_err or xbus_wr_err);
-
-end architecture;
-
-
--- ================================================================================ --
--- NEORV32 SoC - XBUS to AXI4-Compatible Bridge - Generic Low-Latency FIFO          --
--- -------------------------------------------------------------------------------- --
--- The NEORV32 RISC-V Processor - https://github.com/stnolting/neorv32              --
--- Copyright (c) NEORV32 contributors.                                              --
--- Copyright (c) 2020 - 2026 Stephan Nolting. All rights reserved.                  --
--- Licensed under the BSD-3-Clause license, see LICENSE for details.                --
--- SPDX-License-Identifier: BSD-3-Clause                                            --
--- ================================================================================ --
-
-library ieee;
-use ieee.std_logic_1164.all;
-use ieee.numeric_std.all;
-
-entity xbus2axi4_bridge_fifo is
-  generic (
-    AWIDTH : natural; -- address width
-    DWIDTH : natural  -- data width
-  );
-  port (
-    -- global control --
-    clk_i   : in  std_ulogic; -- clock, rising edge
-    rstn_i  : in  std_ulogic; -- async reset, low-active
-    clear_i : in  std_ulogic; -- sync reset, high-active
-    -- write port --
-    wdata_i : in  std_ulogic_vector(DWIDTH-1 downto 0); -- write data
-    we_i    : in  std_ulogic; -- write enable
-    free_o  : out std_ulogic; -- at least one entry is free when set
-    -- read port --
-    re_i    : in  std_ulogic; -- read enable
-    rdata_o : out std_ulogic_vector(DWIDTH-1 downto 0); -- read data
-    avail_o : out std_ulogic  -- data available when set
-  );
-end entity;
-
-architecture xbus2axi4_bridge_fifo_rtl of xbus2axi4_bridge_fifo is
-
-  type ipb_t is array (0 to (2**AWIDTH)-1) of std_ulogic_vector(DWIDTH-1 downto 0);
-  signal w_pnt, r_pnt : std_ulogic_vector(AWIDTH downto 0);
-  signal match, empty, full, re, we : std_ulogic;
-
-begin
-
-  -- Pointers -------------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  pointer_reg: process(rstn_i, clk_i)
-  begin
-    if (rstn_i = '0') then
-      w_pnt <= (others => '0');
-      r_pnt <= (others => '0');
-    elsif rising_edge(clk_i) then
-      if (clear_i = '1') then
-        w_pnt <= (others => '0');
-      elsif (we = '1') then
-        w_pnt <= std_ulogic_vector(unsigned(w_pnt) + 1);
-      end if;
-      if (clear_i = '1') then
-        r_pnt <= (others => '0');
-      elsif (re = '1') then
-        r_pnt <= std_ulogic_vector(unsigned(r_pnt) + 1);
-      end if;
-    end if;
-  end process pointer_reg;
-
-  -- access control --
-  re <= re_i and (not empty); -- read only if data available
-  we <= we_i and (not full);  -- write only if free space available
-
-
-  -- Status ---------------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  -- more than 1 FIFO entry --
-  status_large:
-  if (AWIDTH > 0) generate
-    match <= '1' when (r_pnt(AWIDTH-1 downto 0) = w_pnt(AWIDTH-1 downto 0)) else '0';
-    full  <= '1' when (r_pnt(AWIDTH) /= w_pnt(AWIDTH)) and (match = '1') else '0';
-    empty <= '1' when (r_pnt(AWIDTH)  = w_pnt(AWIDTH)) and (match = '1') else '0';
-  end generate;
-
-  -- just 1 FIFO entry --
-  status_small:
-  if (AWIDTH = 0) generate
-    match <= '1' when (r_pnt(0) = w_pnt(0)) else '0';
-    full  <= not match;
-    empty <= match;
-  end generate;
-
-  -- status output --
-  free_o  <= not full;
-  avail_o <= not empty;
-
-
-  -- Memory ---------------------------------------------------------------------------------
-  -- -------------------------------------------------------------------------------------------
-  -- more than 1 FIFO entry --
-  memory_large:
-  if (AWIDTH > 0) generate
-    signal ipb : ipb_t;
-  begin
-    -- simple dual-port RAM --
-    mem_write: process(clk_i)
-    begin
-      if rising_edge(clk_i) then
-        if (we = '1') then
-          ipb(to_integer(unsigned(w_pnt(AWIDTH-1 downto 0)))) <= wdata_i;
-        end if;
-      end if;
-    end process mem_write;
-    -- asynchronous read --
-    rdata_o <= ipb(to_integer(unsigned(r_pnt(AWIDTH-1 downto 0))));
-  end generate;
-
-  -- just 1 FIFO entry --
-  memory_small:
-  if (AWIDTH = 0) generate
-    signal ipb : ipb_t;
-  begin
-    -- single register --
-    mem_write: process(clk_i)
-    begin
-      if rising_edge(clk_i) then
-        if (we = '1') then
-          ipb(0) <= wdata_i;
-        end if;
-      end if;
-    end process mem_write;
-    -- asynchronous read --
-    rdata_o <= ipb(0);
-  end generate;
+  xbus_rsp_o.data <= std_ulogic_vector(m_axi_rdata);
+  xbus_rsp_o.ack  <= '1' when BURST_EN and (w_ack = '1') else (xbus_rd_ack or xbus_wr_ack);
+  xbus_rsp_o.err  <= '0' when BURST_EN and (w_ack = '1') else (xbus_rd_err or xbus_wr_err);
 
 end architecture;

--- a/rtl/system_integration/xbus2axi4_bridge.vhd
+++ b/rtl/system_integration/xbus2axi4_bridge.vhd
@@ -15,6 +15,9 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
+library neorv32;
+use neorv32.neorv32_package.all;
+
 entity xbus2axi4_bridge is
   generic (
     BURST_EN  : boolean; -- enable burst transfers
@@ -25,17 +28,8 @@ entity xbus2axi4_bridge is
     clk           : in  std_logic;
     resetn        : in  std_logic;
     -- XBUS device interface --
-    xbus_adr_i    : in  std_ulogic_vector(31 downto 0);
-    xbus_dat_i    : in  std_ulogic_vector(31 downto 0);
-    xbus_cti_i    : in  std_ulogic_vector(2 downto 0);
-    xbus_tag_i    : in  std_ulogic_vector(2 downto 0);
-    xbus_we_i     : in  std_ulogic;
-    xbus_sel_i    : in  std_ulogic_vector(3 downto 0);
-    xbus_stb_i    : in  std_ulogic;
-    xbus_cyc_i    : in  std_ulogic;
-    xbus_ack_o    : out std_ulogic;
-    xbus_err_o    : out std_ulogic;
-    xbus_dat_o    : out std_ulogic_vector(31 downto 0);
+    xbus_req_i    : in  xbus_req_t;
+    xbus_rsp_o    : out xbus_rsp_t;
     -- AXI4 host write address channel --
     m_axi_awaddr  : out std_logic_vector(31 downto 0);
     m_axi_awlen   : out std_logic_vector(7 downto 0);
@@ -123,10 +117,10 @@ begin
       if (busy = '0') then -- idle
         arvalid <= '0';
         awvalid <= '0';
-        if (xbus_cyc_i = '1') and (xbus_stb_i = '1') then -- mew access request
-          arvalid <= not xbus_we_i;
-          awvalid <= xbus_we_i;
-          address <= xbus_adr_i;
+        if (xbus_req_i.cyc = '1') and (xbus_req_i.stb = '1') then -- mew access request
+          arvalid <= not xbus_req_i.we;
+          awvalid <= xbus_req_i.we;
+          address <= xbus_req_i.addr;
         end if;
       else
         arvalid <= arvalid and std_ulogic(not m_axi_arready);
@@ -141,7 +135,7 @@ begin
   m_axi_arsize  <= "010"; -- 4 bytes per beat
   m_axi_arburst <= "01"; -- incrementing bursts only
   m_axi_arcache <= "0011"; -- recommended by Vivado
-  m_axi_arprot  <= std_logic_vector(xbus_tag_i);
+  m_axi_arprot  <= std_logic_vector(xbus_req_i.tag);
   m_axi_arvalid <= std_logic(arvalid);
 
   -- AXI write address channel --
@@ -150,7 +144,7 @@ begin
   m_axi_awsize  <= "010"; -- 4 bytes per beat
   m_axi_awburst <= "01"; -- incrementing bursts only
   m_axi_awcache <= "0011"; -- recommended by Vivado
-  m_axi_awprot  <= std_logic_vector(xbus_tag_i);
+  m_axi_awprot  <= std_logic_vector(xbus_req_i.tag);
   m_axi_awvalid <= std_logic(awvalid);
 
 
@@ -178,16 +172,16 @@ begin
     avail_o => fifo.avail
   );
 
-  fifo.clr <= not xbus_cyc_i;
-  fifo.we  <= xbus_cyc_i and xbus_stb_i and xbus_we_i;
+  fifo.clr <= not xbus_req_i.cyc;
+  fifo.we  <= xbus_req_i.cyc and xbus_req_i.stb and xbus_req_i.we;
   fifo.re  <= fifo.avail and std_ulogic(m_axi_wready);
 
-  fifo.wdata(32) <= '1' when (xbus_cti_i = "000") or (xbus_cti_i = "001") else '0'; -- last/only word of transfer
-  fifo.wdata(31 downto 0) <= xbus_dat_i;
+  fifo.wdata(32) <= '1' when (xbus_req_i.cti = "000") or (xbus_req_i.cti = "001") else '0'; -- last/only word of transfer
+  fifo.wdata(31 downto 0) <= xbus_req_i.data;
 
   -- AXI write data channel --
   m_axi_wdata  <= std_logic_vector(fifo.rdata(31 downto 0));
-  m_axi_wstrb  <= std_logic_vector(xbus_sel_i);
+  m_axi_wstrb  <= std_logic_vector(xbus_req_i.sel);
   m_axi_wlast  <= std_logic(fifo.rdata(32)); -- last word of transfer
   m_axi_wvalid <= std_logic(fifo.avail);
 
@@ -205,15 +199,15 @@ begin
 
         when S_IDLE => -- idle, wait for access request
         -- ------------------------------------------------------------
-          if (xbus_cyc_i = '1') and (xbus_stb_i = '1') then
-            if (xbus_cti_i = "000") or (xbus_cti_i = "001") then -- single transfer / AMO operation (RMW)
-              if (xbus_we_i = '0') then
+          if (xbus_req_i.cyc = '1') and (xbus_req_i.stb = '1') then
+            if (xbus_req_i.cti = "000") or (xbus_req_i.cti = "001") then -- single transfer / AMO operation (RMW)
+              if (xbus_req_i.we = '0') then
                 state <= S_SINGLE_READ;
               else
                 state <= S_SINGLE_WRITE;
               end if;
-            elsif BURST_EN and (xbus_cti_i = "010") then -- incrementing address burst
-              if (xbus_we_i = '0') then
+            elsif BURST_EN and (xbus_req_i.cti = "010") then -- incrementing address burst
+              if (xbus_req_i.we = '0') then
                 state <= S_BURST_READ;
               else
                 w_ack <= '1'; -- ACK write-burst start request
@@ -242,7 +236,7 @@ begin
 
         when S_BURST_WRITE => -- write burst in progress
         -- ------------------------------------------------------------
-          if (xbus_cyc_i = '1') and (xbus_stb_i = '1') and (xbus_cti_i = "010") then
+          if (xbus_req_i.cyc = '1') and (xbus_req_i.stb = '1') and (xbus_req_i.cti = "010") then
             w_ack <= '1'; -- issue (BURST_LEN/4)-1 local ACKs
           end if;
           if (m_axi_bvalid = '1') then -- this will also issue the remaining last ACK
@@ -251,7 +245,7 @@ begin
 
         when S_BURST_END => -- wait for host-side burst completion
         -- ------------------------------------------------------------
-          if (xbus_cti_i = "000") then
+          if (xbus_req_i.cti = "000") then
             state <= S_IDLE;
           end if;
 
@@ -272,7 +266,6 @@ begin
   m_axi_rready <= '1' when (busy = '1') and (rw = '0') else '0'; -- always ready when doing read accesses
   xbus_rd_ack  <= '1' when (m_axi_rvalid = '1') and (m_axi_rresp(1) = '0') else '0'; -- OKAY(00)/EXOKAY(01)
   xbus_rd_err  <= '1' when (m_axi_rvalid = '1') and (m_axi_rresp(1) = '1') else '0'; -- SLVERR(10)/DECERR(11)
-  xbus_dat_o   <= std_ulogic_vector(m_axi_rdata);
 
   -- AXI write response channel --
   m_axi_bready <= '1' when (busy = '1') and (rw = '1') else '0'; -- always ready when doing write accesses

--- a/sim/neorv32_tb.vhd
+++ b/sim/neorv32_tb.vhd
@@ -567,7 +567,8 @@ begin
   generic map (
     AWIDTH  => 0,
     DWIDTH  => 32+4+1,
-    OUTGATE => true
+    OUTGATE => true,
+    ASYNCRD => false
   )
   port map (
     -- global control --


### PR DESCRIPTION
* FIFO primitve: add option for asynchronous read
  * use generic FIFO in all modules (including AXI bridge and front-end)
* AXI bridge: use XBUS port types
* Vivado IP: add IP top and AXI bridge to neorv32 library
* SMC: remove SDI FF for maximum sample speed
* SMC: shorten inter-access pause