### PR TITLE
[cpu] improve timing margin without added latency

### DIFF
--- a/rtl/core/neorv32_cpu.vhd
+++ b/rtl/core/neorv32_cpu.vhd
@@ -134,6 +134,8 @@ architecture neorv32_cpu_rtl of neorv32_cpu is
   signal alu_res     : std_ulogic_vector(31 downto 0); -- ALU result
   signal alu_add     : std_ulogic_vector(31 downto 0); -- ALU address result
   signal alu_cmp     : std_ulogic_vector(1 downto 0);  -- comparator result
+  signal branch_cmp  : std_ulogic_vector(1 downto 0);
+  signal rf_cmp      : std_ulogic_vector(3 downto 0);
   signal alu_cp_done : std_ulogic;                     -- ALU co-processor operation done
   signal lsu_rdata   : std_ulogic_vector(31 downto 0); -- LSU memory read data
   signal lsu_mar     : std_ulogic_vector(31 downto 0); -- LSU memory address register
@@ -306,7 +308,7 @@ begin
     hwtrig_i      => hwtrig,      -- hardware trigger
     -- data path interface --
     alu_cp_done_i => alu_cp_done, -- ALU iterative operation done
-    alu_cmp_i     => alu_cmp,     -- comparator status
+    alu_cmp_i     => branch_cmp,  -- comparator status
     alu_add_i     => alu_add,     -- ALU address result
     rf_rs1_i      => rs1,         -- register file source 1
     csr_rdata_o   => csr_rdata,   -- CSR read data
@@ -416,8 +418,20 @@ begin
     rs1_data_o => rs1,
     -- read port 1 (rs2) --
     rs2_addr_i => ctrl.rf_rs2,
-    rs2_data_o => rs2
+    rs2_data_o => rs2,
+    cmp_o      => rf_cmp
   );
+
+  rf_compare:
+  if (CPU_RF_ARCH_SEL = 2) generate
+    branch_cmp(0) <= rf_cmp(3) when RISCV_ISA_Zibi and (ctrl.ir_funct3(2 downto 1) = "01") else rf_cmp(0);
+    branch_cmp(1) <= '0' when is_x(ctrl.alu_unsigned) else rf_cmp(1) when (to_x01(ctrl.alu_unsigned) = '1') else rf_cmp(2);
+  end generate;
+
+  alu_compare:
+  if (CPU_RF_ARCH_SEL /= 2) generate
+    branch_cmp <= alu_cmp;
+  end generate;
 
   -- all buses are zero unless there is an according operation --
   rf_wdata <= alu_res or lsu_rdata or csr_rdata or ctrl.pc_ret;

--- a/rtl/core/neorv32_cpu_alu_bitmanip.vhd
+++ b/rtl/core/neorv32_cpu_alu_bitmanip.vhd
@@ -182,6 +182,7 @@ architecture neorv32_cpu_alu_bitmanip_rtl of neorv32_cpu_alu_bitmanip is
   type res_t is array (op_width_c-1 downto 0) of std_ulogic_vector(31 downto 0);
   signal res_int, res : res_t;
   signal xperm4_res, xperm8_res, adder_res, one_hot_res, zip_res, unzip_res, res_out : std_ulogic_vector(31 downto 0);
+  signal logic_reg, shift_reg, add_reg : std_ulogic_vector(31 downto 0);
 
 begin
 
@@ -581,7 +582,9 @@ begin
   begin
     tmp_v := (others => '0');
     for i in 0 to op_width_c-1 loop
-      tmp_v := tmp_v or res(i);
+      if (i /= op_shadd_c) and (i /= op_cz_c) and (i /= op_cpop_c) and (i /= op_rot_c) then
+        tmp_v := tmp_v or res(i);
+      end if;
     end loop;
     res_out <= tmp_v;
   end process;
@@ -590,14 +593,19 @@ begin
   output_gate: process(clk_i)
   begin
     if rising_edge(clk_i) then
-      res_o <= (others => '0');
+      logic_reg <= (others => '0');
+      shift_reg <= (others => '0');
+      add_reg   <= (others => '0');
       if (valid = '1') then
-        res_o <= res_out;
+        logic_reg <= res_out;
+        shift_reg <= res(op_cz_c) or res(op_cpop_c) or res(op_rot_c);
+        add_reg   <= res(op_shadd_c);
       end if;
     end if;
   end process;
 
   -- valid output --
+  res_o <= logic_reg or shift_reg or add_reg;
   valid_o <= valid;
 
 end architecture;

--- a/rtl/core/neorv32_cpu_alu_cond.vhd
+++ b/rtl/core/neorv32_cpu_alu_cond.vhd
@@ -31,6 +31,8 @@ end entity;
 architecture neorv32_cpu_alu_cond_rtl of neorv32_cpu_alu_cond is
 
   signal valid_cmd, condition : std_ulogic;
+  signal data_reg : std_ulogic_vector(31 downto 0);
+  signal move_reg : std_ulogic;
 
 begin
 
@@ -45,13 +47,16 @@ begin
   cond_out: process(clk_i)
   begin
     if rising_edge(clk_i) then
+      data_reg <= rs1_i;
       if (valid_cmd = '1') and (condition = '1') then -- unit triggered and move-condition is true
-        res_o <= rs1_i;
+        move_reg <= '1';
       else
-        res_o <= (others => '0');
+        move_reg <= '0';
       end if;
     end if;
   end process;
+
+  res_o <= data_reg when move_reg = '1' else (others => '0');
 
   -- condition check: equal zero / non equal zero --
   condition <= or_reduce_f(rs2_i) xor ctrl_i.ir_funct3(1);

--- a/rtl/core/neorv32_cpu_control.vhd
+++ b/rtl/core/neorv32_cpu_control.vhd
@@ -151,6 +151,7 @@ architecture neorv32_cpu_control_rtl of neorv32_cpu_control is
   end record;
   signal csr : csr_t; -- register set
   signal csr_wdata, csr_rdata, dcsr_rdata : std_ulogic_vector(31 downto 0); -- read/write data
+  signal csr_local_rdata, csr_external_rdata : std_ulogic_vector(31 downto 0);
 
   -- debug-mode controller --
   type debug_ctrl_t is record
@@ -1198,134 +1199,141 @@ begin
 
   -- CSR Read Access ------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
+  csr_read_decode: process(all)
+  begin
+    csr_local_rdata <= (others => '0');
+    csr_external_rdata <= (others => '0');
+    case ctrl.csr_addr is
+
+      -- --------------------------------------------------------------------
+      -- machine trap setup
+      -- --------------------------------------------------------------------
+      when csr_mstatus_c => -- machine status register, low word
+        csr_local_rdata(3)  <= csr.mstatus_mie;
+        csr_local_rdata(7)  <= csr.mstatus_mpie;
+        csr_local_rdata(11) <= csr.mstatus_mpp;
+        csr_local_rdata(12) <= csr.mstatus_mpp;
+        csr_local_rdata(17) <= csr.mstatus_mprv;
+        csr_local_rdata(21) <= csr.mstatus_tw and bool_to_ulogic_f(RISCV_ISA_U);
+
+      when csr_misa_c => -- ISA and extensions
+        csr_local_rdata(0)  <= bool_to_ulogic_f(RISCV_ISA_A);
+        csr_local_rdata(1)  <= bool_to_ulogic_f(RISCV_ISA_B);
+        csr_local_rdata(2)  <= bool_to_ulogic_f(RISCV_ISA_C);
+        csr_local_rdata(4)  <= bool_to_ulogic_f(RISCV_ISA_E);
+        csr_local_rdata(8)  <= bool_to_ulogic_f(not RISCV_ISA_E);
+        csr_local_rdata(12) <= bool_to_ulogic_f(RISCV_ISA_M);
+        csr_local_rdata(20) <= bool_to_ulogic_f(RISCV_ISA_U);
+        csr_local_rdata(23) <= '1'; -- X CPU extension (non-standard / NEORV32-specific)
+        csr_local_rdata(31 downto 30) <= "01"; -- MXL = 32
+
+      when csr_mie_c => -- machine interrupt-enable register
+        csr_local_rdata(3)  <= csr.mie_msi;
+        csr_local_rdata(7)  <= csr.mie_mti;
+        csr_local_rdata(11) <= csr.mie_mei;
+        csr_local_rdata(31 downto 16) <= csr.mie_firq;
+
+      when csr_mtvec_c => -- machine trap-handler base address
+        csr_local_rdata <= csr.mtvec;
+
+      when csr_mcounteren_c => -- machine counter enable register
+        if RISCV_ISA_U and (RISCV_ISA_Zicntr or RISCV_ISA_Zihpm) then
+          csr_local_rdata <= csr.mcounteren;
+        end if;
+
+      -- --------------------------------------------------------------------
+      -- machine trap handling
+      -- --------------------------------------------------------------------
+      when csr_mscratch_c => -- machine scratch register
+        csr_local_rdata <= csr.mscratch;
+
+      when csr_mepc_c => -- machine exception program counter
+        csr_local_rdata <= csr.mepc(31 downto 1) & '0';
+
+      when csr_mcause_c => -- machine trap cause
+        csr_local_rdata(31) <= csr.mcause(5);
+        csr_local_rdata(4 downto 0) <= csr.mcause(4 downto 0);
+
+      when csr_mtval_c => -- machine trap value
+        csr_local_rdata <= csr.mtval;
+
+      when csr_mip_c => -- machine interrupt pending
+        csr_local_rdata(3)  <= irq_pnd(irq_msi_irq_c);
+        csr_local_rdata(7)  <= irq_pnd(irq_mti_irq_c);
+        csr_local_rdata(11) <= irq_pnd(irq_mei_irq_c);
+        csr_local_rdata(31 downto 16) <= irq_pnd(irq_firq_15_c downto irq_firq_0_c);
+
+      -- --------------------------------------------------------------------
+      -- machine information
+      -- --------------------------------------------------------------------
+      when csr_mvendorid_c => csr_local_rdata <= VENDOR_ID; -- vendor ID
+      when csr_marchid_c   => csr_local_rdata <= x"00000013"; -- architecture ID
+      when csr_mimpid_c    => csr_local_rdata <= hw_version_c; -- implementation ID
+      when csr_mhartid_c   => csr_local_rdata <= std_ulogic_vector(to_unsigned(HART_ID, 32)); -- hardware thread ID
+
+      -- --------------------------------------------------------------------
+      -- debug-mode
+      -- --------------------------------------------------------------------
+      when csr_dcsr_c      => if RISCV_ISA_Sdext then csr_local_rdata <= dcsr_rdata;    end if; -- control and status
+      when csr_dpc_c       => if RISCV_ISA_Sdext then csr_local_rdata <= csr.dpc;       end if; -- program counter
+      when csr_dscratch0_c => if RISCV_ISA_Sdext then csr_local_rdata <= csr.dscratch0; end if; -- scratch register 0
+
+      -- --------------------------------------------------------------------
+      -- NEORV32-specific
+      -- --------------------------------------------------------------------
+      when csr_mxisa_c => -- machine extended ISA extensions information, low-word
+        csr_local_rdata(0)  <= '1';                                   -- Zicsr: CSR access (always enabled)
+        csr_local_rdata(1)  <= '1';                                   -- Zifencei: instruction stream sync. (always enabled)
+        csr_local_rdata(2)  <= bool_to_ulogic_f(RISCV_ISA_Zmmul);     -- Zmmul: mul/div
+        csr_local_rdata(3)  <= bool_to_ulogic_f(RISCV_ISA_Xcfu);      -- Xcfu: custom instructions
+        csr_local_rdata(4)  <= bool_to_ulogic_f(RISCV_ISA_Zkt);       -- Zkt: data independent execution latency
+        csr_local_rdata(5)  <= bool_to_ulogic_f(RISCV_ISA_Zfinx);     -- Zfinx: FPU using x registers
+        csr_local_rdata(6)  <= bool_to_ulogic_f(RISCV_ISA_Zicond);    -- Zicond: integer conditional operations
+        csr_local_rdata(7)  <= bool_to_ulogic_f(RISCV_ISA_Zicntr);    -- Zicntr: base counters
+        csr_local_rdata(8)  <= bool_to_ulogic_f(RISCV_ISA_Smpmp);     -- Smpmp: physical memory protection
+        csr_local_rdata(9)  <= bool_to_ulogic_f(RISCV_ISA_Zihpm);     -- Zihpm: hardware performance monitors
+        csr_local_rdata(10) <= bool_to_ulogic_f(RISCV_ISA_Sdext);     -- Sdext: external debug
+        csr_local_rdata(11) <= bool_to_ulogic_f(RISCV_ISA_Sdtrig);    -- Sdtrig: trigger module
+        csr_local_rdata(12) <= bool_to_ulogic_f(RISCV_ISA_Zbkx);      -- Zbkx: cryptography crossbar permutation
+        csr_local_rdata(13) <= bool_to_ulogic_f(RISCV_ISA_Zknd);      -- Zknd: cryptography NIST AES decryption
+        csr_local_rdata(14) <= bool_to_ulogic_f(RISCV_ISA_Zkne);      -- Zkne: cryptography NIST AES encryption
+        csr_local_rdata(15) <= bool_to_ulogic_f(RISCV_ISA_Zknh);      -- Zknh: cryptography NIST hash functions
+        csr_local_rdata(16) <= bool_to_ulogic_f(RISCV_ISA_Zbkb);      -- Zbkb: bit manipulation instructions for cryptography
+        csr_local_rdata(17) <= bool_to_ulogic_f(RISCV_ISA_Zbkc);      -- Zbkc: carry-less multiplication for cryptography
+        csr_local_rdata(18) <= bool_to_ulogic_f(RISCV_ISA_Zkn);       -- Zkn: NIST algorithm suite
+        csr_local_rdata(19) <= bool_to_ulogic_f(RISCV_ISA_Zksh);      -- Zksh: ShangMi hash functions
+        csr_local_rdata(20) <= bool_to_ulogic_f(RISCV_ISA_Zksed);     -- Zksed: ShangMi block ciphers
+        csr_local_rdata(21) <= bool_to_ulogic_f(RISCV_ISA_Zks);       -- Zks: ShangMi algorithm suite
+        csr_local_rdata(22) <= bool_to_ulogic_f(RISCV_ISA_Zba);       -- Zba: shifted-add bit-manipulation
+        csr_local_rdata(23) <= bool_to_ulogic_f(RISCV_ISA_Zbb);       -- Zbb: basic bit-manipulation
+        csr_local_rdata(24) <= bool_to_ulogic_f(RISCV_ISA_Zbs);       -- Zbs: single-bit bit-manipulation
+        csr_local_rdata(25) <= bool_to_ulogic_f(RISCV_ISA_Zaamo);     -- Zaamo: atomic memory operations
+        csr_local_rdata(26) <= bool_to_ulogic_f(RISCV_ISA_Zalrsc);    -- Zalrsc: reservation-set operations
+        csr_local_rdata(27) <= bool_to_ulogic_f(RISCV_ISA_Zcb);       -- Zcb: additional code size reduction instructions
+        csr_local_rdata(28) <= bool_to_ulogic_f(RISCV_ISA_C);         -- Zca: C without floating-point
+        csr_local_rdata(29) <= bool_to_ulogic_f(RISCV_ISA_Zibi);      -- Zibi: branch with immediate-comparison
+        csr_local_rdata(30) <= bool_to_ulogic_f(RISCV_ISA_Zimop);     -- Zimop: may-be-operations
+        csr_local_rdata(31) <= bool_to_ulogic_f(RISCV_ISA_Smcntrpmf); -- Smcntrpmf: counter privilege-mode filtering
+
+      when csr_mxisah_c => -- machine extended ISA extensions information, high-word
+        csr_local_rdata(0) <= bool_to_ulogic_f(RISCV_ISA_Zbc);   -- Zbc: carry-less multiplication
+        csr_local_rdata(1) <= bool_to_ulogic_f(RISCV_ISA_Zcmop); -- Zcmop: compressed may-be-operations
+
+      -- --------------------------------------------------------------------
+      -- undefined/unavailable or implemented externally
+      -- --------------------------------------------------------------------
+      when others => -- FPU, PMP, HPM, base counters, etc.
+        csr_external_rdata <= xcsr_rdata_i;
+
+    end case;
+  end process;
+
   csr_read_access: process(clk_i)
   begin
     if rising_edge(clk_i) then
       csr_rdata <= (others => '0'); -- output all-zero if there is no CSR read operation
       if (ctrl.csr_re = '1') then
-        case ctrl.csr_addr is
-
-          -- --------------------------------------------------------------------
-          -- machine trap setup
-          -- --------------------------------------------------------------------
-          when csr_mstatus_c => -- machine status register, low word
-            csr_rdata(3)  <= csr.mstatus_mie;
-            csr_rdata(7)  <= csr.mstatus_mpie;
-            csr_rdata(11) <= csr.mstatus_mpp;
-            csr_rdata(12) <= csr.mstatus_mpp;
-            csr_rdata(17) <= csr.mstatus_mprv;
-            csr_rdata(21) <= csr.mstatus_tw and bool_to_ulogic_f(RISCV_ISA_U);
-
-          when csr_misa_c => -- ISA and extensions
-            csr_rdata(0)  <= bool_to_ulogic_f(RISCV_ISA_A);
-            csr_rdata(1)  <= bool_to_ulogic_f(RISCV_ISA_B);
-            csr_rdata(2)  <= bool_to_ulogic_f(RISCV_ISA_C);
-            csr_rdata(4)  <= bool_to_ulogic_f(RISCV_ISA_E);
-            csr_rdata(8)  <= bool_to_ulogic_f(not RISCV_ISA_E);
-            csr_rdata(12) <= bool_to_ulogic_f(RISCV_ISA_M);
-            csr_rdata(20) <= bool_to_ulogic_f(RISCV_ISA_U);
-            csr_rdata(23) <= '1'; -- X CPU extension (non-standard / NEORV32-specific)
-            csr_rdata(31 downto 30) <= "01"; -- MXL = 32
-
-          when csr_mie_c => -- machine interrupt-enable register
-            csr_rdata(3)  <= csr.mie_msi;
-            csr_rdata(7)  <= csr.mie_mti;
-            csr_rdata(11) <= csr.mie_mei;
-            csr_rdata(31 downto 16) <= csr.mie_firq;
-
-          when csr_mtvec_c => -- machine trap-handler base address
-            csr_rdata <= csr.mtvec;
-
-          when csr_mcounteren_c => -- machine counter enable register
-            if RISCV_ISA_U and (RISCV_ISA_Zicntr or RISCV_ISA_Zihpm) then
-              csr_rdata <= csr.mcounteren;
-            end if;
-
-          -- --------------------------------------------------------------------
-          -- machine trap handling
-          -- --------------------------------------------------------------------
-          when csr_mscratch_c => -- machine scratch register
-            csr_rdata <= csr.mscratch;
-
-          when csr_mepc_c => -- machine exception program counter
-            csr_rdata <= csr.mepc(31 downto 1) & '0';
-
-          when csr_mcause_c => -- machine trap cause
-            csr_rdata(31) <= csr.mcause(5);
-            csr_rdata(4 downto 0) <= csr.mcause(4 downto 0);
-
-          when csr_mtval_c => -- machine trap value
-            csr_rdata <= csr.mtval;
-
-          when csr_mip_c => -- machine interrupt pending
-            csr_rdata(3)  <= irq_pnd(irq_msi_irq_c);
-            csr_rdata(7)  <= irq_pnd(irq_mti_irq_c);
-            csr_rdata(11) <= irq_pnd(irq_mei_irq_c);
-            csr_rdata(31 downto 16) <= irq_pnd(irq_firq_15_c downto irq_firq_0_c);
-
-          -- --------------------------------------------------------------------
-          -- machine information
-          -- --------------------------------------------------------------------
-          when csr_mvendorid_c => csr_rdata <= VENDOR_ID; -- vendor ID
-          when csr_marchid_c   => csr_rdata <= x"00000013"; -- architecture ID
-          when csr_mimpid_c    => csr_rdata <= hw_version_c; -- implementation ID
-          when csr_mhartid_c   => csr_rdata <= std_ulogic_vector(to_unsigned(HART_ID, 32)); -- hardware thread ID
-
-          -- --------------------------------------------------------------------
-          -- debug-mode
-          -- --------------------------------------------------------------------
-          when csr_dcsr_c      => if RISCV_ISA_Sdext then csr_rdata <= dcsr_rdata;    end if; -- control and status
-          when csr_dpc_c       => if RISCV_ISA_Sdext then csr_rdata <= csr.dpc;       end if; -- program counter
-          when csr_dscratch0_c => if RISCV_ISA_Sdext then csr_rdata <= csr.dscratch0; end if; -- scratch register 0
-
-          -- --------------------------------------------------------------------
-          -- NEORV32-specific
-          -- --------------------------------------------------------------------
-          when csr_mxisa_c => -- machine extended ISA extensions information, low-word
-            csr_rdata(0)  <= '1';                                   -- Zicsr: CSR access (always enabled)
-            csr_rdata(1)  <= '1';                                   -- Zifencei: instruction stream sync. (always enabled)
-            csr_rdata(2)  <= bool_to_ulogic_f(RISCV_ISA_Zmmul);     -- Zmmul: mul/div
-            csr_rdata(3)  <= bool_to_ulogic_f(RISCV_ISA_Xcfu);      -- Xcfu: custom instructions
-            csr_rdata(4)  <= bool_to_ulogic_f(RISCV_ISA_Zkt);       -- Zkt: data independent execution latency
-            csr_rdata(5)  <= bool_to_ulogic_f(RISCV_ISA_Zfinx);     -- Zfinx: FPU using x registers
-            csr_rdata(6)  <= bool_to_ulogic_f(RISCV_ISA_Zicond);    -- Zicond: integer conditional operations
-            csr_rdata(7)  <= bool_to_ulogic_f(RISCV_ISA_Zicntr);    -- Zicntr: base counters
-            csr_rdata(8)  <= bool_to_ulogic_f(RISCV_ISA_Smpmp);     -- Smpmp: physical memory protection
-            csr_rdata(9)  <= bool_to_ulogic_f(RISCV_ISA_Zihpm);     -- Zihpm: hardware performance monitors
-            csr_rdata(10) <= bool_to_ulogic_f(RISCV_ISA_Sdext);     -- Sdext: external debug
-            csr_rdata(11) <= bool_to_ulogic_f(RISCV_ISA_Sdtrig);    -- Sdtrig: trigger module
-            csr_rdata(12) <= bool_to_ulogic_f(RISCV_ISA_Zbkx);      -- Zbkx: cryptography crossbar permutation
-            csr_rdata(13) <= bool_to_ulogic_f(RISCV_ISA_Zknd);      -- Zknd: cryptography NIST AES decryption
-            csr_rdata(14) <= bool_to_ulogic_f(RISCV_ISA_Zkne);      -- Zkne: cryptography NIST AES encryption
-            csr_rdata(15) <= bool_to_ulogic_f(RISCV_ISA_Zknh);      -- Zknh: cryptography NIST hash functions
-            csr_rdata(16) <= bool_to_ulogic_f(RISCV_ISA_Zbkb);      -- Zbkb: bit manipulation instructions for cryptography
-            csr_rdata(17) <= bool_to_ulogic_f(RISCV_ISA_Zbkc);      -- Zbkc: carry-less multiplication for cryptography
-            csr_rdata(18) <= bool_to_ulogic_f(RISCV_ISA_Zkn);       -- Zkn: NIST algorithm suite
-            csr_rdata(19) <= bool_to_ulogic_f(RISCV_ISA_Zksh);      -- Zksh: ShangMi hash functions
-            csr_rdata(20) <= bool_to_ulogic_f(RISCV_ISA_Zksed);     -- Zksed: ShangMi block ciphers
-            csr_rdata(21) <= bool_to_ulogic_f(RISCV_ISA_Zks);       -- Zks: ShangMi algorithm suite
-            csr_rdata(22) <= bool_to_ulogic_f(RISCV_ISA_Zba);       -- Zba: shifted-add bit-manipulation
-            csr_rdata(23) <= bool_to_ulogic_f(RISCV_ISA_Zbb);       -- Zbb: basic bit-manipulation
-            csr_rdata(24) <= bool_to_ulogic_f(RISCV_ISA_Zbs);       -- Zbs: single-bit bit-manipulation
-            csr_rdata(25) <= bool_to_ulogic_f(RISCV_ISA_Zaamo);     -- Zaamo: atomic memory operations
-            csr_rdata(26) <= bool_to_ulogic_f(RISCV_ISA_Zalrsc);    -- Zalrsc: reservation-set operations
-            csr_rdata(27) <= bool_to_ulogic_f(RISCV_ISA_Zcb);       -- Zcb: additional code size reduction instructions
-            csr_rdata(28) <= bool_to_ulogic_f(RISCV_ISA_C);         -- Zca: C without floating-point
-            csr_rdata(29) <= bool_to_ulogic_f(RISCV_ISA_Zibi);      -- Zibi: branch with immediate-comparison
-            csr_rdata(30) <= bool_to_ulogic_f(RISCV_ISA_Zimop);     -- Zimop: may-be-operations
-            csr_rdata(31) <= bool_to_ulogic_f(RISCV_ISA_Smcntrpmf); -- Smcntrpmf: counter privilege-mode filtering
-
-          when csr_mxisah_c => -- machine extended ISA extensions information, high-word
-            csr_rdata(0) <= bool_to_ulogic_f(RISCV_ISA_Zbc);   -- Zbc: carry-less multiplication
-            csr_rdata(1) <= bool_to_ulogic_f(RISCV_ISA_Zcmop); -- Zcmop: compressed may-be-operations
-
-          -- --------------------------------------------------------------------
-          -- undefined/unavailable or implemented externally
-          -- --------------------------------------------------------------------
-          when others => -- FPU, PMP, HPM, base counters, etc.
-            csr_rdata <= xcsr_rdata_i;
-
-        end case;
+        csr_rdata <= csr_local_rdata or csr_external_rdata;
       end if;
     end if;
   end process;

--- a/rtl/core/neorv32_cpu_frontend.vhd
+++ b/rtl/core/neorv32_cpu_frontend.vhd
@@ -332,6 +332,7 @@ architecture neorv32_cpu_frontend_ipb_rtl of neorv32_cpu_frontend_ipb is
   -- memory core --
   type ipb_t is array (0 to (2**awidth_c)-1) of std_ulogic_vector(16 downto 0);
   signal ipb : ipb_t;
+  signal w_addr : unsigned(awidth_c-1 downto 0);
 
 begin
 
@@ -361,14 +362,19 @@ begin
 
   -- Memory Core ----------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
-  mem_write: process(clk_i)
-  begin
-    if rising_edge(clk_i) then
-      if (we_i = '1') then
-        ipb(to_integer(unsigned(w_pnt(awidth_c-1 downto 0)))) <= wdata_i;
+  w_addr <= to_01(unsigned(w_pnt(awidth_c-1 downto 0)));
+
+  mem_gen:
+  for i in ipb'range generate
+    mem_write: process(clk_i)
+    begin
+      if rising_edge(clk_i) then
+        if (we_i = '1') and (w_addr = to_unsigned(i, awidth_c)) then
+          ipb(i) <= wdata_i;
+        end if;
       end if;
-    end if;
-  end process;
+    end process;
+  end generate;
 
   -- asynchronous read --
   rdata_o <= ipb(to_integer(unsigned(r_pnt(awidth_c-1 downto 0))));

--- a/rtl/core/neorv32_cpu_regfile.vhd
+++ b/rtl/core/neorv32_cpu_regfile.vhd
@@ -43,7 +43,8 @@ entity neorv32_cpu_regfile is
     rs1_data_o : out std_ulogic_vector(31 downto 0); -- read data
     -- read port 1 (rs2) --
     rs2_addr_i : in  std_ulogic_vector(4 downto 0);  -- address
-    rs2_data_o : out std_ulogic_vector(31 downto 0)  -- read data
+    rs2_data_o : out std_ulogic_vector(31 downto 0); -- read data
+    cmp_o      : out std_ulogic_vector(3 downto 0)   -- ARCHSEL=2: immediate equality, signed/unsigned less-than, equality
   );
 end entity;
 
@@ -138,6 +139,23 @@ begin
   -- -------------------------------------------------------------------------------------------
   arch_reg:
   if (ARCHSEL = 2) generate
+    signal cmp_rs1, cmp_rs2, cmp_imm : std_ulogic_vector(31 downto 0);
+  begin
+
+    cmp_rs1 <= regfile(to_integer(unsigned(rs1_addr_i(AWIDTH-1 downto 0))));
+    cmp_rs2 <= regfile(to_integer(unsigned(rs2_addr_i(AWIDTH-1 downto 0))));
+    cmp_imm <= (others => '1') when (rs2_addr_i = "00000") else x"000000" & "000" & rs2_addr_i;
+
+    -- Comparison and data sample the same register contents at the read edge.
+    cmp_read: process(clk_i)
+    begin
+      if rising_edge(clk_i) then
+        cmp_o(0) <= bool_to_ulogic_f(cmp_rs1 = cmp_rs2);
+        cmp_o(1) <= bool_to_ulogic_f(unsigned(cmp_rs1) < unsigned(cmp_rs2));
+        cmp_o(2) <= bool_to_ulogic_f(signed(cmp_rs1) < signed(cmp_rs2));
+        cmp_o(3) <= bool_to_ulogic_f(cmp_rs1 = cmp_imm);
+      end if;
+    end process;
 
     -- write select --
     onehot_gen:
@@ -177,6 +195,11 @@ begin
 
   end generate;
 
+
+  cmp_unused:
+  if (ARCHSEL /= 2) generate
+    cmp_o <= (others => '0');
+  end generate;
 
   -- Architecture Style 3: Latch-Based ------------------------------------------------------
   -- -------------------------------------------------------------------------------------------

--- a/rtl/core/neorv32_prim.vhd
+++ b/rtl/core/neorv32_prim.vhd
@@ -341,6 +341,7 @@ begin
 
     signal q_ll, q_lh, q_hl, q_hh : signed(pp_width_c-1 downto 0);
     signal q_sum_lo, q_sum_hi     : signed(pr_width_c-1 downto 0);
+    signal pp_outer, pp_lh, pp_hl : signed(pr_width_c-1 downto 0);
   begin
     partial_product_reg: process(clk_i)
     begin
@@ -356,12 +357,15 @@ begin
       end if;
     end process;
 
+    pp_outer <= shift_left(resize(q_hh, pr_width_c), 2*lo_width_c) or resize(q_ll, pr_width_c);
+    pp_lh <= shift_left(resize(q_lh, pr_width_c), lo_width_c);
+    pp_hl <= shift_left(resize(q_hl, pr_width_c), lo_width_c);
+
     partial_sum_reg: process(clk_i)
     begin
       if rising_edge(clk_i) then -- no reset to improve multiplier mapping
-        q_sum_lo <= resize(q_ll, pr_width_c) + shift_left(resize(q_lh, pr_width_c), lo_width_c);
-        q_sum_hi <= shift_left(resize(q_hl, pr_width_c), lo_width_c) +
-                    shift_left(resize(q_hh, pr_width_c), 2*lo_width_c);
+        q_sum_lo <= pp_outer xor pp_lh xor pp_hl;
+        q_sum_hi <= shift_left((pp_outer and pp_lh) or ((pp_outer xor pp_lh) and pp_hl), 1);
       end if;
     end process;
 


### PR DESCRIPTION
### Summary

Improve timing margin across CSR readback, ALU result capture, multiplier partial sums and instruction-fetch control.
The changes redistribute combinational work around existing register edges without adding instruction cycles.

### Standalone μC results

One comparison: unchanged upstream versus this complete branch. Both use the same standalone CPU harness,
Vivado 2026.1, `xczu48dr-ffvg1517-2-e` and a 2.000 ns clock constraint.
There is no application RAM, interconnect or peripheral logic in the synthesis top.

| Metric | Upstream | This branch | Difference |
| --- | ---: | ---: | ---: |
| μC register-to-register WNS | +0.228 ns | +0.367 ns | **+0.139 ns** |
| Setup endpoints below +0.500 ns | 200 | 39 | **-161 (80.5%)** |
| Setup endpoints below +0.300 ns | 63 | 0 | **-63** |
| LUTs | 2,894 | 3,088 | **+194 (6.7%)** |
| FFs | 2,286 | 2,434 | **+148 (6.5%)** |
| BRAM tiles | 0 | 0 | 0 |
| DSPs | 4 | 4 | 0 |
| Latches | 0 | 0 | 0 |

Both designs have zero unconstrained internal endpoints, missing I/O delays and combinational loops.
The remaining worst path is instruction decode to the bitmanip FSM clock enable.
These are synthesis timing estimates, not hardware timing sign-off.

Configuration: RV32I with M, Zba, Zbb, Zbkc, Zbs, Zicntr and Zicond enabled.
RF architecture 2, fast shifting and a three-stage fast multiplier are enabled.
Compressed instructions, constant-time branches, user mode, HPM, PMP and debug are disabled.
CPU buses and interrupt inputs are exposed. Maximum input/output delay is 0.200 ns, minimum delay is zero.
WNS and endpoint counts above cover internal register-to-register setup paths, excluding external I/O timing paths.
One worst path per endpoint is reported, with a 100,000-path limit.

### 1. [cpu/control] separate local and external CSR decode

**Justification.** The CSR read register receives both local CSR data and external contributions, including counters.
Explicit mutually exclusive local/external decode exposes their selection before the existing register
and reduces serial selection on the CSR read path.

**Contract.** Preserve the local address set and decode priority.
Disabled local CSRs return zero rather than admitting external data.
The read-enable, idle-zero output and sampling edge are unchanged.

**Measured CSR-path margin for the complete branch:** +0.228 → +0.441 ns, **+0.213 ns**.

**Optional counter-readback extension.** Select each counter's requested 32-bit word before read-enable masking,
and decode counter reads with full CSR address comparisons. This narrows the readback network and reduces serial address qualification
without changing counter state or the CSR sampling edge.
Measured with this branch, the extension raises CSR margin from +0.441 to +0.583 ns (**+142 ps**)
for **28 additional LUTs and one FF**, and reduces endpoints below +0.500 ns from 39 to seven.
Overall μC WNS remains +0.367 ns. This offers additional CSR margin where that resource tradeoff is useful.

### 2. [cpu/alu_bitmanip] separate result registers

**Justification.** A shared OR reduction combines logic, shift/count and shifted-add results before capture.
Partitioning the result registers by these groups removes part of that reduction from individual capture paths.
The groups are combined after the existing edge, distributing the work across the same register boundary.

**Contract.** Preserve operand capture, live decode, iterative-operation control, valid timing and idle-zero behavior.
Every original OR term remains represented, including overlapping selections. No instruction cycle is added.

**Measured bitmanip-path margin for the complete branch:** +0.278 → +0.367 ns, **+0.089 ns**.

**Tradeoff.** Separate result groups require additional storage and output combination logic.
The remaining worst bitmanip path is instruction decode to the FSM clock enable.

### 3. [cpu/alu_cond] separate result data and control

**Justification.** The conditional move decision otherwise controls selection into a 32-bit result register.
Capture raw data and the one-bit move decision separately, then select data or zero.
This removes the late decode/condition expression from the wide register input selection.

**Contract.** Preserve accepted results, valid timing and the result capture edge.
The unqualified output before the first clock changes from unknown to zero.
The data register captures during idle cycles, which can change switching activity.

**Measured conditional-path margin for the complete branch:** +0.804 → +0.952 ns, **+0.148 ns**.

**Incremental cost.** In the combined μC, this change adds **one FF and no LUTs**.
With all other changes held fixed, conditional-path margin increases from +0.655 to +0.952 ns (**+297 ps**).
Overall WNS remains +0.367 ns, with 39 endpoints below +0.500 ns. Idle data-register switching can change.

### 4. [cpu/frontend] localize prefetch buffer writes

**Justification.** Dynamic indexed writes to the small prefetch buffer can infer storage with less favorable input timing.
Static per-entry write processes expose local write selection without a RAM-style attribute.
This form supports integration with instruction memories whose output-to-buffer path is critical.

**Contract.** Preserve buffer depth, pointer updates, read selection, clear behavior and fetch handshakes.
Normalize the write address once while retaining the unknown-pointer fallback.
Each halfword buffer remains two entries deep. No additional prefetch capacity or fetch cycle is introduced.

**Observation.** The isolated standalone μC measurement showed no WNS or below-target endpoint improvement and increased FF usage.
This harness has no instruction RAM, so it does not establish the intended memory-to-prefetch timing benefit.

**RAM-attached result.** With 512 KiB of synchronous, byte-write-enabled true-dual-port RAM in READ_FIRST mode,
mapped to 128 AMD UltraScale+ RAMB36E2 primitives, RAM-to-prefetch margin improved from +0.134 to +0.423 ns (**+289 ps**).
The RAM uses a one-cycle read with no optional output register. Fetch latency is unchanged.
The prefetch change alone used **82 fewer LUTs and 59 additional FFs**, with unchanged BRAM count.

**RAM-enable integration.** The changed mapping increased loading on the request-qualified RAM enables.
Holding both RAM read enables high removes that enable-path regression, while qualifying each byte-write enable
with the original request enable preserves accepted writes. Together, the prefetch and RAM-enable changes retain
the **+289 ps RAM-to-prefetch gain** at a net cost of **59 FFs and 65 fewer LUTs**, with unchanged BRAM count.
Overall RAM-attached WNS remains +0.132 ns. The RAM-enable adjustment belongs in the external RAM wrapper and is not part of this PR.
It preserves accepted read/write and acknowledgement timing, but allows idle read data to change and increases idle RAM switching.

### 5. [prim] use carry-save multiplier partial sums

**Justification.** Adding aligned partial products with carry-propagate arithmetic creates long partial-sum capture paths.
The low-low and shifted high-high terms occupy non-overlapping bit positions and can be combined directly.
Compress that term and the two cross products into sum and shifted carry, then retain the existing final addition.

**Contract.** Preserve the upstream operand split, signed widths, input-enable behavior and three-stage latency.
Other register-count configurations are unchanged. No extra DSP stage or synthesis attribute is introduced.

**Measured multiplier-path margin for the complete branch:** +0.238 → +0.625 ns, **+0.387 ns**.

**Tradeoff.** Carry-save partial sums use additional **+119 LUTs and +14 FFs**. DSP count remains four.

### 6. [cpu/regfile] capture comparisons at the read edge

**Justification.** Comparing registered operands and then driving fetch/control decisions puts comparison and control decode in one cycle.
For RF architecture 2, the raw operands are already available before the RF read-output edge.
Capture equality, signed/unsigned less-than and immediate equality at that edge, then select the appropriate flag in control.

**Contract.** Comparison flags sample the same register contents and edge as operand data.
Preserve RV32E address truncation, x0 handling and the full five-bit Zibi immediate selector.
Signedness selection occurs after capture.
The RF gains a four-bit internal output, but the CPU external interface is unchanged.
Other RF architectures continue using the ALU comparison path. No branch cycle or operand-data stage is added.

**Measured frontend-path margin for the complete branch:** +0.295 → +0.653 ns, **+0.358 ns**.

**Tradeoff.** Comparison capture adds comparison logic before the RF read-output edge and stores four flags.
In the complete branch, minimum RF destination slack is +0.501 ns.

### Interpretation

Each measurement identifies its comparison: upstream versus the complete branch, a patch applied alone, or the combined design with and
without that patch. Resource costs and timing gains apply to the stated comparison.

### Validation

- Fresh standalone synthesis completed for upstream and the revised six-optimization branch.
  Earlier isolated and combined runs support the observations above.
- The revised run reported zero critical warnings, errors, inferred latches and timing-check deficiencies.
- The branch's seven changed RTL files and restored upstream counter file match the revised synthesis snapshot.
- Prior validation of the optimizations includes processor_check: 62/62 passed with RF architecture 2 and three multiplier stages.
- The real-CPU operand test passed 64 configurations and 128,128 independent signature checks per source set,
  with matching public-bus and retirement traces against its reference.
- Multiplier differential tests passed 45 configurations and 184,230 checked cycles.
- Counter and bitmanip generic elaboration and focused arithmetic/control identity checks passed.
- μC integration pre/post-synthesis Riviera tests passed. XSim pre/post-synthesis passed.